### PR TITLE
Scope managed MCP credentials to each build round

### DIFF
--- a/apps/api/src/agent-backend-env.ts
+++ b/apps/api/src/agent-backend-env.ts
@@ -53,6 +53,7 @@ export interface ManagedBackendDeps {
   kitDigest?: KitDigestLoader;
   // Channel-side round state; without it a finished round looks stalled.
   readSignals?: (issueNumber: number) => Promise<ManagedRoundSignals | null>;
+  readCredentialRef?: (issueNumber: number, sessionRef: string) => Promise<string | undefined>;
 }
 
 // Vendor is a variable; a delivery sink is required.
@@ -112,6 +113,7 @@ export function createManagedPlatformBackendFromEnv(deps?: ManagedBackendDeps, l
         : {}),
       ...(Number.isInteger(maxListCostCents) && maxListCostCents > 0 ? { maxListCostCents } : {}),
       ...(vaultIds?.length ? { vaultIds } : {}),
+      ...(mcpUrl ? { overrideTools: true } : {}),
       ...(process.env.MANAGED_AGENT_BASE_URL?.trim() ? { baseUrl: process.env.MANAGED_AGENT_BASE_URL.trim() } : {}),
     });
   } catch (error) {
@@ -124,9 +126,16 @@ export function createManagedPlatformBackendFromEnv(deps?: ManagedBackendDeps, l
   return createManagedBackend({
     provider,
     ...(deps?.readSignals ? { readSignals: deps.readSignals } : {}),
+    ...(deps?.readCredentialRef ? { readCredentialRef: deps.readCredentialRef } : {}),
     ...(deps?.deliver ? { deliver: deps.deliver } : {}),
     ...(deps?.lock ? { lock: deps.lock } : {}),
     ...(mcpUrl ? { tools: { mcpEndpoints: [{ url: mcpUrl, name: 'gamedevpl' }] } } : {}),
+    ...(mcpUrl
+      ? {
+          mcpBearerCredential: (brief) =>
+            brief.mcpOpenerToken ? { url: mcpUrl, token: brief.mcpOpenerToken } : undefined,
+        }
+      : {}),
     ...(deps?.systemPrompt ? { systemPrompt: deps.systemPrompt } : {}),
     ...(deps?.kitDigest ? { kitDigest: deps.kitDigest } : {}),
     ...(effort ? { effort } : {}),

--- a/apps/api/src/agent-backend.ts
+++ b/apps/api/src/agent-backend.ts
@@ -28,6 +28,7 @@ export interface BuildBrief {
   locale?: string;
   /** Per-job build-channel credential. Scoped to this job and this slug. */
   channelToken: string;
+  mcpOpenerToken?: string;
   /** Where the agent reports progress and delivers its work. */
   apiBaseUrl: string;
   /** Set for a revision round: what the creator asked to change. Untrusted text. */
@@ -96,6 +97,7 @@ export interface DispatchResult {
    * games repo faster than the builds themselves do.
    */
   seedWorkspace?: string;
+  credentialRef?: string;
 }
 
 export interface AgentBackend {
@@ -125,7 +127,7 @@ export interface AgentBackend {
    * (the build channel tells a running agent to stop) and the real guarantee is that we
    * discard whatever arrives afterwards. A runtime we operate can answer true.
    */
-  cancel(ref: string): Promise<{ enforced: boolean }>;
+  cancel(ref: string, credentialRef?: string): Promise<{ enforced: boolean }>;
   /** Releases workspace state once a job is finished. Best effort. */
   cleanup?(previous: DispatchResult): Promise<void>;
 }

--- a/apps/api/src/agent-token.test.ts
+++ b/apps/api/src/agent-token.test.ts
@@ -5,9 +5,11 @@ import {
   InvalidAgentTokenError,
   mintAgentToken,
   mintLegacyAgentToken,
+  mintManagedMcpOpener,
   selfBuildKeyTtlDays,
   STALE_AGENT_TOKEN_REASON,
   verifyAgentToken,
+  verifyManagedMcpOpener,
 } from './agent-token.js';
 
 describe('agent build-channel token', () => {
@@ -26,6 +28,15 @@ describe('agent build-channel token', () => {
       roundGeneration: 1,
       exp: Math.floor(now / 1000) + 14 * 24 * 60 * 60,
     });
+  });
+
+  it('keeps a managed MCP opener separate from the build-channel capability', () => {
+    const opener = mintManagedMcpOpener(42, secret, { roundGeneration: 1, now, ttlDays: 14 });
+    const channel = mintAgentToken(42, secret, { roundGeneration: 1, now, ttlDays: 14 });
+
+    expect(verifyManagedMcpOpener(opener, secret)).toMatchObject({ jobId: 42, roundGeneration: 1 });
+    expect(() => verifyAgentToken(opener, secret)).toThrow(InvalidAgentTokenError);
+    expect(() => verifyManagedMcpOpener(channel, secret)).toThrow(InvalidAgentTokenError);
   });
 
   it('accepts an active generation before expiry', () => {

--- a/apps/api/src/agent-token.ts
+++ b/apps/api/src/agent-token.ts
@@ -31,6 +31,7 @@ export class InvalidAgentTokenError extends Error {
 }
 
 const SCOPE = 'agent-channel-v1';
+const MANAGED_MCP_OPENER_SCOPE = 'managed-mcp-opener-v1';
 
 /** Default lifetime for a round-scoped build key, in days. */
 export const DEFAULT_SELF_BUILD_KEY_TTL_DAYS = 14;
@@ -84,6 +85,12 @@ function signRoundScoped(jobId: number, roundGeneration: number, exp: number, se
   return createHmac('sha256', secret).update(`${SCOPE}:${jobId}:${roundGeneration}:${exp}`).digest('hex');
 }
 
+function signManagedMcpOpener(jobId: number, roundGeneration: number, exp: number, secret: string): string {
+  return createHmac('sha256', secret)
+    .update(`${MANAGED_MCP_OPENER_SCOPE}:${jobId}:${roundGeneration}:${exp}`)
+    .digest('hex');
+}
+
 function safeEqualHex(actual: string, expected: string): boolean {
   const actualBuffer = Buffer.from(actual, 'utf8');
   const expectedBuffer = Buffer.from(expected, 'utf8');
@@ -109,6 +116,57 @@ export function mintAgentToken(jobId: number, secret: string, options: MintAgent
   const exp = Math.floor(nowMs / 1000) + ttlDays * 24 * 60 * 60;
   const signature = signRoundScoped(jobId, options.roundGeneration, exp, secret);
   return Buffer.from(`${jobId}.${options.roundGeneration}.${exp}.${signature}`, 'utf8').toString('base64url');
+}
+
+export function mintManagedMcpOpener(jobId: number, secret: string, options: MintAgentTokenOptions): string {
+  if (!Number.isSafeInteger(jobId) || jobId <= 0) throw new InvalidAgentTokenError('invalid job id');
+  if (!Number.isSafeInteger(options.roundGeneration) || options.roundGeneration < 1) {
+    throw new InvalidAgentTokenError('invalid round generation');
+  }
+  const nowMs = options.now ?? Date.now();
+  const ttlDays = options.ttlDays ?? selfBuildKeyTtlDays();
+  const exp = Math.floor(nowMs / 1000) + ttlDays * 24 * 60 * 60;
+  const signature = signManagedMcpOpener(jobId, options.roundGeneration, exp, secret);
+  return Buffer.from(`${jobId}.${options.roundGeneration}.${exp}.${signature}`, 'utf8').toString('base64url');
+}
+
+export function verifyManagedMcpOpener(token: string, secret: string): AgentTokenClaims {
+  try {
+    const [jobIdRaw, generationRaw, expRaw, signature, ...extra] = Buffer.from(token, 'base64url')
+      .toString('utf8')
+      .split('.');
+    if (
+      extra.length ||
+      !jobIdRaw ||
+      !generationRaw ||
+      !expRaw ||
+      !signature ||
+      !/^\d+$/.test(jobIdRaw) ||
+      !/^\d+$/.test(generationRaw) ||
+      !/^\d+$/.test(expRaw) ||
+      !/^[a-f0-9]{64}$/i.test(signature)
+    ) {
+      throw new InvalidAgentTokenError();
+    }
+    const jobId = Number.parseInt(jobIdRaw, 10);
+    const roundGeneration = Number.parseInt(generationRaw, 10);
+    const exp = Number.parseInt(expRaw, 10);
+    if (
+      !Number.isSafeInteger(jobId) ||
+      jobId <= 0 ||
+      !Number.isSafeInteger(roundGeneration) ||
+      roundGeneration < 1 ||
+      !Number.isSafeInteger(exp) ||
+      exp <= 0 ||
+      !safeEqualHex(signature, signManagedMcpOpener(jobId, roundGeneration, exp, secret))
+    ) {
+      throw new InvalidAgentTokenError();
+    }
+    return { jobId, roundGeneration, exp };
+  } catch (error) {
+    if (error instanceof InvalidAgentTokenError) throw error;
+    throw new InvalidAgentTokenError();
+  }
 }
 
 /**

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -409,6 +409,10 @@ export async function buildApp(options: BuildAppOptions = {}): Promise<FastifyIn
                   }
                 : null;
             },
+            readCredentialRef: async (issueNumber, sessionRef) => {
+              const record = await store.getSubmission(issueNumber);
+              return record?.dispatch?.credentialRefs?.[sessionRef];
+            },
           }),
     gameSeeder: options.submissionRoutes?.gameSeeder ?? createGameSeederFromEnv(app.log),
     agentChannel: {

--- a/apps/api/src/managed-agent.ts
+++ b/apps/api/src/managed-agent.ts
@@ -32,6 +32,7 @@ export interface ManagedTokenUsage {
 export interface ManagedSession {
   id: string;
   state: AgentTaskState;
+  credentialRef?: string;
   // The vendor's own word, kept for operator views.
   vendorState?: string;
   usage?: ManagedTokenUsage;
@@ -47,6 +48,11 @@ export interface ManagedToolAccess {
   credentialNames?: string[];
 }
 
+export interface ManagedMcpBearerCredential {
+  url: string;
+  token: string;
+}
+
 export interface ManagedSessionRequest {
   correlationId: string;
   // Cacheable prefix shared across sessions of one agent version.
@@ -59,6 +65,7 @@ export interface ManagedSessionRequest {
   outputPath: string;
   maxDurationSeconds?: number;
   tools?: ManagedToolAccess;
+  mcpBearerCredential?: ManagedMcpBearerCredential;
 }
 
 export interface ManagedAgentProvider {
@@ -73,6 +80,7 @@ export interface ManagedAgentProvider {
   sendMessage?(sessionId: string, message: string): Promise<void>;
   cancelSession(sessionId: string): Promise<{ enforced: boolean }>;
   deleteSession?(sessionId: string): Promise<void>;
+  releaseCredential?(credentialRef: string): Promise<void>;
 }
 
 export class ManagedAgentError extends Error {

--- a/apps/api/src/managed-backend.test.ts
+++ b/apps/api/src/managed-backend.test.ts
@@ -112,7 +112,7 @@ describe('managed backend', () => {
     await backend.dispatch(brief());
     const observation = await backend.observe('session-1', { hasCandidate: false, issueNumber: ISSUE, slug: SLUG });
 
-    expect(started[0].prompt).toContain('call `start`');
+    expect(started[0].prompt).toContain('Call `start`');
     expect(read).toEqual([]);
     expect(observation).toMatchObject({ state: 'completed', hasCandidate: false });
   });

--- a/apps/api/src/managed-backend.test.ts
+++ b/apps/api/src/managed-backend.test.ts
@@ -99,6 +99,24 @@ describe('managed backend', () => {
     expect(observation).toMatchObject({ state: 'completed', hasCandidate: false });
   });
 
+  it('prefers the MCP delivery contract when both delivery paths are configured', async () => {
+    const { provider, started, setState, setOutputs, read } = fakeProvider();
+    const backend = createManagedBackend({
+      provider,
+      deliver: async () => ({ version: 'v1' }),
+      tools: { mcpEndpoints: [{ url: 'https://www.gamedev.pl/api/mcp', name: 'gamedevpl' }] },
+    });
+    setOutputs([{ path: `games/${SLUG}/game.ts`, content: 'export {};' }]);
+    setState('completed');
+
+    await backend.dispatch(brief());
+    const observation = await backend.observe('session-1', { hasCandidate: false, issueNumber: ISSUE, slug: SLUG });
+
+    expect(started[0].prompt).toContain('call `start`');
+    expect(read).toEqual([]);
+    expect(observation).toMatchObject({ state: 'completed', hasCandidate: false });
+  });
+
   it('mints a vault-only MCP credential and revokes it after agent end', async () => {
     const released: string[] = [];
     const { provider, started, setState } = fakeProvider({

--- a/apps/api/src/managed-backend.test.ts
+++ b/apps/api/src/managed-backend.test.ts
@@ -99,6 +99,33 @@ describe('managed backend', () => {
     expect(observation).toMatchObject({ state: 'completed', hasCandidate: false });
   });
 
+  it('mints a vault-only MCP credential and revokes it after agent end', async () => {
+    const released: string[] = [];
+    const { provider, started, setState } = fakeProvider({
+      startSession: async (request) => {
+        started.push(request);
+        return { id: 'session-1', state: 'queued', credentialRef: 'lease-1' };
+      },
+      releaseCredential: async (ref) => {
+        released.push(ref);
+      },
+    });
+    const backend = createManagedBackend({
+      provider,
+      tools: { mcpEndpoints: [{ url: 'https://www.gamedev.pl/api/mcp', name: 'gamedevpl' }] },
+      mcpBearerCredential: (input) => ({ url: 'https://www.gamedev.pl/api/mcp', token: input.channelToken }),
+      readSignals: async () => ({ agentEndedAt: '2026-08-09T18:00:00.000Z' }),
+    });
+
+    const result = await backend.dispatch(brief({ channelToken: 'round-token' }));
+    setState('idle');
+    await backend.observe(result.ref, { hasCandidate: false, issueNumber: ISSUE, slug: SLUG });
+
+    expect(started[0].mcpBearerCredential).toEqual({ url: 'https://www.gamedev.pl/api/mcp', token: 'round-token' });
+    expect(result.credentialRef).toBe('lease-1');
+    expect(released).toEqual(['lease-1']);
+  });
+
   it('sends the seed as workspace files and the digest as a cacheable prefix', async () => {
     const { provider, started } = fakeProvider();
     const backend = createManagedBackend({

--- a/apps/api/src/managed-backend.test.ts
+++ b/apps/api/src/managed-backend.test.ts
@@ -500,6 +500,20 @@ describe('managed backend', () => {
     expect(await backend.cancel('session-1')).toEqual({ enforced: true });
   });
 
+  it('archives round credentials even when interrupt fails', async () => {
+    const releaseCredential = vi.fn(async () => undefined);
+    const { provider } = fakeProvider({
+      cancelSession: async () => {
+        throw new Error('interrupt unavailable');
+      },
+      releaseCredential,
+    });
+    const backend = createManagedBackend({ provider, deliver: async () => ({ version: 'v1' }) });
+
+    await expect(backend.cancel('session-1', 'vault-1')).rejects.toThrow(/interrupt unavailable/);
+    expect(releaseCredential).toHaveBeenCalledWith('vault-1');
+  });
+
   it('answers null for a session the vendor has forgotten', async () => {
     const { provider } = fakeProvider({ getSession: async () => null });
     const backend = createManagedBackend({ provider, deliver: async () => ({ version: 'v1' }) });

--- a/apps/api/src/managed-backend.ts
+++ b/apps/api/src/managed-backend.ts
@@ -367,9 +367,12 @@ export function createManagedBackend(options: ManagedBackendOptions): AgentBacke
 
     async cancel(ref, credentialRef): Promise<{ enforced: boolean }> {
       if (credentialRef) credentialRefs.set(ref, credentialRef);
-      const result = await options.provider.cancelSession(ref);
-      await releaseCredential(ref);
-      return result;
+      try {
+        return await options.provider.cancelSession(ref);
+      } finally {
+        // Archive even when interrupt fails; job is already terminal.
+        await releaseCredential(ref);
+      }
     },
 
     async cleanup(previous: DispatchResult): Promise<void> {

--- a/apps/api/src/managed-backend.ts
+++ b/apps/api/src/managed-backend.ts
@@ -115,6 +115,7 @@ export function createManagedBackend(options: ManagedBackendOptions): AgentBacke
   }
   const outputPath = options.outputPath ?? DEFAULT_MANAGED_OUTPUT_PATH;
   const deliveryMode = options.deliveryMode ?? 'preview';
+  const channelMode = Boolean(options.tools?.mcpEndpoints?.length);
   const backendName = `managed:${options.provider.vendor}`;
   // At-most-once per session; a re-poll cannot duplicate.
   const harvested = new Set<string>();
@@ -147,7 +148,14 @@ export function createManagedBackend(options: ManagedBackendOptions): AgentBacke
       correlationId: String(brief.issueNumber),
       ...(systemPrompt ? { systemPrompt } : {}),
       // The prompt has to describe the delivery this backend will actually read.
-      prompt: buildPrompt(brief, deliver ? { kind: 'outputs', path: outputPath } : { kind: 'channel', fast: true }),
+      prompt: buildPrompt(
+        brief,
+        channelMode
+          ? { kind: 'channel', fast: true }
+          : deliver
+            ? { kind: 'outputs', path: outputPath }
+            : { kind: 'channel', fast: true },
+      ),
       model: options.provider.model,
       ...(options.effort ? { effort: options.effort } : {}),
       ...(brief.seed
@@ -287,6 +295,7 @@ export function createManagedBackend(options: ManagedBackendOptions): AgentBacke
       let outcome: HarvestOutcome = 'empty';
       const canHarvest =
         Boolean(deliver) &&
+        !channelMode &&
         !hasCandidate &&
         isManagedSessionHarvestable(session.state) &&
         observeOptions.issueNumber !== undefined &&

--- a/apps/api/src/managed-backend.ts
+++ b/apps/api/src/managed-backend.ts
@@ -16,6 +16,7 @@ import {
   type ManagedOutputCaps,
   type ManagedOutputFile,
   type ManagedOutputPlan,
+  type ManagedMcpBearerCredential,
   type ManagedToolAccess,
 } from './managed-agent.js';
 
@@ -92,6 +93,8 @@ export interface ManagedBackendOptions {
   maxDurationSeconds?: number;
   outputCaps?: ManagedOutputCaps;
   tools?: ManagedToolAccess;
+  mcpBearerCredential?: (brief: BuildBrief) => ManagedMcpBearerCredential | undefined;
+  readCredentialRef?: (issueNumber: number, sessionRef: string) => Promise<string | undefined>;
   nudgeIdle?: boolean;
   // Preview keeps the first delivery cheap; publish seals.
   deliveryMode?: 'preview' | 'publish';
@@ -118,12 +121,28 @@ export function createManagedBackend(options: ManagedBackendOptions): AgentBacke
   const startedAt = new Map<string, number>();
   const idleNudged = new Set<string>();
   const sessionGenerations = new Map<string, number>();
+  const credentialRefs = new Map<string, string>();
+  const releasedCredentials = new Set<string>();
+
+  async function releaseCredential(ref: string, issueNumber?: number): Promise<void> {
+    const credentialRef =
+      credentialRefs.get(ref) ?? (issueNumber ? await options.readCredentialRef?.(issueNumber, ref) : undefined);
+    if (!credentialRef || releasedCredentials.has(credentialRef) || !options.provider.releaseCredential) return;
+    releasedCredentials.add(credentialRef);
+    try {
+      await options.provider.releaseCredential(credentialRef);
+    } catch (error) {
+      releasedCredentials.delete(credentialRef);
+      options.log?.warn({ err: error, ref }, 'could not revoke managed round credential');
+    }
+  }
 
   async function start(brief: BuildBrief): Promise<DispatchResult> {
     const systemPrompt = appendKitDigest(
       options.systemPrompt ? await options.systemPrompt() : undefined,
       options.kitDigest ? await options.kitDigest.load() : undefined,
     );
+    const mcpBearerCredential = options.mcpBearerCredential?.(brief);
     const session = await options.provider.startSession({
       correlationId: String(brief.issueNumber),
       ...(systemPrompt ? { systemPrompt } : {}),
@@ -142,10 +161,12 @@ export function createManagedBackend(options: ManagedBackendOptions): AgentBacke
       outputPath,
       ...(options.maxDurationSeconds ? { maxDurationSeconds: options.maxDurationSeconds } : {}),
       ...(options.tools ? { tools: options.tools } : {}),
+      ...(mcpBearerCredential ? { mcpBearerCredential } : {}),
     });
     startedAt.set(session.id, Date.now());
     sessionGenerations.set(session.id, brief.roundGeneration ?? 1);
-    return { ref: session.id };
+    if (session.credentialRef) credentialRefs.set(session.id, session.credentialRef);
+    return { ref: session.id, ...(session.credentialRef ? { credentialRef: session.credentialRef } : {}) };
   }
 
   // `pending` means ask again, so the round is not spent.
@@ -252,6 +273,7 @@ export function createManagedBackend(options: ManagedBackendOptions): AgentBacke
         !['completed', 'failed', 'timed_out', 'cancelled'].includes(session.state);
       if (expired) {
         await options.provider.cancelSession(ref);
+        await releaseCredential(ref, observeOptions.issueNumber);
         return {
           state: 'timed_out',
           hasCandidate: observeOptions.hasCandidate,
@@ -294,8 +316,10 @@ export function createManagedBackend(options: ManagedBackendOptions): AgentBacke
         Boolean(options.provider.sendMessage) &&
         !idleNudged.has(ref);
       // Provider cannot see a channel submit or end; read once.
+      const needsSignals =
+        nudgeCandidate || credentialRefs.has(ref) || Boolean(options.readCredentialRef && session.state === 'idle');
       const signals =
-        nudgeCandidate && options.readSignals && observeOptions.issueNumber !== undefined
+        needsSignals && options.readSignals && observeOptions.issueNumber !== undefined
           ? await options.readSignals(observeOptions.issueNumber)
           : null;
       const roundDelivered = Boolean(signals?.deliveredVersion || signals?.previewVersion);
@@ -316,6 +340,10 @@ export function createManagedBackend(options: ManagedBackendOptions): AgentBacke
         }
       }
 
+      if (isManagedSessionHarvestable(session.state) && (session.state !== 'idle' || agentEnded)) {
+        await releaseCredential(ref, observeOptions.issueNumber);
+      }
+
       // A settled session with no candidate fails the round.
       const state = outcome === 'pending' || nudged ? 'in_progress' : session.state;
 
@@ -328,8 +356,11 @@ export function createManagedBackend(options: ManagedBackendOptions): AgentBacke
       };
     },
 
-    async cancel(ref): Promise<{ enforced: boolean }> {
-      return options.provider.cancelSession(ref);
+    async cancel(ref, credentialRef): Promise<{ enforced: boolean }> {
+      if (credentialRef) credentialRefs.set(ref, credentialRef);
+      const result = await options.provider.cancelSession(ref);
+      await releaseCredential(ref);
+      return result;
     },
 
     async cleanup(previous: DispatchResult): Promise<void> {
@@ -337,6 +368,9 @@ export function createManagedBackend(options: ManagedBackendOptions): AgentBacke
       idleNudged.delete(previous.ref);
       harvested.delete(previous.ref);
       sessionGenerations.delete(previous.ref);
+      if (previous.credentialRef) credentialRefs.set(previous.ref, previous.credentialRef);
+      await releaseCredential(previous.ref);
+      credentialRefs.delete(previous.ref);
       await options.provider.deleteSession?.(previous.ref);
     },
   };

--- a/apps/api/src/managed-provider-anthropic.test.ts
+++ b/apps/api/src/managed-provider-anthropic.test.ts
@@ -64,9 +64,58 @@ describe('anthropic managed provider', () => {
         type: 'limit',
         max_list_cost: { amount: '125', currency: 'USD' },
       },
-      metadata: { correlation_id: '42' },
       initial_events: [{ type: 'user.message', content: [{ type: 'text', text: 'build it' }] }],
     });
+  });
+
+  it('creates a per-round vault and returns its opaque lease', async () => {
+    const fetchImpl = vi.fn(async (url: string) => {
+      if (url.endsWith('/v1/vaults')) return jsonResponse({ id: 'vlt_round' });
+      if (url.endsWith('/credentials')) return jsonResponse({ id: 'cred_round' });
+      if (url.endsWith('/v1/sessions')) return jsonResponse({ id: 'sess_round', status: 'queued' });
+      throw new Error(`unexpected request ${url}`);
+    });
+    const provider = createAnthropicManagedProvider({
+      apiKey: 'secret-key',
+      model: 'test-model',
+      agentId: 'agent_test',
+      environmentId: 'env_test',
+      vaultIds: ['vlt_probe_only'],
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+
+    const session = await provider.startSession({
+      correlationId: '42',
+      prompt: 'build it',
+      model: 'test-model',
+      outputPath: 'outputs',
+      mcpBearerCredential: { url: 'https://www.gamedev.pl/api/mcp', token: 'round-secret' },
+    });
+
+    expect(session.credentialRef).toBe('vlt_round');
+    expect(JSON.parse(String((fetchImpl.mock.calls[1][1] as RequestInit).body))).toEqual({
+      display_name: 'gamedev.pl round 42',
+      auth: {
+        type: 'static_bearer',
+        mcp_server_url: 'https://www.gamedev.pl/api/mcp',
+        token: 'round-secret',
+      },
+    });
+    expect(JSON.parse(String((fetchImpl.mock.calls[2][1] as RequestInit).body)).vault_ids).toEqual(['vlt_round']);
+  });
+
+  it('archives a round vault when the managed backend releases it', async () => {
+    const fetchImpl = vi.fn(async () => jsonResponse({ id: 'vlt_round' }));
+    const provider = createAnthropicManagedProvider({
+      apiKey: 'secret-key',
+      model: 'test-model',
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+
+    await provider.releaseCredential?.('vlt_round');
+
+    expect(fetchImpl.mock.calls[0][0]).toBe('https://api.anthropic.com/v1/vaults/vlt_round/archive');
+    expect((fetchImpl.mock.calls[0][1] as RequestInit).method).toBe('POST');
   });
 
   it('leaves the configured agent its own tools and servers', async () => {

--- a/apps/api/src/managed-provider-anthropic.ts
+++ b/apps/api/src/managed-provider-anthropic.ts
@@ -38,6 +38,10 @@ const SessionSchema = z.object({
   usage: UsageSchema.optional(),
 });
 
+const VaultSchema = z.object({
+  id: z.string().min(1),
+});
+
 const FileListSchema = z.object({
   data: z
     .array(
@@ -116,6 +120,32 @@ export function createAnthropicManagedProvider(config: ManagedProviderConfig): M
     return response.text();
   }
 
+  async function createMcpCredentialVault(url: string, token: string, correlationId: string): Promise<string> {
+    const vault = VaultSchema.safeParse(
+      await call('/v1/vaults', {
+        method: 'POST',
+        body: JSON.stringify({
+          display_name: `gamedev.pl round ${correlationId}`,
+          metadata: { correlation_id: correlationId },
+        }),
+      }),
+    );
+    if (!vault.success) throw new ManagedAgentError('anthropic vault creation returned an unreadable vault');
+    try {
+      await call(`/v1/vaults/${encodeURIComponent(vault.data.id)}/credentials`, {
+        method: 'POST',
+        body: JSON.stringify({
+          display_name: `gamedev.pl round ${correlationId}`,
+          auth: { type: 'static_bearer', mcp_server_url: url, token },
+        }),
+      });
+    } catch (error) {
+      await call(`/v1/vaults/${encodeURIComponent(vault.data.id)}/archive`, { method: 'POST' }).catch(() => undefined);
+      throw error;
+    }
+    return vault.data.id;
+  }
+
   return {
     vendor: ANTHROPIC_VENDOR,
     model: config.model,
@@ -135,6 +165,14 @@ export function createAnthropicManagedProvider(config: ManagedProviderConfig): M
       if (request.tools?.allowedHosts?.length || request.tools?.credentialNames?.length) {
         throw new ManagedAgentError('anthropic managed agents does not map host or credential names from this seam');
       }
+      const credentialRef = request.mcpBearerCredential
+        ? await createMcpCredentialVault(
+            request.mcpBearerCredential.url,
+            request.mcpBearerCredential.token,
+            request.correlationId,
+          )
+        : undefined;
+      const sessionVaultIds = credentialRef ? [credentialRef] : vaultIds;
       // Replacing a configured agent's toolset leaves it nothing to call.
       const mcpServers = overrideTools
         ? request.tools?.mcpEndpoints?.map((endpoint, index) => ({
@@ -160,8 +198,7 @@ export function createAnthropicManagedProvider(config: ManagedProviderConfig): M
             : {}),
         },
         environment_id: environmentId,
-        ...(vaultIds?.length ? { vault_ids: vaultIds } : {}),
-        metadata: { correlation_id: request.correlationId },
+        ...(sessionVaultIds?.length ? { vault_ids: sessionVaultIds } : {}),
         initial_events: [
           {
             type: 'user.message',
@@ -177,11 +214,20 @@ export function createAnthropicManagedProvider(config: ManagedProviderConfig): M
               },
             }),
       };
-      const parsed = SessionSchema.safeParse(
-        await call('/v1/sessions', { method: 'POST', body: JSON.stringify(body) }),
-      );
-      if (!parsed.success) throw new ManagedAgentError('anthropic managed agents returned an unreadable session');
-      return toSession(parsed.data);
+      try {
+        const parsed = SessionSchema.safeParse(
+          await call('/v1/sessions', { method: 'POST', body: JSON.stringify(body) }),
+        );
+        if (!parsed.success) throw new ManagedAgentError('anthropic managed agents returned an unreadable session');
+        return { ...toSession(parsed.data), ...(credentialRef ? { credentialRef } : {}) };
+      } catch (error) {
+        if (credentialRef) {
+          await call(`/v1/vaults/${encodeURIComponent(credentialRef)}/archive`, { method: 'POST' }).catch(
+            () => undefined,
+          );
+        }
+        throw error;
+      }
     },
 
     async getSession(sessionId: string): Promise<ManagedSession | null> {
@@ -231,6 +277,10 @@ export function createAnthropicManagedProvider(config: ManagedProviderConfig): M
 
     async deleteSession(sessionId: string): Promise<void> {
       await call(`/v1/sessions/${encodeURIComponent(sessionId)}`, { method: 'DELETE' }).catch(() => undefined);
+    },
+
+    async releaseCredential(credentialRef: string): Promise<void> {
+      await call(`/v1/vaults/${encodeURIComponent(credentialRef)}/archive`, { method: 'POST' });
     },
   };
 }

--- a/apps/api/src/managed-provider-anthropic.ts
+++ b/apps/api/src/managed-provider-anthropic.ts
@@ -42,6 +42,10 @@ const VaultSchema = z.object({
   id: z.string().min(1),
 });
 
+const VaultCredentialSchema = z.object({
+  id: z.string().min(1),
+});
+
 const FileListSchema = z.object({
   data: z
     .array(
@@ -132,13 +136,16 @@ export function createAnthropicManagedProvider(config: ManagedProviderConfig): M
     );
     if (!vault.success) throw new ManagedAgentError('anthropic vault creation returned an unreadable vault');
     try {
-      await call(`/v1/vaults/${encodeURIComponent(vault.data.id)}/credentials`, {
-        method: 'POST',
-        body: JSON.stringify({
-          display_name: `gamedev.pl round ${correlationId}`,
-          auth: { type: 'static_bearer', mcp_server_url: url, token },
+      const credential = VaultCredentialSchema.safeParse(
+        await call(`/v1/vaults/${encodeURIComponent(vault.data.id)}/credentials`, {
+          method: 'POST',
+          body: JSON.stringify({
+            display_name: `gamedev.pl round ${correlationId}`,
+            auth: { type: 'static_bearer', mcp_server_url: url, token },
+          }),
         }),
-      });
+      );
+      if (!credential.success) throw new ManagedAgentError('anthropic vault credential creation returned no credential');
     } catch (error) {
       await call(`/v1/vaults/${encodeURIComponent(vault.data.id)}/archive`, { method: 'POST' }).catch(() => undefined);
       throw error;

--- a/apps/api/src/mcp-server.test.ts
+++ b/apps/api/src/mcp-server.test.ts
@@ -1,7 +1,12 @@
 import { readFile } from 'node:fs/promises';
 import type { FastifyInstance } from 'fastify';
 import { afterEach, describe, expect, it } from 'vitest';
-import { classifyAgentTokenAccess, mintAgentToken, STALE_AGENT_TOKEN_REASON } from './agent-token.js';
+import {
+  classifyAgentTokenAccess,
+  mintAgentToken,
+  mintManagedMcpOpener,
+  STALE_AGENT_TOKEN_REASON,
+} from './agent-token.js';
 import { mintGameAgentKey } from './agent-game-key.js';
 import { buildApp } from './app.js';
 import type { GamesStore } from './games-store.js';
@@ -682,6 +687,27 @@ describe('POST /api/mcp (BY-05)', () => {
     expect(body).toMatch(/END the session/i);
     expect(body).toMatch(/Inbox:/);
     expect(body).toMatch(/If a call is refused:/i);
+  });
+
+  it('opens a platform round from its vault-injected round capability', async () => {
+    const store = new InMemoryStore();
+    await seedJob(store);
+    await store.setRoundBuilder(ISSUE, 'platform');
+    app = await createApp(store);
+    const sessionId = await initialize(app);
+
+    const started = await callTool(
+      app,
+      'start',
+      { slug: 'comet-courier' },
+      {
+        'mcp-session-id': sessionId,
+        authorization: `Bearer ${mintManagedMcpOpener(ISSUE, secret, { roundGeneration: 1 })}`,
+      },
+    );
+
+    expect(started.isError).toBe(false);
+    expect(started.structured).toMatchObject({ slug: 'comet-courier', round: 1 });
   });
 
   it('retired-key etiquette in start matches the error agents relay on a refused call', async () => {

--- a/apps/api/src/mcp-server.ts
+++ b/apps/api/src/mcp-server.ts
@@ -36,6 +36,7 @@ import {
   readBearerToken,
   STALE_AGENT_TOKEN_REASON,
   verifyAgentToken,
+  verifyManagedMcpOpener,
   type AgentTokenAccess,
   type AgentTokenClaims,
 } from './agent-token.js';
@@ -1508,6 +1509,41 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
           }
 
           return await bindActiveRound(active);
+        }
+
+        if (!key && bearer) {
+          let claims: AgentTokenClaims | null = null;
+          try {
+            claims = verifyManagedMcpOpener(bearer, agentTokenSecret);
+          } catch (error) {
+            if (!(error instanceof InvalidAgentTokenError)) throw error;
+          }
+          if (claims) {
+            const active = await store.getSubmission(claims.jobId);
+            if (!active) {
+              noteInvalidStart(ctx.request);
+              return toolErr('unknown build — ask the creator for the current prompt in their Studio thread');
+            }
+            try {
+              if (classifyAgentTokenAccess(claims, active, now()) !== 'active') {
+                noteInvalidStart(ctx.request);
+                return toolErr(FINISHED_REASON);
+              }
+            } catch (error) {
+              noteInvalidStart(ctx.request);
+              if (error instanceof InvalidAgentTokenError) return toolErr(error.message || FINISHED_REASON);
+              throw error;
+            }
+            if ((active.builder ?? 'platform') !== 'platform') {
+              noteInvalidStart(ctx.request);
+              return toolErr('this round capability belongs to a self-build round');
+            }
+            if (!slugArg || slugArg !== active.slug) {
+              noteInvalidStart(ctx.request);
+              return toolErr('slug is required and must match this platform round');
+            }
+            return await bindActiveRound(active);
+          }
         }
 
         if (key && looksLikeAsAccessToken(key)) {

--- a/apps/api/src/store.ts
+++ b/apps/api/src/store.ts
@@ -295,6 +295,7 @@ export interface SubmissionRecord {
   dispatch?: {
     backend: string;
     refs: string[];
+    credentialRefs?: Record<string, string>;
     workspace?: string;
     /**
      * The disposable branch a seeded build started from, when it was seeded at all.
@@ -1802,7 +1803,7 @@ export interface Store {
   /** Appends a dispatch ref, recording which backend is building this job and where. */
   recordDispatch(
     issueNumber: number,
-    dispatch: { backend: string; ref: string; workspace?: string; seedWorkspace?: string },
+    dispatch: { backend: string; ref: string; workspace?: string; seedWorkspace?: string; credentialRef?: string },
   ): Promise<void>;
   /**
    * Appends one billed thing to a job's ledger. Best-effort by contract: a cost that
@@ -3129,7 +3130,7 @@ export class InMemoryStore implements Store {
 
   async recordDispatch(
     issueNumber: number,
-    dispatch: { backend: string; ref: string; workspace?: string; seedWorkspace?: string },
+    dispatch: { backend: string; ref: string; workspace?: string; seedWorkspace?: string; credentialRef?: string },
   ): Promise<void> {
     const sub = this.submissions.get(issueNumber);
     if (!sub) return;
@@ -3139,6 +3140,9 @@ export class InMemoryStore implements Store {
       dispatch: {
         backend: dispatch.backend,
         refs: [...(existing?.refs ?? []), dispatch.ref],
+        ...(dispatch.credentialRef
+          ? { credentialRefs: { ...existing?.credentialRefs, [dispatch.ref]: dispatch.credentialRef } }
+          : {}),
         workspace: dispatch.workspace ?? existing?.workspace,
         seedWorkspace: dispatch.seedWorkspace ?? existing?.seedWorkspace,
       },
@@ -5404,7 +5408,7 @@ export class FirestoreStore implements Store {
 
   async recordDispatch(
     issueNumber: number,
-    dispatch: { backend: string; ref: string; workspace?: string; seedWorkspace?: string },
+    dispatch: { backend: string; ref: string; workspace?: string; seedWorkspace?: string; credentialRef?: string },
   ): Promise<void> {
     const ref = this.db.collection('submissions').doc(String(issueNumber));
     // Transactional for the same reason transitions are: a dispatch and a reconciler
@@ -5420,6 +5424,9 @@ export class FirestoreStore implements Store {
           dispatch: {
             backend: dispatch.backend,
             refs: [...(existing?.refs ?? []), dispatch.ref],
+            ...(dispatch.credentialRef
+              ? { credentialRefs: { ...existing?.credentialRefs, [dispatch.ref]: dispatch.credentialRef } }
+              : {}),
             ...((dispatch.workspace ?? existing?.workspace)
               ? { workspace: dispatch.workspace ?? existing?.workspace }
               : {}),

--- a/apps/api/src/submissions.ts
+++ b/apps/api/src/submissions.ts
@@ -661,9 +661,7 @@ export async function registerSubmissionRoutes(
         ? {
             ...configuredManagedDeps,
             ...(managedDeliver ? { deliver: managedDeliver } : {}),
-<<<<<<< HEAD
             ...(managedLock ? { lock: managedLock } : {}),
-=======
             ...(store
               ? {
                   readCredentialRef: async (issueNumber: number, sessionRef: string) => {
@@ -672,7 +670,6 @@ export async function registerSubmissionRoutes(
                   },
                 }
               : {}),
->>>>>>> cd677c15 (feat(api): scope managed MCP vaults to rounds)
           }
         : undefined;
     const environmentRegistry = createAgentBackendRegistryFromEnv(app.log, selfOptions, managedDeps);

--- a/apps/api/src/submissions.ts
+++ b/apps/api/src/submissions.ts
@@ -4,7 +4,7 @@ import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
 import { z } from 'zod';
 import { splitConceptBrief } from './agent-build-brief.js';
 import { registerAgentChannelRoutes, type AgentChannelOptions } from './agent-channel.js';
-import { mintAgentToken } from './agent-token.js';
+import { mintAgentToken, mintManagedMcpOpener } from './agent-token.js';
 import { registerMcpServerRoutes } from './mcp-server.js';
 import { assembleGameHtml, CredentialLeakError, EmptyProjectError, ProjectTooLargeError } from './assemble.js';
 import { createCreationGate, CREATION_REFUSAL_CODES, type CreationGate } from './creation-limits.js';
@@ -661,7 +661,18 @@ export async function registerSubmissionRoutes(
         ? {
             ...configuredManagedDeps,
             ...(managedDeliver ? { deliver: managedDeliver } : {}),
+<<<<<<< HEAD
             ...(managedLock ? { lock: managedLock } : {}),
+=======
+            ...(store
+              ? {
+                  readCredentialRef: async (issueNumber: number, sessionRef: string) => {
+                    const record = await store.getSubmission(issueNumber);
+                    return record?.dispatch?.credentialRefs?.[sessionRef];
+                  },
+                }
+              : {}),
+>>>>>>> cd677c15 (feat(api): scope managed MCP vaults to rounds)
           }
         : undefined;
     const environmentRegistry = createAgentBackendRegistryFromEnv(app.log, selfOptions, managedDeps);
@@ -1030,6 +1041,10 @@ export async function registerSubmissionRoutes(
           roundGeneration,
           now: now(),
         }),
+        mcpOpenerToken: mintManagedMcpOpener(input.issueNumber, submissionTokenSecret, {
+          roundGeneration,
+          now: now(),
+        }),
         apiBaseUrl: notifyAppBaseUrl,
         ...(input.slug ? { slug: input.slug } : {}),
         ...(input.feedback ? { feedback: input.feedback } : {}),
@@ -1073,6 +1088,7 @@ export async function registerSubmissionRoutes(
         ref: result.ref,
         workspace: result.workspace,
         seedWorkspace: result.seedWorkspace,
+        credentialRef: result.credentialRef,
       });
       // The round-0 preview: the creator sees a playable rough draft minutes after
       // submitting instead of waiting out the agent's first push. Off the response path
@@ -1178,16 +1194,16 @@ export async function registerSubmissionRoutes(
           resetRoundBudget: !input.preserveRoundBudget,
         });
       }
-      if (!input.undelivered && previousBuilder !== builder && previous?.refs.length) {
-        const previousBackend = backendFor(previousBuilder);
+      const previousBackend = backendFor(previousBuilder);
+      if (previous?.refs.length && (!input.undelivered || previousBackend?.name.startsWith('managed:'))) {
         const previousRef = previous.refs[previous.refs.length - 1];
         if (previousBackend && previousRef) {
           try {
-            await previousBackend.cancel(previousRef);
+            await previousBackend.cancel(previousRef, previous?.credentialRefs?.[previousRef]);
           } catch (error) {
             input.log.error(
               { err: error, issueNumber: input.issueNumber },
-              'previous agent cancel failed during handoff',
+              'previous agent cancel failed before a replacement round',
             );
           }
         }
@@ -1206,6 +1222,10 @@ export async function registerSubmissionRoutes(
         feedback: input.feedback,
         locale: input.locale,
         channelToken: mintAgentToken(input.issueNumber, submissionTokenSecret, {
+          roundGeneration,
+          now: now(),
+        }),
+        mcpOpenerToken: mintManagedMcpOpener(input.issueNumber, submissionTokenSecret, {
           roundGeneration,
           now: now(),
         }),
@@ -1229,6 +1249,7 @@ export async function registerSubmissionRoutes(
         backend: selected.name,
         ref: result.ref,
         workspace: result.workspace,
+        credentialRef: result.credentialRef,
       });
       await recordSessionCost(input.issueNumber, result.ref, selected, input.log);
       // The previous workspace is spent the moment a new round has one of its own: the
@@ -3107,7 +3128,7 @@ export async function registerSubmissionRoutes(
       const cancelBackend = backendFor(builderOf(record));
       if (cancelBackend && ref) {
         try {
-          await cancelBackend.cancel(ref);
+          await cancelBackend.cancel(ref, record.dispatch?.credentialRefs?.[ref]);
         } catch (cancelError) {
           request.log.error({ err: cancelError, issueNumber }, 'agent cancel failed');
         }
@@ -3892,7 +3913,8 @@ export async function registerSubmissionRoutes(
     const cancelBackend = backendFor(builderOf(record));
     if (cancelBackend && refs?.length) {
       try {
-        stopEnforced = (await cancelBackend.cancel(refs[refs.length - 1])).enforced;
+        const ref = refs[refs.length - 1];
+        stopEnforced = (await cancelBackend.cancel(ref, record.dispatch?.credentialRefs?.[ref])).enforced;
       } catch (cancelError) {
         request.log.error({ err: cancelError, issueNumber }, 'agent cancel failed; job is canceled regardless');
       }
@@ -4212,7 +4234,7 @@ export async function registerSubmissionRoutes(
             const ref = record.dispatch?.refs.at(-1);
             if (cancelBackend && ref) {
               try {
-                await cancelBackend.cancel(ref);
+                await cancelBackend.cancel(ref, record.dispatch?.credentialRefs?.[ref]);
               } catch (cancelError) {
                 request.log.error(
                   { err: cancelError, issueNumber: record.issueNumber },

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -101,22 +101,28 @@ a single `--set-secrets` list.
 The managed backend is selected by these Cloud Run variables; the deploy scripts carry them
 on every revision because `--set-env-vars` replaces the whole map:
 
-| Variable                            | Meaning                                           |
-| ----------------------------------- | ------------------------------------------------- |
-| `MANAGED_AGENT_VENDOR`              | Provider adapter, currently `anthropic`           |
-| `MANAGED_AGENT_MODEL`               | Provider model label                              |
-| `MANAGED_AGENT_ID`                  | Managed Agent resource                            |
-| `MANAGED_AGENT_ENVIRONMENT_ID`      | Managed Environment resource                      |
-| `MANAGED_AGENT_MAX_SECONDS`         | Per-session wall-clock limit                      |
-| `MANAGED_AGENT_MAX_LIST_COST_CENTS` | Anthropic budget in whole US cents                |
-| `MANAGED_AGENT_VAULT_IDS`           | Comma-separated vaults containing MCP credentials |
-| `MANAGED_AGENT_MCP_URL`             | The MCP endpoint the agent calls                  |
-| `MANAGED_AGENT_DELIVERY_MODE`       | `preview` or `publish`                            |
+| Variable                            | Meaning                                            |
+| ----------------------------------- | -------------------------------------------------- |
+| `MANAGED_AGENT_VENDOR`              | Provider adapter, currently `anthropic`            |
+| `MANAGED_AGENT_MODEL`               | Provider model label                               |
+| `MANAGED_AGENT_ID`                  | Managed Agent resource                             |
+| `MANAGED_AGENT_ENVIRONMENT_ID`      | Managed Environment resource                       |
+| `MANAGED_AGENT_MAX_SECONDS`         | Per-session wall-clock limit                       |
+| `MANAGED_AGENT_MAX_LIST_COST_CENTS` | Anthropic budget in whole US cents                 |
+| `MANAGED_AGENT_VAULT_IDS`           | Optional static vaults for probe-only integrations |
+| `MANAGED_AGENT_MCP_URL`             | The MCP endpoint the agent calls                   |
+| `MANAGED_AGENT_DELIVERY_MODE`       | `preview` or `publish`                             |
 
 `MANAGED_AGENT_API_KEY` is wired from the `anthropic-api-key` Secret Manager secret and never
 belongs in variables, the repository, or a workflow body. If the managed vendor variables or
 secret are absent, the platform slot remains unset and platform jobs stay queued; self builds
 continue to work.
+
+When `MANAGED_AGENT_MCP_URL` is set, each managed round receives its own short-lived
+build-channel capability through a vendor vault. The vault is created for that session, is
+keyed to the exact MCP URL, and is archived when the session ends or is cancelled. Do not put a
+creator OAuth token or creator key in `MANAGED_AGENT_VAULT_IDS`: those vaults are only a
+backward-compatible probe escape hatch.
 
 `site-basic-auth` is a leftover: the running revision does not wire it, and the site answers
 without an auth challenge. Access is controlled by `PRIVATE_BETA` and the beta allowlist

--- a/docs/managed-agent-backend.md
+++ b/docs/managed-agent-backend.md
@@ -260,9 +260,10 @@ npm run managed:probe -w @gamedevpl/api -- --vendor anthropic
 The probe uses `ANTHROPIC_API_KEY` for this vendor and defaults to
 `claude-sonnet-5`; `MANAGED_AGENT_API_KEY` or `--model` overrides either value.
 `MANAGED_AGENT_ID` and `MANAGED_AGENT_ENVIRONMENT_ID` identify the preconfigured
-Anthropic resources. `MANAGED_AGENT_VAULT_ID` attaches one session vault; use
-`MANAGED_AGENT_VAULT_IDS` for comma-separated vault IDs. The selected vault must contain
-the credential for the exact MCP server URL.
+Anthropic resources. In production, `MANAGED_AGENT_MCP_URL` makes the adapter create a
+round-scoped vault containing the build capability for that exact URL; the agent never sees the
+capability and the vault is archived when the round ends. `MANAGED_AGENT_VAULT_ID` and
+`MANAGED_AGENT_VAULT_IDS` remain available only for probe-only static integrations.
 
 It creates an initial event, polls twice, interrupts and deletes the session. The current
 probe verifies session lifecycle and costs a real run; it does not wait for a game to finish
@@ -303,7 +304,7 @@ ref the round receives, rather than copied into this repository.
 | `MANAGED_AGENT_MODEL`               | Provider model label; Anthropic's actual model is on its Agent  |
 | `MANAGED_AGENT_ID`                  | Anthropic Managed Agent resource id                             |
 | `MANAGED_AGENT_ENVIRONMENT_ID`      | Anthropic Managed Environment resource id                       |
-| `MANAGED_AGENT_VAULT_IDS`           | Comma-separated session vault ids for MCP credentials           |
+| `MANAGED_AGENT_VAULT_IDS`           | Optional static vault ids for probe-only MCP integrations       |
 | `MANAGED_AGENT_EFFORT`              | `low` / `medium` / `high`                                       |
 | `MANAGED_AGENT_MAX_SECONDS`         | Hard ceiling on one session's wall clock                        |
 | `MANAGED_AGENT_MAX_LIST_COST_CENTS` | Anthropic session budget, in whole cents                        |


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Scopes managed MCP vault credentials per round (opener mint/verify, Anthropic vault lifecycle, MCP `start` acceptance) on top of #709.

Rebased onto the updated #709 tip after that stack was rebased onto `master`.

### Codex review follow-ups
- Prefer the MCP channel contract when MCP endpoints are configured (even if a delivery sink is also present) — already landed; retained through rebase
- Archive/release round credentials in `finally` even when Anthropic interrupt fails

## Test plan
- [x] Full green gate on the rebased stack tip
- [x] Managed-backend tests for MCP preference + cancel credential release
- [ ] Production creation round once secrets are configured
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4cf2e9e5-dd15-4c3a-8323-8e026e20823b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4cf2e9e5-dd15-4c3a-8323-8e026e20823b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

