### PR TITLE
Add get_kit_api endpoint and improve kit digest selection

### DIFF
--- a/.claude/skills/byoca-mcp/SKILL.md
+++ b/.claude/skills/byoca-mcp/SKILL.md
@@ -108,14 +108,45 @@ declaration file into whole top-level blocks (`splitDeclarationBlocks`), gives e
 module family a block before any family gets a second one (`selectApiBlocks`), and abridges
 a block too large to fit whole (`GameKitApi`, ~44% of the entire surface — this is where
 `createParty` / `createZone` / `createCommons` / `createPresence` all live) member-wise
-rather than dropping it, ranking module factories first. Whatever a budget still can't fit
-is named in an `// Omitted for length (...)` note instead of vanishing. The digest also
-gained a `## Engine modules` catalog (`digestEngineModules` in the games repo's
-`tools/lib/pack-kit.ts`), generated from each `shared/modules/*.ts` file's own header
-comment — so a module is listed the moment it exists and the catalog cannot drift.
+rather than dropping it, ranking module factories first (`elideDeclaration`). Whatever a
+budget still can't fit is named in an `// Omitted for length (...)` note instead of
+vanishing. The digest also gained a `## Engine modules` catalog (`digestEngineModules` in
+the games repo's `tools/lib/pack-kit.ts`), generated from `GAME_KIT_MODULES` +
+`gameKitModuleEntryPath` (`tools/lib/assemble.ts`) — the same canonical registry
+`GAME.json`'s `engine.modules` validates against, not a `shared/modules/*.ts` directory
+listing, which would have both included `core` (not selectable) and omitted `vehicles` /
+`urban` / `racing` / `football` (they live under `shared/verticals/*/index.ts`). Each
+module's summary is its own header comment's first paragraph, so a module is listed the
+moment it exists and a summary can't drift out of sync with code.
+
+**Two correctness bugs surfaced in review, both confirmed against the real 122 KB
+declaration file before fixing.** `elideDeclaration`'s member splitter used indentation
+alone (1–2 spaces) to find a member's boundary — but a member's own closing line can land
+back at that same indent (`createZone<S>(config: { … }): GameKitZone<S>;` closes with
+`}): GameKitZone<S>;` at 2 spaces, identical to any other member's opener), so that closing
+line was misread as a new member and could be dropped once the budget ran out, emitting
+`createZone` opened but never closed. `splitMembers` now tracks bracket depth instead — a
+line only starts a new member when depth is 0 — safe because the input is always
+comment-stripped (`compactGameKitApi` in the games repo strips comments before the digest
+is ever written), so no brace inside prose can desync the count. Separately, the API
+section's budget was a flat 72% of the total, guessed rather than measured: at the real
+~15 KiB fixed shell (module catalog + audio catalog + exemplar + rules — none proportional
+to the API's size), the platform lane's real 20 KiB default silently truncated
+mid-exemplar-file, dropping `## File-shape rules` entirely, and `get_kit_api`'s old 90 KiB
+budget capped the API at 64.8 KiB despite the ~79 KiB current surface — contradicting its
+own "whole reference in one call" promise. Both lanes now measure the non-API shell first
+and give the API section whatever's actually left (`apiBudget = maxBytes - shellBytes`).
+That in turn exposed a second-order bug: the omission note listing what got cut is itself
+unbounded (up to ~2 KiB for 100 omitted names) with nothing reserving room for it, so it
+could overflow the same way the flat-percentage guess did. `formatOmittedNote` is now
+self-bounded (`OMITTED_NOTE_RESERVE_BYTES`), truncating the name list with "… and N more"
+rather than growing past its reserve.
+
 `DEFAULT_KIT_DIGEST_MAX_BYTES` (the raw-stored-digest sanity ceiling, not a prompt budget)
-moved from 100,000 to 150,000 bytes for this: the stored digest was already at 99,552 bytes
-before the catalog addition, one small API growth from failing regardless.
+moved from 100,000 to 150,000 bytes: the stored digest was already at 99,552 bytes before
+the catalog addition, one small API growth from failing regardless.
+`DEFAULT_MCP_DIGEST_MAX_BYTES` moved from 90,000 to 100,000 so `get_kit_api` comfortably
+covers shell + full current API + the note reserve.
 
 ### `get_gate_media` must stay reachable from the loop
 

--- a/.claude/skills/byoca-mcp/SKILL.md
+++ b/.claude/skills/byoca-mcp/SKILL.md
@@ -58,9 +58,11 @@ Source of truth: `SESSION_WORKFLOW` + `BEHAVIOURAL_CONTRACT` in
 ### MCP tool surface
 
 `/api/mcp` advertises the focused build surface: creation/round control, brief/seed,
-progress, staging/submission, gate media, and inbox. Proposal, example, and kit
-browse/read tools remain callable for compatibility but are not advertised to models.
-The digest and `get_kit` replace routine kit browsing.
+progress, staging/submission, gate media, inbox — and, since 2026-08-09, the kit
+itself. Proposal and example browse/read tools remain callable for compatibility but
+are not advertised to models; kit browse/read tools (`list_kit_files`,
+`search_kit_files`, `read_kit_file`, `read_kit_files`, `read_kit_file_fragment`) now
+are, alongside a new `get_kit_api`.
 
 **Trimming the surface is only half the job — the prose has to follow.** The channel names
 the kit browse tools in every `get_kit` reply, because a REST agent can call them by URL.
@@ -68,10 +70,52 @@ A model can only call what `tools/list` carried, so an unadvertised name that su
 description, in the workflow list, or in the `browse` block of a reply is an invitation the
 host answers with a permission denial. A managed round on 2026-08-09 spent three round trips
 that way and then shipped a game with the audio module stripped out, because the sound-id
-lookup it had been pointed at did not exist for it. The MCP layer now filters `browse` down
-to advertised tools and drops it when none remain; `apps/api/src/mcp-server.test.ts` fails if
-an unadvertised name reappears in the descriptions, the workflow, or a `get_kit` reply. When
-you remove a tool from `MCP_VISIBLE_TOOLS`, grep the prose for its name in the same change.
+lookup it had been pointed at did not exist for it. The MCP layer still filters `browse` down
+to advertised tools (now the whole list, so the block survives intact) and drops it when none
+remain; `apps/api/src/mcp-server.test.ts` fails if an unadvertised name reappears in the
+descriptions, the workflow, or a `get_kit` reply. When you remove a tool from
+`MCP_VISIBLE_TOOLS`, grep the prose for its name in the same change.
+
+**`get_kit_api` — the orientation path that did not exist before 2026-08-09.** `get_kit`
+returns tarball metadata only (engineRef, sha256, unpack one-liner) — it was never the API
+reference its own description claimed to be pointing at, because nothing injected a digest
+into the MCP surface. `appendKitDigest` (`apps/api/src/kit-digest.ts`) had exactly one
+caller, the platform Copilot system prompt (`managed-backend.ts`); a BYOCA agent with no
+shell egress and no system prompt carrying the kit had no in-band way to answer "what can
+this platform build" at all. Observed consequence: an agent asked for a party/multiplayer
+game had nowhere to look and went to the public web for gamedev.pl documentation that was
+never published there — turns wasted on nothing, with third-party multiplayer docs (a
+different engine's networking model entirely) as the real risk if it had read them as
+authoritative.
+
+`get_kit_api` (`GET /api/agent/build/kit/api`, `apps/api/src/agent-channel.ts`) serves the
+same digest object the platform lane compacts, through `compactKitDigestForApi` — a larger
+budget (`DEFAULT_MCP_DIGEST_MAX_BYTES`, 90 KiB vs the platform's 20 KiB) since it is paid
+once per round by an agent that chose to call it, not injected into every turn. Same
+`engineRef` convention as the browse routes: optional, defaults to the registry's current
+entry when omitted, but pass the `engineRef` `get_kit` returned so a mid-round registry
+bump cannot mix kit revisions. `get_kit` and `get_kit_api` both carry
+`BEHAVIOURAL_CONTRACT`'s line that the platform and kit are not on the public web — an
+unanswered capability question is answered by `get_kit_api` / browse, never a web search.
+
+**The digest itself had a silent-drop bug the surface fix didn't touch.**
+`compactKitDigestForPrompt` (`apps/api/src/kit-digest.ts`) used to keep only API lines
+matching a hardcoded regex allowlist, every pattern of which described single-player core
+API — `GameKitParty`, `GameKitZone`, `GameKitCommons`, `GameKitPresence` matched nothing, so
+same-screen multiplayer, real-time shared zones and persistent worlds were invisible to any
+digest reader, platform or MCP, with no signal anything had been cut. It now splits the
+declaration file into whole top-level blocks (`splitDeclarationBlocks`), gives every engine
+module family a block before any family gets a second one (`selectApiBlocks`), and abridges
+a block too large to fit whole (`GameKitApi`, ~44% of the entire surface — this is where
+`createParty` / `createZone` / `createCommons` / `createPresence` all live) member-wise
+rather than dropping it, ranking module factories first. Whatever a budget still can't fit
+is named in an `// Omitted for length (...)` note instead of vanishing. The digest also
+gained a `## Engine modules` catalog (`digestEngineModules` in the games repo's
+`tools/lib/pack-kit.ts`), generated from each `shared/modules/*.ts` file's own header
+comment — so a module is listed the moment it exists and the catalog cannot drift.
+`DEFAULT_KIT_DIGEST_MAX_BYTES` (the raw-stored-digest sanity ceiling, not a prompt budget)
+moved from 100,000 to 150,000 bytes for this: the stored digest was already at 99,552 bytes
+before the catalog addition, one small API growth from failing regardless.
 
 ### `get_gate_media` must stay reachable from the loop
 
@@ -408,6 +452,8 @@ queued.
 | Area                          | Path                                                                                                                                                                      |
 | ----------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | MCP tools                     | `apps/api/src/mcp-server.ts` (`screenshot_upload_url` / `stage_upload_url` → signed PUT; no base64 shot tool)                                                             |
+| Kit API digest (get_kit_api)  | `apps/api/src/kit-digest.ts` (`compactKitDigestForApi`, `splitDeclarationBlocks`, `selectApiBlocks`) + `GET /api/agent/build/kit/api` in `agent-channel.ts`               |
+| Engine modules catalog        | games repo `tools/lib/pack-kit.ts` (`digestEngineModules`) — generated from `shared/modules/*.ts` header comments, not hand-maintained                                    |
 | Upload tokens                 | `apps/api/src/agent-upload-token.ts` + `POST …/shot/upload-url` + `PUT …/shot/upload` + `PUT …/sources/stage/upload`                                                      |
 | Presence pulses               | `apps/api/src/mcp-presence.ts` (`start` → `joining_round` in the MCP dispatcher)                                                                                          |
 | Gate milestones               | `apps/api/src/gate-progress.ts` + `GamesStore.putGateProgress` (GCS; Studio/MCP poll while checks run)                                                                    |

--- a/apps/api/src/agent-build-reads.test.ts
+++ b/apps/api/src/agent-build-reads.test.ts
@@ -100,6 +100,7 @@ describe('agent build reads (BY-04)', () => {
     '/api/agent/build/brief',
     '/api/agent/build/seed',
     '/api/agent/build/kit',
+    '/api/agent/build/kit/api',
     '/api/agent/build/kit/files',
     '/api/agent/build/kit/search?q=GameKit',
     '/api/agent/build/kit/file?path=SKILL.md',
@@ -260,6 +261,82 @@ describe('agent build reads (BY-04)', () => {
       fragment: 'read_kit_file_fragment',
     });
     expect(signReadUrl).toHaveBeenCalledWith(`kits/${ENGINE}.tgz`, expect.any(Number));
+  });
+
+  it('serves the compacted kit API digest, defaulting to the registry current engine', async () => {
+    const store = new InMemoryStore();
+    await seedJob(store);
+    const digest = [
+      '# gamedev.pl Creator Kit digest',
+      '',
+      '## Engine modules',
+      '',
+      '- `party` — multiple players on one shared screen.',
+      '- `zone` — a world the server arbitrates, shared with strangers in real time.',
+      '',
+      '## GameKit API surface',
+      '',
+      '~~~typescript',
+      'interface GameKitApi { locale: string; }',
+      '~~~',
+      '',
+      '## Exemplar game',
+      '',
+      '### games/dodge-the-falling-rocks/game.ts',
+      '',
+      '~~~text',
+      'export {};',
+      '~~~',
+      '',
+      '## File-shape rules',
+      '- Keep files small.',
+    ].join('\n');
+    const objects = new Map<string, Buffer>([
+      [
+        'kits/current.json',
+        Buffer.from(JSON.stringify({ current: ENGINE, previous: null, updatedAt: '2026-08-09T00:00:00.000Z' })),
+      ],
+      [`kits/${ENGINE}.digest.md`, Buffer.from(digest)],
+    ]);
+    app = await createApp(store, mockObjectStore(objects));
+
+    // No engineRef: falls back to the registry current entry.
+    const noRef = await app.inject({ method: 'GET', url: '/api/agent/build/kit/api', headers: agentHeaders() });
+    expect(noRef.statusCode).toBe(200);
+    expect(noRef.json().engineRef).toBe(ENGINE);
+    expect(noRef.json().digest).toMatch(/GameKitApi/);
+    expect(noRef.json().digest).toMatch(/`party`/);
+    expect(noRef.json().digest).toMatch(/`zone`/);
+
+    // Explicit engineRef: reads that engine's digest object directly.
+    const withRef = await app.inject({
+      method: 'GET',
+      url: `/api/agent/build/kit/api?engineRef=${ENGINE}`,
+      headers: agentHeaders(),
+    });
+    expect(withRef.statusCode).toBe(200);
+    expect(withRef.json().engineRef).toBe(ENGINE);
+  });
+
+  it('404s a missing digest object distinctly from a missing registry', async () => {
+    const store = new InMemoryStore();
+    await seedJob(store);
+    app = await createApp(store, mockObjectStore(new Map()));
+
+    const noRegistry = await app.inject({ method: 'GET', url: '/api/agent/build/kit/api', headers: agentHeaders() });
+    expect(noRegistry.statusCode).toBe(404);
+    expect(noRegistry.json().error).toBe('kit_registry_missing');
+
+    const objects = new Map<string, Buffer>([
+      [
+        'kits/current.json',
+        Buffer.from(JSON.stringify({ current: ENGINE, previous: null, updatedAt: '2026-08-09T00:00:00.000Z' })),
+      ],
+    ]);
+    app = await createApp(store, mockObjectStore(objects));
+    const noDigest = await app.inject({ method: 'GET', url: '/api/agent/build/kit/api', headers: agentHeaders() });
+    expect(noDigest.statusCode).toBe(404);
+    expect(noDigest.json().error).toBe('kit_artifact_missing');
   });
 
   it('pins the round to one engine even when the registry pointer advances', async () => {

--- a/apps/api/src/agent-channel.ts
+++ b/apps/api/src/agent-channel.ts
@@ -2130,20 +2130,7 @@ export async function registerAgentChannelRoutes(
     },
   );
 
-  /**
-   * The Creator Kit's prompt-ready API reference over MCP.
-   *
-   * A BYOCA agent has no system prompt carrying the kit the way the platform lane does
-   * (`appendKitDigest` in managed-backend.ts) — before this route, `get_kit` returned only
-   * tarball metadata and the API content lived nowhere an MCP client could read it without
-   * shell egress. That left "what can this platform build" answerable only by unpacking the
-   * tarball or browsing file-by-file, and observably sent at least one agent to the public
-   * web looking for gamedev.pl documentation that was never published there.
-   *
-   * Same engineRef convention as the kit browse routes below: optional, defaults to the
-   * registry's current entry when omitted. Pass the engineRef `get_kit` returned so a
-   * mid-round registry bump cannot mix kit revisions within one round.
-   */
+  // Prompt-ready API reference for MCP get_kit_api — see byoca-mcp SKILL.md.
   app.get(
     '/api/agent/build/kit/api',
     { config: { rateLimit: { max: 60, timeWindow: '1 hour' } } },

--- a/apps/api/src/agent-channel.ts
+++ b/apps/api/src/agent-channel.ts
@@ -30,6 +30,7 @@ import { selfBuildDeliveryCap } from './builder.js';
 import { canonicalAppBaseUrl } from './canonical-app-url.js';
 import { deriveGateStatusString, readGateVerdict } from './gate-verdict.js';
 import { DEFAULT_SIGNED_URL_TTL_SECONDS, type GcsObjectStore } from './gcs-sign.js';
+import { DEFAULT_MCP_DIGEST_MAX_BYTES, compactKitDigestForApi } from './kit-digest.js';
 import {
   InvalidUploadError,
   MAX_UPLOAD_BYTES,
@@ -2119,6 +2120,62 @@ export async function registerAgentChannelRoutes(
             readMany: 'read_kit_files',
             fragment: 'read_kit_file_fragment',
           },
+        });
+      } catch (error) {
+        if (error instanceof KitRegistryError) {
+          return reply.status(404).send({ error: error.code, message: error.message });
+        }
+        throw error;
+      }
+    },
+  );
+
+  /**
+   * The Creator Kit's prompt-ready API reference over MCP.
+   *
+   * A BYOCA agent has no system prompt carrying the kit the way the platform lane does
+   * (`appendKitDigest` in managed-backend.ts) — before this route, `get_kit` returned only
+   * tarball metadata and the API content lived nowhere an MCP client could read it without
+   * shell egress. That left "what can this platform build" answerable only by unpacking the
+   * tarball or browsing file-by-file, and observably sent at least one agent to the public
+   * web looking for gamedev.pl documentation that was never published there.
+   *
+   * Same engineRef convention as the kit browse routes below: optional, defaults to the
+   * registry's current entry when omitted. Pass the engineRef `get_kit` returned so a
+   * mid-round registry bump cannot mix kit revisions within one round.
+   */
+  app.get(
+    '/api/agent/build/kit/api',
+    { config: { rateLimit: { max: 60, timeWindow: '1 hour' } } },
+    async (request, reply) => {
+      const resolved = await resolveBuild(request, reply);
+      if (!resolved) return reply;
+      if (!options.objectStore) {
+        return reply.status(503).send({ error: 'kit_store_unavailable', message: 'the kit store is not configured' });
+      }
+      try {
+        const query = request.query as { engineRef?: string };
+        let engineRef = query.engineRef?.trim();
+        if (!engineRef) {
+          const registryBody = await options.objectStore.readObject('kits/current.json');
+          if (!registryBody) {
+            return reply.status(404).send({
+              error: 'kit_registry_missing',
+              message: 'kits/current.json is not published yet — the games-repo kit publisher has not run',
+            });
+          }
+          engineRef = parseKitRegistry(registryBody.toString('utf8')).current;
+        }
+        const digestBody = await options.objectStore.readObject(`kits/${engineRef}.digest.md`);
+        if (!digestBody) {
+          return reply.status(404).send({
+            error: 'kit_artifact_missing',
+            message: `kits/${engineRef}.digest.md is missing for engineRef ${engineRef}`,
+          });
+        }
+        return reply.send({
+          engineRef,
+          digest: compactKitDigestForApi(digestBody.toString('utf8'), DEFAULT_MCP_DIGEST_MAX_BYTES),
         });
       } catch (error) {
         if (error instanceof KitRegistryError) {

--- a/apps/api/src/kit-digest.test.ts
+++ b/apps/api/src/kit-digest.test.ts
@@ -3,6 +3,7 @@ import {
   appendKitDigest,
   compactKitDigestForPrompt,
   createGcsKitDigestLoader,
+  formatOmittedNote,
   selectApiBlocks,
   splitDeclarationBlocks,
 } from './kit-digest.js';
@@ -100,7 +101,7 @@ describe('Creator Kit digest loader', () => {
       '- Keep files small.',
     ].join('\n');
 
-    const compact = compactKitDigestForPrompt(full, 800);
+    const compact = compactKitDigestForPrompt(full, 1400);
 
     // Party and zone survive whole — the failure this guards against dropped them (or
     // orphaned their members) below any generous-looking budget. What didn't fit (here,
@@ -110,6 +111,91 @@ describe('Creator Kit digest loader', () => {
     expect(compact).toContain('Omitted for length');
     expect(compact).toContain('GameKitApi');
     expect(compact.trim().endsWith('- Keep files small.')).toBe(true);
+  });
+
+  it('formatOmittedNote lists every name when it fits, and never exceeds its byte budget', () => {
+    const note = formatOmittedNote(['GameKitParty', 'GameKitZone'], 600);
+    expect(note).toContain('GameKitParty');
+    expect(note).toContain('GameKitZone');
+    expect(Buffer.byteLength(note, 'utf8')).toBeLessThanOrEqual(600);
+  });
+
+  it('formatOmittedNote truncates a long name list instead of overflowing its reserve', () => {
+    // A realistic tight-budget scenario: most of a 114-declaration API omitted, and the
+    // note listing them all unbounded ran to 2+ KiB with nothing reserving room for it —
+    // the actual bug behind the digest silently dropping the File-shape rules section.
+    const names = Array.from({ length: 100 }, (_, i) => `GameKitDeclarationNumber${i}`);
+    const note = formatOmittedNote(names, 250);
+    expect(Buffer.byteLength(note, 'utf8')).toBeLessThanOrEqual(250);
+    expect(note).toMatch(/… and \d+ more/);
+    expect(note).not.toContain('GameKitDeclarationNumber99');
+
+    // Too tight even for the "… and N more" suffix: still bounded, just without it — a
+    // truncated list beats an overflowing note either way.
+    const tighter = formatOmittedNote(names, 200);
+    expect(Buffer.byteLength(tighter, 'utf8')).toBeLessThanOrEqual(200);
+  });
+
+  it('formatOmittedNote returns empty for nothing omitted', () => {
+    expect(formatOmittedNote([], 600)).toBe('');
+  });
+
+  it('never truncates the exemplar or File-shape rules to make room for the API, at realistic sizes', () => {
+    // A large exemplar (bigger than a flat percentage of a small budget would allow) used
+    // to get cut off mid-file by the final blunt byte-cap safety net, because nothing
+    // measured the shell's real size before guessing how much room the API could have.
+    // Reproduces that at the platform lane's real default budget.
+    const bigFile = 'x'.repeat(6000);
+    const full = [
+      '## GameKit API surface',
+      '~~~typescript',
+      `interface GameKitApi { locale: string; ${'y'.repeat(30000)} }`,
+      '~~~',
+      '## Exemplar game',
+      `### games/dodge-the-falling-rocks/GAME.json\n\n~~~text\n${bigFile}\n~~~`,
+      `### games/dodge-the-falling-rocks/index.html\n\n~~~text\n${bigFile}\n~~~`,
+      '## File-shape rules',
+      '- Keep files small.',
+    ].join('\n');
+
+    const compact = compactKitDigestForPrompt(full); // default 20 KiB budget
+
+    expect(compact.trim().endsWith('- Keep files small.')).toBe(true);
+    expect(compact).toContain('### games/dodge-the-falling-rocks/index.html');
+  });
+
+  it('elideDeclaration keeps a multiline member whole even when its closing brace lands at the interface indent', () => {
+    // Shaped after the real GameKitApi.createZone: a member whose own closing
+    // `}): ReturnType;` sits at the interface's 2-space indent, same as any other member's
+    // opening line. An indentation-only member split misread that closing line as a new
+    // member and could drop it once the tight budget ran out, emitting createZone opened
+    // but never closed — malformed output for exactly the factory this exists to preserve.
+    const pad = 'x'.repeat(400);
+    const api = [
+      'interface GameKitApi {',
+      '  createZone<S>(config: {',
+      '    sim: GameKitZoneSim<S>;',
+      '    onStatus?(status: string, info: { slot: number }): void;',
+      '  }): GameKitZone<S>;',
+      `  other(): ${pad};`,
+      '}',
+    ].join('\n');
+
+    const blocks = splitDeclarationBlocks(api);
+    // Budget too small for the whole interface (the padded `other` member alone forces
+    // that), forcing elideDeclaration's member-wise path.
+    const { kept } = selectApiBlocks(blocks, ['zone'], 250);
+    const text = kept.map((block) => block.text).join('\n');
+
+    expect(text).toContain('createZone<S>(config: {');
+    expect(text).toContain('}): GameKitZone<S>;');
+    // Brace/paren/bracket depth must return to zero — an unclosed opener is the bug.
+    let depth = 0;
+    for (const ch of text) {
+      if (ch === '{' || ch === '(' || ch === '[') depth++;
+      else if (ch === '}' || ch === ')' || ch === ']') depth--;
+    }
+    expect(depth).toBe(0);
   });
 
   it('splits a declaration file into whole top-level blocks by name', () => {

--- a/apps/api/src/kit-digest.test.ts
+++ b/apps/api/src/kit-digest.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it, vi } from 'vitest';
-import { appendKitDigest, compactKitDigestForPrompt, createGcsKitDigestLoader } from './kit-digest.js';
+import {
+  appendKitDigest,
+  compactKitDigestForPrompt,
+  createGcsKitDigestLoader,
+  selectApiBlocks,
+  splitDeclarationBlocks,
+} from './kit-digest.js';
 
 describe('Creator Kit digest loader', () => {
   it('reads the digest matching the current engine ref and caches it', async () => {
@@ -44,11 +50,12 @@ describe('Creator Kit digest loader', () => {
     expect(appendKitDigest('base', undefined)).toBe('base');
   });
 
-  it('compacts the full artifact into core API and template guidance', () => {
+  it('compacts the full artifact into core API and template guidance, keeping whole declarations that fit', () => {
     const full = [
       '## GameKit API surface',
       '~~~typescript',
       'interface GameKitInput { down(...keys: string[]): boolean; }',
+      'interface GameKitParty { down(slot: number): boolean; }',
       'interface Unrelated { huge(): void; }',
       '~~~',
       '## Exemplar game',
@@ -63,9 +70,79 @@ describe('Creator Kit digest loader', () => {
     const compact = compactKitDigestForPrompt(full);
 
     expect(compact).toContain('GameKitInput');
+    // A module family the old line-pattern allowlist could not name (party games were
+    // invisible to platform agents until this was fixed) survives whole, not as an
+    // unlabeled orphan line.
+    expect(compact).toContain('interface GameKitParty { down(slot: number): boolean; }');
     expect(compact).toContain('game/runtime.ts');
     expect(compact).toContain('Keep files small.');
-    expect(compact).not.toContain('interface Unrelated');
+    // Nothing here is dropped — the fixture is well under the default budget, and whole-
+    // block selection only omits when the budget genuinely forces it (see below).
+    expect(compact).toContain('interface Unrelated');
+  });
+
+  it('names what a tight budget omits instead of silently dropping it', () => {
+    // Interfaces sized like the real declaration file's, so a budget can be tight enough
+    // to force an omission without the unrelated final byte-cap safety net (sized off the
+    // whole document, header included) doing the truncating instead.
+    const pad = 'x'.repeat(150);
+    const full = [
+      '## GameKit API surface',
+      '~~~typescript',
+      `interface GameKitApi { locale: string; ${pad} }`,
+      `interface GameKitParty { down(slot: number): boolean; ${pad} }`,
+      `interface GameKitZone { status: string; ${pad} }`,
+      '~~~',
+      '## Exemplar game',
+      '### games/dodge-the-falling-rocks/game/runtime.ts',
+      'GameKit.defineGame().start();',
+      '## File-shape rules',
+      '- Keep files small.',
+    ].join('\n');
+
+    const compact = compactKitDigestForPrompt(full, 800);
+
+    // Party and zone survive whole — the failure this guards against dropped them (or
+    // orphaned their members) below any generous-looking budget. What didn't fit (here,
+    // GameKitApi) is named in an omission note rather than vanishing without a trace.
+    expect(compact).toContain('interface GameKitParty');
+    expect(compact).toContain('interface GameKitZone');
+    expect(compact).toContain('Omitted for length');
+    expect(compact).toContain('GameKitApi');
+    expect(compact.trim().endsWith('- Keep files small.')).toBe(true);
+  });
+
+  it('splits a declaration file into whole top-level blocks by name', () => {
+    const api = [
+      'interface GameKitInput { down(): boolean; }',
+      'type GameLifecycleState = "loading" | "playing";',
+      'interface GameKitParty {',
+      '  down(slot: number): boolean;',
+      '}',
+    ].join('\n');
+
+    const blocks = splitDeclarationBlocks(api);
+
+    expect(blocks.map((block) => block.name)).toEqual(['GameKitInput', 'GameLifecycleState', 'GameKitParty']);
+    expect(blocks[2].text).toBe('interface GameKitParty {\n  down(slot: number): boolean;\n}');
+  });
+
+  it('selectApiBlocks gives every module family a block before any family gets a second one', () => {
+    const blocks = splitDeclarationBlocks(
+      [
+        'interface GameKitParty { a: 1; }',
+        'interface GameKitPartyExtra { b: 1; }',
+        'interface GameKitZone { c: 1; }',
+      ].join('\n'),
+    );
+
+    // A budget that fits exactly one of the three blocks still yields party over its own
+    // second block being crowded out — zone would be starved entirely if the pass took
+    // party's two blocks before zone's one, which is the head-of-file-bias bug this guards.
+    const { kept, omitted } = selectApiBlocks(blocks, ['party', 'zone'], blocks[0].bytes + blocks[2].bytes);
+
+    expect(kept.map((block) => block.name).sort()).toEqual(['GameKitParty', 'GameKitZone']);
+    expect(omitted).toEqual(['GameKitPartyExtra']);
   });
 
   it('keeps the audio catalog, and keeps it ahead of what a byte cap truncates', () => {

--- a/apps/api/src/kit-digest.test.ts
+++ b/apps/api/src/kit-digest.test.ts
@@ -71,21 +71,16 @@ describe('Creator Kit digest loader', () => {
     const compact = compactKitDigestForPrompt(full);
 
     expect(compact).toContain('GameKitInput');
-    // A module family the old line-pattern allowlist could not name (party games were
-    // invisible to platform agents until this was fixed) survives whole, not as an
-    // unlabeled orphan line.
+    // party used to be an unnamed orphan line; now it survives whole.
     expect(compact).toContain('interface GameKitParty { down(slot: number): boolean; }');
     expect(compact).toContain('game/runtime.ts');
     expect(compact).toContain('Keep files small.');
-    // Nothing here is dropped — the fixture is well under the default budget, and whole-
-    // block selection only omits when the budget genuinely forces it (see below).
+    // Fixture is under budget, so nothing is dropped here (see below).
     expect(compact).toContain('interface Unrelated');
   });
 
   it('names what a tight budget omits instead of silently dropping it', () => {
-    // Interfaces sized like the real declaration file's, so a budget can be tight enough
-    // to force an omission without the unrelated final byte-cap safety net (sized off the
-    // whole document, header included) doing the truncating instead.
+    // Sized like the real declaration file, to force a genuine omission.
     const pad = 'x'.repeat(150);
     const full = [
       '## GameKit API surface',
@@ -103,9 +98,7 @@ describe('Creator Kit digest loader', () => {
 
     const compact = compactKitDigestForPrompt(full, 1400);
 
-    // Party and zone survive whole — the failure this guards against dropped them (or
-    // orphaned their members) below any generous-looking budget. What didn't fit (here,
-    // GameKitApi) is named in an omission note rather than vanishing without a trace.
+    // Party/zone survive whole; what didn't fit is named, not vanished.
     expect(compact).toContain('interface GameKitParty');
     expect(compact).toContain('interface GameKitZone');
     expect(compact).toContain('Omitted for length');
@@ -121,17 +114,14 @@ describe('Creator Kit digest loader', () => {
   });
 
   it('formatOmittedNote truncates a long name list instead of overflowing its reserve', () => {
-    // A realistic tight-budget scenario: most of a 114-declaration API omitted, and the
-    // note listing them all unbounded ran to 2+ KiB with nothing reserving room for it —
-    // the actual bug behind the digest silently dropping the File-shape rules section.
+    // An unbounded note list once ran past 2 KiB, unreserved.
     const names = Array.from({ length: 100 }, (_, i) => `GameKitDeclarationNumber${i}`);
     const note = formatOmittedNote(names, 250);
     expect(Buffer.byteLength(note, 'utf8')).toBeLessThanOrEqual(250);
     expect(note).toMatch(/… and \d+ more/);
     expect(note).not.toContain('GameKitDeclarationNumber99');
 
-    // Too tight even for the "… and N more" suffix: still bounded, just without it — a
-    // truncated list beats an overflowing note either way.
+    // Too tight even for the suffix — still bounded, just without it.
     const tighter = formatOmittedNote(names, 200);
     expect(Buffer.byteLength(tighter, 'utf8')).toBeLessThanOrEqual(200);
   });
@@ -141,10 +131,7 @@ describe('Creator Kit digest loader', () => {
   });
 
   it('never truncates the exemplar or File-shape rules to make room for the API, at realistic sizes', () => {
-    // A large exemplar (bigger than a flat percentage of a small budget would allow) used
-    // to get cut off mid-file by the final blunt byte-cap safety net, because nothing
-    // measured the shell's real size before guessing how much room the API could have.
-    // Reproduces that at the platform lane's real default budget.
+    // A big exemplar used to get truncated by an unmeasured budget.
     const bigFile = 'x'.repeat(6000);
     const full = [
       '## GameKit API surface',
@@ -165,11 +152,7 @@ describe('Creator Kit digest loader', () => {
   });
 
   it('elideDeclaration keeps a multiline member whole even when its closing brace lands at the interface indent', () => {
-    // Shaped after the real GameKitApi.createZone: a member whose own closing
-    // `}): ReturnType;` sits at the interface's 2-space indent, same as any other member's
-    // opening line. An indentation-only member split misread that closing line as a new
-    // member and could drop it once the tight budget ran out, emitting createZone opened
-    // but never closed — malformed output for exactly the factory this exists to preserve.
+    // Shaped after createZone: its closing brace shares the opener's indent.
     const pad = 'x'.repeat(400);
     const api = [
       'interface GameKitApi {',
@@ -182,14 +165,13 @@ describe('Creator Kit digest loader', () => {
     ].join('\n');
 
     const blocks = splitDeclarationBlocks(api);
-    // Budget too small for the whole interface (the padded `other` member alone forces
-    // that), forcing elideDeclaration's member-wise path.
+    // Too small for the whole interface, forcing elideDeclaration's path.
     const { kept } = selectApiBlocks(blocks, ['zone'], 250);
     const text = kept.map((block) => block.text).join('\n');
 
     expect(text).toContain('createZone<S>(config: {');
     expect(text).toContain('}): GameKitZone<S>;');
-    // Brace/paren/bracket depth must return to zero — an unclosed opener is the bug.
+    // Depth must return to zero — an unclosed opener is the bug.
     let depth = 0;
     for (const ch of text) {
       if (ch === '{' || ch === '(' || ch === '[') depth++;
@@ -222,9 +204,7 @@ describe('Creator Kit digest loader', () => {
       ].join('\n'),
     );
 
-    // A budget that fits exactly one of the three blocks still yields party over its own
-    // second block being crowded out — zone would be starved entirely if the pass took
-    // party's two blocks before zone's one, which is the head-of-file-bias bug this guards.
+    // Guards against source order starving zone of its one block.
     const { kept, omitted } = selectApiBlocks(blocks, ['party', 'zone'], blocks[0].bytes + blocks[2].bytes);
 
     expect(kept.map((block) => block.name).sort()).toEqual(['GameKitParty', 'GameKitZone']);

--- a/apps/api/src/kit-digest.ts
+++ b/apps/api/src/kit-digest.ts
@@ -19,8 +19,14 @@ export const DEFAULT_PROMPT_DIGEST_MAX_BYTES = 20_000;
  * the API, so it can afford far more than a system prompt injected into every platform
  * run. Sized to carry the whole declaration surface of a current kit (~79 KiB stripped)
  * with headroom, so the MCP lane rarely has to omit anything at all.
+ *
+ * 90_000 undershot this in practice: the fixed shell (module catalog, audio catalog,
+ * exemplar, rules — none of them proportional to the API's size) already costs ~15 KiB, so
+ * a 90 KiB budget left only ~75 KiB for a ~79 KiB API — `get_kit_api` omitted real content
+ * despite its own description promising the whole reference in one call. 100_000 covers
+ * shell + full current API + the omission-note reserve with room to spare.
  */
-export const DEFAULT_MCP_DIGEST_MAX_BYTES = 90_000;
+export const DEFAULT_MCP_DIGEST_MAX_BYTES = 100_000;
 
 /**
  * Engine module families for kits published before the digest carried its own
@@ -113,18 +119,23 @@ export function splitDeclarationBlocks(api: string): DeclarationBlock[] {
   });
 }
 
-/**
- * Split the body of a declaration into its members.
- *
- * Same column trick as `splitDeclarationBlocks`, one level in: a member starts at the
- * first indent and runs to the next one, so a multi-line member (`createZone<S>(config: {
- * … })`) stays whole instead of being cut mid-signature.
- */
+// A member's own closing brace can land back at the interface's 1-2-space indent — e.g.
+// `createZone<S>(config: { … }): GameKitZone<S>;` — so an indent-only split misreads that
+// closing line as a new member, emitting the opener with no matching close. Track bracket
+// depth instead: a line starts a new member only when depth is 0 at its first character.
+// Safe here because the input is always the comment-stripped API text (compactGameKitApi
+// removes every comment before this ever runs), so no brace in prose can desync the count.
 function splitMembers(body: string): Array<{ text: string; bytes: number }> {
   const lines = body.split('\n');
   const starts: number[] = [];
+  let depth = 0;
   for (let i = 0; i < lines.length; i++) {
-    if (/^\s+\S/.test(lines[i]) && /^ {1,2}\S/.test(lines[i])) starts.push(i);
+    const line = lines[i];
+    if (depth === 0 && /\S/.test(line)) starts.push(i);
+    for (const ch of line) {
+      if (ch === '{' || ch === '(' || ch === '[') depth++;
+      else if (ch === '}' || ch === ')' || ch === ']') depth = Math.max(0, depth - 1);
+    }
   }
   if (!starts.length) return [];
   return starts.map((start, index) => {
@@ -188,6 +199,41 @@ function elideDeclaration(
   if (dropped) body.push(`  // … ${dropped} more members omitted; read shared/game-kit.d.ts for the rest`);
   const text = [header, ...body, closer].join('\n');
   return { name: block.name, text, bytes: Buffer.byteLength(`${text}\n`, 'utf8') };
+}
+
+/** Reserved headroom for the omission note (see `formatOmittedNote`) inside the API budget. */
+const OMITTED_NOTE_RESERVE_BYTES = 600;
+
+/**
+ * Render the "what got cut" note, self-bounded to `maxBytes`.
+ *
+ * At a tight budget, most of a 114-declaration API can end up in `omitted` — the full
+ * name list has run past 2 KiB on its own, none of which any caller reserved room for.
+ * An unbounded note is exactly the silent-overflow failure this whole omission-note
+ * mechanism exists to prevent, just moved one level up: instead of a declaration
+ * vanishing without a trace, the *notice* that declarations were cut could itself get
+ * chopped mid-name by the final blunt truncation, or — worse, as measured — crowd out
+ * File-shape rules and the exemplar entirely. List as many full names as fit, then say
+ * how many more there were rather than trailing off mid-word.
+ */
+export function formatOmittedNote(omitted: readonly string[], maxBytes: number): string {
+  if (!omitted.length) return '';
+  const prefix = `\n// Omitted for length (${omitted.length}); read shared/game-kit.d.ts for these: `;
+  if (Buffer.byteLength(prefix, 'utf8') > maxBytes) return '';
+  let text = prefix;
+  let shown = 0;
+  for (const name of omitted) {
+    const candidate = `${text}${shown ? ', ' : ''}${name}`;
+    if (Buffer.byteLength(candidate, 'utf8') > maxBytes) break;
+    text = candidate;
+    shown++;
+  }
+  const remaining = omitted.length - shown;
+  if (remaining > 0) {
+    const suffix = ` … and ${remaining} more`;
+    text = Buffer.byteLength(`${text}${suffix}`, 'utf8') <= maxBytes ? `${text}${suffix}` : text;
+  }
+  return text;
 }
 
 /** Module families named by the digest's own catalog, falling back for older kits. */
@@ -370,18 +416,6 @@ export function compactKitDigestForPrompt(digest: string, maxBytes = DEFAULT_PRO
   const apiStart = digest.indexOf('~~~typescript');
   const apiEnd = apiStart < 0 ? -1 : digest.indexOf('~~~', apiStart + 13);
   const api = apiStart >= 0 && apiEnd >= 0 ? digest.slice(apiStart + 13, apiEnd) : '';
-  // The API section gets the lion's share; the catalog, exemplar and rules are small and
-  // fixed, so reserving a slice for them keeps the tail from being what a cap truncates.
-  const apiBudget = Math.max(0, Math.floor(maxBytes * 0.72));
-  const { kept, omitted } = selectApiBlocks(splitDeclarationBlocks(api), moduleFamiliesOf(digest), apiBudget);
-  const apiLines = kept.map((block) => block.text);
-  // Name what the budget removed. A digest that silently drops declarations reads as a
-  // complete API reference, and an agent cannot ask for what it cannot see is missing.
-  if (omitted.length) {
-    apiLines.push(
-      `\n// Omitted for length (${omitted.length}); read shared/game-kit.d.ts for these: ${omitted.join(', ')}`,
-    );
-  }
 
   const exemplarStart = digest.indexOf('## Exemplar game');
   const rulesStart = digest.indexOf('## File-shape rules');
@@ -397,24 +431,66 @@ export function compactKitDigestForPrompt(digest: string, maxBytes = DEFAULT_PRO
     })
     .filter(Boolean);
   const rules = rulesStart >= 0 ? digest.slice(rulesStart) : '';
+  const engineModules = sectionOf(digest, '## Engine modules');
+  const audioCatalog = sectionOf(digest, '## Audio catalog');
+
+  // Every non-API piece — the module catalog, audio catalog, exemplar, rules, and the
+  // fixed prose/markdown around them — is measured before any of it is assembled, and the
+  // API gets whatever's actually left. A flat percentage guessed this instead of measuring
+  // it: at the real default 20 KiB budget the exemplar alone is ~13.6 KiB, so the guessed
+  // 28% reserve (~5.6 KiB) was already short before the API contributed a single byte, and
+  // the blunt final truncation below silently cut the rules section off entirely rather
+  // than the guess ever being caught. Measuring first means the API section — not File-
+  // shape rules or the exemplar — is what a tight budget trims.
+  const shellBytes = Buffer.byteLength(
+    [
+      '# Creator Kit prompt digest',
+      'Use these signatures and the template shape; unpack the full kit only when needed.',
+      '',
+      engineModules,
+      '## Core API',
+      '~~~typescript',
+      '~~~',
+      '',
+      audioCatalog,
+      exemplarSections.join('\n\n'),
+      '',
+      rules,
+    ].join('\n'),
+    'utf8',
+  );
+  // Reserve room for the omission note up front — it is rendered after selection but must
+  // not be free to grow past what selection actually left behind.
+  const apiBudget = Math.max(0, maxBytes - shellBytes - OMITTED_NOTE_RESERVE_BYTES);
+  const { kept, omitted } = selectApiBlocks(splitDeclarationBlocks(api), moduleFamiliesOf(digest), apiBudget);
+  const apiLines = kept.map((block) => block.text);
+  // Name what the budget removed. A digest that silently drops declarations reads as a
+  // complete API reference, and an agent cannot ask for what it cannot see is missing.
+  const omittedNote = formatOmittedNote(omitted, OMITTED_NOTE_RESERVE_BYTES);
+  if (omittedNote) apiLines.push(omittedNote);
+
   const compact = [
     '# Creator Kit prompt digest',
     'Use these signatures and the template shape; unpack the full kit only when needed.',
     '',
     // First, and ahead of the API: this is the only place that answers "what can this
     // platform build at all" — the question that used to send agents to a web search.
-    sectionOf(digest, '## Engine modules'),
+    engineModules,
     '## Core API',
     '~~~typescript',
     apiLines.join('\n'),
     '~~~',
     '',
     // Before the exemplar: the tail is what a byte cap cuts.
-    sectionOf(digest, '## Audio catalog'),
+    audioCatalog,
     exemplarSections.join('\n\n'),
     '',
     rules,
   ].join('\n');
+  // Still a floor, not the mechanism: apiBudget already sized the API section to leave
+  // room for everything else, so this only fires if the shell itself exceeds maxBytes
+  // (a budget too small to hold even zero API lines) — same shape of failure either way,
+  // just at the very end instead of mid-line.
   return Buffer.byteLength(compact, 'utf8') <= maxBytes
     ? compact
     : Buffer.from(compact, 'utf8').subarray(0, maxBytes).toString('utf8');

--- a/apps/api/src/kit-digest.ts
+++ b/apps/api/src/kit-digest.ts
@@ -4,7 +4,15 @@ import type { GcsObjectStore } from './gcs-sign.js';
 import { readFile } from 'node:fs/promises';
 
 export const KIT_REGISTRY_OBJECT = 'kits/current.json';
-export const DEFAULT_KIT_DIGEST_MAX_BYTES = 100_000;
+/**
+ * Sanity ceiling on the raw stored digest (comment-stripped API + exemplar + rules; not
+ * the prompt-compacted size), not a token budget — `compactKitDigestForPrompt` /
+ * `compactKitDigestForApi` own that. Raised from 100_000: the games repo's own digest
+ * was already at 99,552 bytes — 99.5% of that cap — before it grew a `## Engine modules`
+ * catalog, so the ceiling was one small API addition from failing regardless of this
+ * change. 150_000 restores real headroom.
+ */
+export const DEFAULT_KIT_DIGEST_MAX_BYTES = 150_000;
 export const DEFAULT_PROMPT_DIGEST_MAX_BYTES = 20_000;
 /**
  * `get_kit_api` is opt-in and paid once per round by an agent that has decided it needs

--- a/apps/api/src/kit-digest.ts
+++ b/apps/api/src/kit-digest.ts
@@ -6,6 +6,286 @@ import { readFile } from 'node:fs/promises';
 export const KIT_REGISTRY_OBJECT = 'kits/current.json';
 export const DEFAULT_KIT_DIGEST_MAX_BYTES = 100_000;
 export const DEFAULT_PROMPT_DIGEST_MAX_BYTES = 20_000;
+/**
+ * `get_kit_api` is opt-in and paid once per round by an agent that has decided it needs
+ * the API, so it can afford far more than a system prompt injected into every platform
+ * run. Sized to carry the whole declaration surface of a current kit (~79 KiB stripped)
+ * with headroom, so the MCP lane rarely has to omit anything at all.
+ */
+export const DEFAULT_MCP_DIGEST_MAX_BYTES = 90_000;
+
+/**
+ * Engine module families for kits published before the digest carried its own
+ * `## Engine modules` catalog. Only a fallback: `moduleFamiliesOf` prefers the catalog,
+ * which is generated from `shared/modules/*.ts` in the games repo and cannot go stale.
+ */
+const FALLBACK_MODULE_FAMILIES: readonly string[] = Object.freeze([
+  'actors',
+  'ai',
+  'audio',
+  'collision',
+  'commons',
+  'core',
+  'drawing',
+  'editor',
+  'effects',
+  'gameplay',
+  'gfx3d',
+  'gfx',
+  'input',
+  'mascot',
+  'party',
+  'path',
+  'presence',
+  'rng',
+  'save',
+  'sensing',
+  'voice',
+  'world',
+  'zone',
+]);
+
+/**
+ * Declarations that describe the lifecycle every game uses regardless of module choice.
+ * These are kept before any module block, because a digest that dropped them would not
+ * describe a buildable game at all.
+ */
+const CORE_DECLARATIONS: readonly string[] = Object.freeze([
+  'GameKitApi',
+  'GameKitGameBuilder',
+  'GameKitGameContext',
+  'GameKit',
+  'GameDefinition',
+  'GameKitInput',
+  'GameKitDraw',
+  'GameKitRenderer',
+  'GameKitSurface',
+  'GameLifecycleState',
+  'GameKitEndConfig',
+  'GameKitHudSpec',
+  'GameKitHudSlot',
+  'GameKitGameText',
+  'GameSnapshot',
+  'GameSnapshotValue',
+  'GameKitPointer',
+]);
+
+interface DeclarationBlock {
+  name: string;
+  text: string;
+  bytes: number;
+}
+
+/**
+ * Split a `.d.ts` body into top-level declaration blocks.
+ *
+ * The kit's declaration file puts every top-level declaration at column 0 and indents
+ * everything nested, so a block runs from one column-0 declaration to the next. That is
+ * why this does not count braces: it costs nothing in accuracy here and cannot desync on
+ * a brace inside a string literal or a template type.
+ */
+export function splitDeclarationBlocks(api: string): DeclarationBlock[] {
+  const lines = api.split('\n');
+  const starts: number[] = [];
+  const names: string[] = [];
+  for (let i = 0; i < lines.length; i++) {
+    const match =
+      /^(?:export\s+)?(?:declare\s+)?(?:interface|type|const|class|enum|function|namespace)\s+([A-Za-z_$][\w$]*)/.exec(
+        lines[i],
+      );
+    if (match) {
+      starts.push(i);
+      names.push(match[1]);
+    }
+  }
+  return starts.map((start, index) => {
+    const end = index + 1 < starts.length ? starts[index + 1] : lines.length;
+    const text = lines.slice(start, end).join('\n').replace(/\s+$/, '');
+    return { name: names[index], text, bytes: Buffer.byteLength(`${text}\n`, 'utf8') };
+  });
+}
+
+/**
+ * Split the body of a declaration into its members.
+ *
+ * Same column trick as `splitDeclarationBlocks`, one level in: a member starts at the
+ * first indent and runs to the next one, so a multi-line member (`createZone<S>(config: {
+ * … })`) stays whole instead of being cut mid-signature.
+ */
+function splitMembers(body: string): Array<{ text: string; bytes: number }> {
+  const lines = body.split('\n');
+  const starts: number[] = [];
+  for (let i = 0; i < lines.length; i++) {
+    if (/^\s+\S/.test(lines[i]) && /^ {1,2}\S/.test(lines[i])) starts.push(i);
+  }
+  if (!starts.length) return [];
+  return starts.map((start, index) => {
+    const end = index + 1 < starts.length ? starts[index + 1] : lines.length;
+    const text = lines.slice(start, end).join('\n').replace(/\s+$/, '');
+    return { text, bytes: Buffer.byteLength(`${text}\n`, 'utf8') };
+  });
+}
+
+/**
+ * Shrink one oversized declaration to fit, by dropping members rather than the whole
+ * declaration.
+ *
+ * `GameKitApi` is 34 KiB — 44% of the entire declaration surface in a single interface —
+ * and `createParty`, `createZone`, `createCommons` and `createPresence` are members of it,
+ * near its end. Whole-block selection alone therefore had a sharp edge: below a ~40 KiB API
+ * budget `GameKitApi` did not fit at all and every module factory vanished with it, and any
+ * naive truncation would have cut precisely the tail those four live in. Factories are kept
+ * first for that reason, and what is dropped is counted in place, inside the braces, so the
+ * result reads as an abridged interface rather than a complete one.
+ */
+function elideDeclaration(
+  block: DeclarationBlock,
+  maxBytes: number,
+  families: readonly string[],
+): DeclarationBlock | undefined {
+  const lines = block.text.split('\n');
+  if (lines.length < 3) return undefined;
+  const header = lines[0];
+  const closer = lines[lines.length - 1];
+  if (!/\{\s*$/.test(header) || !/^\}/.test(closer)) return undefined;
+  const members = splitMembers(lines.slice(1, -1).join('\n'));
+  if (!members.length) return undefined;
+
+  const overhead = Buffer.byteLength(`${header}\n${closer}\n`, 'utf8');
+  // Rank module factories above other factories, not just factories above everything.
+  // `GameKitApi` carries dozens of `create*` members — the gfx3d geometry/material/mesh
+  // family alone is most of them — and `createParty` / `createZone` / `createCommons` /
+  // `createPresence` are declared last. Ranking factories only by source order therefore
+  // still spent the whole reserve before reaching them.
+  const rankOf = (text: string): number => {
+    const factory = /^\s*(?:readonly\s+)?create([A-Z]\w*)/.exec(text);
+    if (!factory) return 2;
+    return families.includes(factory[1].toLowerCase()) ? 0 : 1;
+  };
+  const ranked = members
+    .map((member, index) => ({ member, index, rank: rankOf(member.text) }))
+    .sort((a, b) => (a.rank === b.rank ? a.index - b.index : a.rank - b.rank));
+
+  const chosen = new Set<number>();
+  let used = overhead + 80; // room for the elision note itself
+  for (const entry of ranked) {
+    if (used + entry.member.bytes > maxBytes) continue;
+    chosen.add(entry.index);
+    used += entry.member.bytes;
+  }
+  if (!chosen.size) return undefined;
+
+  const dropped = members.length - chosen.size;
+  const body = members.filter((_, index) => chosen.has(index)).map((member) => member.text);
+  if (dropped) body.push(`  // … ${dropped} more members omitted; read shared/game-kit.d.ts for the rest`);
+  const text = [header, ...body, closer].join('\n');
+  return { name: block.name, text, bytes: Buffer.byteLength(`${text}\n`, 'utf8') };
+}
+
+/** Module families named by the digest's own catalog, falling back for older kits. */
+function moduleFamiliesOf(digest: string): readonly string[] {
+  const catalog = sectionOf(digest, '## Engine modules');
+  if (!catalog) return FALLBACK_MODULE_FAMILIES;
+  const found = new Set<string>();
+  for (const line of catalog.split('\n')) {
+    const match = /^[-*]\s+`?([a-z][a-z0-9]*)`?\s*(?:—|-|:)/.exec(line.trim());
+    if (match) found.add(match[1]);
+  }
+  // Longest first so `gfx3d` claims its blocks before `gfx` can.
+  return found.size ? [...found].sort((a, b) => b.length - a.length) : FALLBACK_MODULE_FAMILIES;
+}
+
+/** The module family a declaration belongs to, by longest name match. */
+function familyOf(name: string, families: readonly string[]): string | undefined {
+  const lower = name.toLowerCase();
+  let best: string | undefined;
+  for (const family of families) {
+    if (lower.includes(family) && (!best || family.length > best.length)) best = family;
+  }
+  return best;
+}
+
+/**
+ * Choose which declaration blocks survive a byte budget.
+ *
+ * Selection is tiered rather than filtered, and the tiers exist for one reason: an earlier
+ * implementation kept only lines matching a hardcoded regex allowlist, every pattern of
+ * which described single-player core API. `GameKitParty`, `GameKitZone`, `GameKitCommons`
+ * and `GameKitPresence` matched nothing, so party games, real-time shared zones and
+ * persistent worlds — three of the platform's most differentiated capabilities — were
+ * invisible to the platform agent reading this digest, with no signal that anything had
+ * been removed. The only survivor was an accident: `down(` was meant for input and pulled
+ * in party's `down(slot, ...actions)` as an orphan line with its interface name filtered
+ * away, which is worse than omitting it.
+ *
+ * So: whole blocks only (never an orphan member line), every module family represented
+ * before any family gets a second block, and whatever the budget forces out is named in
+ * the output instead of vanishing.
+ */
+export function selectApiBlocks(
+  blocks: readonly DeclarationBlock[],
+  families: readonly string[],
+  maxBytes: number,
+): { kept: DeclarationBlock[]; omitted: string[] } {
+  const kept = new Map<string, DeclarationBlock>();
+  let used = 0;
+  const take = (block: DeclarationBlock, limit = maxBytes): boolean => {
+    if (kept.has(block.name)) return true;
+    if (used + block.bytes > limit) return false;
+    kept.set(block.name, block);
+    used += block.bytes;
+    return true;
+  };
+
+  // Reserve a share up front for core declarations too large to fit whole, instead of
+  // letting them have only what earlier passes leave behind. `GameKitApi` is the only such
+  // block today, and it is where every module factory lives, so "whatever is left over"
+  // meant the factories were funded last from an empty purse: at a 14 KiB API budget the
+  // earlier passes spent everything and `createParty` / `createZone` / `createCommons` /
+  // `createPresence` never appeared at all.
+  const oversized = CORE_DECLARATIONS.map((name) => blocks.find((block) => block.name === name)).filter(
+    (block): block is DeclarationBlock => Boolean(block) && block!.bytes > Math.floor(maxBytes * 0.45),
+  );
+  const reserve = oversized.length ? Math.floor(maxBytes * 0.45) : 0;
+  const earlyLimit = maxBytes - reserve;
+
+  // Families first, and deliberately ahead of core. Every family primary together costs a
+  // few KiB, while one core declaration (`GameKitApi`) costs 34 KiB; letting the big block
+  // bid first is what made party, zone, commons and presence disappear below a ~40 KiB
+  // budget. The block chosen per family is its primary declaration — `GameKitParty`, not
+  // whichever of `PartyAction` / `PartySlotConfig` / `PartySlot` comes first in the file.
+  const claimed = new Set<string>();
+  for (const family of families) {
+    if (claimed.has(family)) continue;
+    const candidates = blocks.filter((block) => familyOf(block.name, families) === family);
+    if (!candidates.length) continue;
+    const primary =
+      candidates.find((block) => block.name.toLowerCase() === `gamekit${family}`) ??
+      candidates.find((block) => block.name.toLowerCase() === family) ??
+      candidates.reduce((shortest, block) => (block.name.length < shortest.name.length ? block : shortest));
+    if (take(primary, earlyLimit)) claimed.add(family);
+  }
+  // Then core that fits whole, in CORE_DECLARATIONS order rather than source order: that
+  // list is written most-important first.
+  for (const name of CORE_DECLARATIONS) {
+    const block = blocks.find((candidate) => candidate.name === name);
+    if (block && !oversized.includes(block)) take(block, earlyLimit);
+  }
+  // Now spend the reserve: abridge the oversized core declarations member-wise rather than
+  // dropping them, so `GameKitApi` still contributes its factory signatures.
+  for (const block of oversized) {
+    if (kept.has(block.name)) continue;
+    if (take(block)) continue;
+    const elided = elideDeclaration(block, maxBytes - used, families);
+    if (elided) take(elided);
+  }
+  for (const block of blocks) take(block);
+
+  const omitted = blocks.filter((block) => !kept.has(block.name)).map((block) => block.name);
+  // Emit in source order, taking the stored copy rather than the original: a block that
+  // was abridged must reach the output abridged, not restored to full size.
+  return { kept: blocks.filter((block) => kept.has(block.name)).map((block) => kept.get(block.name)!), omitted };
+}
 
 export interface KitDigestLoader {
   load(): Promise<string | undefined>;
@@ -82,18 +362,18 @@ export function compactKitDigestForPrompt(digest: string, maxBytes = DEFAULT_PRO
   const apiStart = digest.indexOf('~~~typescript');
   const apiEnd = apiStart < 0 ? -1 : digest.indexOf('~~~', apiStart + 13);
   const api = apiStart >= 0 && apiEnd >= 0 ? digest.slice(apiStart + 13, apiEnd) : '';
-  const apiPatterns = [
-    /GameKit(Input|GameContext|GameBuilder|Api|Draw)/,
-    /GameLifecycleState|GameKitEndConfig|GameKitHudSpec/,
-    /create(Renderer|Input|Audio)|defineGame/,
-    /orientation\(|renderer\(|input\(|audio\(|init\(|win\(|lose\(|hud\(|update\(|render\(|snapshot\(|start\(/,
-    /down\(|consume(Real|Press|Click)|position\(|held\(|vector\(/,
-    /end(Soon)?\(|restart\(|clear\(|rect\(|circle\(|poly\(|text\(|line\(/,
-  ];
-  const apiLines = api
-    .split('\n')
-    .filter((line) => apiPatterns.some((pattern) => pattern.test(line)))
-    .slice(0, 180);
+  // The API section gets the lion's share; the catalog, exemplar and rules are small and
+  // fixed, so reserving a slice for them keeps the tail from being what a cap truncates.
+  const apiBudget = Math.max(0, Math.floor(maxBytes * 0.72));
+  const { kept, omitted } = selectApiBlocks(splitDeclarationBlocks(api), moduleFamiliesOf(digest), apiBudget);
+  const apiLines = kept.map((block) => block.text);
+  // Name what the budget removed. A digest that silently drops declarations reads as a
+  // complete API reference, and an agent cannot ask for what it cannot see is missing.
+  if (omitted.length) {
+    apiLines.push(
+      `\n// Omitted for length (${omitted.length}); read shared/game-kit.d.ts for these: ${omitted.join(', ')}`,
+    );
+  }
 
   const exemplarStart = digest.indexOf('## Exemplar game');
   const rulesStart = digest.indexOf('## File-shape rules');
@@ -113,6 +393,9 @@ export function compactKitDigestForPrompt(digest: string, maxBytes = DEFAULT_PRO
     '# Creator Kit prompt digest',
     'Use these signatures and the template shape; unpack the full kit only when needed.',
     '',
+    // First, and ahead of the API: this is the only place that answers "what can this
+    // platform build at all" — the question that used to send agents to a web search.
+    sectionOf(digest, '## Engine modules'),
     '## Core API',
     '~~~typescript',
     apiLines.join('\n'),
@@ -127,4 +410,14 @@ export function compactKitDigestForPrompt(digest: string, maxBytes = DEFAULT_PRO
   return Buffer.byteLength(compact, 'utf8') <= maxBytes
     ? compact
     : Buffer.from(compact, 'utf8').subarray(0, maxBytes).toString('utf8');
+}
+
+/**
+ * The same digest for `get_kit_api` over MCP, where the budget is per-round and opt-in
+ * rather than per-prompt. Distinct from the platform lane only in size: an MCP agent has
+ * no system prompt carrying the kit, so this is the whole reference it gets before it
+ * falls back to the browse tools.
+ */
+export function compactKitDigestForApi(digest: string, maxBytes = DEFAULT_MCP_DIGEST_MAX_BYTES): string {
+  return compactKitDigestForPrompt(digest, maxBytes);
 }

--- a/apps/api/src/kit-digest.ts
+++ b/apps/api/src/kit-digest.ts
@@ -4,35 +4,13 @@ import type { GcsObjectStore } from './gcs-sign.js';
 import { readFile } from 'node:fs/promises';
 
 export const KIT_REGISTRY_OBJECT = 'kits/current.json';
-/**
- * Sanity ceiling on the raw stored digest (comment-stripped API + exemplar + rules; not
- * the prompt-compacted size), not a token budget — `compactKitDigestForPrompt` /
- * `compactKitDigestForApi` own that. Raised from 100_000: the games repo's own digest
- * was already at 99,552 bytes — 99.5% of that cap — before it grew a `## Engine modules`
- * catalog, so the ceiling was one small API addition from failing regardless of this
- * change. 150_000 restores real headroom.
- */
+// Sanity ceiling on raw digest bytes, not a prompt budget.
 export const DEFAULT_KIT_DIGEST_MAX_BYTES = 150_000;
 export const DEFAULT_PROMPT_DIGEST_MAX_BYTES = 20_000;
-/**
- * `get_kit_api` is opt-in and paid once per round by an agent that has decided it needs
- * the API, so it can afford far more than a system prompt injected into every platform
- * run. Sized to carry the whole declaration surface of a current kit (~79 KiB stripped)
- * with headroom, so the MCP lane rarely has to omit anything at all.
- *
- * 90_000 undershot this in practice: the fixed shell (module catalog, audio catalog,
- * exemplar, rules — none of them proportional to the API's size) already costs ~15 KiB, so
- * a 90 KiB budget left only ~75 KiB for a ~79 KiB API — `get_kit_api` omitted real content
- * despite its own description promising the whole reference in one call. 100_000 covers
- * shell + full current API + the omission-note reserve with room to spare.
- */
+// Per-round budget for get_kit_api: shell plus the full API.
 export const DEFAULT_MCP_DIGEST_MAX_BYTES = 100_000;
 
-/**
- * Engine module families for kits published before the digest carried its own
- * `## Engine modules` catalog. Only a fallback: `moduleFamiliesOf` prefers the catalog,
- * which is generated from `shared/modules/*.ts` in the games repo and cannot go stale.
- */
+// Fallback only — moduleFamiliesOf prefers the digest's own catalog.
 const FALLBACK_MODULE_FAMILIES: readonly string[] = Object.freeze([
   'actors',
   'ai',
@@ -59,11 +37,7 @@ const FALLBACK_MODULE_FAMILIES: readonly string[] = Object.freeze([
   'zone',
 ]);
 
-/**
- * Declarations that describe the lifecycle every game uses regardless of module choice.
- * These are kept before any module block, because a digest that dropped them would not
- * describe a buildable game at all.
- */
+// Lifecycle declarations every game needs; kept before any module block.
 const CORE_DECLARATIONS: readonly string[] = Object.freeze([
   'GameKitApi',
   'GameKitGameBuilder',
@@ -90,14 +64,7 @@ interface DeclarationBlock {
   bytes: number;
 }
 
-/**
- * Split a `.d.ts` body into top-level declaration blocks.
- *
- * The kit's declaration file puts every top-level declaration at column 0 and indents
- * everything nested, so a block runs from one column-0 declaration to the next. That is
- * why this does not count braces: it costs nothing in accuracy here and cannot desync on
- * a brace inside a string literal or a template type.
- */
+// Top-level declarations start at column 0, ending at the next.
 export function splitDeclarationBlocks(api: string): DeclarationBlock[] {
   const lines = api.split('\n');
   const starts: number[] = [];
@@ -119,12 +86,7 @@ export function splitDeclarationBlocks(api: string): DeclarationBlock[] {
   });
 }
 
-// A member's own closing brace can land back at the interface's 1-2-space indent — e.g.
-// `createZone<S>(config: { … }): GameKitZone<S>;` — so an indent-only split misreads that
-// closing line as a new member, emitting the opener with no matching close. Track bracket
-// depth instead: a line starts a new member only when depth is 0 at its first character.
-// Safe here because the input is always the comment-stripped API text (compactGameKitApi
-// removes every comment before this ever runs), so no brace in prose can desync the count.
+// Tracks bracket depth, not indentation (see SKILL.md for the bug fixed).
 function splitMembers(body: string): Array<{ text: string; bytes: number }> {
   const lines = body.split('\n');
   const starts: number[] = [];
@@ -145,18 +107,7 @@ function splitMembers(body: string): Array<{ text: string; bytes: number }> {
   });
 }
 
-/**
- * Shrink one oversized declaration to fit, by dropping members rather than the whole
- * declaration.
- *
- * `GameKitApi` is 34 KiB — 44% of the entire declaration surface in a single interface —
- * and `createParty`, `createZone`, `createCommons` and `createPresence` are members of it,
- * near its end. Whole-block selection alone therefore had a sharp edge: below a ~40 KiB API
- * budget `GameKitApi` did not fit at all and every module factory vanished with it, and any
- * naive truncation would have cut precisely the tail those four live in. Factories are kept
- * first for that reason, and what is dropped is counted in place, inside the braces, so the
- * result reads as an abridged interface rather than a complete one.
- */
+// Abridge an oversized declaration member-wise (factories first) instead of dropping it.
 function elideDeclaration(
   block: DeclarationBlock,
   maxBytes: number,
@@ -171,11 +122,7 @@ function elideDeclaration(
   if (!members.length) return undefined;
 
   const overhead = Buffer.byteLength(`${header}\n${closer}\n`, 'utf8');
-  // Rank module factories above other factories, not just factories above everything.
-  // `GameKitApi` carries dozens of `create*` members — the gfx3d geometry/material/mesh
-  // family alone is most of them — and `createParty` / `createZone` / `createCommons` /
-  // `createPresence` are declared last. Ranking factories only by source order therefore
-  // still spent the whole reserve before reaching them.
+  // Module-family factories outrank other factories — see byoca-mcp SKILL.md.
   const rankOf = (text: string): number => {
     const factory = /^\s*(?:readonly\s+)?create([A-Z]\w*)/.exec(text);
     if (!factory) return 2;
@@ -201,21 +148,10 @@ function elideDeclaration(
   return { name: block.name, text, bytes: Buffer.byteLength(`${text}\n`, 'utf8') };
 }
 
-/** Reserved headroom for the omission note (see `formatOmittedNote`) inside the API budget. */
+// Reserved headroom for the omission note (formatOmittedNote) inside the API budget.
 const OMITTED_NOTE_RESERVE_BYTES = 600;
 
-/**
- * Render the "what got cut" note, self-bounded to `maxBytes`.
- *
- * At a tight budget, most of a 114-declaration API can end up in `omitted` — the full
- * name list has run past 2 KiB on its own, none of which any caller reserved room for.
- * An unbounded note is exactly the silent-overflow failure this whole omission-note
- * mechanism exists to prevent, just moved one level up: instead of a declaration
- * vanishing without a trace, the *notice* that declarations were cut could itself get
- * chopped mid-name by the final blunt truncation, or — worse, as measured — crowd out
- * File-shape rules and the exemplar entirely. List as many full names as fit, then say
- * how many more there were rather than trailing off mid-word.
- */
+// Self-bounded omission note; see SKILL.md for why it matters.
 export function formatOmittedNote(omitted: readonly string[], maxBytes: number): string {
   if (!omitted.length) return '';
   const prefix = `\n// Omitted for length (${omitted.length}); read shared/game-kit.d.ts for these: `;
@@ -236,7 +172,7 @@ export function formatOmittedNote(omitted: readonly string[], maxBytes: number):
   return text;
 }
 
-/** Module families named by the digest's own catalog, falling back for older kits. */
+// Module families from the digest's own catalog, or a fallback list.
 function moduleFamiliesOf(digest: string): readonly string[] {
   const catalog = sectionOf(digest, '## Engine modules');
   if (!catalog) return FALLBACK_MODULE_FAMILIES;
@@ -249,7 +185,7 @@ function moduleFamiliesOf(digest: string): readonly string[] {
   return found.size ? [...found].sort((a, b) => b.length - a.length) : FALLBACK_MODULE_FAMILIES;
 }
 
-/** The module family a declaration belongs to, by longest name match. */
+// The module family a declaration belongs to, by longest name match.
 function familyOf(name: string, families: readonly string[]): string | undefined {
   const lower = name.toLowerCase();
   let best: string | undefined;
@@ -259,23 +195,7 @@ function familyOf(name: string, families: readonly string[]): string | undefined
   return best;
 }
 
-/**
- * Choose which declaration blocks survive a byte budget.
- *
- * Selection is tiered rather than filtered, and the tiers exist for one reason: an earlier
- * implementation kept only lines matching a hardcoded regex allowlist, every pattern of
- * which described single-player core API. `GameKitParty`, `GameKitZone`, `GameKitCommons`
- * and `GameKitPresence` matched nothing, so party games, real-time shared zones and
- * persistent worlds — three of the platform's most differentiated capabilities — were
- * invisible to the platform agent reading this digest, with no signal that anything had
- * been removed. The only survivor was an accident: `down(` was meant for input and pulled
- * in party's `down(slot, ...actions)` as an orphan line with its interface name filtered
- * away, which is worse than omitting it.
- *
- * So: whole blocks only (never an orphan member line), every module family represented
- * before any family gets a second block, and whatever the budget forces out is named in
- * the output instead of vanishing.
- */
+// Whole blocks, every family represented first (see SKILL.md for the bug).
 export function selectApiBlocks(
   blocks: readonly DeclarationBlock[],
   families: readonly string[],
@@ -291,23 +211,14 @@ export function selectApiBlocks(
     return true;
   };
 
-  // Reserve a share up front for core declarations too large to fit whole, instead of
-  // letting them have only what earlier passes leave behind. `GameKitApi` is the only such
-  // block today, and it is where every module factory lives, so "whatever is left over"
-  // meant the factories were funded last from an empty purse: at a 14 KiB API budget the
-  // earlier passes spent everything and `createParty` / `createZone` / `createCommons` /
-  // `createPresence` never appeared at all.
+  // Reserve a share up front for oversized core declarations like GameKitApi.
   const oversized = CORE_DECLARATIONS.map((name) => blocks.find((block) => block.name === name)).filter(
     (block): block is DeclarationBlock => Boolean(block) && block!.bytes > Math.floor(maxBytes * 0.45),
   );
   const reserve = oversized.length ? Math.floor(maxBytes * 0.45) : 0;
   const earlyLimit = maxBytes - reserve;
 
-  // Families first, and deliberately ahead of core. Every family primary together costs a
-  // few KiB, while one core declaration (`GameKitApi`) costs 34 KiB; letting the big block
-  // bid first is what made party, zone, commons and presence disappear below a ~40 KiB
-  // budget. The block chosen per family is its primary declaration — `GameKitParty`, not
-  // whichever of `PartyAction` / `PartySlotConfig` / `PartySlot` comes first in the file.
+  // Families first, ahead of core, so one block cannot starve them.
   const claimed = new Set<string>();
   for (const family of families) {
     if (claimed.has(family)) continue;
@@ -319,14 +230,12 @@ export function selectApiBlocks(
       candidates.reduce((shortest, block) => (block.name.length < shortest.name.length ? block : shortest));
     if (take(primary, earlyLimit)) claimed.add(family);
   }
-  // Then core that fits whole, in CORE_DECLARATIONS order rather than source order: that
-  // list is written most-important first.
+  // Core that fits whole, in CORE_DECLARATIONS order (most-important first).
   for (const name of CORE_DECLARATIONS) {
     const block = blocks.find((candidate) => candidate.name === name);
     if (block && !oversized.includes(block)) take(block, earlyLimit);
   }
-  // Now spend the reserve: abridge the oversized core declarations member-wise rather than
-  // dropping them, so `GameKitApi` still contributes its factory signatures.
+  // Spend the reserve: abridge oversized core declarations instead of dropping them.
   for (const block of oversized) {
     if (kept.has(block.name)) continue;
     if (take(block)) continue;
@@ -336,8 +245,7 @@ export function selectApiBlocks(
   for (const block of blocks) take(block);
 
   const omitted = blocks.filter((block) => !kept.has(block.name)).map((block) => block.name);
-  // Emit in source order, taking the stored copy rather than the original: a block that
-  // was abridged must reach the output abridged, not restored to full size.
+  // Source order, using the stored (possibly abridged) copy, not the original.
   return { kept: blocks.filter((block) => kept.has(block.name)).map((block) => kept.get(block.name)!), omitted };
 }
 
@@ -434,14 +342,7 @@ export function compactKitDigestForPrompt(digest: string, maxBytes = DEFAULT_PRO
   const engineModules = sectionOf(digest, '## Engine modules');
   const audioCatalog = sectionOf(digest, '## Audio catalog');
 
-  // Every non-API piece — the module catalog, audio catalog, exemplar, rules, and the
-  // fixed prose/markdown around them — is measured before any of it is assembled, and the
-  // API gets whatever's actually left. A flat percentage guessed this instead of measuring
-  // it: at the real default 20 KiB budget the exemplar alone is ~13.6 KiB, so the guessed
-  // 28% reserve (~5.6 KiB) was already short before the API contributed a single byte, and
-  // the blunt final truncation below silently cut the rules section off entirely rather
-  // than the guess ever being caught. Measuring first means the API section — not File-
-  // shape rules or the exemplar — is what a tight budget trims.
+  // Measure the fixed shell first — a guessed percentage silently truncated rules.
   const shellBytes = Buffer.byteLength(
     [
       '# Creator Kit prompt digest',
@@ -459,13 +360,11 @@ export function compactKitDigestForPrompt(digest: string, maxBytes = DEFAULT_PRO
     ].join('\n'),
     'utf8',
   );
-  // Reserve room for the omission note up front — it is rendered after selection but must
-  // not be free to grow past what selection actually left behind.
+  // Reserve room for the omission note before selection spends the rest.
   const apiBudget = Math.max(0, maxBytes - shellBytes - OMITTED_NOTE_RESERVE_BYTES);
   const { kept, omitted } = selectApiBlocks(splitDeclarationBlocks(api), moduleFamiliesOf(digest), apiBudget);
   const apiLines = kept.map((block) => block.text);
-  // Name what the budget removed. A digest that silently drops declarations reads as a
-  // complete API reference, and an agent cannot ask for what it cannot see is missing.
+  // Name what got cut instead of dropping it silently.
   const omittedNote = formatOmittedNote(omitted, OMITTED_NOTE_RESERVE_BYTES);
   if (omittedNote) apiLines.push(omittedNote);
 
@@ -473,8 +372,7 @@ export function compactKitDigestForPrompt(digest: string, maxBytes = DEFAULT_PRO
     '# Creator Kit prompt digest',
     'Use these signatures and the template shape; unpack the full kit only when needed.',
     '',
-    // First, and ahead of the API: this is the only place that answers "what can this
-    // platform build at all" — the question that used to send agents to a web search.
+    // Ahead of the API: what this platform can build.
     engineModules,
     '## Core API',
     '~~~typescript',
@@ -487,21 +385,13 @@ export function compactKitDigestForPrompt(digest: string, maxBytes = DEFAULT_PRO
     '',
     rules,
   ].join('\n');
-  // Still a floor, not the mechanism: apiBudget already sized the API section to leave
-  // room for everything else, so this only fires if the shell itself exceeds maxBytes
-  // (a budget too small to hold even zero API lines) — same shape of failure either way,
-  // just at the very end instead of mid-line.
+  // Floor only — fires when the shell alone exceeds maxBytes (zero API lines).
   return Buffer.byteLength(compact, 'utf8') <= maxBytes
     ? compact
     : Buffer.from(compact, 'utf8').subarray(0, maxBytes).toString('utf8');
 }
 
-/**
- * The same digest for `get_kit_api` over MCP, where the budget is per-round and opt-in
- * rather than per-prompt. Distinct from the platform lane only in size: an MCP agent has
- * no system prompt carrying the kit, so this is the whole reference it gets before it
- * falls back to the browse tools.
- */
+// get_kit_api's digest: same shape, a per-round budget.
 export function compactKitDigestForApi(digest: string, maxBytes = DEFAULT_MCP_DIGEST_MAX_BYTES): string {
   return compactKitDigestForPrompt(digest, maxBytes);
 }

--- a/apps/api/src/mcp-presence.ts
+++ b/apps/api/src/mcp-presence.ts
@@ -51,6 +51,7 @@ const PRESENCE_BY_TOOL: Record<string, { key: string; text: string }> = {
   get_brief: { key: 'reading_brief', text: 'Reading the build brief…' },
   get_seed: { key: 'loading_seed', text: 'Loading the seed draft…' },
   get_kit: { key: 'fetching_kit', text: 'Fetching Creator Kit metadata…' },
+  get_kit_api: { key: 'reading_kit_api', text: 'Reading the Creator Kit API reference…' },
   list_kit_files: { key: 'browsing_kit', text: 'Browsing the Creator Kit…' },
   search_kit_files: { key: 'searching_kit', text: 'Searching the Creator Kit…' },
   read_kit_file: { key: 'reading_kit', text: 'Reading Creator Kit files…' },

--- a/apps/api/src/mcp-server.test.ts
+++ b/apps/api/src/mcp-server.test.ts
@@ -375,17 +375,20 @@ describe('POST /api/mcp (BY-05)', () => {
         'ack_inbox',
       ]),
     );
-    expect(names).not.toEqual(
+    // Kit browse tools are advertised: get_kit_api is the orientation path (whole digest,
+    // one call), these are the depth path (specific files) once an agent knows what it
+    // wants. Example/proposal browse tools stay off the model-visible surface.
+    expect(names).toEqual(
       expect.arrayContaining([
+        'get_kit_api',
         'list_kit_files',
         'search_kit_files',
         'read_kit_file',
         'read_kit_files',
         'read_kit_file_fragment',
-        'list_examples',
-        'get_example',
       ]),
     );
+    expect(names).not.toEqual(expect.arrayContaining(['list_examples', 'get_example']));
     expect(names).not.toContain('send_screenshot');
     const tools = listed.json().result.tools as Array<{
       name: string;
@@ -417,12 +420,21 @@ describe('POST /api/mcp (BY-05)', () => {
     expect(getKit?.description).toMatch(/gamedevpl-creator-kit/);
     expect(getKit?.description).toMatch(/entry=gamedevpl-creator-kit\/SKILL\.md/);
     expect(getKit?.description).toMatch(/do not assume a `cd` persists/i);
-    expect(getKit?.description).not.toMatch(/list_kit_files|search_kit_files|read_kit_file/);
-    expect(tools.find((t) => t.name === 'list_kit_files')).toBeUndefined();
-    expect(tools.find((t) => t.name === 'search_kit_files')).toBeUndefined();
-    expect(tools.find((t) => t.name === 'read_kit_file')).toBeUndefined();
-    expect(tools.find((t) => t.name === 'read_kit_files')).toBeUndefined();
-    expect(tools.find((t) => t.name === 'read_kit_file_fragment')).toBeUndefined();
+    // The platform and kit are not on the public web — an agent with an unanswered
+    // capability question (multiplayer? persistent worlds?) has an in-band answer now,
+    // so it never has to guess by searching for docs that were never published.
+    expect(getKit?.description).toMatch(/not on the public web/i);
+    expect(getKit?.description).toMatch(/get_kit_api/);
+    expect(tools.find((t) => t.name === 'get_kit_api')).toBeDefined();
+    expect(tools.find((t) => t.name === 'list_kit_files')).toBeDefined();
+    expect(tools.find((t) => t.name === 'search_kit_files')).toBeDefined();
+    expect(tools.find((t) => t.name === 'read_kit_file')).toBeDefined();
+    expect(tools.find((t) => t.name === 'read_kit_files')).toBeDefined();
+    expect(tools.find((t) => t.name === 'read_kit_file_fragment')).toBeDefined();
+
+    const getKitApi = tools.find((t) => t.name === 'get_kit_api');
+    expect(getKitApi?.description).toMatch(/party|zone|commons|presence/i);
+    expect(getKitApi?.description).toMatch(/engineRef/);
 
     const gateVerdict = tools.find((t) => t.name === 'get_gate_verdict');
     expect(gateVerdict?.annotations?.title).toBe('Check the gate once');
@@ -452,12 +464,15 @@ describe('POST /api/mcp (BY-05)', () => {
         'get_brief',
         'get_seed',
         'get_kit',
+        'get_kit_api',
         'stage_source_file',
         'submit_sources',
         'end',
       ]),
     );
-    expect(names).not.toEqual(expect.arrayContaining(['search_kit_files', 'submit_proposal']));
+    // Kit browse/orientation tools are the focused build surface now; example and
+    // proposal tooling stay off it.
+    expect(names).not.toEqual(expect.arrayContaining(['list_examples', 'submit_proposal']));
   });
 
   it('never names an unadvertised tool in anything the model reads', async () => {
@@ -480,7 +495,7 @@ describe('POST /api/mcp (BY-05)', () => {
     }
   });
 
-  it('get_kit does not name kit browse tools this surface never advertised', async () => {
+  it('get_kit names the kit browse tools this surface advertises', async () => {
     const store = new InMemoryStore();
     await seedJob(store);
     const engine = 'c21f5132cedb5133aa87f75654549391f4a5c633';
@@ -503,7 +518,68 @@ describe('POST /api/mcp (BY-05)', () => {
     expect(kit.isError).toBe(false);
     const structured = kit.structured as { engineRef?: string; browse?: Record<string, string> };
     expect(structured.engineRef).toBe(engine);
-    expect(JSON.stringify(structured)).not.toMatch(/list_kit_files|search_kit_files|read_kit_file/);
+    // Browse tools are advertised now, so withAdvertisedBrowseTools keeps the whole block
+    // rather than stripping it — this was the reverse assertion when they were hidden.
+    expect(structured.browse).toEqual({
+      list: 'list_kit_files',
+      search: 'search_kit_files',
+      read: 'read_kit_file',
+      readMany: 'read_kit_files',
+      fragment: 'read_kit_file_fragment',
+    });
+  });
+
+  it('get_kit_api returns the compacted digest for the pinned engineRef', async () => {
+    const store = new InMemoryStore();
+    await seedJob(store);
+    const engine = 'c21f5132cedb5133aa87f75654549391f4a5c633';
+    const digest = [
+      '# gamedev.pl Creator Kit digest',
+      '',
+      '## Engine modules',
+      '',
+      '- `party` — multiple players on one shared screen.',
+      '- `zone` — a world the server arbitrates, shared with strangers in real time.',
+      '',
+      '## GameKit API surface',
+      '',
+      '~~~typescript',
+      'interface GameKitApi { locale: string; }',
+      '~~~',
+      '',
+      '## Exemplar game',
+      '',
+      '### games/dodge-the-falling-rocks/game.ts',
+      '',
+      '~~~text',
+      'export {};',
+      '~~~',
+      '',
+      '## File-shape rules',
+      '- Keep files small.',
+    ].join('\n');
+    const objectStore: GcsObjectStore = {
+      readObject: async (name: string) =>
+        name === 'kits/current.json'
+          ? Buffer.from(JSON.stringify({ current: engine, previous: null, updatedAt: '2026-08-09T00:00:00.000Z' }))
+          : name === `kits/${engine}.digest.md`
+            ? Buffer.from(digest)
+            : null,
+      objectExists: async () => true,
+      signReadUrl: async (name: string) => `https://signed.example/${name}?sig=1`,
+    };
+    app = await createApp(store, undefined, objectStore);
+    const sessionId = await initialize(app);
+    const started = await callTool(app, 'start', { key: roundKey() }, { 'mcp-session-id': sessionId });
+    const sessionKey = (started.structured as { sessionKey: string }).sessionKey;
+
+    const kitApi = await callTool(app, 'get_kit_api', { sessionKey }, { 'mcp-session-id': sessionId });
+    expect(kitApi.isError).toBe(false);
+    const structured = kitApi.structured as { engineRef?: string; digest?: string };
+    expect(structured.engineRef).toBe(engine);
+    expect(structured.digest).toMatch(/GameKitApi/);
+    expect(structured.digest).toMatch(/`party`/);
+    expect(structured.digest).toMatch(/`zone`/);
   });
 
   it('start issues a sessionKey; subsequent tools work with it', async () => {
@@ -645,7 +721,10 @@ describe('POST /api/mcp (BY-05)', () => {
     expect(joined).toMatch(/available:true/);
     expect(joined).toMatch(/never scaffold over them/i);
     expect(joined).toMatch(/get_kit/);
-    expect(joined).not.toMatch(/list_kit_files|search_kit_files|read_kit_file/);
+    expect(joined).toMatch(/get_kit_api/);
+    // The platform and kit are not on the public web — an agent following the loop should
+    // never end up guessing via a web search for gamedev.pl documentation.
+    expect(joined).toMatch(/not on the public web|never a web search|never.*web search/i);
     expect(joined).toMatch(/screenshot_upload_url/);
     expect(joined).not.toMatch(/send_screenshot/);
     expect(joined).toMatch(/stage_source_file|fromStaged/);

--- a/apps/api/src/mcp-server.test.ts
+++ b/apps/api/src/mcp-server.test.ts
@@ -375,9 +375,7 @@ describe('POST /api/mcp (BY-05)', () => {
         'ack_inbox',
       ]),
     );
-    // Kit browse tools are advertised: get_kit_api is the orientation path (whole digest,
-    // one call), these are the depth path (specific files) once an agent knows what it
-    // wants. Example/proposal browse tools stay off the model-visible surface.
+    // Kit browse tools are advertised now; example/proposal ones stay hidden.
     expect(names).toEqual(
       expect.arrayContaining([
         'get_kit_api',
@@ -420,9 +418,7 @@ describe('POST /api/mcp (BY-05)', () => {
     expect(getKit?.description).toMatch(/gamedevpl-creator-kit/);
     expect(getKit?.description).toMatch(/entry=gamedevpl-creator-kit\/SKILL\.md/);
     expect(getKit?.description).toMatch(/do not assume a `cd` persists/i);
-    // The platform and kit are not on the public web — an agent with an unanswered
-    // capability question (multiplayer? persistent worlds?) has an in-band answer now,
-    // so it never has to guess by searching for docs that were never published.
+    // Capability questions now have an in-band answer, not a web search.
     expect(getKit?.description).toMatch(/not on the public web/i);
     expect(getKit?.description).toMatch(/get_kit_api/);
     expect(tools.find((t) => t.name === 'get_kit_api')).toBeDefined();
@@ -470,8 +466,7 @@ describe('POST /api/mcp (BY-05)', () => {
         'end',
       ]),
     );
-    // Kit browse/orientation tools are the focused build surface now; example and
-    // proposal tooling stay off it.
+    // Example/proposal tooling stays off the focused build surface.
     expect(names).not.toEqual(expect.arrayContaining(['list_examples', 'submit_proposal']));
   });
 
@@ -518,8 +513,7 @@ describe('POST /api/mcp (BY-05)', () => {
     expect(kit.isError).toBe(false);
     const structured = kit.structured as { engineRef?: string; browse?: Record<string, string> };
     expect(structured.engineRef).toBe(engine);
-    // Browse tools are advertised now, so withAdvertisedBrowseTools keeps the whole block
-    // rather than stripping it — this was the reverse assertion when they were hidden.
+    // Advertised now, so the whole block survives (reverse of the old assertion).
     expect(structured.browse).toEqual({
       list: 'list_kit_files',
       search: 'search_kit_files',
@@ -722,8 +716,7 @@ describe('POST /api/mcp (BY-05)', () => {
     expect(joined).toMatch(/never scaffold over them/i);
     expect(joined).toMatch(/get_kit/);
     expect(joined).toMatch(/get_kit_api/);
-    // The platform and kit are not on the public web — an agent following the loop should
-    // never end up guessing via a web search for gamedev.pl documentation.
+    // The loop must never send an agent to a web search instead.
     expect(joined).toMatch(/not on the public web|never a web search|never.*web search/i);
     expect(joined).toMatch(/screenshot_upload_url/);
     expect(joined).not.toMatch(/send_screenshot/);

--- a/apps/api/src/mcp-server.ts
+++ b/apps/api/src/mcp-server.ts
@@ -125,12 +125,7 @@ const MCP_VISIBLE_TOOLS = new Set([
   'get_seed',
   'get_sources',
   'get_kit',
-  // get_kit returns tarball metadata only — no MCP client has a system prompt carrying
-  // the kit the way the platform lane does. get_kit_api is the orientation path (the
-  // digest, in one call); the browse tools below are the depth path once an agent knows
-  // what it's looking for. Advertising both was the fix for an agent that, having no
-  // in-band way to answer "what can this platform build", went to the public web looking
-  // for gamedev.pl documentation that was never published there.
+  // get_kit_api is the orientation path; browse tools are the depth path.
   'get_kit_api',
   'list_kit_files',
   'search_kit_files',

--- a/apps/api/src/mcp-server.ts
+++ b/apps/api/src/mcp-server.ts
@@ -125,6 +125,18 @@ const MCP_VISIBLE_TOOLS = new Set([
   'get_seed',
   'get_sources',
   'get_kit',
+  // get_kit returns tarball metadata only — no MCP client has a system prompt carrying
+  // the kit the way the platform lane does. get_kit_api is the orientation path (the
+  // digest, in one call); the browse tools below are the depth path once an agent knows
+  // what it's looking for. Advertising both was the fix for an agent that, having no
+  // in-band way to answer "what can this platform build", went to the public web looking
+  // for gamedev.pl documentation that was never published there.
+  'get_kit_api',
+  'list_kit_files',
+  'search_kit_files',
+  'read_kit_file',
+  'read_kit_files',
+  'read_kit_file_fragment',
   'report_progress',
   'screenshot_upload_url',
   'stage_upload_url',
@@ -149,11 +161,6 @@ export const MCP_UNADVERTISED_TOOLS: readonly string[] = Object.freeze([
   'open_proposal_round',
   'submit_proposal',
   'get_proposal_status',
-  'list_kit_files',
-  'search_kit_files',
-  'read_kit_file',
-  'read_kit_files',
-  'read_kit_file_fragment',
   'list_examples',
   'get_example',
   'list_example_files',
@@ -637,7 +644,7 @@ const SESSION_WORKFLOW: readonly string[] = [
   // one. get_sources is cheap and answers available:false on a new game, so it is
   // unconditional rather than gated on a round type the agent cannot see.
   'get_sources — when it returns available:true this round improves an existing game: continue those files. Never scaffold over them. If warnings.code=module_too_large, split those oversized modules into cohesive game/*.ts pieces BEFORE adding features — do not grow them further.',
-  'get_kit — keep engineRef for submit_sources; the reply names any kit browse tools this surface offers, and offers none when the digest already covers the API. With shell egress, unpack via the returned one-liner and follow SKILL.md locally. Never dump the whole kit into context, and never call a tool this session did not advertise.',
+  "get_kit — keep engineRef for submit_sources and for get_kit_api. This platform and its Creator Kit are not on the public web: for what the kit can build (module names — party, zone, commons, presence, and the rest — or the API itself), call get_kit_api or the kit browse tools, never a web search; the digest and browse tools are the complete, authoritative reference, and a web search for gamedev.pl documentation will not find anything, or worse, finds an unrelated platform's docs that do not describe this kit. With shell egress, unpack via the returned one-liner and follow SKILL.md locally instead of either. Never dump the whole kit into context, and never call a tool this session did not advertise.",
   'Build the game — continuing the seed or sources you fetched, otherwise from the kit; report_progress before and after long steps. Soft module budget: keep each game/*.ts under ~350 lines / ~12 KiB. When a file approaches that, split cohesive pieces (render→art/ui/hud/rooms; model→tables/layout/types; runtime→systems) before more feature work. Honour warnings.code=module_too_large the same way you honour call_end — act, then continue.',
   'As soon as the game draws anything playable: screenshot_upload_url then curl --upload-file <png> "$url". There is no base64 send path — PNG bytes must never enter the model. Without shell egress, skip mid-build screenshots; the gate still captures on delivery.',
   'While iterating: run only npm run typecheck -- <slug> locally, then prefer stage_upload_url({ path }) and curl --upload-file <file> "$url" for new/rewritten paths when you have shell egress (bytes never re-enter the model). Fall back to stage_source_file({ path, content }) without shell. For edits prefer patch_source_file({ path, old, new }) — exact unique substring replace, no unified-diff arithmetic. Or patch_source_file({ path, patch }) with a unified diff (bare @@ ok). Stage only changed paths — never re-upload the whole tree. Then submit_sources({ fromStaged: true, mode: "preview", kitEngineRef }) — fromStaged overlays onto the latest delivery/seed and the server verifies it; no browser, npm ci, capture, playtest, or agency is required for this preview. If a browser is available near delivery, optionally run npm run check:game -- <slug> --preview. Run the full gate only immediately before a mode:"publish" seal. Inline files[] still works for tiny trees.',
@@ -2504,9 +2511,13 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
         'registry moves. kitEngineChanged:true means the pin was replaced — after a kit_outdated ' +
         'verdict, or because the pinned kit is no longer retained — so rebuild against the ' +
         'engine in this reply. ' +
-        'browse is present only when this surface advertises kit browse tools; when it is absent, ' +
-        'the injected digest is the API reference and there is no browse path — ' +
-        'do not pull the whole kit into context. ' +
+        'This platform and its Creator Kit are not on the public web — an unanswered question ' +
+        'about what it can build (multiplayer, persistent worlds, party games, …) is answered by ' +
+        'get_kit_api or browse, never by web search. ' +
+        'For the API itself: get_kit_api (with this engineRef) for the whole prompt-ready reference ' +
+        "in one call, or the browse tools named in this reply's browse block (list/search/read) to " +
+        'read specific kit files instead — do not pull the whole kit into context. ' +
+        'With shell egress, unpack via kitUrl/unpack and follow SKILL.md locally instead of either. ' +
         'entry=gamedevpl-creator-kit/SKILL.md (tarball roots at gamedevpl-creator-kit/; ' +
         'do not assume a `cd` persists across tool calls). ' +
         BEHAVIOURAL_CONTRACT,
@@ -2524,6 +2535,57 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
           return toolErr(body.message ?? body.error ?? `kit failed (${res.statusCode})`, body);
         }
         return toolOk(withAdvertisedBrowseTools(body));
+      },
+    },
+
+    get_kit_api: {
+      annotations: { title: "Fetch the Creator Kit's API reference", ...READS },
+      outputSchema: {
+        type: 'object',
+        properties: {
+          engineRef: { type: 'string' },
+          digest: { type: 'string' },
+        },
+        required: ['engineRef', 'digest'],
+      },
+      description:
+        "The Creator Kit's prompt-ready orientation in one call: what engine modules exist " +
+        '(party for same-screen multiplayer, zone for a real-time server-arbitrated world, ' +
+        'commons and presence for persistent/shared state, and the rest — this is the answer ' +
+        'to "can this platform build X", not a web search), the core API ' +
+        'signatures, the audio catalog, and a complete small exemplar game. Call this once near ' +
+        'the start of a round, before scaffolding, rather than repeatedly — its content only ' +
+        'changes when engineRef does. Pass engineRef from get_kit so a mid-round registry bump ' +
+        "cannot mix kit revisions. Falls back to the registry's current engine when engineRef is " +
+        'omitted, but that risks reading a different kit than the round is pinned to. ' +
+        'Prefer this over unpacking the whole kit into context; use the browse tools ' +
+        '(list_kit_files / search_kit_files / read_kit_file) instead when what you need is a ' +
+        'specific file this digest omitted or summarized. ' +
+        BEHAVIOURAL_CONTRACT,
+      inputSchema: {
+        type: 'object',
+        properties: { sessionKey: SESSION_KEY_PROP, engineRef: KIT_ENGINE_REF_PROP },
+        required: [],
+      },
+      handler: async (args, ctx) => {
+        const auth = await resolveAuth(ctx, args);
+        if (!('channelToken' in auth)) return auth;
+        const params = new URLSearchParams();
+        if (typeof args.engineRef === 'string' && args.engineRef.trim()) {
+          params.set('engineRef', args.engineRef.trim());
+        }
+        const qs = params.toString();
+        const res = await injectChannel(
+          ctx.request,
+          'GET',
+          `/api/agent/build/kit/api${qs ? `?${qs}` : ''}`,
+          auth.channelToken,
+        );
+        const body = res.json() as { error?: string; message?: string };
+        if (res.statusCode !== 200) {
+          return toolErr(body.message ?? body.error ?? `get_kit_api failed (${res.statusCode})`, body);
+        }
+        return toolOk(body);
       },
     },
 

--- a/apps/api/src/mcp-session-nudges.ts
+++ b/apps/api/src/mcp-session-nudges.ts
@@ -87,6 +87,7 @@ export const PROGRESS_NUDGE_EXEMPT = new Set([
  */
 export const INBOX_PIGGYBACK_TOOLS = new Set([
   'get_kit',
+  'get_kit_api',
   'list_kit_files',
   'search_kit_files',
   'read_kit_file',
@@ -101,6 +102,7 @@ export const INBOX_PIGGYBACK_TOOLS = new Set([
 /** Kit browse without get_seed while a draft is ready → seed_unread. */
 export const SEED_NUDGE_TOOLS = new Set([
   'get_kit',
+  'get_kit_api',
   'list_kit_files',
   'search_kit_files',
   'read_kit_file',

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -771,6 +771,7 @@
       "reading_brief": "Reading the build brief…",
       "loading_seed": "Loading the seed draft…",
       "fetching_kit": "Fetching Creator Kit metadata…",
+      "reading_kit_api": "Reading the Creator Kit API reference…",
       "browsing_kit": "Browsing the Creator Kit…",
       "searching_kit": "Searching the Creator Kit…",
       "reading_kit": "Reading Creator Kit files…",

--- a/apps/web/src/i18n/locales/pl.json
+++ b/apps/web/src/i18n/locales/pl.json
@@ -775,6 +775,7 @@
       "reading_brief": "Czytanie briefu…",
       "loading_seed": "Ładowanie szkicu startowego…",
       "fetching_kit": "Pobieranie metadanych Creator Kit…",
+      "reading_kit_api": "Czytanie dokumentacji API Creator Kit…",
       "browsing_kit": "Przeglądanie Creator Kit…",
       "searching_kit": "Szukanie w Creator Kit…",
       "reading_kit": "Czytanie plików Creator Kit…",


### PR DESCRIPTION
## Summary

This change adds a new `get_kit_api` MCP endpoint that serves a compacted Creator Kit API digest to agents, and significantly improves how kit declarations are selected and presented when space is constrained. Previously, agents had no in-band way to discover what capabilities the platform supports (party/multiplayer, zones, commons, presence, etc.), leading them to search the public web for documentation that doesn't exist there.

## Key Changes

- **New `get_kit_api` endpoint** (`/api/agent/build/kit/api`): Serves the compacted kit digest with a larger budget (90 KiB) than the platform prompt lane (20 KiB), since it's paid once per round by agents that explicitly request it. Supports optional `engineRef` parameter, defaulting to the registry's current entry.

- **Improved kit digest selection algorithm**: Replaced simple line-pattern filtering with a sophisticated whole-block selection strategy that:
  - Splits declarations into top-level blocks and preserves them whole rather than orphaning individual lines
  - Ensures every module family (party, zone, commons, presence, etc.) gets representation before any family gets a second block
  - Reserves budget for oversized core declarations like `GameKitApi` and abridges them member-wise rather than dropping them entirely
  - Names omitted declarations in the output instead of silently dropping them

- **New declaration parsing utilities**:
  - `splitDeclarationBlocks()`: Parses `.d.ts` files into top-level declaration blocks
  - `selectApiBlocks()`: Implements the tiered selection algorithm with family-aware prioritization
  - `elideDeclaration()`: Abridges oversized declarations by dropping less-important members while preserving factory methods
  - `moduleFamiliesOf()`: Extracts module families from the digest's own catalog with fallback for older kits

- **Increased default digest size limits**:
  - `DEFAULT_KIT_DIGEST_MAX_BYTES`: 100 KiB → 150 KiB (games repo digest was already at 99.5% of old limit)
  - New `DEFAULT_MCP_DIGEST_MAX_BYTES`: 90 KiB for MCP lane

- **MCP surface changes**: Kit browse tools (`list_kit_files`, `search_kit_files`, `read_kit_file`, etc.) and the new `get_kit_api` are now advertised to models, replacing the previous hidden-tool approach. Example and proposal tools remain unadvertised.

- **Updated workflow guidance**: Clarified that the platform and kit are not on the public web, directing agents to use `get_kit_api` or browse tools instead of web searches.

## Notable Implementation Details

- The selection algorithm uses a "reserve" strategy: oversized core declarations get a dedicated budget slice to prevent them from being starved by earlier passes
- Module factories are ranked above other members when abridging, ensuring `createParty`, `createZone`, `createCommons`, and `createPresence` survive even tight budgets
- Omission notes are included in the output so agents can see what was dropped and know to use the full kit if needed
- The `Engine modules` catalog section is now placed first in the compacted digest, answering "what can this platform build" before the API details

https://claude.ai/code/session_0155jrUy76vVwwcdPLm2Vh3u