### PR TITLE
Wire managed backend selection into production deploys

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -91,6 +91,10 @@ jobs:
             SECRET_MAPPINGS+=("AGENT_TASKS_TOKEN=agent-tasks-token:latest")
           fi
 
+          if gcloud secrets describe anthropic-api-key --project "$PROJECT_ID" >/dev/null 2>&1; then
+            SECRET_MAPPINGS+=("MANAGED_AGENT_API_KEY=anthropic-api-key:latest")
+          fi
+
           # Resend API key for outbound email (beta invites, notifications). The
           # mailer degrades to a no-op without it, so email is simply off until
           # the secret exists — the deploy stays green either way.
@@ -153,6 +157,22 @@ jobs:
           SWEEP_SA="notify-sweep@${PROJECT_ID}.iam.gserviceaccount.com"
           ACCOUNT_DELETION_SWEEP_URL="https://${SERVICE}-${PROJECT_NUMBER}.${REGION}.run.app/api/internal/account-deletion-sweep"
           ENV_VARS="^|^GAMES_REPO=${GAMES_REPO}|GAMES_SNAPSHOT_BUCKET=${GAMES_SNAPSHOT_BUCKET}|GAMES_STORE_BUCKET=${GAMES_STORE_BUCKET}|GATE_BUILD_PROJECT=${{ env.PROJECT_ID }}|GOOGLE_OAUTH_CLIENT_ID=${{ vars.GOOGLE_OAUTH_CLIENT_ID }}|APPLE_CLIENT_IDS=${{ vars.APPLE_CLIENT_IDS }}|WEB_ORIGIN=https://gamedev-app-334141807880.europe-west1.run.app,https://www.gamedev.pl,https://gamedev.pl|CANONICAL_HOST=www.gamedev.pl|MCP_AUTHORIZATION_SERVERS=https://www.gamedev.pl|PRIVATE_BETA=true|PUBLIC_PLAY_SLUGS=${PUBLIC_PLAY_SLUGS_VAL}|BETA_ALLOWED_UIDS=${{ vars.BETA_ALLOWED_UIDS }}|BETA_ALLOWED_EMAILS=${{ vars.BETA_ALLOWED_EMAILS }}|ADMIN_UIDS=${{ vars.ADMIN_UIDS }}|REVIEWER_UIDS=${{ vars.REVIEWER_UIDS }}|NOTIFY_SWEEP_AUDIENCE=${{ vars.NOTIFY_SWEEP_AUDIENCE }}|NOTIFY_SWEEP_SA=${SWEEP_SA}|SCORECARD_SWEEP_AUDIENCE=${{ vars.SCORECARD_SWEEP_AUDIENCE }}|DIGEST_SWEEP_AUDIENCE=${{ vars.DIGEST_SWEEP_AUDIENCE }}|SUGGESTION_SWEEP_AUDIENCE=${{ vars.SUGGESTION_SWEEP_AUDIENCE }}|HEALTH_SWEEP_AUDIENCE=${{ vars.HEALTH_SWEEP_AUDIENCE }}|ACCOUNT_DELETION_SWEEP_AUDIENCE=${ACCOUNT_DELETION_SWEEP_URL}|VAPID_PUBLIC_KEY=${{ vars.VAPID_PUBLIC_KEY }}|VAPID_SUBJECT=${{ vars.VAPID_SUBJECT }}|OPENAI_APPS_CHALLENGE_TOKEN=${{ vars.OPENAI_APPS_CHALLENGE_TOKEN }}"
+          for MANAGED_VAR in MANAGED_AGENT_VENDOR MANAGED_AGENT_MODEL MANAGED_AGENT_ID MANAGED_AGENT_ENVIRONMENT_ID MANAGED_AGENT_MAX_SECONDS MANAGED_AGENT_MAX_LIST_COST_CENTS MANAGED_AGENT_VAULT_IDS MANAGED_AGENT_MCP_URL MANAGED_AGENT_DELIVERY_MODE; do
+            case "$MANAGED_VAR" in
+              MANAGED_AGENT_VENDOR) MANAGED_VAL="${{ vars.MANAGED_AGENT_VENDOR }}" ;;
+              MANAGED_AGENT_MODEL) MANAGED_VAL="${{ vars.MANAGED_AGENT_MODEL }}" ;;
+              MANAGED_AGENT_ID) MANAGED_VAL="${{ vars.MANAGED_AGENT_ID }}" ;;
+              MANAGED_AGENT_ENVIRONMENT_ID) MANAGED_VAL="${{ vars.MANAGED_AGENT_ENVIRONMENT_ID }}" ;;
+              MANAGED_AGENT_MAX_SECONDS) MANAGED_VAL="${{ vars.MANAGED_AGENT_MAX_SECONDS }}" ;;
+              MANAGED_AGENT_MAX_LIST_COST_CENTS) MANAGED_VAL="${{ vars.MANAGED_AGENT_MAX_LIST_COST_CENTS }}" ;;
+              MANAGED_AGENT_VAULT_IDS) MANAGED_VAL="${{ vars.MANAGED_AGENT_VAULT_IDS }}" ;;
+              MANAGED_AGENT_MCP_URL) MANAGED_VAL="${{ vars.MANAGED_AGENT_MCP_URL }}" ;;
+              MANAGED_AGENT_DELIVERY_MODE) MANAGED_VAL="${{ vars.MANAGED_AGENT_DELIVERY_MODE }}" ;;
+            esac
+            if [ -n "$MANAGED_VAL" ]; then
+              ENV_VARS="${ENV_VARS}|${MANAGED_VAR}=${MANAGED_VAL}"
+            fi
+          done
           ZONE_HOST_URL_VAL="${{ vars.ZONE_HOST_URL }}"
           if [ -n "$ZONE_HOST_URL_VAL" ]; then
             ENV_VARS="${ENV_VARS}|ZONE_HOST_URL=${ZONE_HOST_URL_VAL}"

--- a/apps/api/src/agent-backend-env.test.ts
+++ b/apps/api/src/agent-backend-env.test.ts
@@ -1,0 +1,63 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { createAgentBackendRegistryFromEnv } from './agent-backend-env.js';
+
+const ENV_KEYS = [
+  'MANAGED_AGENT_VENDOR',
+  'MANAGED_AGENT_API_KEY',
+  'MANAGED_AGENT_MODEL',
+  'MANAGED_AGENT_ID',
+  'MANAGED_AGENT_ENVIRONMENT_ID',
+  'MANAGED_AGENT_MAX_SECONDS',
+  'MANAGED_AGENT_MAX_LIST_COST_CENTS',
+  'MANAGED_AGENT_MCP_URL',
+  'AGENT_TASKS_TOKEN',
+] as const;
+
+describe('createAgentBackendRegistryFromEnv', () => {
+  const previous = new Map<string, string | undefined>();
+
+  afterEach(() => {
+    for (const key of ENV_KEYS) {
+      const value = previous.get(key);
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+    previous.clear();
+    vi.restoreAllMocks();
+  });
+
+  function setEnv(values: Partial<Record<(typeof ENV_KEYS)[number], string | undefined>>): void {
+    for (const key of ENV_KEYS) {
+      if (!previous.has(key)) previous.set(key, process.env[key]);
+      const next = values[key];
+      if (next === undefined) delete process.env[key];
+      else process.env[key] = next;
+    }
+  }
+
+  it('fails closed when a managed vendor is selected but invalid', () => {
+    setEnv({
+      MANAGED_AGENT_VENDOR: 'anthropic',
+      // Missing key/model/ids — config is invalid.
+      AGENT_TASKS_TOKEN: 'ghp_test_token_for_fail_closed',
+    });
+    const warn = vi.fn();
+    const registry = createAgentBackendRegistryFromEnv({ info: vi.fn(), warn });
+
+    expect(registry.platform).toBeUndefined();
+    expect(registry.self.name).toBe('self');
+    expect(warn).toHaveBeenCalledWith(
+      expect.objectContaining({ vendor: 'anthropic' }),
+      expect.stringContaining('platform dispatch stays off'),
+    );
+  });
+
+  it('falls back to Copilot only when no managed vendor was selected', () => {
+    setEnv({
+      MANAGED_AGENT_VENDOR: undefined,
+      AGENT_TASKS_TOKEN: 'ghp_test_token_for_copilot_fallback',
+    });
+    const registry = createAgentBackendRegistryFromEnv({ info: vi.fn(), warn: vi.fn() });
+    expect(registry.platform?.name).toBe('copilot');
+  });
+});

--- a/apps/api/src/agent-backend-env.ts
+++ b/apps/api/src/agent-backend-env.ts
@@ -12,7 +12,12 @@ import { VertexGameSeeder, type GameSeeder } from './game-seed.js';
 import { createGitHubClient } from './github-client.js';
 import { createManagedProvider, type ManagedAgentEffort } from './managed-agent.js';
 import './managed-provider-anthropic.js';
-import { createManagedBackend, type ManagedDeliverySink, type ManagedRoundSignals } from './managed-backend.js';
+import {
+  createManagedBackend,
+  type ManagedDeliveryLock,
+  type ManagedDeliverySink,
+  type ManagedRoundSignals,
+} from './managed-backend.js';
 import type { KitDigestLoader } from './kit-digest.js';
 import { createArchiveSeedContextSource } from './seed-context.js';
 import { createSelfBuildBackend, type SelfBuildBackendOptions } from './self-build-backend.js';
@@ -43,6 +48,7 @@ export function resolveBuilderBackend(registry: AgentBackendRegistry, builder: B
 // What the managed backend needs that the environment cannot supply.
 export interface ManagedBackendDeps {
   deliver?: ManagedDeliverySink;
+  lock?: ManagedDeliveryLock;
   systemPrompt?: () => Promise<string | undefined>;
   kitDigest?: KitDigestLoader;
   // Channel-side round state; without it a finished round looks stalled.
@@ -119,6 +125,7 @@ export function createManagedPlatformBackendFromEnv(deps?: ManagedBackendDeps, l
     provider,
     ...(deps?.readSignals ? { readSignals: deps.readSignals } : {}),
     ...(deps?.deliver ? { deliver: deps.deliver } : {}),
+    ...(deps?.lock ? { lock: deps.lock } : {}),
     ...(mcpUrl ? { tools: { mcpEndpoints: [{ url: mcpUrl, name: 'gamedevpl' }] } } : {}),
     ...(deps?.systemPrompt ? { systemPrompt: deps.systemPrompt } : {}),
     ...(deps?.kitDigest ? { kitDigest: deps.kitDigest } : {}),

--- a/apps/api/src/agent-backend-env.ts
+++ b/apps/api/src/agent-backend-env.ts
@@ -174,10 +174,14 @@ export function createAgentBackendRegistryFromEnv(
   selfOptions?: SelfBuildBackendOptions,
   managedDeps?: ManagedBackendDeps,
 ): AgentBackendRegistry {
-  // A configured managed vendor takes the platform slot; routing above is unchanged.
-  const platform = createManagedPlatformBackendFromEnv(managedDeps, log) ?? createPlatformBackendFromEnv(log);
+  const selectedVendor = process.env.MANAGED_AGENT_VENDOR?.trim();
+  const managed = createManagedPlatformBackendFromEnv(managedDeps, log);
+  // Explicit vendor must not silently fall back to Copilot.
+  const platform = selectedVendor ? managed : (managed ?? createPlatformBackendFromEnv(log));
   const self = createSelfBuildBackend(selfOptions);
-  if (!platform) {
+  if (selectedVendor && !managed) {
+    log?.warn({ vendor: selectedVendor }, 'managed agent vendor is set but invalid; platform dispatch stays off');
+  } else if (!platform) {
     log?.info({ backend: 'self' }, 'self-build backend enabled (no platform dispatch credential)');
   }
   return { ...(platform ? { platform } : {}), self };

--- a/apps/api/src/agent-backend.ts
+++ b/apps/api/src/agent-backend.ts
@@ -18,7 +18,6 @@ import type { AgentObservation } from './job-state.js';
 export interface BuildBrief {
   /** Our job identity, for correlating an agent's reports back to the job. */
   issueNumber: number;
-  /** The round generation this dispatch belongs to, when the backend harvests output. */
   roundGeneration?: number;
   /** The game directory the agent may touch, and nothing else. */
   slug?: string;

--- a/apps/api/src/agent-backend.ts
+++ b/apps/api/src/agent-backend.ts
@@ -115,7 +115,7 @@ export interface AgentBackend {
   // Job identity is for pull-delivery backends; push backends ignore it.
   observe(
     ref: string,
-    options: { hasCandidate: boolean; issueNumber?: number; slug?: string },
+    options: { hasCandidate: boolean; issueNumber?: number; slug?: string; roundGeneration?: number },
   ): Promise<AgentObservation | null>;
   /**
    * Stops work, as far as the backend allows.

--- a/apps/api/src/agent-backend.ts
+++ b/apps/api/src/agent-backend.ts
@@ -18,6 +18,8 @@ import type { AgentObservation } from './job-state.js';
 export interface BuildBrief {
   /** Our job identity, for correlating an agent's reports back to the job. */
   issueNumber: number;
+  /** The round generation this dispatch belongs to, when the backend harvests output. */
+  roundGeneration?: number;
   /** The game directory the agent may touch, and nothing else. */
   slug?: string;
   createGame?: { title: string; concept: string; locale?: string };

--- a/apps/api/src/agent-channel.ts
+++ b/apps/api/src/agent-channel.ts
@@ -1117,6 +1117,9 @@ export async function registerAgentChannelRoutes(
         return reply.status(400).send({ error: parsed.error.issues[0]?.message ?? 'invalid request' });
       }
 
+      if (record.slug && record.slug !== parsed.data.slug) {
+        return reply.status(409).send({ error: `this build delivers to ${record.slug}, not ${parsed.data.slug}` });
+      }
       const slug = record.slug ?? parsed.data.slug;
       if (!slug) {
         return reply.status(400).send({

--- a/apps/api/src/agent-channel.ts
+++ b/apps/api/src/agent-channel.ts
@@ -60,7 +60,7 @@ import { largeSourceFileHint } from './module-size.js';
 import { gameManifestHint } from './game-manifest-hint.js';
 import { applyExactReplace, applySourcePatch, SourcePatchError } from './source-patch.js';
 import { overlayGameSources } from './staged-preview.js';
-import type { SourceDeliveryService } from './source-delivery.js';
+import { SourceDeliveryValidationError, type SourceDeliveryService } from './source-delivery.js';
 import { type BuilderHandoff, type CreatorMessage, type Store, type SubmissionRecord } from './store.js';
 import { BUILD_EVENT_KINDS, BUILD_STEPS, sanitizeCreatorText, type BuildEvent } from './submission-status.js';
 import { normalizeAtIntake, type IntakeText } from './localize-intake.js';
@@ -1664,6 +1664,9 @@ export async function registerAgentChannelRoutes(
           ...(await channelState(issueNumber, fresh)),
         });
       } catch (error) {
+        if (error instanceof SourceDeliveryValidationError) {
+          return reply.status(400).send({ error: error.message, reason: error.reason });
+        }
         // A rejected upload is the agent's to fix, so the reason goes back in full. This
         // is the one place a 400 body is worth writing carefully: the alternative is an
         // agent burning a session guessing which file was refused.

--- a/apps/api/src/agent-channel.ts
+++ b/apps/api/src/agent-channel.ts
@@ -26,7 +26,6 @@ import {
   type UploadKind,
   type UploadTokenClaims,
 } from './agent-upload-token.js';
-import { selfBuildDeliveryCap } from './builder.js';
 import { canonicalAppBaseUrl } from './canonical-app-url.js';
 import { deriveGateStatusString, readGateVerdict } from './gate-verdict.js';
 import { DEFAULT_SIGNED_URL_TTL_SECONDS, type GcsObjectStore } from './gcs-sign.js';
@@ -37,7 +36,7 @@ import {
   type DeliveryMode,
   type GamesStore,
 } from './games-store.js';
-import { parseGameMedia, parseSpecTitle } from './github-client.js';
+import { parseGameMedia } from './github-client.js';
 import { canTransition, resolveJobState, type JobState } from './job-state.js';
 import {
   KitFilesError,
@@ -61,6 +60,7 @@ import { largeSourceFileHint } from './module-size.js';
 import { gameManifestHint } from './game-manifest-hint.js';
 import { applyExactReplace, applySourcePatch, SourcePatchError } from './source-patch.js';
 import { overlayGameSources } from './staged-preview.js';
+import type { SourceDeliveryService } from './source-delivery.js';
 import { type BuilderHandoff, type CreatorMessage, type Store, type SubmissionRecord } from './store.js';
 import { BUILD_EVENT_KINDS, BUILD_STEPS, sanitizeCreatorText, type BuildEvent } from './submission-status.js';
 import { normalizeAtIntake, type IntakeText } from './localize-intake.js';
@@ -166,10 +166,6 @@ const MAX_PREVIEW_LABEL = 120;
  * copies of one number is how the first two came to disagree.
  */
 export const MAX_BUILD_PREVIEW_BYTES = 320 * 1024;
-// Deliveries are rare by nature — a build delivers once, a revision round once more — so
-// this bounds a looping agent rather than shaping normal use.
-const DEFAULT_MAX_SUBMITS_PER_WINDOW = 20;
-
 /**
  * A delivery: the game's own source files, and nothing else.
  *
@@ -383,6 +379,8 @@ export interface AgentChannelOptions {
   objectStore?: GcsObjectStore;
   /** Deliveries one build may make per hour. */
   maxSubmitsPerWindow?: number;
+  /** Shared source-delivery core used by HTTP/MCP and managed harvest. */
+  sourceDelivery?: SourceDeliveryService;
   /** Called when a candidate version lands, so the job can move on to the gate. */
   /**
    * Starts whatever verifies a delivery. May answer with what the run cost — the gate
@@ -479,12 +477,10 @@ export async function registerAgentChannelRoutes(
   // recompiles every thirty seconds for half an hour is working exactly as intended.
   const keepPreviews = options.keepPreviews ?? 4;
   const maxPreviewsPerWindow = options.maxPreviewsPerWindow ?? 90;
-  const maxSubmitsPerWindow = options.maxSubmitsPerWindow ?? DEFAULT_MAX_SUBMITS_PER_WINDOW;
   const eventsByBuild = new Map<number, number[]>();
   const inboxChecksByBuild = new Map<number, number[]>();
   const shotsByBuild = new Map<number, number[]>();
   const previewsByBuild = new Map<number, number[]>();
-  const submitsByBuild = new Map<number, number[]>();
   const kitFileStore = options.objectStore ? createKitFileStore(options.objectStore) : null;
   const exampleFileStore = options.objectStore ? createExampleFileStore(options.objectStore) : null;
 
@@ -1522,80 +1518,9 @@ export async function registerAgentChannelRoutes(
         return reply.status(400).send({ error: parsed.error.issues[0]?.message ?? 'invalid request' });
       }
 
-      if (stopReason(record)) {
-        return reply.send({ accepted: false, rejected: 'stopped', ...(await channelState(issueNumber, record)) });
-      }
-      if (isRateLimited(submitsByBuild, issueNumber, now(), maxSubmitsPerWindow)) {
-        return reply.send({ accepted: false, rejected: 'rate_limited', ...(await channelState(issueNumber, record)) });
-      }
-      // Self rounds bound gate spend per round. The budget resets when a new round
-      // opens, so exhausting it never bricks the game's next attempt.
-      if (record.builder === 'self') {
-        const cap = selfBuildDeliveryCap();
-        const used = record.roundDeliveryCount ?? 0;
-        if (used >= cap) {
-          return reply.send({
-            accepted: false,
-            rejected: 'delivery_cap',
-            reason: 'self_build_delivery_cap',
-            deliveryCap: cap,
-            deliveriesUsed: used,
-            ...(await channelState(issueNumber, record)),
-          });
-        }
-        // Self-build deliveries must name the kit they built against — without it the
-        // gate cannot apply the N/N−1 window and would burn a delivery slot guessing.
-        if (!parsed.data.kitEngineRef) {
-          return reply.status(400).send({
-            error:
-              'kitEngineRef is required for self-build deliveries — send the engineRef from ' +
-              'the Creator Kit you built against (kit.json / get_kit).',
-            reason: 'kit_engine_ref_required',
-          });
-        }
-      }
-
-      // One round, one engine: a mismatch means unvalidated sources.
-      const pinnedEngineRef = record.roundKitEngineRef;
-      if (pinnedEngineRef && parsed.data.kitEngineRef && parsed.data.kitEngineRef !== pinnedEngineRef) {
-        return reply.status(400).send({
-          error:
-            `This round is pinned to Creator Kit engine ${pinnedEngineRef}, not ${parsed.data.kitEngineRef}. ` +
-            'Call get_kit and submit with the engineRef it returns.',
-          reason: 'kit_engine_ref_mismatch',
-        });
-      }
-
-      // The job's own slug wins whenever it has one. A build that has already been
-      // associated with a game cannot deliver into a different one, whatever it sends.
-      //
-      // A job now carries its slug from the moment it is created — minted from the
-      // creator's confirmed title and named in the agent's brief — so this check bites
-      // on the *first* delivery rather than only on later ones. That is deliberate and
-      // it is not a tightening for its own sake: the creator has been given
-      // `/studio/<slug>` since they pressed create, and may already have shared a link
-      // to the game, so a delivery that renamed it would break an address that was
-      // handed out in good faith. The error names the slug the agent was briefed with,
-      // which is the one piece of information it needs to deliver again correctly.
       const slug = record.slug ?? parsed.data.slug;
-      if (record.slug && record.slug !== parsed.data.slug) {
-        return reply.status(409).send({ error: `this build delivers to ${record.slug}, not ${parsed.data.slug}` });
-      }
-      // Bind the job to this slug on the first delivery, and do it *before* storing
-      // anything. Without this the check above never fires for a job that arrived
-      // without a slug: every delivery would find `record.slug` unset and be free to
-      // name a different game. Writing it first rather than after the upload means a
-      // second delivery racing the first still finds the binding in place.
-      if (!record.slug && store) {
-        await store.setSubmissionSlug(issueNumber, slug);
-      }
 
       try {
-        // Fresh walk state — not `record.state`. Delivery often races the background
-        // dispatch that flips `queued`→`dispatched`; the local snapshot stays `queued`,
-        // and `canTransition('queued','submitted')` is false, so the protective
-        // transition was skipped and the job stayed `building` (CP-1 double-close).
-        const stateAfterSignal = await markBuildingFromChannel(issueNumber, record);
         // Explicit mode wins. Omitting mode defaults to publish — except
         // fromLatestDelivery, which reuses the previous candidate's lane so a
         // kit_outdated preview recovery does not suddenly demand TRACE/PLAYTEST.
@@ -1688,87 +1613,40 @@ export async function registerAgentChannelRoutes(
         }
         mode ??= 'publish';
 
-        const { version } = await options.gamesStore.putCandidateSources({
-          slug,
+        if (!options.sourceDelivery) {
+          return reply.status(503).send({ error: 'delivery is not configured on this deployment' });
+        }
+        const delivery = await options.sourceDelivery.deliver({
           issueNumber,
+          slug,
           files,
-          // Provenance: which backend built this version. Backend name on the dispatch
-          // ('copilot' / 'self') is the durable record; builder is the round selector.
-          backend: record.dispatch?.backend ?? record.builder,
           mode,
+          bindSlug: true,
           ...(parsed.data.kitEngineRef ? { kitEngineRef: parsed.data.kitEngineRef } : {}),
+          ...(record.dispatch?.backend || record.builder
+            ? { backend: record.dispatch?.backend ?? record.builder }
+            : {}),
         });
+        if (!delivery.accepted) {
+          return reply.send({
+            accepted: false,
+            rejected: delivery.rejected,
+            ...(delivery.rejected === 'delivery_cap'
+              ? {
+                  reason: 'self_build_delivery_cap',
+                  deliveryCap: delivery.deliveryCap,
+                  deliveriesUsed: delivery.deliveriesUsed,
+                }
+              : {}),
+            ...(await channelState(issueNumber, (await store!.getSubmission(issueNumber)) ?? record)),
+          });
+        }
+        const { version, buildId, gateStarted } = delivery;
         // Staging is spent once the candidate is written — clear so the next iterate
         // starts clean and a half-edited buffer cannot leak into a later round.
         if (parsed.data.fromStaged) {
           await options.gamesStore.clearStagedSources({ slug, issueNumber, roundGeneration }).catch(() => {});
         }
-        // Preview updates Studio's playable pointer without marking a sealed delivery —
-        // control.delivered / publication reconciliation still wait for mode=publish.
-        // Publish sets both (setSubmissionDeliveredVersion also refreshes previewVersion).
-        if (mode === 'preview') {
-          await store?.setSubmissionPreviewVersion(issueNumber, version);
-        } else {
-          await store?.setSubmissionDeliveredVersion(issueNumber, version);
-        }
-        if (store && record.builder === 'self') {
-          await store.incrementRoundDeliveryCount(issueNumber);
-        }
-        // The shelf, studio, and notifications all show `record.title`. Games that
-        // predated the naming step still carry the truncated prompt there, even after
-        // the agent wrote a real name into SPEC.md — and publish already prefers the
-        // SPEC title for the catalog, so the two surfaces disagreed. Adopting it here
-        // keeps them aligned for every delivery from now on.
-        if (store) {
-          const spec = files.find((file) => file.path === 'SPEC.md')?.content;
-          const deliveredTitle = spec ? parseSpecTitle(spec) : null;
-          if (deliveredTitle) {
-            const sanitized = sanitizeCreatorText(deliveredTitle, { singleLine: true }).slice(0, 80);
-            if (sanitized.length >= 3 && sanitized !== record.title) {
-              await store.setSubmissionTitle(issueNumber, sanitized);
-            }
-          }
-        }
-        // Publish only: without this the job stays `building`, and the agent's own
-        // session then reports `completed` with a candidate present — which the
-        // reconciler reads as "done, ready for review". Preview stays in building so a
-        // vibe-coding loop never looks like a sealed candidate.
-        if (store && mode === 'publish') {
-          if (canTransition(stateAfterSignal, 'submitted')) {
-            await store.recordJobTransition(issueNumber, {
-              to: 'submitted',
-              at: new Date().toISOString(),
-              by: 'agent',
-              reason: 'sources_delivered',
-            });
-          }
-        }
-        const gate = await options.onSourcesDelivered?.({
-          issueNumber,
-          slug,
-          version,
-          ...(mode === 'preview' ? { mode: 'preview' as const } : {}),
-        });
-        // Booked here rather than inside the trigger because this is where the job is
-        // known: the trigger takes a slug and a version and has no idea whose ledger to
-        // write to. Best-effort like every other write in this handler — the delivery has
-        // already been accepted, and refusing it now would make the agent upload again.
-        const buildId = gate && typeof gate === 'object' && typeof gate.buildId === 'string' ? gate.buildId : undefined;
-        const gateAccepted = Boolean(buildId || (gate && typeof gate === 'object' && gate.accepted === true));
-        if (store && buildId) {
-          await store
-            .recordJobCost(issueNumber, {
-              kind: 'gate_run',
-              at: new Date().toISOString(),
-              by: 'cloud-build',
-              ref: buildId,
-            })
-            .catch(() => {});
-        }
-        options.onEvent?.(issueNumber);
-
-        // Delivery is channel activity — refresh the quiet clock and revoke a prior MCP `end`.
-        await store?.touchLastAgentSignalAt(issueNumber);
 
         const fresh = store ? ((await store.getSubmission(issueNumber)) ?? record) : record;
         return reply.send({
@@ -1778,7 +1656,7 @@ export async function registerAgentChannelRoutes(
           // True when Cloud Build accepted the create (build id and/or accepted:true).
           // False only when the trigger was missing or failed — not when the id was
           // unparseable from an otherwise successful create.
-          gateStarted: gateAccepted,
+          gateStarted,
           ...(buildId ? { buildId } : {}),
           ...(await channelState(issueNumber, fresh)),
         });

--- a/apps/api/src/agent-channel.ts
+++ b/apps/api/src/agent-channel.ts
@@ -1117,9 +1117,6 @@ export async function registerAgentChannelRoutes(
         return reply.status(400).send({ error: parsed.error.issues[0]?.message ?? 'invalid request' });
       }
 
-      if (record.slug && record.slug !== parsed.data.slug) {
-        return reply.status(409).send({ error: `this build delivers to ${record.slug}, not ${parsed.data.slug}` });
-      }
       const slug = record.slug ?? parsed.data.slug;
       if (!slug) {
         return reply.status(400).send({
@@ -1521,6 +1518,9 @@ export async function registerAgentChannelRoutes(
         return reply.status(400).send({ error: parsed.error.issues[0]?.message ?? 'invalid request' });
       }
 
+      if (record.slug && record.slug !== parsed.data.slug) {
+        return reply.status(409).send({ error: `this build delivers to ${record.slug}, not ${parsed.data.slug}` });
+      }
       const slug = record.slug ?? parsed.data.slug;
 
       try {

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -9,7 +9,7 @@ import { z } from 'zod';
 import { assembleGameHtml, CredentialLeakError, EmptyProjectError, ProjectTooLargeError } from './assemble.js';
 import { registerAccessTokenRoutes } from './access-token-routes.js';
 import { registerJobAdminRoutes } from './job-admin-routes.js';
-import { createGameSeederFromEnv } from './agent-backend-env.js';
+import { createGameSeederFromEnv, createPlatformBackendFromEnv } from './agent-backend-env.js';
 import { createManagedDeliveryLock } from './managed-backend.js';
 import { createGcsGamesStore } from './games-store.js';
 import { createGcsObjectStore } from './gcs-sign.js';

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -9,7 +9,7 @@ import { z } from 'zod';
 import { assembleGameHtml, CredentialLeakError, EmptyProjectError, ProjectTooLargeError } from './assemble.js';
 import { registerAccessTokenRoutes } from './access-token-routes.js';
 import { registerJobAdminRoutes } from './job-admin-routes.js';
-import { createGameSeederFromEnv, createPlatformBackendFromEnv } from './agent-backend-env.js';
+import { createGameSeederFromEnv } from './agent-backend-env.js';
 import { createGcsGamesStore } from './games-store.js';
 import { createGcsObjectStore } from './gcs-sign.js';
 import { createCloudBuildGateTrigger, gateTriggerOptionsFromEnv } from './gate-trigger.js';
@@ -390,7 +390,27 @@ export async function buildApp(options: BuildAppOptions = {}): Promise<FastifyIn
     agentBackend: options.submissionRoutes?.agentBackend,
     // Platform only here — `self` is wired inside registerSubmissionRoutes with store
     // callbacks for seed persistence. Passing a pre-built self would skip those.
+<<<<<<< HEAD
     agentBackends: resolvedAgentBackends,
+=======
+    agentBackends: options.submissionRoutes?.agentBackends,
+    managedBackendDeps:
+      options.submissionRoutes?.managedBackendDeps ??
+      (options.submissionRoutes?.agentBackend
+        ? undefined
+        : {
+            readSignals: async (issueNumber) => {
+              const record = await store.getSubmission(issueNumber);
+              return record
+                ? {
+                    deliveredVersion: record.deliveredVersion,
+                    previewVersion: record.previewVersion,
+                    agentEndedAt: record.agentEndedAt,
+                  }
+                : null;
+            },
+          }),
+>>>>>>> 649aa3cd (feat(api): select the managed backend from production configuration)
     gameSeeder: options.submissionRoutes?.gameSeeder ?? createGameSeederFromEnv(app.log),
     agentChannel: {
       ...options.submissionRoutes?.agentChannel,

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -10,6 +10,7 @@ import { assembleGameHtml, CredentialLeakError, EmptyProjectError, ProjectTooLar
 import { registerAccessTokenRoutes } from './access-token-routes.js';
 import { registerJobAdminRoutes } from './job-admin-routes.js';
 import { createGameSeederFromEnv } from './agent-backend-env.js';
+import { createManagedDeliveryLock } from './managed-backend.js';
 import { createGcsGamesStore } from './games-store.js';
 import { createGcsObjectStore } from './gcs-sign.js';
 import { createCloudBuildGateTrigger, gateTriggerOptionsFromEnv } from './gate-trigger.js';
@@ -390,15 +391,14 @@ export async function buildApp(options: BuildAppOptions = {}): Promise<FastifyIn
     agentBackend: options.submissionRoutes?.agentBackend,
     // Platform only here — `self` is wired inside registerSubmissionRoutes with store
     // callbacks for seed persistence. Passing a pre-built self would skip those.
-<<<<<<< HEAD
     agentBackends: resolvedAgentBackends,
-=======
-    agentBackends: options.submissionRoutes?.agentBackends,
     managedBackendDeps:
       options.submissionRoutes?.managedBackendDeps ??
       (options.submissionRoutes?.agentBackend
         ? undefined
         : {
+            // Multi-instance at-most-once harvest; see ManagedDeliveryLock.
+            lock: createManagedDeliveryLock(store),
             readSignals: async (issueNumber) => {
               const record = await store.getSubmission(issueNumber);
               return record
@@ -410,7 +410,6 @@ export async function buildApp(options: BuildAppOptions = {}): Promise<FastifyIn
                 : null;
             },
           }),
->>>>>>> 649aa3cd (feat(api): select the managed backend from production configuration)
     gameSeeder: options.submissionRoutes?.gameSeeder ?? createGameSeederFromEnv(app.log),
     agentChannel: {
       ...options.submissionRoutes?.agentChannel,

--- a/apps/api/src/managed-backend.test.ts
+++ b/apps/api/src/managed-backend.test.ts
@@ -145,6 +145,8 @@ describe('managed backend', () => {
         issueNumber: ISSUE,
         slug: SLUG,
         sessionRef: 'session-1',
+        backend: 'managed:fake',
+        roundGeneration: 1,
         mode: 'preview',
         files: [{ path: 'game.ts', content: 'export {};' }],
       },

--- a/apps/api/src/managed-backend.test.ts
+++ b/apps/api/src/managed-backend.test.ts
@@ -153,6 +153,29 @@ describe('managed backend', () => {
     ]);
   });
 
+  it('uses the durable round generation from observe, not process memory', async () => {
+    const { provider, setState, setOutputs } = fakeProvider();
+    const delivered: ManagedDeliveryInput[] = [];
+    const backend = createManagedBackend({
+      provider,
+      deliver: async (input) => {
+        delivered.push(input);
+        return { version: 'v1' };
+      },
+    });
+    setOutputs([{ path: `games/${SLUG}/game.ts`, content: 'export {};' }]);
+    setState('completed');
+
+    await backend.observe('session-1', {
+      hasCandidate: false,
+      issueNumber: ISSUE,
+      slug: SLUG,
+      roundGeneration: 3,
+    });
+
+    expect(delivered[0]?.roundGeneration).toBe(3);
+  });
+
   it('harvests at most once, however often the reconciler polls', async () => {
     const { provider, setState, setOutputs } = fakeProvider();
     const deliver = vi.fn(async () => ({ version: 'v1' }));

--- a/apps/api/src/managed-backend.ts
+++ b/apps/api/src/managed-backend.ts
@@ -51,7 +51,7 @@ export interface ManagedDeliveryLock {
   release(claim: ManagedDeliveryClaim): Promise<void>;
 }
 
-/** Store-backed lock for multi-instance managed harvest. */
+// Store-backed lock for multi-instance harvest.
 export function createManagedDeliveryLock(
   store: {
     claimManagedDelivery(

--- a/apps/api/src/managed-backend.ts
+++ b/apps/api/src/managed-backend.ts
@@ -51,6 +51,23 @@ export interface ManagedDeliveryLock {
   release(claim: ManagedDeliveryClaim): Promise<void>;
 }
 
+/** Store-backed lock for multi-instance managed harvest. */
+export function createManagedDeliveryLock(
+  store: {
+    claimManagedDelivery(
+      claim: { issueNumber: number; sessionRef: string; slug: string },
+      at: string,
+    ): Promise<boolean>;
+    releaseManagedDelivery(claim: { issueNumber: number; sessionRef: string }): Promise<void>;
+  },
+  now: () => string = () => new Date().toISOString(),
+): ManagedDeliveryLock {
+  return {
+    acquire: (claim) => store.claimManagedDelivery(claim, now()),
+    release: (claim) => store.releaseManagedDelivery(claim),
+  };
+}
+
 // Round state from the build channel, which the vendor session cannot see.
 export interface ManagedRoundSignals {
   // A sealed publish delivery.
@@ -144,7 +161,12 @@ export function createManagedBackend(options: ManagedBackendOptions): AgentBacke
     return files;
   }
 
-  async function harvest(sessionRef: string, issueNumber: number, slug: string): Promise<HarvestOutcome> {
+  async function harvest(
+    sessionRef: string,
+    issueNumber: number,
+    slug: string,
+    roundGeneration?: number,
+  ): Promise<HarvestOutcome> {
     if (!deliver || harvested.has(sessionRef)) return 'empty';
     const claim = { issueNumber, slug, sessionRef };
     const listed = await options.provider.listOutputs(sessionRef);
@@ -178,13 +200,15 @@ export function createManagedBackend(options: ManagedBackendOptions): AgentBacke
     }
     try {
       const files = await download(sessionRef, plan);
+      // Prefer the durable job generation over process memory.
+      const generation = roundGeneration ?? sessionGenerations.get(sessionRef) ?? 1;
       await deliver({
         issueNumber,
         slug,
         files,
         sessionRef,
         backend: backendName,
-        roundGeneration: sessionGenerations.get(sessionRef) ?? 1,
+        roundGeneration: generation,
         mode: deliveryMode,
       });
       harvested.add(sessionRef);
@@ -247,7 +271,12 @@ export function createManagedBackend(options: ManagedBackendOptions): AgentBacke
         Boolean(observeOptions.slug);
       if (canHarvest) {
         try {
-          outcome = await harvest(ref, observeOptions.issueNumber!, observeOptions.slug!);
+          outcome = await harvest(
+            ref,
+            observeOptions.issueNumber!,
+            observeOptions.slug!,
+            observeOptions.roundGeneration,
+          );
           hasCandidate = outcome === 'delivered';
         } catch (error) {
           // A failed pull retries on the next poll.

--- a/apps/api/src/managed-backend.ts
+++ b/apps/api/src/managed-backend.ts
@@ -25,6 +25,9 @@ export interface ManagedDeliveryInput {
   files: ManagedOutputFile[];
   // The vendor session the files were harvested from.
   sessionRef: string;
+  // Authority captured at dispatch and checked again immediately before storage.
+  backend: string;
+  roundGeneration: number;
   mode: 'preview' | 'publish';
 }
 
@@ -92,10 +95,12 @@ export function createManagedBackend(options: ManagedBackendOptions): AgentBacke
   }
   const outputPath = options.outputPath ?? DEFAULT_MANAGED_OUTPUT_PATH;
   const deliveryMode = options.deliveryMode ?? 'preview';
+  const backendName = `managed:${options.provider.vendor}`;
   // At-most-once per session; a re-poll cannot duplicate.
   const harvested = new Set<string>();
   const startedAt = new Map<string, number>();
   const idleNudged = new Set<string>();
+  const sessionGenerations = new Map<string, number>();
 
   async function start(brief: BuildBrief): Promise<DispatchResult> {
     const systemPrompt = appendKitDigest(
@@ -122,6 +127,7 @@ export function createManagedBackend(options: ManagedBackendOptions): AgentBacke
       ...(options.tools ? { tools: options.tools } : {}),
     });
     startedAt.set(session.id, Date.now());
+    sessionGenerations.set(session.id, brief.roundGeneration ?? 1);
     return { ref: session.id };
   }
 
@@ -172,7 +178,15 @@ export function createManagedBackend(options: ManagedBackendOptions): AgentBacke
     }
     try {
       const files = await download(sessionRef, plan);
-      await deliver({ issueNumber, slug, files, sessionRef, mode: deliveryMode });
+      await deliver({
+        issueNumber,
+        slug,
+        files,
+        sessionRef,
+        backend: backendName,
+        roundGeneration: sessionGenerations.get(sessionRef) ?? 1,
+        mode: deliveryMode,
+      });
       harvested.add(sessionRef);
       options.log?.info?.(
         { ...claim, files: files.length, vendor: options.provider.vendor },
@@ -191,7 +205,7 @@ export function createManagedBackend(options: ManagedBackendOptions): AgentBacke
   }
 
   return {
-    name: `managed:${options.provider.vendor}`,
+    name: backendName,
 
     async dispatch(brief: BuildBrief): Promise<DispatchResult> {
       return start(brief);
@@ -293,6 +307,7 @@ export function createManagedBackend(options: ManagedBackendOptions): AgentBacke
       startedAt.delete(previous.ref);
       idleNudged.delete(previous.ref);
       harvested.delete(previous.ref);
+      sessionGenerations.delete(previous.ref);
       await options.provider.deleteSession?.(previous.ref);
     },
   };

--- a/apps/api/src/source-delivery.test.ts
+++ b/apps/api/src/source-delivery.test.ts
@@ -93,12 +93,13 @@ describe('shared source delivery', () => {
       expect.objectContaining({ issueNumber: ISSUE, slug: SLUG, backend: BACKEND, mode: 'preview' }),
     );
     expect(gate).toHaveBeenCalledWith({ issueNumber: ISSUE, slug: SLUG, version: 'v-managed-1', mode: 'preview' });
-    expect((await store.getSubmission(ISSUE)) ?? {}).toMatchObject({
+    const record = await store.getSubmission(ISSUE);
+    expect(record).toMatchObject({
       slug: SLUG,
       previewVersion: 'v-managed-1',
-      deliveredVersion: undefined,
       title: 'Managed Comet',
     });
+    expect(record?.deliveredVersion).toBeUndefined();
   });
 
   it('uses the same service for publish side effects and transition', async () => {

--- a/apps/api/src/source-delivery.test.ts
+++ b/apps/api/src/source-delivery.test.ts
@@ -1,0 +1,182 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { GamesStore, SourceFile, VersionManifest } from './games-store.js';
+import { InMemoryStore } from './store.js';
+import {
+  createSourceDeliveryService,
+  SourceDeliveryAuthorityError,
+  type SourceDeliveryAuthority,
+} from './source-delivery.js';
+
+const ISSUE = 701;
+const SLUG = 'managed-comet';
+const BACKEND = 'managed:fake';
+const SESSION = 'session-701';
+
+const PREVIEW_FILES: SourceFile[] = [
+  { path: 'SPEC.md', content: '---\ntitle: Managed Comet\n---\n' },
+  { path: 'index.html', content: '<!doctype html>' },
+  { path: 'game.ts', content: 'export {};' },
+];
+
+const PUBLISH_FILES: SourceFile[] = [
+  ...PREVIEW_FILES,
+  { path: 'TRACE.json', content: '{"samples":[]}' },
+  { path: 'PLAYTEST.json', content: '{"expectProgress":["round-start"]}' },
+];
+
+function manifest(files: SourceFile[], version: string): VersionManifest {
+  return {
+    slug: SLUG,
+    version,
+    createdAt: '2026-08-09T18:00:00.000Z',
+    issueNumber: ISSUE,
+    sourceFiles: files.map((file) => file.path),
+  };
+}
+
+async function setup() {
+  const store = new InMemoryStore();
+  await store.createSubmission(ISSUE, 'owner', 'Original title');
+  await store.setSubmissionSlug(ISSUE, SLUG);
+  await store.recordDispatch(ISSUE, { backend: BACKEND, ref: SESSION });
+  await store.recordJobTransition(ISSUE, {
+    to: 'building',
+    at: '2026-08-09T18:00:00.000Z',
+    by: 'system',
+    reason: 'managed_test',
+  });
+
+  let versionNumber = 0;
+  const putCandidateSources = vi.fn(async (input: { files: SourceFile[] }) => {
+    versionNumber += 1;
+    const version = `v-managed-${versionNumber}`;
+    return { version, manifest: manifest(input.files, version) };
+  });
+  const gamesStore = { putCandidateSources } as unknown as GamesStore;
+  const gate = vi.fn(async () => ({ buildId: 'build-managed-1' }));
+  const service = createSourceDeliveryService({
+    store,
+    gamesStore,
+    onSourcesDelivered: gate,
+    onEvent: vi.fn(),
+  });
+  const authority: SourceDeliveryAuthority = {
+    backend: BACKEND,
+    sessionRef: SESSION,
+    roundGeneration: 1,
+  };
+  return { store, putCandidateSources, gate, service, authority };
+}
+
+describe('shared source delivery', () => {
+  it('accepts managed output and applies the common preview side effects', async () => {
+    const { store, putCandidateSources, gate, service, authority } = await setup();
+
+    const result = await service.deliver({
+      issueNumber: ISSUE,
+      slug: SLUG,
+      files: PREVIEW_FILES,
+      mode: 'preview',
+      backend: BACKEND,
+      authority,
+    });
+
+    expect(result).toMatchObject({
+      accepted: true,
+      slug: SLUG,
+      version: 'v-managed-1',
+      mode: 'preview',
+      gateStarted: true,
+      buildId: 'build-managed-1',
+    });
+    expect(putCandidateSources).toHaveBeenCalledWith(
+      expect.objectContaining({ issueNumber: ISSUE, slug: SLUG, backend: BACKEND, mode: 'preview' }),
+    );
+    expect(gate).toHaveBeenCalledWith({ issueNumber: ISSUE, slug: SLUG, version: 'v-managed-1', mode: 'preview' });
+    expect((await store.getSubmission(ISSUE)) ?? {}).toMatchObject({
+      slug: SLUG,
+      previewVersion: 'v-managed-1',
+      deliveredVersion: undefined,
+      title: 'Managed Comet',
+    });
+  });
+
+  it('uses the same service for publish side effects and transition', async () => {
+    const { store, service, authority } = await setup();
+
+    const result = await service.deliver({
+      issueNumber: ISSUE,
+      slug: SLUG,
+      files: PUBLISH_FILES,
+      mode: 'publish',
+      backend: BACKEND,
+      authority,
+    });
+
+    expect(result).toMatchObject({ accepted: true, mode: 'publish' });
+    expect((await store.getSubmission(ISSUE)) ?? {}).toMatchObject({
+      deliveredVersion: 'v-managed-1',
+      previewVersion: 'v-managed-1',
+      state: 'submitted',
+    });
+  });
+
+  it.each([
+    ['backend', { backend: 'managed:other' }],
+    ['session', { sessionRef: 'session-old' }],
+    ['generation', { roundGeneration: 2 }],
+  ])('rejects managed output with a wrong %s authority before storing', async (_label, change) => {
+    const { putCandidateSources, service, authority } = await setup();
+
+    await expect(
+      service.deliver({
+        issueNumber: ISSUE,
+        slug: SLUG,
+        files: PREVIEW_FILES,
+        mode: 'preview',
+        backend: BACKEND,
+        authority: { ...authority, ...change },
+      }),
+    ).rejects.toBeInstanceOf(SourceDeliveryAuthorityError);
+    expect(putCandidateSources).not.toHaveBeenCalled();
+  });
+
+  it('re-reads the record and rejects a stale session after the round generation advances', async () => {
+    const { putCandidateSources, service, authority, store } = await setup();
+    await store.bumpRoundGeneration(ISSUE);
+
+    await expect(
+      service.deliver({
+        issueNumber: ISSUE,
+        slug: SLUG,
+        files: PREVIEW_FILES,
+        mode: 'preview',
+        backend: BACKEND,
+        authority,
+      }),
+    ).rejects.toMatchObject({ reason: 'round_generation_mismatch' });
+    expect(putCandidateSources).not.toHaveBeenCalled();
+  });
+
+  it('rejects a cancelled round even when the caller presents its new generation', async () => {
+    const { putCandidateSources, service, authority, store } = await setup();
+    await store.recordJobTransition(ISSUE, {
+      to: 'canceled',
+      at: '2026-08-09T18:01:00.000Z',
+      by: 'operator',
+      reason: 'managed_test_cancel',
+    });
+
+    await expect(
+      service.deliver({
+        issueNumber: ISSUE,
+        slug: SLUG,
+        files: PREVIEW_FILES,
+        mode: 'preview',
+        backend: BACKEND,
+        authority: { ...authority, roundGeneration: 2 },
+      }),
+    ).rejects.toMatchObject({ reason: 'round_closed' });
+    expect(putCandidateSources).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/source-delivery.ts
+++ b/apps/api/src/source-delivery.ts
@@ -1,5 +1,5 @@
 import { selfBuildDeliveryCap } from './builder.js';
-import { InvalidUploadError, type DeliveryMode, type GamesStore, type SourceFile } from './games-store.js';
+import { InvalidUploadError, type GamesStore, type SourceFile } from './games-store.js';
 import { parseSpecTitle } from './github-client.js';
 import { canTransition, resolveJobState, TERMINAL_JOB_STATES, type JobState } from './job-state.js';
 import { sanitizeCreatorText } from './submission-status.js';
@@ -135,7 +135,8 @@ function managedAuthorityError(
       'managed delivery arrived after builder handoff was requested',
     );
   }
-  if (TERMINAL_JOB_STATES.has(resolveJobState(record))) {
+  const resolvedState = resolveJobState(record);
+  if (resolvedState && TERMINAL_JOB_STATES.has(resolvedState)) {
     return new SourceDeliveryAuthorityError('round_closed', 'managed delivery arrived after the build round closed');
   }
   return null;

--- a/apps/api/src/source-delivery.ts
+++ b/apps/api/src/source-delivery.ts
@@ -1,0 +1,310 @@
+import { selfBuildDeliveryCap } from './builder.js';
+import { InvalidUploadError, type DeliveryMode, type GamesStore, type SourceFile } from './games-store.js';
+import { parseSpecTitle } from './github-client.js';
+import { canTransition, resolveJobState, TERMINAL_JOB_STATES, type JobState } from './job-state.js';
+import { sanitizeCreatorText } from './submission-status.js';
+import type { Store, SubmissionRecord } from './store.js';
+
+export interface SourceDeliveryAuthority {
+  /** The backend identity recorded at dispatch time. */
+  backend: string;
+  /** The vendor session that produced these files. */
+  sessionRef: string;
+  /** The round generation captured when that session was started. */
+  roundGeneration: number;
+}
+
+export interface SourceDeliveryInput {
+  issueNumber: number;
+  slug: string;
+  files: SourceFile[];
+  mode: 'preview' | 'publish';
+  backend?: string;
+  kitEngineRef?: string;
+  /**
+   * Channel deliveries may bind a legacy job's missing slug before writing. Managed
+   * harvests never may: their authority must match a slug already on the job.
+   */
+  bindSlug?: boolean;
+  authority?: SourceDeliveryAuthority;
+}
+
+export interface SourceDeliveryAccepted {
+  accepted: true;
+  slug: string;
+  version: string;
+  mode: 'preview' | 'publish';
+  gateStarted: boolean;
+  buildId?: string;
+}
+
+export type SourceDeliveryRejected = {
+  accepted: false;
+  rejected: 'stopped' | 'rate_limited' | 'delivery_cap';
+  deliveryCap?: number;
+  deliveriesUsed?: number;
+};
+
+export type SourceDeliveryOutcome = SourceDeliveryAccepted | SourceDeliveryRejected;
+
+export class SourceDeliveryAuthorityError extends Error {
+  readonly reason:
+    | 'job_not_found'
+    | 'slug_mismatch'
+    | 'backend_mismatch'
+    | 'session_mismatch'
+    | 'round_generation_mismatch'
+    | 'round_closed'
+    | 'round_handed_off';
+
+  constructor(reason: SourceDeliveryAuthorityError['reason'], message: string) {
+    super(message);
+    this.name = 'SourceDeliveryAuthorityError';
+    this.reason = reason;
+  }
+}
+
+export interface SourceDeliveryService {
+  deliver(input: SourceDeliveryInput): Promise<SourceDeliveryOutcome>;
+}
+
+export interface SourceDeliveryServiceOptions {
+  store: Store;
+  gamesStore: GamesStore;
+  now?: () => number;
+  maxSubmitsPerWindow?: number;
+  onSourcesDelivered?: (input: {
+    issueNumber: number;
+    slug: string;
+    version: string;
+    mode?: 'health' | 'preview' | 'proposal';
+  }) => Promise<{ buildId?: string; accepted?: boolean } | void> | void;
+  onEvent?: (issueNumber: number) => void;
+  log?: {
+    error: (context: object, message: string) => void;
+  };
+}
+
+const DEFAULT_MAX_SUBMITS_PER_WINDOW = 20;
+const RATE_LIMIT_WINDOW_MS = 60 * 60 * 1000;
+
+function stopReason(record: SubmissionRecord): 'stopped' | null {
+  if (record.abandonedAt || record.publishedAt || resolveJobState(record) === 'canceled') return 'stopped';
+  if (record.builderHandoff && record.builderHandoff.awaitsAgentAck !== false) return 'stopped';
+  return null;
+}
+
+function currentState(record: SubmissionRecord): JobState {
+  return (record.state ?? 'queued') as JobState;
+}
+
+function managedAuthorityError(
+  record: SubmissionRecord,
+  input: SourceDeliveryInput,
+  authority: SourceDeliveryAuthority,
+): SourceDeliveryAuthorityError | null {
+  if (!record.slug || record.slug !== input.slug) {
+    return new SourceDeliveryAuthorityError(
+      'slug_mismatch',
+      `managed delivery is for ${record.slug ?? 'the job slug'}, not ${input.slug}`,
+    );
+  }
+  if (record.dispatch?.backend !== authority.backend) {
+    return new SourceDeliveryAuthorityError(
+      'backend_mismatch',
+      `managed delivery backend ${authority.backend} is not current for this job`,
+    );
+  }
+  const currentSessionRef = record.dispatch.refs[record.dispatch.refs.length - 1];
+  if (currentSessionRef !== authority.sessionRef) {
+    return new SourceDeliveryAuthorityError(
+      'session_mismatch',
+      'managed delivery came from a superseded agent session',
+    );
+  }
+  const currentGeneration = record.roundGeneration ?? 1;
+  if (currentGeneration !== authority.roundGeneration) {
+    return new SourceDeliveryAuthorityError(
+      'round_generation_mismatch',
+      `managed delivery is for round ${authority.roundGeneration}, but round ${currentGeneration} is current`,
+    );
+  }
+  if (record.builderHandoff && record.builderHandoff.awaitsAgentAck !== false) {
+    return new SourceDeliveryAuthorityError(
+      'round_handed_off',
+      'managed delivery arrived after builder handoff was requested',
+    );
+  }
+  if (TERMINAL_JOB_STATES.has(resolveJobState(record))) {
+    return new SourceDeliveryAuthorityError('round_closed', 'managed delivery arrived after the build round closed');
+  }
+  return null;
+}
+
+export function createSourceDeliveryService(options: SourceDeliveryServiceOptions): SourceDeliveryService {
+  const now = options.now ?? Date.now;
+  const maxSubmitsPerWindow = options.maxSubmitsPerWindow ?? DEFAULT_MAX_SUBMITS_PER_WINDOW;
+  const submitsByBuild = new Map<number, number[]>();
+
+  function isRateLimited(issueNumber: number): boolean {
+    const currentTime = now();
+    const hits = (submitsByBuild.get(issueNumber) ?? []).filter(
+      (timestamp) => currentTime - timestamp < RATE_LIMIT_WINDOW_MS,
+    );
+    if (hits.length >= maxSubmitsPerWindow) {
+      submitsByBuild.set(issueNumber, hits);
+      return true;
+    }
+    hits.push(currentTime);
+    submitsByBuild.set(issueNumber, hits);
+    return false;
+  }
+
+  async function markBuilding(issueNumber: number, record: SubmissionRecord): Promise<JobState> {
+    const state = currentState(record);
+    if (!canTransition(state, 'building')) return state;
+    await options.store.recordJobTransition(issueNumber, {
+      to: 'building',
+      at: new Date(now()).toISOString(),
+      by: 'agent',
+      reason: 'channel_signal',
+    });
+    return 'building';
+  }
+
+  return {
+    async deliver(input): Promise<SourceDeliveryOutcome> {
+      let record = await options.store.getSubmission(input.issueNumber);
+      if (!record) {
+        if (input.authority) {
+          throw new SourceDeliveryAuthorityError('job_not_found', 'managed delivery job no longer exists');
+        }
+        throw new InvalidUploadError('unknown build');
+      }
+
+      if (input.authority) {
+        const authorityError = managedAuthorityError(record, input, input.authority);
+        if (authorityError) throw authorityError;
+      }
+
+      if (stopReason(record)) return { accepted: false, rejected: 'stopped' };
+      if (isRateLimited(input.issueNumber)) return { accepted: false, rejected: 'rate_limited' };
+
+      if (record.builder === 'self') {
+        const cap = selfBuildDeliveryCap();
+        const used = record.roundDeliveryCount ?? 0;
+        if (used >= cap) {
+          return {
+            accepted: false,
+            rejected: 'delivery_cap',
+            deliveryCap: cap,
+            deliveriesUsed: used,
+          };
+        }
+        if (!input.kitEngineRef) {
+          throw new InvalidUploadError(
+            'kitEngineRef is required for self-build deliveries — send the engineRef from the Creator Kit you built against (kit.json / get_kit).',
+          );
+        }
+      }
+
+      const pinnedEngineRef = record.roundKitEngineRef;
+      if (pinnedEngineRef && input.kitEngineRef && input.kitEngineRef !== pinnedEngineRef) {
+        throw new InvalidUploadError(
+          `This round is pinned to Creator Kit engine ${pinnedEngineRef}, not ${input.kitEngineRef}. ` +
+            'Call get_kit and submit with the engineRef it returns.',
+        );
+      }
+
+      if (record.slug && record.slug !== input.slug) {
+        if (input.authority) {
+          throw new SourceDeliveryAuthorityError(
+            'slug_mismatch',
+            `managed delivery is for ${record.slug}, not ${input.slug}`,
+          );
+        }
+        throw new InvalidUploadError(`this build delivers to ${record.slug}, not ${input.slug}`);
+      }
+      if (!record.slug) {
+        if (!input.bindSlug || input.authority) {
+          throw new SourceDeliveryAuthorityError(
+            'slug_mismatch',
+            'managed delivery requires the job to have a bound slug',
+          );
+        }
+        await options.store.setSubmissionSlug(input.issueNumber, input.slug);
+        record = (await options.store.getSubmission(input.issueNumber)) ?? record;
+      }
+
+      const stateAfterSignal = await markBuilding(input.issueNumber, record);
+      const { version } = await options.gamesStore.putCandidateSources({
+        slug: input.slug,
+        issueNumber: input.issueNumber,
+        files: input.files,
+        backend: input.backend ?? record.dispatch?.backend ?? record.builder,
+        mode: input.mode,
+        ...(input.kitEngineRef ? { kitEngineRef: input.kitEngineRef } : {}),
+      });
+
+      if (input.mode === 'preview') {
+        await options.store.setSubmissionPreviewVersion(input.issueNumber, version);
+      } else {
+        await options.store.setSubmissionDeliveredVersion(input.issueNumber, version);
+      }
+      if (record.builder === 'self') {
+        await options.store.incrementRoundDeliveryCount(input.issueNumber);
+      }
+
+      const spec = input.files.find((file) => file.path === 'SPEC.md')?.content;
+      const deliveredTitle = spec ? parseSpecTitle(spec) : null;
+      if (deliveredTitle) {
+        const sanitized = sanitizeCreatorText(deliveredTitle, { singleLine: true }).slice(0, 80);
+        if (sanitized.length >= 3 && sanitized !== record.title) {
+          await options.store.setSubmissionTitle(input.issueNumber, sanitized);
+        }
+      }
+
+      if (input.mode === 'publish' && canTransition(stateAfterSignal, 'submitted')) {
+        await options.store.recordJobTransition(input.issueNumber, {
+          to: 'submitted',
+          at: new Date(now()).toISOString(),
+          by: 'agent',
+          reason: 'sources_delivered',
+        });
+      }
+
+      const gate = await options.onSourcesDelivered?.({
+        issueNumber: input.issueNumber,
+        slug: input.slug,
+        version,
+        ...(input.mode === 'preview' ? { mode: 'preview' as const } : {}),
+      });
+      const buildId = gate && typeof gate === 'object' && typeof gate.buildId === 'string' ? gate.buildId : undefined;
+      const gateStarted = Boolean(buildId || (gate && typeof gate === 'object' && gate.accepted === true));
+      if (buildId) {
+        await options.store
+          .recordJobCost(input.issueNumber, {
+            kind: 'gate_run',
+            at: new Date(now()).toISOString(),
+            by: 'cloud-build',
+            ref: buildId,
+          })
+          .catch((error) => {
+            options.log?.error({ err: error, issueNumber: input.issueNumber }, 'could not record gate cost');
+          });
+      }
+
+      options.onEvent?.(input.issueNumber);
+      await options.store.touchLastAgentSignalAt(input.issueNumber);
+
+      return {
+        accepted: true,
+        slug: input.slug,
+        version,
+        mode: input.mode,
+        gateStarted,
+        ...(buildId ? { buildId } : {}),
+      };
+    },
+  };
+}

--- a/apps/api/src/source-delivery.ts
+++ b/apps/api/src/source-delivery.ts
@@ -61,6 +61,16 @@ export class SourceDeliveryAuthorityError extends Error {
   }
 }
 
+export class SourceDeliveryValidationError extends InvalidUploadError {
+  readonly reason: 'kit_engine_ref_required' | 'kit_engine_ref_mismatch';
+
+  constructor(reason: SourceDeliveryValidationError['reason'], message: string) {
+    super(message);
+    this.name = 'SourceDeliveryValidationError';
+    this.reason = reason;
+  }
+}
+
 export interface SourceDeliveryService {
   deliver(input: SourceDeliveryInput): Promise<SourceDeliveryOutcome>;
 }
@@ -200,7 +210,8 @@ export function createSourceDeliveryService(options: SourceDeliveryServiceOption
           };
         }
         if (!input.kitEngineRef) {
-          throw new InvalidUploadError(
+          throw new SourceDeliveryValidationError(
+            'kit_engine_ref_required',
             'kitEngineRef is required for self-build deliveries — send the engineRef from the Creator Kit you built against (kit.json / get_kit).',
           );
         }
@@ -208,7 +219,8 @@ export function createSourceDeliveryService(options: SourceDeliveryServiceOption
 
       const pinnedEngineRef = record.roundKitEngineRef;
       if (pinnedEngineRef && input.kitEngineRef && input.kitEngineRef !== pinnedEngineRef) {
-        throw new InvalidUploadError(
+        throw new SourceDeliveryValidationError(
+          'kit_engine_ref_mismatch',
           `This round is pinned to Creator Kit engine ${pinnedEngineRef}, not ${input.kitEngineRef}. ` +
             'Call get_kit and submit with the engineRef it returns.',
         );

--- a/apps/api/src/source-delivery.ts
+++ b/apps/api/src/source-delivery.ts
@@ -6,11 +6,11 @@ import { sanitizeCreatorText } from './submission-status.js';
 import type { Store, SubmissionRecord } from './store.js';
 
 export interface SourceDeliveryAuthority {
-  /** The backend identity recorded at dispatch time. */
+  // Backend identity recorded at dispatch time.
   backend: string;
-  /** The vendor session that produced these files. */
+  // Vendor session that produced these files.
   sessionRef: string;
-  /** The round generation captured when that session was started. */
+  // Round generation captured when that session started.
   roundGeneration: number;
 }
 
@@ -21,10 +21,7 @@ export interface SourceDeliveryInput {
   mode: 'preview' | 'publish';
   backend?: string;
   kitEngineRef?: string;
-  /**
-   * Channel deliveries may bind a legacy job's missing slug before writing. Managed
-   * harvests never may: their authority must match a slug already on the job.
-   */
+  // Channel may bind a legacy slug; managed harvest may not.
   bindSlug?: boolean;
   authority?: SourceDeliveryAuthority;
 }

--- a/apps/api/src/store.ts
+++ b/apps/api/src/store.ts
@@ -2443,6 +2443,13 @@ export interface Store {
   beginAgentOpenRound(slug: string, at: string): Promise<boolean>;
   /** BY-24: release the admission lock after `open_round` completes or aborts. */
   finishAgentOpenRound(slug: string, at: string): Promise<void>;
+  /**
+   * Claims at-most-once managed harvest for a vendor session. Returns false when another
+   * instance already holds the claim for this `(issueNumber, sessionRef)`.
+   */
+  claimManagedDelivery(claim: { issueNumber: number; sessionRef: string; slug: string }, at: string): Promise<boolean>;
+  /** Releases a failed managed harvest claim so a later poll can retry. */
+  releaseManagedDelivery(claim: { issueNumber: number; sessionRef: string }): Promise<void>;
   /** Creator-wide opener record, or null when the creator has never minted one. */
   getCreatorAgentKey(ownerUid: string): Promise<CreatorAgentKeyRecord | null>;
   /**
@@ -2659,6 +2666,11 @@ export class InMemoryStore implements Store {
   private accessTokens = new Map<string, AccessTokenRecord>();
   // slug -> durable per-game agent opener state (BY-23)
   private gameAgentKeys = new Map<string, GameAgentKeyRecord>();
+  // `${issueNumber}:${sessionRef}` -> managed harvest claim
+  private managedDeliveryClaims = new Map<
+    string,
+    { issueNumber: number; sessionRef: string; slug: string; claimedAt: string }
+  >();
   private creatorAgentKeys = new Map<string, CreatorAgentKeyRecord>();
   private oauthClients = new Map<string, OAuthClientRecord>();
   private oauthGrants = new Map<string, OAuthGrantRecord>();
@@ -4508,6 +4520,20 @@ export class InMemoryStore implements Store {
     const next: GameAgentKeyRecord = { ...existing, updatedAt: at };
     delete next.agentOpenRoundPending;
     this.gameAgentKeys.set(slug, next);
+  }
+
+  async claimManagedDelivery(
+    claim: { issueNumber: number; sessionRef: string; slug: string },
+    at: string,
+  ): Promise<boolean> {
+    const key = `${claim.issueNumber}:${claim.sessionRef}`;
+    if (this.managedDeliveryClaims.has(key)) return false;
+    this.managedDeliveryClaims.set(key, { ...claim, claimedAt: at });
+    return true;
+  }
+
+  async releaseManagedDelivery(claim: { issueNumber: number; sessionRef: string }): Promise<void> {
+    this.managedDeliveryClaims.delete(`${claim.issueNumber}:${claim.sessionRef}`);
   }
 
   async getCreatorAgentKey(ownerUid: string): Promise<CreatorAgentKeyRecord | null> {
@@ -7472,6 +7498,33 @@ export class FirestoreStore implements Store {
       delete next.agentOpenRoundPending;
       tx.set(docRef, next);
     });
+  }
+
+  private managedDeliveryClaimRef(issueNumber: number, sessionRef: string) {
+    // Session refs are opaque vendor ids; colon keeps the composite key readable.
+    return this.db.collection('managedDeliveryClaims').doc(`${issueNumber}:${sessionRef}`);
+  }
+
+  async claimManagedDelivery(
+    claim: { issueNumber: number; sessionRef: string; slug: string },
+    at: string,
+  ): Promise<boolean> {
+    const docRef = this.managedDeliveryClaimRef(claim.issueNumber, claim.sessionRef);
+    return this.db.runTransaction(async (tx) => {
+      const snap = await tx.get(docRef);
+      if (snap.exists) return false;
+      tx.set(docRef, {
+        issueNumber: claim.issueNumber,
+        sessionRef: claim.sessionRef,
+        slug: claim.slug,
+        claimedAt: at,
+      });
+      return true;
+    });
+  }
+
+  async releaseManagedDelivery(claim: { issueNumber: number; sessionRef: string }): Promise<void> {
+    await this.managedDeliveryClaimRef(claim.issueNumber, claim.sessionRef).delete();
   }
 
   async getCreatorAgentKey(ownerUid: string): Promise<CreatorAgentKeyRecord | null> {

--- a/apps/api/src/store.ts
+++ b/apps/api/src/store.ts
@@ -2443,12 +2443,9 @@ export interface Store {
   beginAgentOpenRound(slug: string, at: string): Promise<boolean>;
   /** BY-24: release the admission lock after `open_round` completes or aborts. */
   finishAgentOpenRound(slug: string, at: string): Promise<void>;
-  /**
-   * Claims at-most-once managed harvest for a vendor session. Returns false when another
-   * instance already holds the claim for this `(issueNumber, sessionRef)`.
-   */
+  // At-most-once managed harvest claim across instances.
   claimManagedDelivery(claim: { issueNumber: number; sessionRef: string; slug: string }, at: string): Promise<boolean>;
-  /** Releases a failed managed harvest claim so a later poll can retry. */
+  // Release a failed harvest claim for retry.
   releaseManagedDelivery(claim: { issueNumber: number; sessionRef: string }): Promise<void>;
   /** Creator-wide opener record, or null when the creator has never minted one. */
   getCreatorAgentKey(ownerUid: string): Promise<CreatorAgentKeyRecord | null>;

--- a/apps/api/src/submissions.test.ts
+++ b/apps/api/src/submissions.test.ts
@@ -1389,6 +1389,7 @@ describe('submission routes', () => {
       hasCandidate: false,
       issueNumber: job.issueNumber,
       slug: 'a-game',
+      roundGeneration: 1,
     });
     expect((await store.getSubmission(job.issueNumber))?.state).toBe('building');
     expect(early.json().phase).toBe('building');

--- a/apps/api/src/submissions.ts
+++ b/apps/api/src/submissions.ts
@@ -52,6 +52,7 @@ import {
 } from './builder.js';
 import type { GameSeeder, SeedDraft } from './game-seed.js';
 import { ManagedOutputRejectedError } from './managed-agent.js';
+import { createManagedDeliveryLock } from './managed-backend.js';
 import { createSourceDeliveryService, SourceDeliveryAuthorityError } from './source-delivery.js';
 import { InvalidUploadError } from './games-store.js';
 import {
@@ -653,11 +654,14 @@ export async function registerSubmissionRoutes(
             }
           }
         : undefined;
+    // Durable across Cloud Run instances; process-local harvested is not enough.
+    const managedLock = configuredManagedDeps?.lock ?? (store ? createManagedDeliveryLock(store) : undefined);
     const managedDeps =
-      managedDeliver || configuredManagedDeps
+      managedDeliver || configuredManagedDeps || managedLock
         ? {
             ...configuredManagedDeps,
             ...(managedDeliver ? { deliver: managedDeliver } : {}),
+            ...(managedLock ? { lock: managedLock } : {}),
           }
         : undefined;
     const environmentRegistry = createAgentBackendRegistryFromEnv(app.log, selfOptions, managedDeps);
@@ -2414,6 +2418,8 @@ export async function registerSubmissionRoutes(
         // Pull-delivery backends harvest inside observe.
         issueNumber: record.issueNumber,
         ...(record.slug ? { slug: record.slug } : {}),
+        // Durable generation — process memory is empty after restart.
+        roundGeneration: record.roundGeneration ?? 1,
       });
       if (!observation) return null;
       if (observation.sessionTokens) {
@@ -2440,9 +2446,14 @@ export async function registerSubmissionRoutes(
           app.log.error({ err: error, issueNumber: record.issueNumber }, 'could not store agent task state');
         }
       }
+      // Re-read after harvest; do not skip the gate.
+      const fresh = await store.getSubmission(record.issueNumber);
+      const stateAfterObserve = (fresh?.state ?? state) as JobState;
+      const stillAgentActive =
+        stateAfterObserve === 'queued' || stateAfterObserve === 'dispatched' || stateAfterObserve === 'building';
       // A cost-only poll on a job past the agent: write the credits and stop. State
       // transitions from a late observation would snatch a delivered candidate back.
-      if (!agentActive) return null;
+      if (!stillAgentActive) return null;
       if (observation.workspace && observation.workspace !== record.dispatch?.workspace) {
         await store.setDispatchWorkspace(record.issueNumber, observation.workspace);
         // Learning the agent's own branch is proof it has forked, which is the exact
@@ -2455,7 +2466,7 @@ export async function registerSubmissionRoutes(
           await store.clearDispatchSeedWorkspace(record.issueNumber);
         }
       }
-      const result = reconcileAgentObservation(state, observation);
+      const result = reconcileAgentObservation(stateAfterObserve, observation);
       if (!result) return null;
 
       // A session that ran to completion and uploaded nothing is the one failure worth

--- a/apps/api/src/submissions.ts
+++ b/apps/api/src/submissions.ts
@@ -51,6 +51,9 @@ import {
   type BuilderKind,
 } from './builder.js';
 import type { GameSeeder, SeedDraft } from './game-seed.js';
+import { ManagedOutputRejectedError } from './managed-agent.js';
+import { createSourceDeliveryService, SourceDeliveryAuthorityError } from './source-delivery.js';
+import { InvalidUploadError } from './games-store.js';
 import {
   canTransition,
   detectStall,
@@ -582,6 +585,22 @@ export async function registerSubmissionRoutes(
   const internalAuthVerifier = options.internalAuthVerifier ?? createInternalAuthVerifierFromEnv();
   const gameSeeder = options.gameSeeder;
   const gamesStoreForSeed = options.agentChannel?.gamesStore;
+  function invalidateDeliveryCaches(issueNumber: number): void {
+    eventsCache.delete(issueNumber);
+    invalidateStatusCache(issueNumber);
+  }
+  const sourceDelivery =
+    store && gamesStoreForSeed
+      ? createSourceDeliveryService({
+          store,
+          gamesStore: gamesStoreForSeed,
+          now,
+          maxSubmitsPerWindow: options.agentChannel?.maxSubmitsPerWindow,
+          onSourcesDelivered: options.agentChannel?.onSourcesDelivered,
+          onEvent: invalidateDeliveryCaches,
+          log: app.log,
+        })
+      : undefined;
 
   function buildAgentRegistry(): AgentBackendRegistry {
     const selfOptions = store
@@ -605,7 +624,44 @@ export async function registerSubmissionRoutes(
           },
         }
       : undefined;
-    const environmentRegistry = createAgentBackendRegistryFromEnv(app.log, selfOptions, options.managedBackendDeps);
+    const configuredManagedDeps = options.managedBackendDeps;
+    const managedDeliver =
+      sourceDelivery && !configuredManagedDeps?.deliver
+        ? async (input: Parameters<NonNullable<ManagedBackendDeps['deliver']>>[0]) => {
+            try {
+              const outcome = await sourceDelivery.deliver({
+                issueNumber: input.issueNumber,
+                slug: input.slug,
+                files: input.files,
+                sessionRef: input.sessionRef,
+                backend: input.backend,
+                mode: input.mode,
+                authority: {
+                  backend: input.backend,
+                  sessionRef: input.sessionRef,
+                  roundGeneration: input.roundGeneration,
+                },
+              });
+              if (!outcome.accepted) {
+                throw new ManagedOutputRejectedError(`source delivery rejected: ${outcome.rejected}`);
+              }
+              return { version: outcome.version };
+            } catch (error) {
+              if (error instanceof SourceDeliveryAuthorityError || error instanceof InvalidUploadError) {
+                throw new ManagedOutputRejectedError(error.message);
+              }
+              throw error;
+            }
+          }
+        : undefined;
+    const managedDeps =
+      managedDeliver || configuredManagedDeps
+        ? {
+            ...configuredManagedDeps,
+            ...(managedDeliver ? { deliver: managedDeliver } : {}),
+          }
+        : undefined;
+    const environmentRegistry = createAgentBackendRegistryFromEnv(app.log, selfOptions, managedDeps);
     // Explicit backends win over the environment registry.
     const self = options.agentBackends?.self ?? environmentRegistry.self;
     const platform = options.agentBackend ?? options.agentBackends?.platform ?? environmentRegistry.platform;
@@ -963,6 +1019,7 @@ export async function registerSubmissionRoutes(
       }
       const result = await selected.dispatch({
         issueNumber: input.issueNumber,
+        roundGeneration,
         ...(input.slug ? { slug: input.slug } : {}),
         spec: input.spec,
         locale: input.locale,
@@ -1140,6 +1197,7 @@ export async function registerSubmissionRoutes(
       const reusedSelfSeed = input.undelivered && builder === 'self' ? record?.seed : undefined;
       const brief = {
         issueNumber: input.issueNumber,
+        roundGeneration,
         slug: record?.slug,
         spec: input.feedback,
         feedback: input.feedback,
@@ -5092,6 +5150,7 @@ export async function registerSubmissionRoutes(
   // the store, the token secret, and the caches it has to invalidate.
   await registerAgentChannelRoutes(app, {
     ...options.agentChannel,
+    ...(sourceDelivery ? { sourceDelivery } : {}),
     store,
     agentTokenSecret: submissionTokenSecret,
     now,

--- a/apps/api/src/submissions.ts
+++ b/apps/api/src/submissions.ts
@@ -34,7 +34,12 @@ import { startHealthCheck } from './game-health.js';
 import { createStagedPreviewPublisher, type StagedPreviewOptions } from './staged-preview.js';
 import { createInternalAuthVerifierFromEnv, type InternalAuthVerifier } from './internal-auth.js';
 import type { AgentBackend, SeedFiles } from './agent-backend.js';
-import { resolveBuilderBackend, type AgentBackendRegistry } from './agent-backend-env.js';
+import {
+  createAgentBackendRegistryFromEnv,
+  resolveBuilderBackend,
+  type AgentBackendRegistry,
+  type ManagedBackendDeps,
+} from './agent-backend-env.js';
 import {
   allowsCreatorBuilderHandoff,
   allowsSelfToPlatformHandoff,
@@ -60,7 +65,6 @@ import {
 } from './job-state.js';
 import { isMcpPresenceEventText } from './mcp-presence.js';
 import { logSeedStagingFailure } from './seed-metrics.js';
-import { createSelfBuildBackend } from './self-build-backend.js';
 import { mintConnectPayload } from './self-build-connect.js';
 import { createLocalGamesClient, resolveLocalGamesDir } from './local-games-repo.js';
 import { createMailerFromEnv, type Mailer } from './mailer.js';
@@ -318,6 +322,8 @@ export interface SubmissionRoutesOptions {
    * filled in (a default self backend) if the caller omits it.
    */
   agentBackends?: Partial<AgentBackendRegistry> & { platform?: AgentBackend };
+  /** Dependencies for the environment-selected managed platform backend. */
+  managedBackendDeps?: ManagedBackendDeps;
   /**
    * Writes the first draft a new build starts from. Absent means every build starts from
    * an empty directory, which is what they all did before seeding existed.
@@ -593,14 +599,16 @@ export async function registerSubmissionRoutes(
             return {
               lastAgentSignalAt: record.lastAgentSignalAt,
               deliveredVersion: record.deliveredVersion,
+              previewVersion: record.previewVersion,
+              agentEndedAt: record.agentEndedAt,
             };
           },
         }
       : undefined;
-    // An explicit `agentBackend` (tests, one-off wiring) wins over the env registry's
-    // platform entry — same precedence the single-backend option had before the registry.
-    const self = options.agentBackends?.self ?? createSelfBuildBackend(selfOptions);
-    const platform = options.agentBackend ?? options.agentBackends?.platform;
+    const environmentRegistry = createAgentBackendRegistryFromEnv(app.log, selfOptions, options.managedBackendDeps);
+    // Explicit backends win over the environment registry.
+    const self = options.agentBackends?.self ?? environmentRegistry.self;
+    const platform = options.agentBackend ?? options.agentBackends?.platform ?? environmentRegistry.platform;
     return { ...(platform ? { platform } : {}), self };
   }
 

--- a/apps/api/src/submissions.ts
+++ b/apps/api/src/submissions.ts
@@ -633,7 +633,6 @@ export async function registerSubmissionRoutes(
                 issueNumber: input.issueNumber,
                 slug: input.slug,
                 files: input.files,
-                sessionRef: input.sessionRef,
                 backend: input.backend,
                 mode: input.mode,
                 authority: {

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -96,6 +96,28 @@ a single `--set-secrets` list.
 | `vapid-private-key`                    | Web push signing → `VAPID_PRIVATE_KEY`                                                                                                                                                                                                                         | ✅ set                                                                                              |
 | `site-basic-auth`                      | Former "not public yet" lock → `SITE_BASIC_AUTH`                                                                                                                                                                                                               | ⚠️ exists but **unused**                                                                            |
 
+### Managed agent configuration
+
+The managed backend is selected by these Cloud Run variables; the deploy scripts carry them
+on every revision because `--set-env-vars` replaces the whole map:
+
+| Variable                            | Meaning                                           |
+| ----------------------------------- | ------------------------------------------------- |
+| `MANAGED_AGENT_VENDOR`              | Provider adapter, currently `anthropic`           |
+| `MANAGED_AGENT_MODEL`               | Provider model label                              |
+| `MANAGED_AGENT_ID`                  | Managed Agent resource                            |
+| `MANAGED_AGENT_ENVIRONMENT_ID`      | Managed Environment resource                      |
+| `MANAGED_AGENT_MAX_SECONDS`         | Per-session wall-clock limit                      |
+| `MANAGED_AGENT_MAX_LIST_COST_CENTS` | Anthropic budget in whole US cents                |
+| `MANAGED_AGENT_VAULT_IDS`           | Comma-separated vaults containing MCP credentials |
+| `MANAGED_AGENT_MCP_URL`             | The MCP endpoint the agent calls                  |
+| `MANAGED_AGENT_DELIVERY_MODE`       | `preview` or `publish`                            |
+
+`MANAGED_AGENT_API_KEY` is wired from the `anthropic-api-key` Secret Manager secret and never
+belongs in variables, the repository, or a workflow body. If the managed vendor variables or
+secret are absent, the platform slot remains unset and platform jobs stay queued; self builds
+continue to work.
+
 `site-basic-auth` is a leftover: the running revision does not wire it, and the site answers
 without an auth challenge. Access is controlled by `PRIVATE_BETA` and the beta allowlist
 instead. Delete the secret when you are sure nothing references it.

--- a/infra/deploy-api.sh
+++ b/infra/deploy-api.sh
@@ -180,6 +180,11 @@ else
   echo "==> agent-tasks-token not found; submissions will queue without being dispatched."
 fi
 
+if gcloud secrets describe anthropic-api-key --project "$PROJECT_ID" >/dev/null 2>&1; then
+  SECRET_MAPPINGS+=("MANAGED_AGENT_API_KEY=anthropic-api-key:latest")
+  echo "==> anthropic-api-key found; managed agent API access enabled."
+fi
+
 if gcloud secrets describe session-secret --project "$PROJECT_ID" >/dev/null 2>&1; then
   SECRET_MAPPINGS+=("SESSION_SECRET=session-secret:latest")
   echo "==> session-secret found; session authentication enabled."
@@ -263,6 +268,21 @@ for FLAG_VAR in SEED_DISPATCH CODE_LANE EDITOR_ASSIST MCP_AUTHORIZATION_SERVERS 
   eval "FLAG_VAL=\${${FLAG_VAR}:-}"
   if [ -n "${FLAG_VAL}" ]; then
     ENV_VARS="${ENV_VARS}|${FLAG_VAR}=${FLAG_VAL}"
+  fi
+done
+for MANAGED_VAR in \
+  MANAGED_AGENT_VENDOR \
+  MANAGED_AGENT_MODEL \
+  MANAGED_AGENT_ID \
+  MANAGED_AGENT_ENVIRONMENT_ID \
+  MANAGED_AGENT_MAX_SECONDS \
+  MANAGED_AGENT_MAX_LIST_COST_CENTS \
+  MANAGED_AGENT_VAULT_IDS \
+  MANAGED_AGENT_MCP_URL \
+  MANAGED_AGENT_DELIVERY_MODE; do
+  eval "MANAGED_VAL=\${${MANAGED_VAR}:-}"
+  if [ -n "${MANAGED_VAL}" ]; then
+    ENV_VARS="${ENV_VARS}|${MANAGED_VAR}=${MANAGED_VAL}"
   fi
 done
 if [ -n "$GOOGLE_OAUTH_CLIENT_ID" ]; then


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Wires the managed (platform) agent backend into production configuration and extracts shared source-delivery authority used by HTTP, MCP, and managed harvest.

Rebased onto current `master` (resolves merge conflicts with the managed-availability / platform-backend wiring from #708).

### Codex review follow-ups
- Re-read job state after harvest so publish deliveries stay in `submitted` for gate reconciliation (no premature `ready_for_review`)
- Pass durable `roundGeneration` into `observe` (not process-local memory only)
- Wire a store-backed `ManagedDeliveryLock` for multi-instance at-most-once harvest
- Fail closed when `MANAGED_AGENT_VENDOR` is set but invalid (no silent Copilot fallback)

## Test plan
- [x] `npm run type-check && npm run lint && npm run test && npm run build`
- [x] Focused suites for source-delivery, managed-backend, agent-backend-env
- [ ] Production creation round once secrets are configured
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4cf2e9e5-dd15-4c3a-8323-8e026e20823b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4cf2e9e5-dd15-4c3a-8323-8e026e20823b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

