### PR TITLE
Add a switch to disable the managed (platform) coding agent, with honest UI

### DIFF
--- a/apps/api/fixtures/games-repo/shared/assemble-contract.json
+++ b/apps/api/fixtures/games-repo/shared/assemble-contract.json
@@ -5,6 +5,7 @@
     "input",
     "collision",
     "world",
+    "grid",
     "path",
     "ai",
     "gameplay",

--- a/apps/api/src/admin.test.ts
+++ b/apps/api/src/admin.test.ts
@@ -483,7 +483,14 @@ describe('/api/admin/creation-limits', () => {
 
     expect(res.statusCode).toBe(200);
     const body = res.json() as CreationLimitsResponse;
-    expect(body.effective).toEqual({ paused: true, globalDailySubmissionCap: 25 });
+    expect(body.effective).toEqual({
+      paused: true,
+      globalDailySubmissionCap: 25,
+      managedBuilderMode: 'auto',
+      managedDailyCap: null,
+      managedDailyUserCap: null,
+      hasPlatformBackend: false,
+    });
     // A pause left on by accident is this feature's own failure mode, so the record of
     // who set it is part of the deliverable.
     expect(body.stored).toMatchObject({ paused: true, updatedBy: 'g:boss' });
@@ -506,6 +513,10 @@ describe('/api/admin/creation-limits', () => {
     expect((res.json() as CreationLimitsResponse).effective).toEqual({
       paused: false,
       globalDailySubmissionCap: 25,
+      managedBuilderMode: 'auto',
+      managedDailyCap: null,
+      managedDailyUserCap: null,
+      hasPlatformBackend: false,
     });
     await app.close();
   });

--- a/apps/api/src/admin.ts
+++ b/apps/api/src/admin.ts
@@ -103,6 +103,8 @@ export interface AdminRoutesOptions {
   creationLimitsTtlMs?: number;
   publicPlayFallbackSlugs?: string[];
   publicPlayTtlMs?: number;
+  /** Whether this environment has a platform backend configured at all. See managed-availability.ts. */
+  hasPlatformBackend?: boolean;
 }
 
 /**
@@ -117,8 +119,17 @@ export interface AdminRoutesOptions {
 export interface CreationLimitsResponse {
   /** Null when nothing has ever been written — the defaults below are what is in force. */
   stored: CreationLimits | null;
-  effective: { paused: boolean; globalDailySubmissionCap: number };
-  today: { dateStr: string; submissions: number };
+  effective: {
+    paused: boolean;
+    globalDailySubmissionCap: number;
+    /** `auto` defers to whether a platform backend is configured — see `hasPlatformBackend`. */
+    managedBuilderMode: 'auto' | 'off' | 'coming_soon';
+    managedDailyCap: number | null;
+    managedDailyUserCap: number | null;
+    /** Whether the environment itself has a platform backend wired, independent of the mode above. */
+    hasPlatformBackend: boolean;
+  };
+  today: { dateStr: string; submissions: number; managedBuilds: number };
   /** Upper bound, in ms, on how long a change takes to reach every instance. */
   propagationMs: number;
 }
@@ -138,14 +149,22 @@ const CreationLimitsPatchSchema = z
     // The editing lanes' breaker rides the same document — one place to look.
     editingPaused: z.boolean().optional(),
     globalDailyEditCap: z.number().int().min(0).max(100_000).nullable().optional(),
+    // Same document, one more switch: whether the `platform` builder is offered at all.
+    // See managed-availability.ts.
+    managedBuilderMode: z.enum(['auto', 'off', 'coming_soon']).optional(),
+    managedDailyCap: z.number().int().min(0).max(100_000).nullable().optional(),
+    managedDailyUserCap: z.number().int().min(0).max(100_000).nullable().optional(),
   })
   .refine(
     (patch) =>
       patch.paused !== undefined ||
       patch.globalDailySubmissionCap !== undefined ||
       patch.editingPaused !== undefined ||
-      patch.globalDailyEditCap !== undefined,
-    'nothing to change: send paused, globalDailySubmissionCap, editingPaused and/or globalDailyEditCap',
+      patch.globalDailyEditCap !== undefined ||
+      patch.managedBuilderMode !== undefined ||
+      patch.managedDailyCap !== undefined ||
+      patch.managedDailyUserCap !== undefined,
+    'nothing to change: send paused, globalDailySubmissionCap, editingPaused, globalDailyEditCap, managedBuilderMode, managedDailyCap and/or managedDailyUserCap',
   );
 
 const PublicPlayPatchSchema = z.object({
@@ -338,17 +357,22 @@ export async function registerAdminRoutes(app: FastifyInstance, options: AdminRo
   /** Reads the stored breaker plus today's spend, uncached — an operator wants truth. */
   async function readCreationLimits(): Promise<CreationLimitsResponse> {
     const dateStr = new Date(now()).toISOString().slice(0, 10);
-    const [stored, submissions] = await Promise.all([
+    const [stored, submissions, managedBuilds] = await Promise.all([
       store.getCreationLimits(),
       store.getGlobalSubmissionCount(dateStr),
+      store.getGlobalManagedBuildCount(dateStr),
     ]);
     return {
       stored,
       effective: {
         paused: stored?.paused === true,
         globalDailySubmissionCap: stored?.globalDailySubmissionCap ?? defaultGlobalCap,
+        managedBuilderMode: stored?.managedBuilderMode ?? 'auto',
+        managedDailyCap: stored?.managedDailyCap ?? null,
+        managedDailyUserCap: stored?.managedDailyUserCap ?? null,
+        hasPlatformBackend: options.hasPlatformBackend === true,
       },
-      today: { dateStr, submissions },
+      today: { dateStr, submissions, managedBuilds },
       propagationMs: creationLimitsTtlMs,
     };
   }

--- a/apps/api/src/admin.ts
+++ b/apps/api/src/admin.ts
@@ -103,7 +103,7 @@ export interface AdminRoutesOptions {
   creationLimitsTtlMs?: number;
   publicPlayFallbackSlugs?: string[];
   publicPlayTtlMs?: number;
-  /** Whether this environment has a platform backend configured at all. See managed-availability.ts. */
+  // Whether a platform backend is configured. See managed-availability.ts.
   hasPlatformBackend?: boolean;
 }
 
@@ -122,11 +122,11 @@ export interface CreationLimitsResponse {
   effective: {
     paused: boolean;
     globalDailySubmissionCap: number;
-    /** `auto` defers to whether a platform backend is configured — see `hasPlatformBackend`. */
+    // `auto` defers to `hasPlatformBackend` below.
     managedBuilderMode: 'auto' | 'off' | 'coming_soon';
     managedDailyCap: number | null;
     managedDailyUserCap: number | null;
-    /** Whether the environment itself has a platform backend wired, independent of the mode above. */
+    // Independent of managedBuilderMode above.
     hasPlatformBackend: boolean;
   };
   today: { dateStr: string; submissions: number; managedBuilds: number };
@@ -149,8 +149,7 @@ const CreationLimitsPatchSchema = z
     // The editing lanes' breaker rides the same document — one place to look.
     editingPaused: z.boolean().optional(),
     globalDailyEditCap: z.number().int().min(0).max(100_000).nullable().optional(),
-    // Same document, one more switch: whether the `platform` builder is offered at all.
-    // See managed-availability.ts.
+    // Same document: whether the platform builder is offered. See managed-availability.ts.
     managedBuilderMode: z.enum(['auto', 'off', 'coming_soon']).optional(),
     managedDailyCap: z.number().int().min(0).max(100_000).nullable().optional(),
     managedDailyUserCap: z.number().int().min(0).max(100_000).nullable().optional(),

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -367,6 +367,13 @@ export async function buildApp(options: BuildAppOptions = {}): Promise<FastifyIn
     }
   };
 
+  // Computed once and reused below (admin routes report whether a platform backend is
+  // configured at all) — calling createPlatformBackendFromEnv a second time would both
+  // waste the lookup and double the "agent dispatch enabled" log line.
+  const resolvedAgentBackends =
+    options.submissionRoutes?.agentBackends ??
+    (options.submissionRoutes?.agentBackend ? undefined : { platform: createPlatformBackendFromEnv(app.log) });
+
   const submissionSeams = await registerSubmissionRoutes(app, {
     ...options.submissionRoutes,
     resolveProposalBase: resolveBaseForProposal,
@@ -383,9 +390,7 @@ export async function buildApp(options: BuildAppOptions = {}): Promise<FastifyIn
     agentBackend: options.submissionRoutes?.agentBackend,
     // Platform only here — `self` is wired inside registerSubmissionRoutes with store
     // callbacks for seed persistence. Passing a pre-built self would skip those.
-    agentBackends:
-      options.submissionRoutes?.agentBackends ??
-      (options.submissionRoutes?.agentBackend ? undefined : { platform: createPlatformBackendFromEnv(app.log) }),
+    agentBackends: resolvedAgentBackends,
     gameSeeder: options.submissionRoutes?.gameSeeder ?? createGameSeederFromEnv(app.log),
     agentChannel: {
       ...options.submissionRoutes?.agentChannel,
@@ -556,6 +561,7 @@ export async function buildApp(options: BuildAppOptions = {}): Promise<FastifyIn
     creationLimitsTtlMs: options.submissionRoutes?.creationLimitsTtlMs,
     publicPlayFallbackSlugs: [...publicPlayFallbackSlugs],
     publicPlayTtlMs,
+    hasPlatformBackend: Boolean(options.submissionRoutes?.agentBackend ?? resolvedAgentBackends?.platform),
   });
 
   // Review catalog matches /api/catalog; snapshot first in prod.

--- a/apps/api/src/creation-limits.ts
+++ b/apps/api/src/creation-limits.ts
@@ -138,6 +138,8 @@ export function createCreationGate(options: CreationGateOptions): CreationGate {
     globalDailySubmissionCap: null,
     editingPaused: false,
     globalDailyEditCap: null,
+    managedDailyCap: null,
+    managedDailyUserCap: null,
   };
   let cache: { value: CreationLimits; expiresAt: number } | null = null;
 
@@ -246,6 +248,8 @@ export function createEditingGate(options: CreationGateOptions): EditingGate {
     editingPaused: false,
     globalDailyEditCap: null,
     remixTracePaused: false,
+    managedDailyCap: null,
+    managedDailyUserCap: null,
   };
   let cache: { value: CreationLimits; expiresAt: number } | null = null;
 

--- a/apps/api/src/creator-agent-key-routes.test.ts
+++ b/apps/api/src/creator-agent-key-routes.test.ts
@@ -53,8 +53,7 @@ async function createApp(store: InMemoryStore) {
       githubClient: stubGitHub(),
       githubToken: 'gh',
       submissionTokenSecret: secret,
-      // Predates the platform-builder availability switch; these tests are about
-      // creator-key routing, not managed availability. See managed-availability.ts.
+      // Not under test here — see managed-availability.ts.
       managedAvailabilityGate: null,
     },
   });

--- a/apps/api/src/creator-agent-key-routes.test.ts
+++ b/apps/api/src/creator-agent-key-routes.test.ts
@@ -53,6 +53,9 @@ async function createApp(store: InMemoryStore) {
       githubClient: stubGitHub(),
       githubToken: 'gh',
       submissionTokenSecret: secret,
+      // Predates the platform-builder availability switch; these tests are about
+      // creator-key routing, not managed availability. See managed-availability.ts.
+      managedAvailabilityGate: null,
     },
   });
 }

--- a/apps/api/src/games-repo-contract.test.ts
+++ b/apps/api/src/games-repo-contract.test.ts
@@ -93,6 +93,7 @@ describe('games-repo-contract (website half)', () => {
       'input',
       'collision',
       'world',
+      'grid',
       'path',
       'ai',
       'gameplay',
@@ -227,7 +228,7 @@ describe('games-repo source extractors', () => {
     const source = `
       // Canonical order
       export const GAME_KIT_MODULES = [
-        'input', 'collision', 'world', 'path', 'ai', 'gameplay', 'rng', 'vehicles', 'urban',
+        'input', 'collision', 'world', 'grid', 'path', 'ai', 'gameplay', 'rng', 'vehicles', 'urban',
         'drawing', 'actors', 'gfx', 'gfx3d', 'racing', 'football', 'effects', 'audio', 'party', 'save', 'commons', 'presence', 'mascot', 'zone',
         'sensing', 'voice', 'editor',
       ] as const;

--- a/apps/api/src/games-repo-contract.ts
+++ b/apps/api/src/games-repo-contract.ts
@@ -42,6 +42,8 @@ export const GAME_KIT_MODULES = [
   'input',
   'collision',
   'world',
+  // Tile/cell grid helpers (games-repo tip). Genre-agnostic, like path/collision.
+  'grid',
   'path',
   'ai',
   'gameplay',

--- a/apps/api/src/managed-availability.test.ts
+++ b/apps/api/src/managed-availability.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest';
+import { createManagedAvailabilityGate } from './managed-availability.js';
+import { InMemoryStore } from './store.js';
+
+const today = '2026-08-09';
+
+function gate(params: { store?: InMemoryStore; hasPlatformBackend?: boolean; ttlMs?: number; now?: () => number }) {
+  const store = params.store ?? new InMemoryStore();
+  return {
+    store,
+    gate: createManagedAvailabilityGate({
+      store,
+      hasPlatformBackend: params.hasPlatformBackend ?? true,
+      ttlMs: params.ttlMs ?? 60_000,
+      now: params.now,
+    }),
+  };
+}
+
+describe('createManagedAvailabilityGate', () => {
+  it('reads as coming_soon when this environment has no platform backend at all', async () => {
+    const { gate: g } = gate({ hasPlatformBackend: false });
+    expect(await g.peek('g:creator', today)).toEqual({ available: false, reason: 'coming_soon' });
+    expect(await g.checkAndSpend('g:creator', today)).toEqual({ available: false, reason: 'coming_soon' });
+  });
+
+  it('is available when a backend is configured and nothing else says otherwise', async () => {
+    const { gate: g } = gate({ hasPlatformBackend: true });
+    expect(await g.peek('g:creator', today)).toEqual({ available: true });
+    expect(await g.checkAndSpend('g:creator', today)).toEqual({ available: true });
+  });
+
+  it('honours an operator-set outage even when a backend is configured', async () => {
+    const { store, gate: g } = gate({ hasPlatformBackend: true });
+    await store.setCreationLimits({ managedBuilderMode: 'off' }, 'g:boss');
+    expect(await g.peek('g:creator', today)).toEqual({ available: false, reason: 'outage' });
+  });
+
+  it('reports coming_soon when the operator marks it as not yet launched here', async () => {
+    const { store, gate: g } = gate({ hasPlatformBackend: true });
+    await store.setCreationLimits({ managedBuilderMode: 'coming_soon' }, 'g:boss');
+    expect(await g.peek('g:creator', today)).toEqual({ available: false, reason: 'coming_soon' });
+  });
+
+  it('refuses once the shared daily cap is spent, and peek never spends it', async () => {
+    const { store, gate: g } = gate({ hasPlatformBackend: true });
+    await store.setCreationLimits({ managedDailyCap: 2 }, 'g:boss');
+
+    // Peeking repeatedly must not itself exhaust the cap.
+    expect(await g.peek('g:a', today)).toEqual({ available: true });
+    expect(await g.peek('g:a', today)).toEqual({ available: true });
+    expect(await store.getGlobalManagedBuildCount(today)).toBe(0);
+
+    expect(await g.checkAndSpend('g:a', today)).toEqual({ available: true });
+    expect(await g.checkAndSpend('g:b', today)).toEqual({ available: true });
+    expect(await g.checkAndSpend('g:c', today)).toEqual({ available: false, reason: 'global_limit' });
+  });
+
+  it('refuses once a creator’s own daily cap is spent, independent of the shared one', async () => {
+    const { store, gate: g } = gate({ hasPlatformBackend: true });
+    await store.setCreationLimits({ managedDailyUserCap: 1 }, 'g:boss');
+    await store.upsertUser({ uid: 'g:a' });
+    await store.upsertUser({ uid: 'g:b' });
+
+    expect(await g.checkAndSpend('g:a', today)).toEqual({ available: true });
+    expect(await g.checkAndSpend('g:a', today)).toEqual({ available: false, reason: 'user_limit' });
+    // A different creator's cap is untouched by g:a spending theirs.
+    expect(await g.checkAndSpend('g:b', today)).toEqual({ available: true });
+  });
+
+  it('lets bot: accounts through every cap, the same as the creation breaker does', async () => {
+    const { store, gate: g } = gate({ hasPlatformBackend: true });
+    await store.setCreationLimits({ managedDailyCap: 0, managedDailyUserCap: 0 }, 'g:boss');
+    expect(await g.checkAndSpend('bot:smoke', today)).toEqual({ available: true });
+  });
+
+  it('never enforces caps when none are set, even with no store at all', async () => {
+    const g = createManagedAvailabilityGate({ hasPlatformBackend: true });
+    expect(await g.checkAndSpend('g:creator', today)).toEqual({ available: true });
+  });
+});

--- a/apps/api/src/managed-availability.ts
+++ b/apps/api/src/managed-availability.ts
@@ -1,0 +1,136 @@
+// Whether the `platform` builder (the Gamedev.pl-run coding agent) can be offered right
+// now — as opposed to `self` (BYOCA), which needs no backend and is always available.
+//
+// Reuses the creation-limits chassis: the switch lives on the same `opsConfig/creationLimits`
+// document, read with the same short TTL, so an operator pulling it during an incident and
+// an operator pulling the creation breaker are looking at the same console panel. See
+// creation-limits.ts for why a document rather than an env var.
+
+import { BOT_UID_PREFIX, type CreationLimits, type Store } from './store.js';
+
+export type ManagedUnavailableReason = 'coming_soon' | 'outage' | 'global_limit' | 'user_limit';
+
+export type ManagedAvailability = { available: true } | { available: false; reason: ManagedUnavailableReason };
+
+/** Wire error code for a request that named `builder: 'platform'` while it is unavailable. */
+export const MANAGED_UNAVAILABLE_ERROR = 'platform_builder_unavailable';
+
+export const DEFAULT_MANAGED_AVAILABILITY_TTL_MS = 60_000;
+
+export interface ManagedAvailabilityOptions {
+  /** Absent only in tests with no backing store; caps and the ops-doc mode are skipped. */
+  store?: Store;
+  now?: () => number;
+  ttlMs?: number;
+  /**
+   * Whether this environment actually has a platform backend wired (the registry's
+   * `platform` entry). A missing backend reads as `coming_soon`, not `outage` — an
+   * unconfigured environment is a feature that has not launched here, not an incident.
+   */
+  hasPlatformBackend: boolean;
+  logWarn?: (payload: Record<string, unknown>, message: string) => void;
+}
+
+export interface ManagedAvailabilityGate {
+  /** Read-only — never spends a slot. For quota/status display and pre-flight UI checks. */
+  peek(uid: string, dateStr: string): Promise<ManagedAvailability>;
+  /**
+   * Same checks as {@link peek}, but spends the global and per-creator daily slot on
+   * success. Call this once, right before a fresh platform dispatch — never for a round
+   * that is only continuing (an in-flight platform round keeps running when the switch
+   * flips; this gates new dispatches, not existing ones).
+   */
+  checkAndSpend(uid: string, dateStr: string): Promise<ManagedAvailability>;
+}
+
+function bypassesBreaker(uid: string): boolean {
+  return uid.startsWith(BOT_UID_PREFIX);
+}
+
+export function createManagedAvailabilityGate(options: ManagedAvailabilityOptions): ManagedAvailabilityGate {
+  const { store, hasPlatformBackend } = options;
+  const now = options.now ?? Date.now;
+  const ttlMs = options.ttlMs ?? DEFAULT_MANAGED_AVAILABILITY_TTL_MS;
+  const logWarn = options.logWarn ?? (() => {});
+
+  let cache: { value: CreationLimits | null; expiresAt: number } | null = null;
+
+  async function config(): Promise<CreationLimits | null> {
+    if (!store) return null;
+    if (cache && cache.expiresAt > now()) return cache.value;
+    try {
+      const stored = await store.getCreationLimits();
+      cache = { value: stored, expiresAt: now() + ttlMs };
+      return stored;
+    } catch (error) {
+      if (cache) {
+        logWarn({ err: error }, 'managed availability config unreadable; using the last known values');
+        return cache.value;
+      }
+      logWarn({ err: error }, 'managed availability config unreadable and never read; treating as unset');
+      return null;
+    }
+  }
+
+  /** The switch and configuration state, ahead of any per-day counting. */
+  async function baseAvailability(): Promise<ManagedAvailability> {
+    const stored = await config();
+    const mode = stored?.managedBuilderMode ?? 'auto';
+    if (mode === 'off') return { available: false, reason: 'outage' };
+    if (mode === 'coming_soon') return { available: false, reason: 'coming_soon' };
+    if (!hasPlatformBackend) return { available: false, reason: 'coming_soon' };
+    return { available: true };
+  }
+
+  async function checkCaps(uid: string, dateStr: string, spend: boolean): Promise<ManagedAvailability> {
+    if (bypassesBreaker(uid)) return { available: true };
+    if (!store) return { available: true };
+
+    const stored = await config();
+    const globalCap = stored?.managedDailyCap ?? null;
+    const userCap = stored?.managedDailyUserCap ?? null;
+
+    if (globalCap !== null) {
+      let allowed: boolean;
+      try {
+        if (spend) {
+          allowed = (await store.checkAndIncrementGlobalManagedBuilds(dateStr, globalCap)).allowed;
+        } else {
+          allowed = (await store.getGlobalManagedBuildCount(dateStr)) < globalCap;
+        }
+      } catch (error) {
+        logWarn({ err: error, dateStr }, 'global managed build counter unreachable; admitting the request');
+        allowed = true;
+      }
+      if (!allowed) return { available: false, reason: 'global_limit' };
+    }
+
+    if (userCap !== null) {
+      let allowed: boolean;
+      try {
+        if (spend) {
+          allowed = (await store.checkAndIncrementQuota(uid, dateStr, userCap, 'managedBuilds')).allowed;
+        } else {
+          allowed = (await store.getUsage(uid, dateStr)).managedBuilds < userCap;
+        }
+      } catch (error) {
+        logWarn({ err: error, uid, dateStr }, 'per-creator managed build counter unreachable; admitting the request');
+        allowed = true;
+      }
+      if (!allowed) return { available: false, reason: 'user_limit' };
+    }
+
+    return { available: true };
+  }
+
+  async function resolve(uid: string, dateStr: string, spend: boolean): Promise<ManagedAvailability> {
+    const base = await baseAvailability();
+    if (!base.available) return base;
+    return checkCaps(uid, dateStr, spend);
+  }
+
+  return {
+    peek: (uid, dateStr) => resolve(uid, dateStr, false),
+    checkAndSpend: (uid, dateStr) => resolve(uid, dateStr, true),
+  };
+}

--- a/apps/api/src/managed-availability.ts
+++ b/apps/api/src/managed-availability.ts
@@ -1,10 +1,6 @@
-// Whether the `platform` builder (the Gamedev.pl-run coding agent) can be offered right
-// now — as opposed to `self` (BYOCA), which needs no backend and is always available.
-//
-// Reuses the creation-limits chassis: the switch lives on the same `opsConfig/creationLimits`
-// document, read with the same short TTL, so an operator pulling it during an incident and
-// an operator pulling the creation breaker are looking at the same console panel. See
-// creation-limits.ts for why a document rather than an env var.
+// Whether the platform builder is available right now (self is always available).
+
+// Reuses the creation-limits document and TTL cache; see creation-limits.ts.
 
 import { BOT_UID_PREFIX, type CreationLimits, type Store } from './store.js';
 
@@ -12,34 +8,25 @@ export type ManagedUnavailableReason = 'coming_soon' | 'outage' | 'global_limit'
 
 export type ManagedAvailability = { available: true } | { available: false; reason: ManagedUnavailableReason };
 
-/** Wire error code for a request that named `builder: 'platform'` while it is unavailable. */
+// Wire error code for a refused `builder: 'platform'` request.
 export const MANAGED_UNAVAILABLE_ERROR = 'platform_builder_unavailable';
 
 export const DEFAULT_MANAGED_AVAILABILITY_TTL_MS = 60_000;
 
 export interface ManagedAvailabilityOptions {
-  /** Absent only in tests with no backing store; caps and the ops-doc mode are skipped. */
+  // Absent only in tests with no store; caps and mode are skipped.
   store?: Store;
   now?: () => number;
   ttlMs?: number;
-  /**
-   * Whether this environment actually has a platform backend wired (the registry's
-   * `platform` entry). A missing backend reads as `coming_soon`, not `outage` — an
-   * unconfigured environment is a feature that has not launched here, not an incident.
-   */
+  // Whether the registry's `platform` backend is actually wired.
   hasPlatformBackend: boolean;
   logWarn?: (payload: Record<string, unknown>, message: string) => void;
 }
 
 export interface ManagedAvailabilityGate {
-  /** Read-only — never spends a slot. For quota/status display and pre-flight UI checks. */
+  // Read-only — never spends a slot. For display and pre-flight checks.
   peek(uid: string, dateStr: string): Promise<ManagedAvailability>;
-  /**
-   * Same checks as {@link peek}, but spends the global and per-creator daily slot on
-   * success. Call this once, right before a fresh platform dispatch — never for a round
-   * that is only continuing (an in-flight platform round keeps running when the switch
-   * flips; this gates new dispatches, not existing ones).
-   */
+  // Spends the daily slot on success. Call right before a fresh dispatch.
   checkAndSpend(uid: string, dateStr: string): Promise<ManagedAvailability>;
 }
 
@@ -72,7 +59,6 @@ export function createManagedAvailabilityGate(options: ManagedAvailabilityOption
     }
   }
 
-  /** The switch and configuration state, ahead of any per-day counting. */
   async function baseAvailability(): Promise<ManagedAvailability> {
     const stored = await config();
     const mode = stored?.managedBuilderMode ?? 'auto';
@@ -90,21 +76,7 @@ export function createManagedAvailabilityGate(options: ManagedAvailabilityOption
     const globalCap = stored?.managedDailyCap ?? null;
     const userCap = stored?.managedDailyUserCap ?? null;
 
-    if (globalCap !== null) {
-      let allowed: boolean;
-      try {
-        if (spend) {
-          allowed = (await store.checkAndIncrementGlobalManagedBuilds(dateStr, globalCap)).allowed;
-        } else {
-          allowed = (await store.getGlobalManagedBuildCount(dateStr)) < globalCap;
-        }
-      } catch (error) {
-        logWarn({ err: error, dateStr }, 'global managed build counter unreachable; admitting the request');
-        allowed = true;
-      }
-      if (!allowed) return { available: false, reason: 'global_limit' };
-    }
-
+    // Checked first: an exhausted creator must never spend the shared slot.
     if (userCap !== null) {
       let allowed: boolean;
       try {
@@ -119,6 +91,21 @@ export function createManagedAvailabilityGate(options: ManagedAvailabilityOption
       }
       if (!allowed) return { available: false, reason: 'user_limit' };
     }
+
+    // Counted even uncapped, for an accurate admin count; enforced only when capped.
+    const globalLimit = globalCap ?? Infinity;
+    let globalAllowed: boolean;
+    try {
+      if (spend) {
+        globalAllowed = (await store.checkAndIncrementGlobalManagedBuilds(dateStr, globalLimit)).allowed;
+      } else {
+        globalAllowed = (await store.getGlobalManagedBuildCount(dateStr)) < globalLimit;
+      }
+    } catch (error) {
+      logWarn({ err: error, dateStr }, 'global managed build counter unreachable; admitting the request');
+      globalAllowed = true;
+    }
+    if (!globalAllowed) return { available: false, reason: 'global_limit' };
 
     return { available: true };
   }

--- a/apps/api/src/mcp-server.ts
+++ b/apps/api/src/mcp-server.ts
@@ -43,6 +43,7 @@ import { DEFAULT_UPLOAD_URL_TTL_SECONDS, mintUploadToken, uploadCurlCommand } fr
 import { decodeCanonicalBase64Utf8, InvalidBase64Error } from './canonical-base64.js';
 import { selfBuildDeliveryCap } from './builder.js';
 import type { BuilderKind } from './builder.js';
+import type { ManagedUnavailableReason } from './managed-availability.js';
 import { assertDeliverableSourcePath, InvalidUploadError, MAX_UPLOAD_FILES, type GamesStore } from './games-store.js';
 import { deriveGateStatusString, readGateVerdict } from './gate-verdict.js';
 import { gameManifestHint } from './game-manifest-hint.js';
@@ -322,7 +323,7 @@ export interface McpServerOptions {
     requestedBy?: 'creator' | 'agent';
     /** When set, the new job is owned by this uid (slug-transfer safe). */
     ownerUid?: string;
-  }) => Promise<{ route: 'job'; jobId: number } | null>;
+  }) => Promise<{ route: 'job'; jobId: number } | { route: 'unavailable'; reason: ManagedUnavailableReason } | null>;
   /**
    * Reopens an unpublished draft after a closed round (gate-green ready_for_review, etc.).
    * Injected from submissions so MCP and Studio feedback share the same resume path.
@@ -2168,7 +2169,7 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
             // Authorized creator wins over the published record's owner after a transfer.
             ownerUid: resolved.creatorUid,
           });
-          if (!started) {
+          if (!started || started.route === 'unavailable') {
             return toolErr('could not open an improvement round for this game');
           }
 

--- a/apps/api/src/self-build-connect.test.ts
+++ b/apps/api/src/self-build-connect.test.ts
@@ -62,8 +62,7 @@ async function createApp(options: { now?: () => number } = {}) {
       submissionTokenSecret: secret,
       notifyAppBaseUrl: APP_BASE,
       now: options.now,
-      // Predates the platform-builder availability switch; these tests are about the
-      // connect route's own gating, not managed availability. See managed-availability.ts.
+      // Not under test here — see managed-availability.ts.
       managedAvailabilityGate: null,
     },
   });

--- a/apps/api/src/self-build-connect.test.ts
+++ b/apps/api/src/self-build-connect.test.ts
@@ -62,6 +62,9 @@ async function createApp(options: { now?: () => number } = {}) {
       submissionTokenSecret: secret,
       notifyAppBaseUrl: APP_BASE,
       now: options.now,
+      // Predates the platform-builder availability switch; these tests are about the
+      // connect route's own gating, not managed availability. See managed-availability.ts.
+      managedAvailabilityGate: null,
     },
   });
   return { app, store };

--- a/apps/api/src/store.ts
+++ b/apps/api/src/store.ts
@@ -637,21 +637,11 @@ export interface CreationLimits {
    * flag goes on. Same null semantics as the submission cap.
    */
   globalDailyEditCap: number | null;
-  /**
-   * Switches the `platform` builder option: whether the Gamedev.pl coding agent is
-   * offered at all, independent of BYOCA (`self`).
-   *
-   * `auto` (or absent) defers to whether a platform backend is actually configured for
-   * this environment. `off` and `coming_soon` both refuse regardless of configuration —
-   * the copy differs (an incident vs. a feature not yet launched here) but the effect on
-   * dispatch is the same. Never hides the option: the UI keeps it visible and disabled,
-   * with the reason in a tooltip, so BYOCA does not look like the only thing that ever
-   * existed.
-   */
+  // Switches the `platform` option; `auto` defers to whether a backend exists.
   managedBuilderMode?: 'auto' | 'off' | 'coming_soon';
-  /** Ceiling on managed (platform) rounds started per UTC day, everyone together. `null` = no cap. */
+  // Shared daily ceiling on platform rounds started. `null` = no cap.
   managedDailyCap: number | null;
-  /** Same ceiling, per creator per UTC day. `null` = no cap. */
+  // Same ceiling, per creator per UTC day.
   managedDailyUserCap: number | null;
   /** Who last changed this and when, so a leftover pause is legible as a leftover. */
   updatedAt?: string;
@@ -675,7 +665,7 @@ export interface UsageCounters {
   improvements: number;
   /** Natural-language tuning requests in the editor (one Vertex call each). */
   assists: number;
-  /** Rounds this creator started (or resumed) on the platform builder today. */
+  // Platform rounds this creator started today.
   managedBuilds: number;
 }
 
@@ -2112,9 +2102,9 @@ export interface Store {
   checkAndIncrementGlobalSubmissions(dateStr: string, limit: number): Promise<{ allowed: boolean; current: number }>;
   /** Same shape for the editing lanes' shared daily allowance of model calls. */
   checkAndIncrementGlobalEdits(dateStr: string, limit: number): Promise<{ allowed: boolean; current: number }>;
-  /** How many platform-builder rounds everyone together has started on `dateStr`. */
+  // Platform rounds everyone together has started on `dateStr`.
   getGlobalManagedBuildCount(dateStr: string): Promise<number>;
-  /** Same shape, for the shared daily ceiling on platform-builder rounds. */
+  // Same shape, for the shared daily ceiling.
   checkAndIncrementGlobalManagedBuilds(dateStr: string, limit: number): Promise<{ allowed: boolean; current: number }>;
   upsertWaitlistEntry(entry: { uid: string; email?: string; name?: string; locale?: string }): Promise<WaitlistEntry>;
   getWaitlistEntry(uid: string): Promise<WaitlistEntry | null>;

--- a/apps/api/src/store.ts
+++ b/apps/api/src/store.ts
@@ -637,6 +637,22 @@ export interface CreationLimits {
    * flag goes on. Same null semantics as the submission cap.
    */
   globalDailyEditCap: number | null;
+  /**
+   * Switches the `platform` builder option: whether the Gamedev.pl coding agent is
+   * offered at all, independent of BYOCA (`self`).
+   *
+   * `auto` (or absent) defers to whether a platform backend is actually configured for
+   * this environment. `off` and `coming_soon` both refuse regardless of configuration —
+   * the copy differs (an incident vs. a feature not yet launched here) but the effect on
+   * dispatch is the same. Never hides the option: the UI keeps it visible and disabled,
+   * with the reason in a tooltip, so BYOCA does not look like the only thing that ever
+   * existed.
+   */
+  managedBuilderMode?: 'auto' | 'off' | 'coming_soon';
+  /** Ceiling on managed (platform) rounds started per UTC day, everyone together. `null` = no cap. */
+  managedDailyCap: number | null;
+  /** Same ceiling, per creator per UTC day. `null` = no cap. */
+  managedDailyUserCap: number | null;
   /** Who last changed this and when, so a leftover pause is legible as a leftover. */
   updatedAt?: string;
   updatedBy?: string;
@@ -659,6 +675,8 @@ export interface UsageCounters {
   improvements: number;
   /** Natural-language tuning requests in the editor (one Vertex call each). */
   assists: number;
+  /** Rounds this creator started (or resumed) on the platform builder today. */
+  managedBuilds: number;
 }
 
 /**
@@ -2094,6 +2112,10 @@ export interface Store {
   checkAndIncrementGlobalSubmissions(dateStr: string, limit: number): Promise<{ allowed: boolean; current: number }>;
   /** Same shape for the editing lanes' shared daily allowance of model calls. */
   checkAndIncrementGlobalEdits(dateStr: string, limit: number): Promise<{ allowed: boolean; current: number }>;
+  /** How many platform-builder rounds everyone together has started on `dateStr`. */
+  getGlobalManagedBuildCount(dateStr: string): Promise<number>;
+  /** Same shape, for the shared daily ceiling on platform-builder rounds. */
+  checkAndIncrementGlobalManagedBuilds(dateStr: string, limit: number): Promise<{ allowed: boolean; current: number }>;
   upsertWaitlistEntry(entry: { uid: string; email?: string; name?: string; locale?: string }): Promise<WaitlistEntry>;
   getWaitlistEntry(uid: string): Promise<WaitlistEntry | null>;
   isWaitlistApproved(uid: string, email?: string): Promise<boolean>;
@@ -2585,6 +2607,7 @@ function emptyUsageCounters(): UsageCounters {
     playerFeedback: 0,
     improvements: 0,
     assists: 0,
+    managedBuilds: 0,
   };
 }
 
@@ -2606,6 +2629,7 @@ export class InMemoryStore implements Store {
   // yyyy-mm-dd -> submissions accepted that day across every account
   private globalSubmissions = new Map<string, number>();
   private globalEdits = new Map<string, number>();
+  private globalManagedBuilds = new Map<string, number>();
   private creationLimits: CreationLimits | null = null;
   private publicPlayConfig: PublicPlayConfig | null = null;
   private waitlist = new Map<string, WaitlistEntry>();
@@ -3602,6 +3626,13 @@ export class InMemoryStore implements Store {
         patch.globalDailyEditCap !== undefined
           ? patch.globalDailyEditCap
           : (this.creationLimits?.globalDailyEditCap ?? null),
+      managedBuilderMode: patch.managedBuilderMode ?? this.creationLimits?.managedBuilderMode ?? 'auto',
+      managedDailyCap:
+        patch.managedDailyCap !== undefined ? patch.managedDailyCap : (this.creationLimits?.managedDailyCap ?? null),
+      managedDailyUserCap:
+        patch.managedDailyUserCap !== undefined
+          ? patch.managedDailyUserCap
+          : (this.creationLimits?.managedDailyUserCap ?? null),
       updatedAt: new Date().toISOString(),
       updatedBy,
     };
@@ -3645,6 +3676,22 @@ export class InMemoryStore implements Store {
       return { allowed: false, current };
     }
     this.globalEdits.set(dateStr, current + 1);
+    return { allowed: true, current: current + 1 };
+  }
+
+  async getGlobalManagedBuildCount(dateStr: string): Promise<number> {
+    return this.globalManagedBuilds.get(dateStr) ?? 0;
+  }
+
+  async checkAndIncrementGlobalManagedBuilds(
+    dateStr: string,
+    limit: number,
+  ): Promise<{ allowed: boolean; current: number }> {
+    const current = this.globalManagedBuilds.get(dateStr) ?? 0;
+    if (current >= limit) {
+      return { allowed: false, current };
+    }
+    this.globalManagedBuilds.set(dateStr, current + 1);
     return { allowed: true, current: current + 1 };
   }
 
@@ -6007,6 +6054,12 @@ export class FirestoreStore implements Store {
       editingPaused: data?.editingPaused === true,
       remixTracePaused: data?.remixTracePaused === true,
       globalDailyEditCap: typeof data?.globalDailyEditCap === 'number' ? data.globalDailyEditCap : null,
+      managedBuilderMode:
+        data?.managedBuilderMode === 'off' || data?.managedBuilderMode === 'coming_soon'
+          ? data.managedBuilderMode
+          : 'auto',
+      managedDailyCap: typeof data?.managedDailyCap === 'number' ? data.managedDailyCap : null,
+      managedDailyUserCap: typeof data?.managedDailyUserCap === 'number' ? data.managedDailyUserCap : null,
       ...(data?.updatedAt ? { updatedAt: data.updatedAt } : {}),
       ...(data?.updatedBy ? { updatedBy: data.updatedBy } : {}),
     };
@@ -6029,6 +6082,11 @@ export class FirestoreStore implements Store {
         editingPaused: patch.editingPaused ?? existing.editingPaused ?? false,
         globalDailyEditCap:
           patch.globalDailyEditCap !== undefined ? patch.globalDailyEditCap : (existing.globalDailyEditCap ?? null),
+        managedBuilderMode: patch.managedBuilderMode ?? existing.managedBuilderMode ?? 'auto',
+        managedDailyCap:
+          patch.managedDailyCap !== undefined ? patch.managedDailyCap : (existing.managedDailyCap ?? null),
+        managedDailyUserCap:
+          patch.managedDailyUserCap !== undefined ? patch.managedDailyUserCap : (existing.managedDailyUserCap ?? null),
         updatedAt: new Date().toISOString(),
         updatedBy,
       };
@@ -6098,6 +6156,32 @@ export class FirestoreStore implements Store {
 
       const nextVal = current + 1;
       transaction.set(ref, { edits: nextVal }, { merge: true });
+      return { allowed: true, current: nextVal };
+    });
+  }
+
+  async getGlobalManagedBuildCount(dateStr: string): Promise<number> {
+    const snap = await this.globalUsageRef(dateStr).get();
+    const value = snap.data()?.managedBuilds;
+    return typeof value === 'number' ? value : 0;
+  }
+
+  async checkAndIncrementGlobalManagedBuilds(
+    dateStr: string,
+    limit: number,
+  ): Promise<{ allowed: boolean; current: number }> {
+    const ref = this.globalUsageRef(dateStr);
+    return await this.db.runTransaction(async (transaction) => {
+      const snap = await transaction.get(ref);
+      const value = snap.data()?.managedBuilds;
+      const current = typeof value === 'number' ? value : 0;
+
+      if (current >= limit) {
+        return { allowed: false, current };
+      }
+
+      const nextVal = current + 1;
+      transaction.set(ref, { managedBuilds: nextVal }, { merge: true });
       return { allowed: true, current: nextVal };
     });
   }

--- a/apps/api/src/submission-status.ts
+++ b/apps/api/src/submission-status.ts
@@ -255,6 +255,14 @@ export interface SubmissionStatusResponseBase {
     acknowledgedAt?: string;
   };
   /**
+   * Whether the `platform` builder can be picked or handed off to right now — off, not
+   * yet launched here, or over a daily ceiling. Absent means "no opinion" (no gate
+   * wired), which older/test callers should read as available, matching behaviour
+   * before this field existed. `self` (BYOCA) is never gated and carries no such field.
+   */
+  platformBuilder?:
+    { available: true } | { available: false; reason: 'coming_soon' | 'outage' | 'global_limit' | 'user_limit' };
+  /**
    * Why this build is asking the creator to act, when it is. Set alongside `status`
    * because the public vocabulary projects both `failed` and a gate bounce onto
    * `needs_changes` — without this the page only shows the label, and a creator who

--- a/apps/api/src/submission-status.ts
+++ b/apps/api/src/submission-status.ts
@@ -254,12 +254,7 @@ export interface SubmissionStatusResponseBase {
     requestedAt: string;
     acknowledgedAt?: string;
   };
-  /**
-   * Whether the `platform` builder can be picked or handed off to right now — off, not
-   * yet launched here, or over a daily ceiling. Absent means "no opinion" (no gate
-   * wired), which older/test callers should read as available, matching behaviour
-   * before this field existed. `self` (BYOCA) is never gated and carries no such field.
-   */
+  // Whether platform can be picked right now; absent means no opinion.
   platformBuilder?:
     { available: true } | { available: false; reason: 'coming_soon' | 'outage' | 'global_limit' | 'user_limit' };
   /**

--- a/apps/api/src/submissions.test.ts
+++ b/apps/api/src/submissions.test.ts
@@ -12,6 +12,7 @@ import { canTransition } from './job-state.js';
 import type { AgentBackend, BuildBrief } from './agent-backend.js';
 import type { GamesStore } from './games-store.js';
 import { JOB_ID_FLOOR } from './store.js';
+import { createManagedAvailabilityGate, type ManagedAvailabilityGate } from './managed-availability.js';
 
 const secret = 'submission-secret';
 const repo = 'gamedevpl/www.gamedev.pl-games';
@@ -131,6 +132,12 @@ async function createApp(params: {
   };
   adminUids?: string;
   gameSeeder?: GameSeeder;
+  /**
+   * Whether the `platform` builder is offered. Defaults to `null` (always available) so
+   * every test predating this switch keeps behaving as if it were never built — tests
+   * that exercise the switch itself pass an explicit gate. See managed-availability.ts.
+   */
+  managedAvailabilityGate?: ManagedAvailabilityGate | null;
 }): Promise<{ app: FastifyInstance; store: Store; authHeaders: Record<string, string> }> {
   const store = params.store ?? new InMemoryStore();
   await store.upsertUser({ uid: 'g:test-user' });
@@ -153,6 +160,7 @@ async function createApp(params: {
       creationLimitsTtlMs: params.creationLimitsTtlMs,
       maxCachedDraftPreviews: params.maxCachedDraftPreviews,
       ...(params.agentChannel ? { agentChannel: params.agentChannel } : {}),
+      managedAvailabilityGate: params.managedAvailabilityGate === undefined ? null : params.managedAvailabilityGate,
     },
   });
   return { app, store, authHeaders: getAuthHeaders('g:test-user') };
@@ -3254,6 +3262,122 @@ describe('GET /api/me/quota', () => {
     expect(res.json()).toEqual({ submissions: { used: 0, limit: null } });
 
     await app.close();
+  });
+});
+
+describe('managed (platform) builder availability', () => {
+  it('exposes platformBuilder on /api/me/quota when a gate is wired', async () => {
+    const { githubClient } = createGithubClientStub({});
+    const { app, authHeaders } = await createApp({
+      githubClient,
+      submissionTokenSecret: secret,
+      managedAvailabilityGate: createManagedAvailabilityGate({ hasPlatformBackend: false }),
+    });
+
+    const res = await app.inject({ method: 'GET', url: '/api/me/quota', headers: authHeaders });
+    expect(res.json()).toMatchObject({ platformBuilder: { available: false, reason: 'coming_soon' } });
+
+    await app.close();
+  });
+
+  it('refuses a new platform-builder submission with a clear reason, spending no quota', async () => {
+    const { githubClient } = createGithubClientStub({});
+    const { app, authHeaders, store } = await createApp({
+      githubClient,
+      submissionTokenSecret: secret,
+      managedAvailabilityGate: createManagedAvailabilityGate({ hasPlatformBackend: false }),
+    });
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/submissions',
+      headers: authHeaders,
+      payload: { title: 'Game idea', concept: 'A concept long enough to pass validation rules.', builder: 'platform' },
+    });
+
+    expect(res.statusCode).toBe(409);
+    expect(res.json()).toEqual({ error: 'platform_builder_unavailable', reason: 'coming_soon' });
+    expect(await store.listSubmissionsByOwner('g:test-user')).toHaveLength(0);
+    const quota = await app.inject({ method: 'GET', url: '/api/me/quota', headers: authHeaders });
+    expect((quota.json() as { submissions: { used: number } }).submissions.used).toBe(0);
+
+    await app.close();
+  });
+
+  it('still creates a self (BYOCA) round when the platform builder is unavailable', async () => {
+    const { githubClient } = createGithubClientStub({});
+    const { app, authHeaders } = await createApp({
+      githubClient,
+      submissionTokenSecret: secret,
+      managedAvailabilityGate: createManagedAvailabilityGate({ hasPlatformBackend: false }),
+    });
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/submissions',
+      headers: authHeaders,
+      payload: { title: 'Game idea', concept: 'A concept long enough to pass validation rules.', builder: 'self' },
+    });
+
+    expect(res.statusCode).toBe(200);
+
+    await app.close();
+  });
+
+  it('refuses a quiet self round’s handoff to the platform builder, with a clear reason', async () => {
+    const { githubClient } = createGithubClientStub({});
+    const { backend } = createBackendStub();
+    const { app, authHeaders, store } = await createApp({
+      githubClient,
+      submissionTokenSecret: secret,
+      agentBackend: backend,
+      // The vendor is configured (a backend exists), but an operator has switched it off
+      // — the scenario an incident pull actually produces.
+      managedAvailabilityGate: createManagedAvailabilityGate({ store: undefined, hasPlatformBackend: true }),
+    });
+
+    const submit = await app.inject({
+      method: 'POST',
+      url: '/api/submissions',
+      headers: authHeaders,
+      payload: {
+        title: 'Quiet Self Round',
+        concept: 'A concept long enough to pass validation rules.',
+        builder: 'self',
+      },
+    });
+    expect(submit.statusCode).toBe(200);
+    const { token } = submit.json() as { token: string };
+    let issueNumber = 0;
+    await vi.waitFor(async () => {
+      issueNumber = (await store.listSubmissionsByOwner('g:test-user'))[0]!.issueNumber;
+      expect((await store.getSubmission(issueNumber))?.state).toBe('dispatched');
+    });
+
+    // Rebuild the app with the switch actually off — the daily-cap/mode config lives on
+    // the store, and a build with no store never sees it, so this exercises the mode path.
+    await store.setCreationLimits({ managedBuilderMode: 'off' }, 'g:boss');
+    const { app: appWithGate, authHeaders: freshHeaders } = await createApp({
+      githubClient,
+      submissionTokenSecret: secret,
+      store,
+      agentBackend: backend,
+      managedAvailabilityGate: createManagedAvailabilityGate({ store, hasPlatformBackend: true, ttlMs: 0 }),
+    });
+
+    // No agent signal yet — the quiet self round is eligible for a handoff, which
+    // defaults to `platform` when the request body omits `builder`.
+    const handoff = await appWithGate.inject({
+      method: 'POST',
+      url: `/api/submissions/${token}/handoff`,
+      headers: freshHeaders,
+    });
+
+    expect(handoff.statusCode).toBe(409);
+    expect(handoff.json()).toEqual({ error: 'platform_builder_unavailable', reason: 'outage' });
+    expect((await store.getSubmission(issueNumber))?.builder).toBe('self');
+
+    await appWithGate.close();
   });
 });
 

--- a/apps/api/src/submissions.test.ts
+++ b/apps/api/src/submissions.test.ts
@@ -132,11 +132,7 @@ async function createApp(params: {
   };
   adminUids?: string;
   gameSeeder?: GameSeeder;
-  /**
-   * Whether the `platform` builder is offered. Defaults to `null` (always available) so
-   * every test predating this switch keeps behaving as if it were never built — tests
-   * that exercise the switch itself pass an explicit gate. See managed-availability.ts.
-   */
+  // Defaults to always-available; tests of the switch pass an explicit gate.
   managedAvailabilityGate?: ManagedAvailabilityGate | null;
 }): Promise<{ app: FastifyInstance; store: Store; authHeaders: Record<string, string> }> {
   const store = params.store ?? new InMemoryStore();
@@ -3331,8 +3327,7 @@ describe('managed (platform) builder availability', () => {
       githubClient,
       submissionTokenSecret: secret,
       agentBackend: backend,
-      // The vendor is configured (a backend exists), but an operator has switched it off
-      // — the scenario an incident pull actually produces.
+      // A backend exists; an operator has switched it off.
       managedAvailabilityGate: createManagedAvailabilityGate({ store: undefined, hasPlatformBackend: true }),
     });
 
@@ -3354,8 +3349,7 @@ describe('managed (platform) builder availability', () => {
       expect((await store.getSubmission(issueNumber))?.state).toBe('dispatched');
     });
 
-    // Rebuild the app with the switch actually off — the daily-cap/mode config lives on
-    // the store, and a build with no store never sees it, so this exercises the mode path.
+    // Rebuild with the switch off — config lives on the store.
     await store.setCreationLimits({ managedBuilderMode: 'off' }, 'g:boss');
     const { app: appWithGate, authHeaders: freshHeaders } = await createApp({
       githubClient,
@@ -3365,8 +3359,7 @@ describe('managed (platform) builder availability', () => {
       managedAvailabilityGate: createManagedAvailabilityGate({ store, hasPlatformBackend: true, ttlMs: 0 }),
     });
 
-    // No agent signal yet — the quiet self round is eligible for a handoff, which
-    // defaults to `platform` when the request body omits `builder`.
+    // No agent signal yet; omitting `builder` defaults the handoff to platform.
     const handoff = await appWithGate.inject({
       method: 'POST',
       url: `/api/submissions/${token}/handoff`,

--- a/apps/api/src/submissions.ts
+++ b/apps/api/src/submissions.ts
@@ -289,11 +289,7 @@ export interface SubmissionRoutesOptions {
    * pre-breaker behaviour pass.
    */
   creationGate?: CreationGate | null;
-  /**
-   * Whether the `platform` builder can be offered right now. Built from the store and
-   * the resolved agent-backend registry by default; an explicit value (including null,
-   * meaning "always available") is what tests that predate this switch pass.
-   */
+  // Whether `platform` can be offered right now; null means always available.
   managedAvailabilityGate?: ManagedAvailabilityGate | null;
   /** Global ceiling used when the Firestore config doc sets none. See creation-limits.ts. */
   globalDailySubmissionCap?: number;
@@ -521,7 +517,7 @@ export interface SubmissionRoutesHandle {
     requestedBy?: CreatorMessageOrigin;
     /** When set, the new job is owned by this uid (slug-transfer safe). */
     ownerUid?: string;
-  }) => Promise<{ route: 'job'; jobId: number } | null>;
+  }) => Promise<{ route: 'job'; jobId: number } | { route: 'unavailable'; reason: ManagedUnavailableReason } | null>;
 }
 
 /**
@@ -1093,7 +1089,8 @@ export async function registerSubmissionRoutes(
     const builder = input.undelivered ? previousBuilder : (input.builder ?? record?.defaultBuilder ?? previousBuilder);
     const selected = backendFor(builder);
     if (!selected) return { started: false, reason: 'not_configured' };
-    if (builder === 'platform' && managedAvailabilityGate && record?.ownerUid) {
+    // Skip for undelivered continuations — not a fresh dispatch.
+    if (builder === 'platform' && !input.undelivered && managedAvailabilityGate && record?.ownerUid) {
       const dateStr = new Date(now()).toISOString().slice(0, 10);
       const availability = await managedAvailabilityGate.checkAndSpend(record.ownerUid, dateStr);
       if (!availability.available) {
@@ -1280,7 +1277,7 @@ export async function registerSubmissionRoutes(
      * authorized creator after a slug transfer so quota and Studio stay aligned.
      */
     ownerUid?: string;
-  }): Promise<{ route: 'job'; jobId: number } | null> {
+  }): Promise<{ route: 'job'; jobId: number } | { route: 'unavailable'; reason: ManagedUnavailableReason } | null> {
     if (!store) return null;
     const source = await store.getSubmission(input.issueNumber);
     // Without a slug there is no game to improve, and dispatching would quietly
@@ -1295,7 +1292,7 @@ export async function registerSubmissionRoutes(
       const ownerUid = input.ownerUid ?? source.ownerUid;
       const dateStr = new Date(now()).toISOString().slice(0, 10);
       const availability = await managedAvailabilityGate.checkAndSpend(ownerUid, dateStr);
-      if (!availability.available) return null;
+      if (!availability.available) return { route: 'unavailable', reason: availability.reason };
     }
 
     const jobId = await store.allocateJobId();
@@ -2610,10 +2607,7 @@ export async function registerSubmissionRoutes(
       }
     }
 
-    // 5.5. Whether the `platform` builder can be offered right now — off, not yet
-    // launched here, or over a daily ceiling. `self` (BYOCA) needs no backend and is
-    // never gated. Ahead of the per-user quota, same reasoning as the breaker above: a
-    // request this route is going to refuse anyway must not spend a creator's quota.
+    // Ahead of quota, same as the breaker above; self is never gated.
     const requestedBuilder: BuilderKind = parsed.data.builder ?? 'platform';
     if (requestedBuilder === 'platform' && managedAvailabilityGate) {
       const availability = await managedAvailabilityGate.checkAndSpend(input.uid, dateStr);
@@ -3707,6 +3701,19 @@ export async function registerSubmissionRoutes(
 
       const currentTime = now();
       const dateStr = new Date(currentTime).toISOString().slice(0, 10);
+      const requestedBuilderForCheck = parsed.data.builder;
+      const effectiveBuilder =
+        requestedBuilderForCheck && isBuilderKind(requestedBuilderForCheck)
+          ? requestedBuilderForCheck
+          : builderOf(record);
+      // Ahead of quota spend — a refused request must not cost a slot.
+      if (effectiveBuilder === 'platform' && managedAvailabilityGate) {
+        const availability = await managedAvailabilityGate.peek(request.user!.uid, dateStr);
+        if (!availability.available) {
+          return reply.status(409).send({ error: MANAGED_UNAVAILABLE_ERROR, reason: availability.reason });
+        }
+      }
+
       const quota = await store.checkAndIncrementQuota(
         request.user!.uid,
         dateStr,
@@ -3749,6 +3756,9 @@ export async function registerSubmissionRoutes(
       });
       if (!started) {
         return reply.status(502).send({ error: 'failed to submit improvement request' });
+      }
+      if (started.route === 'unavailable') {
+        return reply.status(409).send({ error: MANAGED_UNAVAILABLE_ERROR, reason: started.reason });
       }
       // Publishing is terminal, so this is a *new* job with its own capability. The
       // creator's thread has to move onto it — the old (published) token cannot address

--- a/apps/api/src/submissions.ts
+++ b/apps/api/src/submissions.ts
@@ -8,6 +8,12 @@ import { mintAgentToken } from './agent-token.js';
 import { registerMcpServerRoutes } from './mcp-server.js';
 import { assembleGameHtml, CredentialLeakError, EmptyProjectError, ProjectTooLargeError } from './assemble.js';
 import { createCreationGate, CREATION_REFUSAL_CODES, type CreationGate } from './creation-limits.js';
+import {
+  createManagedAvailabilityGate,
+  MANAGED_UNAVAILABLE_ERROR,
+  type ManagedAvailabilityGate,
+  type ManagedUnavailableReason,
+} from './managed-availability.js';
 import { postGateScreenshotToThread } from './gate-screenshot.js';
 import { profileBylineName, toPublicCreatorProfile } from './creator-profile.js';
 import {
@@ -125,9 +131,10 @@ export { CREATOR_FEEDBACK_MARKER };
  * ("something went wrong"), and so an operator reading the queue knows to go and look at
  * billing rather than at the build.
  */
-export type ResumeFailureReason = 'not_configured' | 'no_capacity' | 'dispatch_failed';
+export type ResumeFailureReason = 'not_configured' | 'no_capacity' | 'dispatch_failed' | 'platform_unavailable';
 
-export type ResumeOutcome = { started: true } | { started: false; reason: ResumeFailureReason };
+export type ResumeOutcome =
+  { started: true } | { started: false; reason: ResumeFailureReason; unavailableReason?: ManagedUnavailableReason };
 
 /**
  * Reads a dispatch failure for the one distinction a caller can act on.
@@ -282,6 +289,12 @@ export interface SubmissionRoutesOptions {
    * pre-breaker behaviour pass.
    */
   creationGate?: CreationGate | null;
+  /**
+   * Whether the `platform` builder can be offered right now. Built from the store and
+   * the resolved agent-backend registry by default; an explicit value (including null,
+   * meaning "always available") is what tests that predate this switch pass.
+   */
+  managedAvailabilityGate?: ManagedAvailabilityGate | null;
   /** Global ceiling used when the Firestore config doc sets none. See creation-limits.ts. */
   globalDailySubmissionCap?: number;
   /** How long the breaker's config is cached — the delay on a flip taking effect. */
@@ -596,6 +609,17 @@ export async function registerSubmissionRoutes(
   }
 
   const agentBackends = buildAgentRegistry();
+
+  const managedAvailabilityGate =
+    options.managedAvailabilityGate === undefined
+      ? createManagedAvailabilityGate({
+          store,
+          now,
+          ttlMs: options.creationLimitsTtlMs,
+          hasPlatformBackend: Boolean(agentBackends.platform),
+          logWarn: (payload, message) => app.log.warn(payload, message),
+        })
+      : options.managedAvailabilityGate;
 
   function backendFor(builder: BuilderKind | undefined): AgentBackend | undefined {
     return resolveBuilderBackend(agentBackends, builder ?? 'platform');
@@ -1069,6 +1093,13 @@ export async function registerSubmissionRoutes(
     const builder = input.undelivered ? previousBuilder : (input.builder ?? record?.defaultBuilder ?? previousBuilder);
     const selected = backendFor(builder);
     if (!selected) return { started: false, reason: 'not_configured' };
+    if (builder === 'platform' && managedAvailabilityGate && record?.ownerUid) {
+      const dateStr = new Date(now()).toISOString().slice(0, 10);
+      const availability = await managedAvailabilityGate.checkAndSpend(record.ownerUid, dateStr);
+      if (!availability.available) {
+        return { started: false, reason: 'platform_unavailable', unavailableReason: availability.reason };
+      }
+    }
     try {
       // A new round closes the previous one's token. Bump *before* minting so the brief
       // carries the generation that is now active. An undelivered nudge is the same
@@ -1259,6 +1290,13 @@ export async function registerSubmissionRoutes(
     // Resolve against the *source* game before the new job exists. `dispatchBuild`
     // would otherwise ask `builderOf` on a blank record and always pick `platform`.
     const builder = input.builder ?? builderOf(source);
+
+    if (builder === 'platform' && managedAvailabilityGate) {
+      const ownerUid = input.ownerUid ?? source.ownerUid;
+      const dateStr = new Date(now()).toISOString().slice(0, 10);
+      const availability = await managedAvailabilityGate.checkAndSpend(ownerUid, dateStr);
+      if (!availability.available) return null;
+    }
 
     const jobId = await store.allocateJobId();
     await store.createSubmission(jobId, input.ownerUid ?? source.ownerUid, source.title);
@@ -1755,6 +1793,12 @@ export async function registerSubmissionRoutes(
     else delete next.lastAgentPresence;
     if (record.agentEndedAt) next.agentEndedAt = record.agentEndedAt;
     else delete next.agentEndedAt;
+    if (managedAvailabilityGate) {
+      next.platformBuilder = await managedAvailabilityGate.peek(
+        record.ownerUid,
+        new Date(now()).toISOString().slice(0, 10),
+      );
+    }
 
     const stall = detectStall({
       state: record.state ?? 'queued',
@@ -2194,6 +2238,12 @@ export async function registerSubmissionRoutes(
     if (roundBuilder) status.builder = roundBuilder;
     const lastBuilder = record.defaultBuilder ?? record.builder;
     if (lastBuilder) status.defaultBuilder = lastBuilder;
+    if (managedAvailabilityGate) {
+      status.platformBuilder = await managedAvailabilityGate.peek(
+        record.ownerUid,
+        new Date(now()).toISOString().slice(0, 10),
+      );
+    }
     if (record.builderHandoff && record.builderHandoff.awaitsAgentAck !== false) {
       status.builderHandoff = {
         target: record.builderHandoff.to,
@@ -2507,7 +2557,8 @@ export async function registerSubmissionRoutes(
     openedBy?: 'creator' | 'agent';
     log: { error: (context: object, message: string) => void; info?: (context: object, message: string) => void };
   }): Promise<
-    { ok: true; jobId: number; slug: string } | { ok: false; status: number; error: string; category?: string }
+    | { ok: true; jobId: number; slug: string }
+    | { ok: false; status: number; error: string; category?: string; reason?: ManagedUnavailableReason }
   > {
     if (!githubClient || !submissionTokenSecret) {
       return { ok: false, status: 503, error: 'submissions are not configured' };
@@ -2556,6 +2607,18 @@ export async function registerSubmissionRoutes(
       const gate = await creationGate.checkAndSpend(input.uid, dateStr);
       if (!gate.allowed) {
         return { ok: false, status: 429, error: CREATION_REFUSAL_CODES[gate.reason] };
+      }
+    }
+
+    // 5.5. Whether the `platform` builder can be offered right now — off, not yet
+    // launched here, or over a daily ceiling. `self` (BYOCA) needs no backend and is
+    // never gated. Ahead of the per-user quota, same reasoning as the breaker above: a
+    // request this route is going to refuse anyway must not spend a creator's quota.
+    const requestedBuilder: BuilderKind = parsed.data.builder ?? 'platform';
+    if (requestedBuilder === 'platform' && managedAvailabilityGate) {
+      const availability = await managedAvailabilityGate.checkAndSpend(input.uid, dateStr);
+      if (!availability.available) {
+        return { ok: false, status: 409, error: MANAGED_UNAVAILABLE_ERROR, reason: availability.reason };
       }
     }
 
@@ -2638,7 +2701,7 @@ export async function registerSubmissionRoutes(
       });
 
       const dispatchLog = input.log;
-      const builder: BuilderKind = parsed.data.builder ?? 'platform';
+      const builder: BuilderKind = requestedBuilder;
       // Persist before returning: Connect and Studio read `record.builder` immediately.
       await store.setRoundBuilder(jobId, builder, { resetRoundBudget: false });
       void dispatchBuild({
@@ -2689,6 +2752,9 @@ export async function registerSubmissionRoutes(
       if (created.error === 'content_rejected') {
         return reply.status(created.status).send({ error: created.error, category: created.category ?? 'other' });
       }
+      if (created.error === MANAGED_UNAVAILABLE_ERROR) {
+        return reply.status(created.status).send({ error: created.error, reason: created.reason });
+      }
       return reply.status(created.status).send({ error: created.error });
     }
 
@@ -2704,14 +2770,20 @@ export async function registerSubmissionRoutes(
     if (!checkUserAccess(request, reply)) {
       return;
     }
+    const dateStr = new Date(now()).toISOString().slice(0, 10);
     if (!store) {
-      return reply.send({ submissions: { used: 0, limit: dailySubmissionQuota } });
+      return reply.send({
+        submissions: { used: 0, limit: dailySubmissionQuota },
+        ...(managedAvailabilityGate
+          ? { platformBuilder: await managedAvailabilityGate.peek(request.user!.uid, dateStr) }
+          : {}),
+      });
     }
 
-    const dateStr = new Date(now()).toISOString().slice(0, 10);
-    const [usage, user] = await Promise.all([
+    const [usage, user, platformBuilder] = await Promise.all([
       store.getUsage(request.user!.uid, dateStr),
       store.getUser(request.user!.uid),
+      managedAvailabilityGate ? managedAvailabilityGate.peek(request.user!.uid, dateStr) : undefined,
     ]);
     return reply.send({
       submissions: {
@@ -2720,6 +2792,7 @@ export async function registerSubmissionRoutes(
         // than a number that will never be enforced.
         limit: user?.tier === 'trusted' ? null : dailySubmissionQuota,
       },
+      ...(platformBuilder ? { platformBuilder } : {}),
     });
   });
 
@@ -3046,6 +3119,15 @@ export async function registerSubmissionRoutes(
           : parsedBody.data.stopActiveSelfAgent === true;
 
       const currentBuilder = builderOf(record);
+      if (requestedBuilder === 'platform' && managedAvailabilityGate) {
+        const availability = await managedAvailabilityGate.peek(
+          record.ownerUid,
+          new Date(now()).toISOString().slice(0, 10),
+        );
+        if (!availability.available) {
+          return reply.status(409).send({ error: MANAGED_UNAVAILABLE_ERROR, reason: availability.reason });
+        }
+      }
       if (record.builderHandoff?.acknowledgedAt && record.builderHandoff.to === requestedBuilder) {
         const retry = await resumeBuild({
           issueNumber,
@@ -3061,7 +3143,12 @@ export async function registerSubmissionRoutes(
         });
         if (retry.started) await store.clearBuilderHandoff(issueNumber);
         invalidateStatusCache(issueNumber);
-        if (!retry.started) return reply.status(502).send({ error: retry.reason });
+        if (!retry.started) {
+          if (retry.reason === 'platform_unavailable') {
+            return reply.status(409).send({ error: MANAGED_UNAVAILABLE_ERROR, reason: retry.unavailableReason });
+          }
+          return reply.status(502).send({ error: retry.reason });
+        }
         return reply.send({ ok: true });
       }
       const stall = detectStall({
@@ -3143,6 +3230,9 @@ export async function registerSubmissionRoutes(
       invalidateStatusCache(issueNumber);
 
       if (!outcome.started) {
+        if (outcome.reason === 'platform_unavailable') {
+          return reply.status(409).send({ error: MANAGED_UNAVAILABLE_ERROR, reason: outcome.unavailableReason });
+        }
         const status = outcome.reason === 'not_configured' ? 503 : 502;
         return reply.status(status).send({ error: outcome.reason });
       }

--- a/apps/api/src/suggestion-inbox.ts
+++ b/apps/api/src/suggestion-inbox.ts
@@ -237,13 +237,15 @@ export async function registerSuggestionInboxRoutes(
         statusReason: 'work cannot be dispatched from this deployment',
       };
     } else {
-      const started = await startImprovementRound({
+      const outcome = await startImprovementRound({
         issueNumber: submission.issueNumber,
         text: brief,
         title: `Improve ${record.slug}: ${record.class}`,
         locale: submission.locale ?? 'en',
         log: request.log,
       });
+      // No per-reason copy here — folded into the ordinary "no implementer" case.
+      const started = outcome?.route === 'job' ? outcome : null;
       next = started
         ? {
             ...record,

--- a/apps/api/src/suggestion-sweep.ts
+++ b/apps/api/src/suggestion-sweep.ts
@@ -1,5 +1,6 @@
 import type { FastifyInstance } from 'fastify';
 import type { BuilderKind } from './builder.js';
+import type { ManagedUnavailableReason } from './managed-availability.js';
 import type { InternalAuthVerifier } from './internal-auth.js';
 import {
   aggregateCreatorAssessments,
@@ -132,7 +133,7 @@ export interface SuggestionSweepDeps {
     locale: string;
     log: { error: (context: object, message: string) => void };
     builder?: BuilderKind;
-  }) => Promise<{ route: 'job'; jobId: number } | null>;
+  }) => Promise<{ route: 'job'; jobId: number } | { route: 'unavailable'; reason: ManagedUnavailableReason } | null>;
   /** Builds the brief an autonomously dispatched agent receives. */
   buildBrief?: (record: SuggestionRecord, untrusted: Scorecard['untrusted'] | null) => string;
   log?: { error: (context: object, message: string) => void };
@@ -287,13 +288,15 @@ export async function runSuggestionSweep(deps: SuggestionSweepDeps): Promise<Sug
       }
 
       const metric = hypothesisMetric(routed.class);
-      const started = await deps.startImprovementRound({
+      const outcome = await deps.startImprovementRound({
         issueNumber: submission.issueNumber,
         text: deps.buildBrief(fresh, card.untrusted),
         title: `Improve ${card.slug}: ${routed.class}`,
         locale: submission.locale ?? 'en',
         log: deps.log ?? { error: () => {} },
       });
+      // No creator waiting on the reason — treated like any other failed start.
+      const started = outcome?.route === 'job' ? outcome : null;
 
       await store.putSuggestion({
         ...fresh,

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -60,7 +60,7 @@ function readLocationRoute(): AppRoute {
   }
   return parsePathRoute(window.location.pathname, window.location.hash);
 }
-import { submitSpec, refineSpec, type SubmissionApiError } from './submissionApi.js';
+import { submitSpec, refineSpec, type SubmissionApiError, type PlatformBuilderAvailability } from './submissionApi.js';
 import { useActiveBuildCount } from './activeBuilds.js';
 import { getSavedSpecs, saveSpec, type SavedSpec } from './mySpecs.js';
 import { saveLastBuilder, type BuilderKind } from './builderKind.js';
@@ -141,6 +141,9 @@ export function App() {
   const [qaBuilder, setQaBuilder] = useState<BuilderKind>(restoredQa.current?.builder ?? 'platform');
   const qaBuilderRef = useRef(qaBuilder);
   qaBuilderRef.current = qaBuilder;
+  // Whether the Gamedev.pl (platform) builder can be picked right now — reported by the
+  // hero's own quota poll, which already fetches this alongside the daily allowance.
+  const [platformBuilderAvailability, setPlatformBuilderAvailability] = useState<PlatformBuilderAvailability>();
   // Bumped when questions are rewritten for a new language so CreatorQA remounts
   // with empty answers — English chip labels must not survive as "selected" under
   // Polish options that no longer match.
@@ -1187,6 +1190,7 @@ export function App() {
                     mockStatus={mockStatus}
                     mockError={mockError}
                     onGenerateMock={(prompt) => void handleGenerateMock(prompt)}
+                    onPlatformBuilderAvailability={setPlatformBuilderAvailability}
                   />
                 </div>
 
@@ -1208,6 +1212,9 @@ export function App() {
                     onAnswersChange={handleQaAnswersChange}
                     initialBuilder={qaBuilder}
                     onBuilderChange={handleQaBuilderChange}
+                    platformUnavailable={
+                      platformBuilderAvailability?.available === false ? platformBuilderAvailability.reason : undefined
+                    }
                   />
                 )}
               </>

--- a/apps/web/src/BuilderChoice.test.tsx
+++ b/apps/web/src/BuilderChoice.test.tsx
@@ -60,6 +60,46 @@ describe('BuilderChoice', () => {
     await act(async () => root.unmount());
   });
 
+  it('keeps the unavailable platform option visible, focusable, and non-selectable', async () => {
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    await i18n.changeLanguage('en');
+
+    let value: BuilderKind = 'platform';
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(
+        createElement(BuilderChoice, {
+          value,
+          onChange: (next: BuilderKind) => {
+            value = next;
+          },
+          platformUnavailable: 'coming_soon',
+        }),
+      );
+      await flush();
+    });
+
+    const platformOption = container.querySelectorAll<HTMLButtonElement>('.builder-choice-option')[0];
+    // Never `disabled`: a disabled button drops out of the tab order and shows no
+    // tooltip in Chrome/Safari, hiding the reason from keyboard/screen-reader creators.
+    expect(platformOption.disabled).toBe(false);
+    expect(platformOption.getAttribute('aria-disabled')).toBe('true');
+    expect(platformOption.title).toContain('hasn');
+    expect(platformOption.textContent).toContain('Coming soon');
+
+    await act(async () => {
+      platformOption.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      await flush();
+    });
+    // A click on the unavailable option is a no-op — it never fires onChange.
+    expect(value).toBe('platform');
+
+    await act(async () => root.unmount());
+  });
+
   it('renders Polish labels without the word token', async () => {
     (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
     await i18n.changeLanguage('pl');

--- a/apps/web/src/BuilderChoice.test.tsx
+++ b/apps/web/src/BuilderChoice.test.tsx
@@ -83,8 +83,7 @@ describe('BuilderChoice', () => {
     });
 
     const platformOption = container.querySelectorAll<HTMLButtonElement>('.builder-choice-option')[0];
-    // Never `disabled`: a disabled button drops out of the tab order and shows no
-    // tooltip in Chrome/Safari, hiding the reason from keyboard/screen-reader creators.
+    // Never disabled — that would drop it from the tab order.
     expect(platformOption.disabled).toBe(false);
     expect(platformOption.getAttribute('aria-disabled')).toBe('true');
     expect(platformOption.title).toContain('hasn');
@@ -94,7 +93,7 @@ describe('BuilderChoice', () => {
       platformOption.dispatchEvent(new MouseEvent('click', { bubbles: true }));
       await flush();
     });
-    // A click on the unavailable option is a no-op — it never fires onChange.
+    // A click on it is a no-op.
     expect(value).toBe('platform');
 
     await act(async () => root.unmount());

--- a/apps/web/src/BuilderChoice.tsx
+++ b/apps/web/src/BuilderChoice.tsx
@@ -1,6 +1,9 @@
+import { useId } from 'react';
 import { useTranslation } from 'react-i18next';
 import type { BuilderKind } from './builderKind.js';
 import { recordStudioStep } from './visitTelemetry.js';
+
+export type BuilderUnavailableReason = 'coming_soon' | 'outage' | 'global_limit' | 'user_limit';
 
 type BuilderChoiceProps = {
   value: BuilderKind;
@@ -14,6 +17,15 @@ type BuilderChoiceProps = {
    * tree, because a fieldset without a legend is a group a screen reader can't name.
    */
   hideLegend?: boolean;
+  /**
+   * Why the `platform` option cannot be picked right now, when it can't. The option
+   * stays visible and in the tab order — never `disabled` — because a disabled button
+   * shows no tooltip in Chrome or Safari and drops out of focus order, which would hide
+   * the reason from exactly the people who need it read aloud. Selecting it is a no-op
+   * instead: the reason renders as a badge plus a short visible note (`aria-describedby`)
+   * and a fuller sentence in `title` for a mouse hover.
+   */
+  platformUnavailable?: BuilderUnavailableReason;
 };
 
 /**
@@ -29,10 +41,13 @@ export function BuilderChoice({
   disabled = false,
   compact = false,
   hideLegend = false,
+  platformUnavailable,
 }: BuilderChoiceProps) {
   const { t } = useTranslation();
+  const noteId = useId();
 
   const select = (next: BuilderKind) => {
+    if (next === 'platform' && platformUnavailable) return;
     onChange(next);
     recordStudioStep('builder_chosen', next);
   };
@@ -47,12 +62,30 @@ export function BuilderChoice({
           type="button"
           role="radio"
           aria-checked={value === 'platform'}
-          className={`builder-choice-option${value === 'platform' ? ' is-selected' : ''}`}
+          aria-disabled={platformUnavailable ? true : undefined}
+          aria-describedby={platformUnavailable ? noteId : undefined}
+          className={`builder-choice-option${value === 'platform' ? ' is-selected' : ''}${
+            platformUnavailable ? ' is-unavailable' : ''
+          }`}
           disabled={disabled}
+          title={platformUnavailable ? t(`builder.platform.unavailable.detail.${platformUnavailable}`) : undefined}
           onClick={() => select('platform')}
         >
-          <span className="builder-choice-option-title">{t('builder.platform.title')}</span>
-          <span className="builder-choice-option-detail">{t('builder.platform.detail')}</span>
+          <span className="builder-choice-option-title">
+            {t('builder.platform.title')}
+            {platformUnavailable && (
+              <span className="builder-choice-option-badge">
+                {t(`builder.platform.unavailable.badge.${platformUnavailable}`)}
+              </span>
+            )}
+          </span>
+          <span className="builder-choice-option-detail">
+            {platformUnavailable ? (
+              <span id={noteId}>{t(`builder.platform.unavailable.note.${platformUnavailable}`)}</span>
+            ) : (
+              t('builder.platform.detail')
+            )}
+          </span>
         </button>
         <button
           type="button"

--- a/apps/web/src/BuilderChoice.tsx
+++ b/apps/web/src/BuilderChoice.tsx
@@ -17,14 +17,7 @@ type BuilderChoiceProps = {
    * tree, because a fieldset without a legend is a group a screen reader can't name.
    */
   hideLegend?: boolean;
-  /**
-   * Why the `platform` option cannot be picked right now, when it can't. The option
-   * stays visible and in the tab order — never `disabled` — because a disabled button
-   * shows no tooltip in Chrome or Safari and drops out of focus order, which would hide
-   * the reason from exactly the people who need it read aloud. Selecting it is a no-op
-   * instead: the reason renders as a badge plus a short visible note (`aria-describedby`)
-   * and a fuller sentence in `title` for a mouse hover.
-   */
+  // Why platform is unavailable. Never disabled; see the aria attribute below.
   platformUnavailable?: BuilderUnavailableReason;
 };
 

--- a/apps/web/src/BuilderModeBadge.tsx
+++ b/apps/web/src/BuilderModeBadge.tsx
@@ -14,7 +14,7 @@ type BuilderModeBadgeProps = {
    */
   canChange: boolean;
   disabled?: boolean;
-  /** Why `platform` cannot be picked right now, when it can't. See BuilderChoice. */
+  // Why platform is unavailable, if it is. See BuilderChoice.
   platformUnavailable?: BuilderUnavailableReason;
 };
 

--- a/apps/web/src/BuilderModeBadge.tsx
+++ b/apps/web/src/BuilderModeBadge.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useId, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { useTranslation } from 'react-i18next';
-import { BuilderChoice } from './BuilderChoice.js';
+import { BuilderChoice, type BuilderUnavailableReason } from './BuilderChoice.js';
 import type { BuilderKind } from './builderKind.js';
 import { PixelIcon } from './PixelIcon.js';
 
@@ -14,6 +14,8 @@ type BuilderModeBadgeProps = {
    */
   canChange: boolean;
   disabled?: boolean;
+  /** Why `platform` cannot be picked right now, when it can't. See BuilderChoice. */
+  platformUnavailable?: BuilderUnavailableReason;
 };
 
 /**
@@ -23,7 +25,13 @@ type BuilderModeBadgeProps = {
  * not as a floating badge over the textarea. Changeable only while generation is
  * silent; opens the same two-up choice the create wizard uses.
  */
-export function BuilderModeBadge({ value, onChange, canChange, disabled = false }: BuilderModeBadgeProps) {
+export function BuilderModeBadge({
+  value,
+  onChange,
+  canChange,
+  disabled = false,
+  platformUnavailable,
+}: BuilderModeBadgeProps) {
   const { t } = useTranslation();
   const [open, setOpen] = useState(false);
   const titleId = useId();
@@ -83,7 +91,13 @@ export function BuilderModeBadge({ value, onChange, canChange, disabled = false 
                   {t('builder.legend')}
                 </h2>
                 <p className="builder-choice-modal-lede">{t('builder.badge.modalLede')}</p>
-                <BuilderChoice value={value} onChange={onChange} disabled={disabled} hideLegend />
+                <BuilderChoice
+                  value={value}
+                  onChange={onChange}
+                  disabled={disabled}
+                  hideLegend
+                  platformUnavailable={platformUnavailable}
+                />
                 <button type="button" className="primary-btn builder-choice-modal-done" onClick={() => setOpen(false)}>
                   {t('builder.badge.modalDone')}
                 </button>

--- a/apps/web/src/CreationLimitsPanel.test.tsx
+++ b/apps/web/src/CreationLimitsPanel.test.tsx
@@ -23,8 +23,15 @@ vi.mock('./adminApi.js', () => mocked);
 function limits(overrides: Partial<CreationLimits> = {}): CreationLimits {
   return {
     stored: null,
-    effective: { paused: false, globalDailySubmissionCap: 50 },
-    today: { dateStr: '2026-07-30', submissions: 12 },
+    effective: {
+      paused: false,
+      globalDailySubmissionCap: 50,
+      managedBuilderMode: 'auto',
+      managedDailyCap: null,
+      managedDailyUserCap: null,
+      hasPlatformBackend: true,
+    },
+    today: { dateStr: '2026-07-30', submissions: 12, managedBuilds: 3 },
     propagationMs: 60_000,
     ...overrides,
   };
@@ -76,7 +83,17 @@ describe('CreationLimitsPanel', () => {
   it('pauses creation and reports when the change is everywhere', async () => {
     mocked.fetchCreationLimits.mockResolvedValue(limits());
     mocked.setCreationLimits.mockResolvedValue(
-      limits({ stored: { paused: true }, effective: { paused: true, globalDailySubmissionCap: 50 } }),
+      limits({
+        stored: { paused: true },
+        effective: {
+          paused: true,
+          globalDailySubmissionCap: 50,
+          managedBuilderMode: 'auto',
+          managedDailyCap: null,
+          managedDailyUserCap: null,
+          hasPlatformBackend: true,
+        },
+      }),
     );
 
     const { container, root } = await render();

--- a/apps/web/src/CreationLimitsPanel.tsx
+++ b/apps/web/src/CreationLimitsPanel.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useState } from 'react';
-import { fetchCreationLimits, setCreationLimits, type CreationLimits } from './adminApi.js';
+import { fetchCreationLimits, setCreationLimits, type CreationLimits, type ManagedBuilderMode } from './adminApi.js';
 import { PublicPlayPanel } from './PublicPlayPanel.js';
 
 /**
@@ -27,6 +27,8 @@ export function CreationLimitsPanel({ onChanged }: { onChanged?: () => void }) {
   const [busy, setBusy] = useState(false);
   const [message, setMessage] = useState<string | null>(null);
   const [capDraft, setCapDraft] = useState('');
+  const [managedCapDraft, setManagedCapDraft] = useState('');
+  const [managedUserCapDraft, setManagedUserCapDraft] = useState('');
 
   const load = useCallback(async () => {
     try {
@@ -37,6 +39,10 @@ export function CreationLimitsPanel({ onChanged }: { onChanged?: () => void }) {
       }
       setLimits(response);
       setCapDraft(String(response.effective.globalDailySubmissionCap));
+      setManagedCapDraft(response.effective.managedDailyCap === null ? '' : String(response.effective.managedDailyCap));
+      setManagedUserCapDraft(
+        response.effective.managedDailyUserCap === null ? '' : String(response.effective.managedDailyUserCap),
+      );
       setState('ready');
     } catch {
       setState('error');
@@ -48,7 +54,13 @@ export function CreationLimitsPanel({ onChanged }: { onChanged?: () => void }) {
   }, [load]);
 
   const apply = useCallback(
-    async (patch: { paused?: boolean; globalDailySubmissionCap?: number | null }) => {
+    async (patch: {
+      paused?: boolean;
+      globalDailySubmissionCap?: number | null;
+      managedBuilderMode?: ManagedBuilderMode;
+      managedDailyCap?: number | null;
+      managedDailyUserCap?: number | null;
+    }) => {
       setBusy(true);
       setMessage(null);
       try {
@@ -59,6 +71,10 @@ export function CreationLimitsPanel({ onChanged }: { onChanged?: () => void }) {
         }
         setLimits(result);
         setCapDraft(String(result.effective.globalDailySubmissionCap));
+        setManagedCapDraft(result.effective.managedDailyCap === null ? '' : String(result.effective.managedDailyCap));
+        setManagedUserCapDraft(
+          result.effective.managedDailyUserCap === null ? '' : String(result.effective.managedDailyUserCap),
+        );
         // The change lands in Firestore, and instances read it through a cache — so say
         // when it will be everywhere rather than implying it already is.
         setMessage(`in force everywhere within ${relative(result.propagationMs)}`);
@@ -79,6 +95,20 @@ export function CreationLimitsPanel({ onChanged }: { onChanged?: () => void }) {
   const { effective, stored, today } = limits;
   const parsedCap = Number(capDraft);
   const capValid = Number.isInteger(parsedCap) && parsedCap >= 0;
+
+  const parsedManagedCap = managedCapDraft.trim() === '' ? null : Number(managedCapDraft);
+  const managedCapValid = parsedManagedCap === null || (Number.isInteger(parsedManagedCap) && parsedManagedCap >= 0);
+  const parsedManagedUserCap = managedUserCapDraft.trim() === '' ? null : Number(managedUserCapDraft);
+  const managedUserCapValid =
+    parsedManagedUserCap === null || (Number.isInteger(parsedManagedUserCap) && parsedManagedUserCap >= 0);
+
+  const managedStatusLine = !effective.hasPlatformBackend
+    ? 'Not configured in this environment (reads as "coming soon" regardless of the switch below).'
+    : effective.managedBuilderMode === 'off'
+      ? 'Off — the platform option shows as temporarily unavailable.'
+      : effective.managedBuilderMode === 'coming_soon'
+        ? 'Marked coming soon — the platform option shows as not yet launched.'
+        : 'Auto — offered normally.';
 
   return (
     <>
@@ -137,6 +167,74 @@ export function CreationLimitsPanel({ onChanged }: { onChanged?: () => void }) {
             ? `Stored by ${stored.updatedBy ?? 'unknown'}${stored.updatedAt ? ` at ${stored.updatedAt}` : ''}.`
             : 'Nothing stored — the deployed defaults are what is in force.'}{' '}
           A change needs no redeploy and reaches every instance within {relative(limits.propagationMs)}.
+        </p>
+      </section>
+
+      <section className="admin-limits">
+        <h2 className="health-section-title">Managed (Gamedev.pl) builder</h2>
+        <p className="health-summary">
+          {managedStatusLine} {today.managedBuilds} platform round{today.managedBuilds === 1 ? '' : 's'} started today (
+          {today.dateStr}).
+        </p>
+
+        <div className="admin-limits-controls">
+          <label className="admin-limits-cap">
+            Mode
+            <select
+              value={effective.managedBuilderMode}
+              disabled={busy}
+              onChange={(event) => void apply({ managedBuilderMode: event.target.value as ManagedBuilderMode })}
+            >
+              <option value="auto">Auto (offer when configured)</option>
+              <option value="coming_soon">Coming soon</option>
+              <option value="off">Off (incident)</option>
+            </select>
+          </label>
+
+          <label className="admin-limits-cap">
+            Daily cap (shared)
+            <input
+              type="number"
+              min={0}
+              placeholder="no cap"
+              value={managedCapDraft}
+              disabled={busy}
+              onChange={(event) => setManagedCapDraft(event.target.value)}
+            />
+          </label>
+          <button
+            type="button"
+            disabled={!managedCapValid || busy || parsedManagedCap === effective.managedDailyCap}
+            onClick={() => void apply({ managedDailyCap: parsedManagedCap })}
+          >
+            Set shared cap
+          </button>
+
+          <label className="admin-limits-cap">
+            Daily cap (per creator)
+            <input
+              type="number"
+              min={0}
+              placeholder="no cap"
+              value={managedUserCapDraft}
+              disabled={busy}
+              onChange={(event) => setManagedUserCapDraft(event.target.value)}
+            />
+          </label>
+          <button
+            type="button"
+            disabled={!managedUserCapValid || busy || parsedManagedUserCap === effective.managedDailyUserCap}
+            onClick={() => void apply({ managedDailyUserCap: parsedManagedUserCap })}
+          >
+            Set per-creator cap
+          </button>
+        </div>
+
+        {message && <p className="admin-limits-message">{message}</p>}
+
+        <p className="health-note">
+          An in-flight platform round keeps running when this changes — the switch only gates new dispatches. Reaches
+          every instance within {relative(limits.propagationMs)}.
         </p>
       </section>
       <PublicPlayPanel onChanged={onChanged} />

--- a/apps/web/src/CreatorQA.tsx
+++ b/apps/web/src/CreatorQA.tsx
@@ -45,12 +45,7 @@ interface CreatorQAProps {
   initialBuilder?: BuilderKind;
   /** Fires when the builder choice changes so a reload keeps the selection. */
   onBuilderChange?: (builder: BuilderKind) => void;
-  /**
-   * Why the `platform` option cannot be picked right now, when it can't. The wizard
-   * keeps `platform` selectable-looking but blocks advancing past the builder stage (and
-   * submitting from review) while it is both selected and unavailable — the creator must
-   * explicitly choose `self` to continue, rather than being switched over for them.
-   */
+  // Blocks advancing past builder/review until the creator picks self.
   platformUnavailable?: BuilderUnavailableReason;
 }
 
@@ -99,7 +94,7 @@ export function CreatorQA({
   const [builder, setBuilder] = useState<BuilderKind>(isBuilderKind(initialBuilder) ? initialBuilder : 'platform');
   const [step, setStep] = useState(0);
   const titleReady = isSubmittableTitle(title);
-  // The creator must explicitly pick `self` to continue — never switched over for them.
+  // Never switched over automatically — the creator must pick self.
   const builderBlocked = builder === 'platform' && Boolean(platformUnavailable);
 
   const stages = useMemo<Stage[]>(

--- a/apps/web/src/CreatorQA.tsx
+++ b/apps/web/src/CreatorQA.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { useTranslation } from 'react-i18next';
-import { BuilderChoice } from './BuilderChoice.js';
+import { BuilderChoice, type BuilderUnavailableReason } from './BuilderChoice.js';
 import { isBuilderKind, type BuilderKind } from './builderKind.js';
 import { isSubmittableTitle, MAX_TITLE_LENGTH } from './gameTitle.js';
 import { PixelIcon } from './PixelIcon.js';
@@ -45,6 +45,13 @@ interface CreatorQAProps {
   initialBuilder?: BuilderKind;
   /** Fires when the builder choice changes so a reload keeps the selection. */
   onBuilderChange?: (builder: BuilderKind) => void;
+  /**
+   * Why the `platform` option cannot be picked right now, when it can't. The wizard
+   * keeps `platform` selectable-looking but blocks advancing past the builder stage (and
+   * submitting from review) while it is both selected and unavailable — the creator must
+   * explicitly choose `self` to continue, rather than being switched over for them.
+   */
+  platformUnavailable?: BuilderUnavailableReason;
 }
 
 /**
@@ -83,6 +90,7 @@ export function CreatorQA({
   onAnswersChange,
   initialBuilder = 'platform',
   onBuilderChange,
+  platformUnavailable,
 }: CreatorQAProps) {
   const { t } = useTranslation();
   const [title, setTitle] = useState(initialTitle);
@@ -91,6 +99,8 @@ export function CreatorQA({
   const [builder, setBuilder] = useState<BuilderKind>(isBuilderKind(initialBuilder) ? initialBuilder : 'platform');
   const [step, setStep] = useState(0);
   const titleReady = isSubmittableTitle(title);
+  // The creator must explicitly pick `self` to continue — never switched over for them.
+  const builderBlocked = builder === 'platform' && Boolean(platformUnavailable);
 
   const stages = useMemo<Stage[]>(
     () => [
@@ -457,7 +467,14 @@ export function CreatorQA({
                 {t('builder.legend')}
               </h2>
               <p className="qa-stage-lede">{t('qa.builderLede')}</p>
-              <BuilderChoice value={builder} onChange={handleBuilderChange} disabled={submitting} hideLegend />
+              <BuilderChoice
+                value={builder}
+                onChange={handleBuilderChange}
+                disabled={submitting}
+                hideLegend
+                platformUnavailable={platformUnavailable}
+              />
+              {builderBlocked && <p className="qa-builder-blocked">{t('qa.builderBlocked')}</p>}
             </>
           )}
 
@@ -550,7 +567,7 @@ export function CreatorQA({
             type="button"
             className="qa-shortcut"
             onClick={() => goTo(reviewIndex)}
-            disabled={submitting || !titleReady}
+            disabled={submitting || !titleReady || builderBlocked}
           >
             {t('qa.skipToReview')}
           </button>
@@ -561,7 +578,7 @@ export function CreatorQA({
             type="button"
             className="btn btn-primary qa-primary btn-create-now"
             onClick={handleSubmit}
-            disabled={submitting || !titleReady}
+            disabled={submitting || !titleReady || builderBlocked}
           >
             <PixelIcon name="send" size={14} /> {submitting ? t('submit.submitting') : t('qa.createNow')}
           </button>
@@ -572,7 +589,9 @@ export function CreatorQA({
               stage.kind === 'question' && !currentAnswer ? ' qa-next--skip' : ''
             }`}
             onClick={() => goTo(stepIndex + 1)}
-            disabled={submitting || (stage.kind === 'name' && !titleReady)}
+            disabled={
+              submitting || (stage.kind === 'name' && !titleReady) || (stage.kind === 'builder' && builderBlocked)
+            }
           >
             {nextLabel()} <PixelIcon name="arrowRight" size={12} />
           </button>

--- a/apps/web/src/HeroPromptSection.tsx
+++ b/apps/web/src/HeroPromptSection.tsx
@@ -22,7 +22,7 @@ type HeroPromptSectionProps = {
   mockError: string | null;
   // Demo mock only; Build runs QA before any generation
   onGenerateMock?: (prompt: string) => void;
-  /** Fires once the quota poll resolves, so the create wizard can gate the builder step. */
+  // Fires once the quota poll resolves.
   onPlatformBuilderAvailability?: (availability: PlatformBuilderAvailability | undefined) => void;
 };
 

--- a/apps/web/src/HeroPromptSection.tsx
+++ b/apps/web/src/HeroPromptSection.tsx
@@ -4,7 +4,7 @@ import { recordCreateStep } from './visitTelemetry.js';
 import type { CatalogEntry } from './catalog.js';
 import { SketchModal } from './SketchModal.js';
 import { PixelIcon } from './PixelIcon.js';
-import { getQuota } from './submissionApi.js';
+import { getQuota, type PlatformBuilderAvailability } from './submissionApi.js';
 
 /**
  * Gemini-style composer: attach / prompt / mic / build in one pill.
@@ -22,6 +22,8 @@ type HeroPromptSectionProps = {
   mockError: string | null;
   // Demo mock only; Build runs QA before any generation
   onGenerateMock?: (prompt: string) => void;
+  /** Fires once the quota poll resolves, so the create wizard can gate the builder step. */
+  onPlatformBuilderAvailability?: (availability: PlatformBuilderAvailability | undefined) => void;
 };
 
 export type VisualAttachment = {
@@ -114,6 +116,7 @@ export function HeroPromptSection({
   onSubmitSpec,
   mockStatus,
   mockError,
+  onPlatformBuilderAvailability,
 }: HeroPromptSectionProps) {
   const { t } = useTranslation();
   // Skip autofocus on phone — keyboard would hide the composer.
@@ -135,7 +138,9 @@ export function HeroPromptSection({
     let cancelled = false;
     getQuota()
       .then((result) => {
-        if (!cancelled) setQuota(result.submissions);
+        if (cancelled) return;
+        setQuota(result.submissions);
+        onPlatformBuilderAvailability?.(result.platformBuilder);
       })
       .catch(() => {
         // Signed out or unreachable — the line simply doesn't render.
@@ -143,6 +148,7 @@ export function HeroPromptSection({
     return () => {
       cancelled = true;
     };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   // Web Speech Recognition

--- a/apps/web/src/StudioConnectCard.tsx
+++ b/apps/web/src/StudioConnectCard.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useId, useRef, useState, type ReactNode } from 'react';
 import { useTranslation } from 'react-i18next';
 import { PixelIcon } from './PixelIcon.js';
+import type { BuilderUnavailableReason } from './BuilderChoice.js';
 import {
   CONNECT_CLIENTS,
   getConnectPayload,
@@ -93,6 +94,8 @@ type StudioConnectCardProps = {
   panelHeading?: string;
   onSwitchToPlatform?: SwitchHandler;
   builderHandoffPending?: boolean;
+  /** Why switching to `platform` cannot be offered right now, when it can't. */
+  platformUnavailable?: BuilderUnavailableReason;
 };
 
 type BuilderHandoffTarget = 'platform' | 'self';
@@ -105,6 +108,8 @@ type SwitchBuilderControlProps = {
   compact?: boolean;
   active?: boolean;
   pending?: boolean;
+  /** Why `platform` cannot be switched to right now. Meaningless for `target: 'self'`. */
+  unavailable?: BuilderUnavailableReason;
 };
 
 function SwitchBuilderControl({
@@ -113,6 +118,7 @@ function SwitchBuilderControl({
   compact = false,
   active = false,
   pending = false,
+  unavailable,
 }: SwitchBuilderControlProps) {
   const { t } = useTranslation();
   const [armed, setArmed] = useState(false);
@@ -152,7 +158,20 @@ function SwitchBuilderControl({
       }
     >
       {!compact ? <p className="studio-connect-switch-hint">{t('connect.switchBuilder.hint')}</p> : null}
-      {handoffPending ? (
+      {target === 'platform' && unavailable ? (
+        // Not `disabled`: a disabled button shows no title tooltip in Chrome/Safari and
+        // drops out of the tab order, hiding the reason from keyboard/screen-reader
+        // creators. aria-disabled plus a visible note keeps it focusable and legible.
+        <button
+          type="button"
+          className={`${compact ? 'studio-active-handoff-button' : 'studio-connect-switch-button'} is-unavailable`}
+          aria-disabled="true"
+          title={t(`builder.platform.unavailable.detail.${unavailable}`)}
+          onClick={(event) => event.preventDefault()}
+        >
+          {t(`builder.platform.unavailable.badge.${unavailable}`)}
+        </button>
+      ) : handoffPending ? (
         <p className={compact ? 'studio-active-handoff-pending' : 'studio-connect-switch-pending'} aria-live="polite">
           {t('connect.switchBuilder.pending')}
         </p>
@@ -205,11 +224,13 @@ export function SwitchToPlatformControl({
   compact = false,
   active = false,
   pending = false,
+  unavailable,
 }: {
   onSwitchToPlatform: SwitchHandler;
   compact?: boolean;
   active?: boolean;
   pending?: boolean;
+  unavailable?: BuilderUnavailableReason;
 }) {
   return (
     <SwitchBuilderControl
@@ -218,6 +239,7 @@ export function SwitchToPlatformControl({
       compact={compact}
       active={active}
       pending={pending}
+      unavailable={unavailable}
     />
   );
 }
@@ -259,6 +281,7 @@ export function StudioConnectCard({
   onSwitchToPlatform,
   builderHandoffPending = false,
   waitingCaptionElsewhere = false,
+  platformUnavailable,
 }: StudioConnectCardProps) {
   const isPanel = density === 'panel';
   const { t, i18n } = useTranslation();
@@ -357,7 +380,12 @@ export function StudioConnectCard({
             <PixelIcon name="expand" size={12} /> {t('connect.show')}
           </button>
           {payload?.canSwitchToPlatform && onSwitchToPlatform ? (
-            <SwitchToPlatformControl compact onSwitchToPlatform={onSwitchToPlatform} pending={builderHandoffPending} />
+            <SwitchToPlatformControl
+              compact
+              onSwitchToPlatform={onSwitchToPlatform}
+              pending={builderHandoffPending}
+              unavailable={platformUnavailable}
+            />
           ) : null}
           <span className="studio-connect-collapsed-hint">{t('connect.collapsed.hint')}</span>
         </div>
@@ -653,7 +681,11 @@ export function StudioConnectCard({
       {error ? <p className="error">{error}</p> : null}
 
       {payload?.canSwitchToPlatform && onSwitchToPlatform ? (
-        <SwitchToPlatformControl onSwitchToPlatform={onSwitchToPlatform} pending={builderHandoffPending} />
+        <SwitchToPlatformControl
+          onSwitchToPlatform={onSwitchToPlatform}
+          pending={builderHandoffPending}
+          unavailable={platformUnavailable}
+        />
       ) : null}
 
       {payload && !loading ? (

--- a/apps/web/src/StudioConnectCard.tsx
+++ b/apps/web/src/StudioConnectCard.tsx
@@ -94,7 +94,7 @@ type StudioConnectCardProps = {
   panelHeading?: string;
   onSwitchToPlatform?: SwitchHandler;
   builderHandoffPending?: boolean;
-  /** Why switching to `platform` cannot be offered right now, when it can't. */
+  // Why switching to platform is unavailable, if it is.
   platformUnavailable?: BuilderUnavailableReason;
 };
 
@@ -108,7 +108,7 @@ type SwitchBuilderControlProps = {
   compact?: boolean;
   active?: boolean;
   pending?: boolean;
-  /** Why `platform` cannot be switched to right now. Meaningless for `target: 'self'`. */
+  // Meaningless for target: 'self'.
   unavailable?: BuilderUnavailableReason;
 };
 
@@ -159,9 +159,7 @@ function SwitchBuilderControl({
     >
       {!compact ? <p className="studio-connect-switch-hint">{t('connect.switchBuilder.hint')}</p> : null}
       {target === 'platform' && unavailable ? (
-        // Not `disabled`: a disabled button shows no title tooltip in Chrome/Safari and
-        // drops out of the tab order, hiding the reason from keyboard/screen-reader
-        // creators. aria-disabled plus a visible note keeps it focusable and legible.
+        // Never disabled — that would drop it from the tab order.
         <button
           type="button"
           className={`${compact ? 'studio-active-handoff-button' : 'studio-connect-switch-button'} is-unavailable`}

--- a/apps/web/src/SubmissionStatusView.tsx
+++ b/apps/web/src/SubmissionStatusView.tsx
@@ -1397,7 +1397,7 @@ function FeedbackPanel({
   onSwitchToPlatform?: BuilderHandoffHandler;
   onSwitchToSelf?: BuilderHandoffHandler;
   handoffPending?: BuilderKind;
-  /** Why `platform` cannot be picked or handed off to right now. See BuilderChoice. */
+  // Why platform is unavailable, if it is. See BuilderChoice.
   platformUnavailable?: BuilderUnavailableReason;
   /**
    * Hide the "saved until you start your agent" line — the connect card above already

--- a/apps/web/src/SubmissionStatusView.tsx
+++ b/apps/web/src/SubmissionStatusView.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
 import { useTranslation } from 'react-i18next';
 import { BuilderModeBadge } from './BuilderModeBadge.js';
+import type { BuilderUnavailableReason } from './BuilderChoice.js';
 import { defaultBuilderFor, isBuilderKind, saveLastBuilder, type BuilderKind } from './builderKind.js';
 import { GameTheater } from './GameTheater.js';
 import { PixelIcon, type PixelIconName } from './PixelIcon.js';
@@ -800,6 +801,9 @@ export function SubmissionStatusView({
                       waitingCaptionElsewhere={footBarShowing}
                       onSwitchToPlatform={handoffToPlatformFromUi}
                       builderHandoffPending={status.builderHandoff?.target === 'platform'}
+                      platformUnavailable={
+                        status.platformBuilder?.available === false ? status.platformBuilder.reason : undefined
+                      }
                     />
                   ) : null
                 }
@@ -929,6 +933,9 @@ export function SubmissionStatusView({
                         ? handoffToSelfFromUi
                         : undefined
                     }
+                    platformUnavailable={
+                      status.platformBuilder?.available === false ? status.platformBuilder.reason : undefined
+                    }
                     suppressRouteNote={isAwaitingOwnAgent(status) || status.phase === 'ready_for_review'}
                     onSent={(text) => {
                       setPendingRevisions((current) => [...current, { text, at: Date.now() }]);
@@ -1042,6 +1049,9 @@ export function SubmissionStatusView({
                 mode={connectCardMode(copyInputFromStatus(status)) ?? 'setup'}
                 onSwitchToPlatform={handoffToPlatformFromUi}
                 builderHandoffPending={status.builderHandoff?.target === 'platform'}
+                platformUnavailable={
+                  status.platformBuilder?.available === false ? status.platformBuilder.reason : undefined
+                }
               />
             ) : null}
 
@@ -1146,6 +1156,9 @@ export function SubmissionStatusView({
                   canInterruptPlatformAgent(status) || status.builderHandoff?.target === 'self'
                     ? handoffToSelfFromUi
                     : undefined
+                }
+                platformUnavailable={
+                  status.platformBuilder?.available === false ? status.platformBuilder.reason : undefined
                 }
                 onSent={(text) => {
                   setPendingRevisions((current) => [...current, { text, at: Date.now() }]);
@@ -1362,6 +1375,7 @@ function FeedbackPanel({
   onSwitchToPlatform,
   onSwitchToSelf,
   handoffPending,
+  platformUnavailable,
   onSent,
   onPublishedImprove,
 }: {
@@ -1383,6 +1397,8 @@ function FeedbackPanel({
   onSwitchToPlatform?: BuilderHandoffHandler;
   onSwitchToSelf?: BuilderHandoffHandler;
   handoffPending?: BuilderKind;
+  /** Why `platform` cannot be picked or handed off to right now. See BuilderChoice. */
+  platformUnavailable?: BuilderUnavailableReason;
   /**
    * Hide the "saved until you start your agent" line — the connect card above already
    * says we are waiting, so a third copy under the box is noise.
@@ -1563,6 +1579,7 @@ function FeedbackPanel({
       onChange={handleBuilderChange}
       canChange={chooseBuilder}
       disabled={state === 'sending'}
+      platformUnavailable={platformUnavailable}
     />
   ) : null;
   const activeSelfHandoff =
@@ -1572,6 +1589,7 @@ function FeedbackPanel({
         active
         onSwitchToPlatform={onSwitchToPlatform}
         pending={handoffPending === 'platform'}
+        unavailable={platformUnavailable}
       />
     ) : null;
   const activePlatformHandoff =

--- a/apps/web/src/adminApi.ts
+++ b/apps/web/src/adminApi.ts
@@ -66,10 +66,27 @@ export async function fetchAdminSummary(): Promise<AdminSummary | null> {
   return (await res.json()) as AdminSummary;
 }
 
+export type ManagedBuilderMode = 'auto' | 'off' | 'coming_soon';
+
 export interface CreationLimits {
-  stored: { paused?: boolean; globalDailySubmissionCap?: number | null; updatedAt?: string; updatedBy?: string } | null;
-  effective: { paused: boolean; globalDailySubmissionCap: number };
-  today: { dateStr: string; submissions: number };
+  stored: {
+    paused?: boolean;
+    globalDailySubmissionCap?: number | null;
+    managedBuilderMode?: ManagedBuilderMode;
+    managedDailyCap?: number | null;
+    managedDailyUserCap?: number | null;
+    updatedAt?: string;
+    updatedBy?: string;
+  } | null;
+  effective: {
+    paused: boolean;
+    globalDailySubmissionCap: number;
+    managedBuilderMode: ManagedBuilderMode;
+    managedDailyCap: number | null;
+    managedDailyUserCap: number | null;
+    hasPlatformBackend: boolean;
+  };
+  today: { dateStr: string; submissions: number; managedBuilds: number };
   propagationMs: number;
 }
 
@@ -90,6 +107,9 @@ export async function fetchCreationLimits(): Promise<CreationLimits | null> {
 export async function setCreationLimits(patch: {
   paused?: boolean;
   globalDailySubmissionCap?: number | null;
+  managedBuilderMode?: ManagedBuilderMode;
+  managedDailyCap?: number | null;
+  managedDailyUserCap?: number | null;
 }): Promise<CreationLimits | { error: string }> {
   const res = await fetch(`${API_BASE}/api/admin/creation-limits`, {
     method: 'POST',

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -540,6 +540,7 @@
     "eyebrowIdea": "Your idea",
     "eyebrowBuilder": "Last choice",
     "builderLede": "Gamedev.pl can build it for you, or you connect your own coding agent.",
+    "builderBlocked": "The Gamedev.pl coding agent isn't available right now — choose your own coding agent to continue.",
     "back": "Back",
     "continue": "Continue",
     "next": "Next",
@@ -1163,7 +1164,27 @@
     "legend": "Who builds this round?",
     "platform": {
       "title": "Gamedev.pl coding agent",
-      "detail": "We assign a coding agent and you watch progress here."
+      "detail": "We assign a coding agent and you watch progress here.",
+      "unavailable": {
+        "badge": {
+          "coming_soon": "Coming soon",
+          "outage": "Temporarily unavailable",
+          "global_limit": "Daily limit reached",
+          "user_limit": "Your daily limit reached"
+        },
+        "note": {
+          "coming_soon": "Not launched here yet.",
+          "outage": "Down for a bit — try again shortly.",
+          "global_limit": "Everyone's used up today's builds.",
+          "user_limit": "You've used today's builds."
+        },
+        "detail": {
+          "coming_soon": "The Gamedev.pl coding agent hasn't launched in this environment yet. Use your own coding agent instead.",
+          "outage": "The Gamedev.pl coding agent is temporarily unavailable. Use your own coding agent, or try again shortly.",
+          "global_limit": "The Gamedev.pl coding agent has reached today's shared build limit. Use your own coding agent, or try again tomorrow.",
+          "user_limit": "You've reached your daily limit for the Gamedev.pl coding agent. Use your own coding agent, or try again tomorrow."
+        }
+      }
     },
     "self": {
       "title": "My own coding agent",

--- a/apps/web/src/i18n/locales/pl.json
+++ b/apps/web/src/i18n/locales/pl.json
@@ -544,6 +544,7 @@
     "eyebrowIdea": "Twój pomysł",
     "eyebrowBuilder": "Ostatni wybór",
     "builderLede": "Gamedev.pl może zbudować to za Ciebie, albo podłączysz własnego agenta.",
+    "builderBlocked": "Agent kodujący Gamedev.pl jest teraz niedostępny — wybierz własnego agenta, aby kontynuować.",
     "back": "Wstecz",
     "continue": "Dalej",
     "next": "Dalej",
@@ -1167,7 +1168,27 @@
     "legend": "Kto buduje tę rundę?",
     "platform": {
       "title": "Agent Gamedev.pl",
-      "detail": "Przypisujemy agenta i postęp widać tutaj."
+      "detail": "Przypisujemy agenta i postęp widać tutaj.",
+      "unavailable": {
+        "badge": {
+          "coming_soon": "Już wkrótce",
+          "outage": "Chwilowo niedostępny",
+          "global_limit": "Dzienny limit osiągnięty",
+          "user_limit": "Twój dzienny limit osiągnięty"
+        },
+        "note": {
+          "coming_soon": "Jeszcze tu nie wystartował.",
+          "outage": "Chwilowo nie działa — spróbuj za chwilę.",
+          "global_limit": "Dzisiejsza wspólna pula budów się skończyła.",
+          "user_limit": "Wykorzystałeś dzisiejszą pulę budów."
+        },
+        "detail": {
+          "coming_soon": "Agent kodujący Gamedev.pl nie wystartował jeszcze w tym środowisku. Użyj własnego agenta kodującego.",
+          "outage": "Agent kodujący Gamedev.pl jest chwilowo niedostępny. Użyj własnego agenta kodującego albo spróbuj ponownie za chwilę.",
+          "global_limit": "Agent kodujący Gamedev.pl osiągnął dzisiejszy wspólny limit budów. Użyj własnego agenta kodującego albo spróbuj jutro.",
+          "user_limit": "Osiągnąłeś dzisiejszy limit agenta kodującego Gamedev.pl. Użyj własnego agenta kodującego albo spróbuj jutro."
+        }
+      }
     },
     "self": {
       "title": "Mój własny agent",

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -5038,6 +5038,13 @@ a.user-name--profile:focus-visible {
   max-width: 46ch;
 }
 
+.qa-builder-blocked {
+  margin: -4px 0 0;
+  font-size: 0.85rem;
+  line-height: 1.4;
+  color: var(--warning, #f5a623);
+}
+
 .qa-idea-quote {
   margin: 0;
   border-left: 3px solid var(--turquoise, #00e4ac);
@@ -7079,6 +7086,31 @@ button.builder-mode-selector:disabled {
   line-height: 1.35;
 }
 
+/* Deliberately not `disabled` — see BuilderChoice.tsx. Styled to read as inactive while
+   staying focusable and its tooltip reachable on hover and via aria-describedby. */
+.builder-choice-option.is-unavailable {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.builder-choice-option.is-unavailable:hover {
+  border-color: var(--panel-border, #33383d);
+}
+
+.builder-choice-option-badge {
+  display: inline-block;
+  margin-left: 8px;
+  padding: 1px 7px;
+  border-radius: 999px;
+  font-size: 0.65rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.02em;
+  color: var(--muted, #94a3b8);
+  background: color-mix(in srgb, var(--muted, #94a3b8) 16%, transparent);
+  vertical-align: middle;
+}
+
 .builder-choice.is-compact .builder-choice-option {
   padding: 10px 12px;
 }
@@ -7377,6 +7409,18 @@ button.builder-mode-selector:disabled {
   border-color: rgba(0, 228, 172, 0.55);
   background: rgba(0, 228, 172, 0.12);
   color: var(--turquoise, #00e4ac);
+}
+
+/* Deliberately not `disabled` — see StudioConnectCard.tsx's SwitchBuilderControl. */
+.studio-connect-switch-button.is-unavailable,
+.studio-active-handoff-button.is-unavailable {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.studio-connect-switch-button.is-unavailable:hover {
+  border-color: rgba(148, 163, 184, 0.4);
+  color: var(--text, #e2e8f0);
 }
 
 .studio-connect-switch-confirm {

--- a/apps/web/src/submissionApi.ts
+++ b/apps/web/src/submissionApi.ts
@@ -174,6 +174,8 @@ export type SubmissionStatus = {
     requestedAt: string;
     acknowledgedAt?: string;
   };
+  /** Whether the `platform` builder can be picked or handed off to right now. */
+  platformBuilder?: PlatformBuilderAvailability;
   /**
    * Why this build is asking the creator to act. Covers a dead agent round
    * (`task_failed`, …) and a gate bounce (`gate_red`) — both arrive as public
@@ -415,15 +417,24 @@ export async function handoffToSelf(token: string): Promise<BuilderHandoffRespon
   return (await response.json()) as BuilderHandoffResponse;
 }
 
+export type PlatformBuilderAvailability =
+  { available: true } | { available: false; reason: 'coming_soon' | 'outage' | 'global_limit' | 'user_limit' };
+
 /** Today's submission allowance, so a creator sees it before they hit a 429. */
-export async function getQuota(): Promise<{ submissions: { used: number; limit: number | null } }> {
+export async function getQuota(): Promise<{
+  submissions: { used: number; limit: number | null };
+  platformBuilder?: PlatformBuilderAvailability;
+}> {
   const response = await fetch(`${API_BASE}/api/me/quota`, { credentials: 'include' });
 
   if (!response.ok) {
     await throwResponseError(response);
   }
 
-  return (await response.json()) as { submissions: { used: number; limit: number | null } };
+  return (await response.json()) as {
+    submissions: { used: number; limit: number | null };
+    platformBuilder?: PlatformBuilderAvailability;
+  };
 }
 
 /**

--- a/apps/web/src/submissionApi.ts
+++ b/apps/web/src/submissionApi.ts
@@ -174,7 +174,7 @@ export type SubmissionStatus = {
     requestedAt: string;
     acknowledgedAt?: string;
   };
-  /** Whether the `platform` builder can be picked or handed off to right now. */
+  // Whether platform can be picked or handed off to right now.
   platformBuilder?: PlatformBuilderAvailability;
   /**
    * Why this build is asking the creator to act. Covers a dead agent round


### PR DESCRIPTION
## Summary

Creators can always fall back to BYOCA (`self`), but until now an unconfigured or paused platform (Gamedev.pl) backend failed silently: a submission asking for `builder: 'platform'` just sat in `queued` forever with no explanation, and the builder picker kept offering an option that could never actually dispatch.

This adds an explicit, operator-controlled switch for the managed agent, with four distinguishable "why not" reasons, and makes the UI say so honestly instead of hiding the option.

- **`managed-availability.ts`** — resolves whether `platform` can be offered right now:
  1. operator switch `off` → *outage*
  2. operator switch `coming_soon` → *coming soon*
  3. no platform backend configured in this environment → *coming soon*
  4. shared or per-creator daily cap spent → *global limit* / *user limit*

  Reads from the same `opsConfig/creationLimits` document the creation breaker already uses (~60s propagation, no redeploy). Bots bypass it, same as the breaker.
- **Server-side enforcement** on new submissions, resumes, and handoffs targeting `platform`, refusing with `platform_builder_unavailable` + reason. An **in-flight platform round keeps running** — only new dispatches are gated. Availability is echoed on `GET /api/me/quota` and the submission status payload so the UI never has to guess.
- **UI never hides the option.** `BuilderChoice`, `BuilderModeBadge`, and the Studio "switch to platform" control show `platform` visibly disabled with a reason badge and note. Uses `aria-disabled` rather than the `disabled` attribute — a truly disabled button shows no tooltip in Chrome/Safari and drops out of the tab order, which would hide the reason from keyboard/screen-reader users. The create wizard blocks advancing past the builder step (and submitting from review) until the creator explicitly picks BYOCA, rather than switching them over automatically.
- **`CreationLimitsPanel`** (admin console) gains the mode selector plus both daily caps, so pulling the switch during an incident is a console click, not a deploy.

One thing worth flagging: on the next deploy, production will show *Coming soon* on the Gamedev.pl option unless a platform backend is actually configured there (`AGENT_TASKS_TOKEN` or the `MANAGED_AGENT_*` vars) — the "unconfigured reads as coming soon" behavior is deliberate per the requester's explicit confirmation.

## Test plan

- [x] `apps/api`: `tsc --noEmit` clean; full vitest suite (2846 tests) passes, including new `managed-availability.test.ts` and enforcement tests in `submissions.test.ts`
- [x] `apps/web`: `tsc --noEmit` clean; full vitest suite (1210 tests) passes, including new coverage in `BuilderChoice.test.tsx`
- [x] `apps/web`: i18n key-parity test passes for the new `builder.platform.unavailable.*` and `qa.builderBlocked` keys (en + pl)
- [x] Both packages build cleanly (`vite build` / `tsc -p tsconfig.json`)
- [x] ESLint clean on all changed files
- [ ] Manual click-through in a running Studio session (not done in this session)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TBimyB3MuY7ugDHC7RMnF5

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBimyB3MuY7ugDHC7RMnF5)_