### PR TITLE
Float Studio removal notice as toast

### DIFF
--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -10775,20 +10775,31 @@ button.builder-mode-selector:disabled {
   color: var(--muted);
 }
 
-/* Same docked-card look as .app-update, but static in the panel flow — this bar
-   only ever appears already inside Studio, so it never needs to float over it. */
+/* Match the app-update toast instead of pushing Studio down below the top bar. */
 .studio-abandon-notice {
+  position: fixed;
+  left: 12px;
+  right: 12px;
+  bottom: max(12px, env(safe-area-inset-bottom));
+  z-index: 900;
   display: flex;
   align-items: center;
   gap: 12px;
-  margin: 0 0 1.5rem;
+  width: auto;
+  max-width: 560px;
+  margin: 0 auto;
   padding: 12px 14px;
   border: 1px solid var(--panel-border);
   border-radius: 14px;
   background: rgba(22, 28, 34, 0.96);
   -webkit-backdrop-filter: blur(10px);
   backdrop-filter: blur(10px);
+  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.45);
   animation: install-prompt-in 220ms ease-out;
+}
+
+.app:has(:is(.install-prompt, .app-update)) .studio-abandon-notice {
+  bottom: max(88px, calc(76px + env(safe-area-inset-bottom)));
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/apps/web/src/styles.studioAbandonNotice.test.ts
+++ b/apps/web/src/styles.studioAbandonNotice.test.ts
@@ -1,0 +1,23 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const css = readFileSync(fileURLToPath(new URL('./styles.css', import.meta.url)), 'utf8');
+
+describe('Studio removal notice', () => {
+  it('floats like the app update toast without spanning the workspace', () => {
+    const start = css.indexOf('.studio-abandon-notice {');
+    const end = css.indexOf('}', start);
+    const rule = css.slice(start, end);
+
+    expect(start).toBeGreaterThan(-1);
+    expect(rule).toMatch(/position:\s*fixed/);
+    expect(rule).toMatch(/bottom:\s*max\(12px, env\(safe-area-inset-bottom\)\)/);
+    expect(rule).toMatch(/max-width:\s*560px/);
+    expect(rule).toMatch(/box-shadow:/);
+  });
+
+  it('stacks above another bottom toast', () => {
+    expect(css).toMatch(/\.app:has\(:is\(\.install-prompt, \.app-update\)\) \.studio-abandon-notice\s*{[^}]*bottom:/s);
+  });
+});


### PR DESCRIPTION
### Motivation
- The Studio "removal" / abandon confirmation was a static panel-banner that pushed the studio layout and could be visually intrusive under the top chrome; it should behave like other transient toasts (e.g. the app-update toast) and not change the page flow.

### Description
- Convert `.studio-abandon-notice` from a static in-flow card to a bottom-centered floating toast with `position: fixed`, constrained `max-width`, backdrop blur, shadow, and safe-area spacing; add a stacking rule so it moves above `.install-prompt` / `.app-update` when present (`apps/web/src/styles.css`).
- Add a small CSS regression test that asserts the notice is fixed, has the correct bottom inset / max-width / shadow, and that it stacks above the bottom toast when one is present (`apps/web/src/styles.studioAbandonNotice.test.ts`).

### Testing
- Ran the project green-gate: `npm install` and `npm run type-check && npm run lint && npm run test && npm run build`, and the build and test suites completed successfully.
- Ran the targeted web unit tests `vitest` for the new CSS test plus `CreatorStudioView` (`npm run test -w @gamedevpl/web -- --run src/styles.studioAbandonNotice.test.ts src/CreatorStudioView.test.tsx`) and they passed; visual screenshot capture via Playwright/Chromium was not available in this environment, but the CSS contract is covered by the added regression test.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a78dc06f12483238c73718a5f30e0b5)