### PR TITLE
Wire per-round MCP vault credentials into managed:probe --mcp

### DIFF
--- a/apps/api/scripts/managed-probe.ts
+++ b/apps/api/scripts/managed-probe.ts
@@ -162,7 +162,7 @@ if (wait && (!Number.isInteger(waitSeconds) || waitSeconds <= 0 || !Number.isFin
   console.error('--wait requires positive --wait-seconds and --budget-usd values');
   process.exit(1);
 }
-// Match production: MCP endpoint → override the Agent's tool list for this session.
+// MCP rounds override the Agent tool list, like production.
 const overrideTools = mcpOnly || flag('override-tools');
 const provider = vendor
   ? createManagedProvider(vendor, {
@@ -189,7 +189,7 @@ const backend = createManagedBackend({
   ...(mcpOnly
     ? {
         tools: { mcpEndpoints: [{ url: mcpUrl, name: 'gamedevpl' }] },
-        // Same shape as createManagedPlatformBackendFromEnv — vault holds the opener.
+        // Per-round vault holds the opener, as in production.
         mcpBearerCredential: (input) =>
           input.mcpOpenerToken ? { url: mcpUrl, token: input.mcpOpenerToken } : undefined,
       }

--- a/apps/api/scripts/managed-probe.ts
+++ b/apps/api/scripts/managed-probe.ts
@@ -4,6 +4,7 @@ import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import type { BuildBrief } from '../src/agent-backend.js';
+import { mintManagedMcpOpener } from '../src/agent-token.js';
 import { buildPrompt } from '../src/build-prompt.js';
 import {
   createManagedProvider,
@@ -36,14 +37,38 @@ const vaultIds = (process.env.MANAGED_AGENT_VAULT_IDS ?? process.env.MANAGED_AGE
   ?.split(',')
   .map((id) => id.trim())
   .filter(Boolean);
+const mcpOnly = flag('mcp');
+const mcpUrl = (value('mcp-url') ?? process.env.MANAGED_AGENT_MCP_URL ?? 'https://www.gamedev.pl/api/mcp').replace(
+  /\/$/,
+  '',
+);
+const roundGeneration = Number(value('round-generation') ?? 1);
+const openerSecret =
+  process.env.SUBMISSION_TOKEN_SECRET?.trim() ||
+  process.env.MANAGED_PROBE_OPENER_SECRET?.trim() ||
+  'probe-mcp-opener-secret';
+const usingProdOpenerSecret = Boolean(process.env.SUBMISSION_TOKEN_SECRET?.trim());
 const rule = (title: string) => console.log(`\n${'─'.repeat(72)}\n${title}\n${'─'.repeat(72)}`);
+
+if (mcpOnly && (!Number.isSafeInteger(ISSUE) || ISSUE <= 0)) {
+  console.error('--mcp needs a positive --issue (job id) for the opener token');
+  process.exit(1);
+}
+if (mcpOnly && (!Number.isSafeInteger(roundGeneration) || roundGeneration < 1)) {
+  console.error('--round-generation must be a positive integer');
+  process.exit(1);
+}
+
+const mcpOpenerToken = mcpOnly ? mintManagedMcpOpener(ISSUE, openerSecret, { roundGeneration }) : undefined;
 
 const brief: BuildBrief = {
   issueNumber: ISSUE,
+  roundGeneration,
   ...(SLUG ? { slug: SLUG } : {}),
   ...(creation ? { createGame: { title: CREATE_TITLE, concept: CREATE_CONCEPT } } : {}),
   spec: value('spec') ?? CREATE_CONCEPT,
   channelToken: 'tok_probe',
+  ...(mcpOpenerToken ? { mcpOpenerToken } : {}),
   apiBaseUrl: 'http://127.0.0.1:3001',
   ...(flag('feedback') ? { feedback: 'make the comets bigger' } : {}),
 };
@@ -80,8 +105,15 @@ function stubProvider(): ManagedAgentProvider {
       console.log(`systemPrompt     ${request.systemPrompt ? `${request.systemPrompt.length} chars` : '(none)'}`);
       console.log(`workspaceFiles   ${request.workspaceFiles?.length ?? 0}`);
       console.log(`mcpEndpoints     ${request.tools?.mcpEndpoints?.map((e) => e.url).join(', ') || '(none)'}`);
+      console.log(
+        `mcpBearer        ${request.mcpBearerCredential ? `url=${request.mcpBearerCredential.url} token=${request.mcpBearerCredential.token.length} chars` : '(none)'}`,
+      );
       console.log(`prompt           ${request.prompt.length} chars — run with --prompt to read it`);
-      return { id: 'stub-session-1', state: 'queued' };
+      return {
+        id: 'stub-session-1',
+        state: 'queued',
+        ...(request.mcpBearerCredential ? { credentialRef: 'stub-vault-1' } : {}),
+      };
     },
     async getSession(): Promise<ManagedSession> {
       polls += 1;
@@ -109,6 +141,9 @@ function stubProvider(): ManagedAgentProvider {
     async cancelSession() {
       return { enforced: true };
     },
+    async releaseCredential(credentialRef) {
+      console.log(`released credential ${credentialRef}`);
+    },
     async deleteSession() {},
   };
 }
@@ -127,6 +162,8 @@ if (wait && (!Number.isInteger(waitSeconds) || waitSeconds <= 0 || !Number.isFin
   console.error('--wait requires positive --wait-seconds and --budget-usd values');
   process.exit(1);
 }
+// Match production: MCP endpoint → override the Agent's tool list for this session.
+const overrideTools = mcpOnly || flag('override-tools');
 const provider = vendor
   ? createManagedProvider(vendor, {
       apiKey: apiKey!,
@@ -139,19 +176,23 @@ const provider = vendor
         ? { maxListCostCents: Math.max(1, Math.round(budgetUsd * 100)) }
         : {}),
       ...(vaultIds?.length ? { vaultIds } : {}),
-      ...(flag('override-tools') ? { overrideTools: true } : {}),
+      ...(overrideTools ? { overrideTools: true } : {}),
       baseUrl: apiBaseUrl,
     })
   : stubProvider();
 
 const delivered: ManagedDeliveryInput[] = [];
-const mcpOnly = flag('mcp');
 
 const backend = createManagedBackend({
   provider,
   // Stands in for the submit_sources route, still to be extracted.
   ...(mcpOnly
-    ? { tools: { mcpEndpoints: [{ url: 'https://www.gamedev.pl/api/mcp', name: 'gamedevpl' }] } }
+    ? {
+        tools: { mcpEndpoints: [{ url: mcpUrl, name: 'gamedevpl' }] },
+        // Same shape as createManagedPlatformBackendFromEnv — vault holds the opener.
+        mcpBearerCredential: (input) =>
+          input.mcpOpenerToken ? { url: mcpUrl, token: input.mcpOpenerToken } : undefined,
+      }
     : {
         deliver: async (input) => {
           delivered.push(input);
@@ -170,9 +211,25 @@ const backend = createManagedBackend({
 });
 
 rule(`probe — backend ${backend.name}${mcpOnly ? ' (MCP shape)' : ' (pull shape)'}`);
+if (mcpOnly) {
+  console.log(`mcpUrl           ${mcpUrl}`);
+  console.log(`issue            ${ISSUE}  roundGeneration ${roundGeneration}`);
+  console.log(
+    `opener           ${usingProdOpenerSecret ? 'SUBMISSION_TOKEN_SECRET (may auth live MCP)' : 'probe-local secret (Anthropic vault proof only)'}`,
+  );
+  if (!usingProdOpenerSecret) {
+    console.log(
+      'note             Live MCP start against prod still needs SUBMISSION_TOKEN_SECRET + a real Firestore job.',
+    );
+  }
+}
 
 const dispatch = await backend.dispatch(brief);
 console.log(`\nref              ${dispatch.ref}`);
+console.log(`credentialRef    ${dispatch.credentialRef ?? '(none)'}`);
+if (mcpOnly && vendor === 'anthropic' && !dispatch.credentialRef) {
+  console.warn('WARN  expected a per-round vault credentialRef when --mcp is set for Anthropic');
+}
 
 const pollCount = wait ? Math.ceil((waitSeconds * 1000) / 5000) + 1 : 2;
 for (let attempt = 1; attempt <= pollCount; attempt += 1) {
@@ -182,6 +239,7 @@ for (let attempt = 1; attempt <= pollCount; attempt += 1) {
     hasCandidate: delivered.length > 0,
     issueNumber: ISSUE,
     slug: SLUG,
+    roundGeneration,
   });
   console.log(observation ?? '(vendor has forgotten this session)');
   if (
@@ -216,6 +274,8 @@ if (delivered.length === 0) {
 // A deleted session takes the only record of what the agent tried.
 if (vendor === 'anthropic') {
   rule('session transcript');
+  let mcpStartOk = 0;
+  let mcpStartErr = 0;
   try {
     const response = await fetch(`${apiBaseUrl}/v1/sessions/${dispatch.ref}/events`, {
       headers: {
@@ -231,9 +291,10 @@ if (vendor === 'anthropic') {
       const type = String(event.type);
       if (!['agent.tool_use', 'agent.mcp_tool_use', 'agent.mcp_tool_result', 'agent.message'].includes(type)) continue;
       const at = ((Date.parse(String(event.processed_at)) - started) / 1000).toFixed(1);
+      const toolName = String(event.name ?? '');
       const detail =
         type === 'agent.mcp_tool_use'
-          ? `mcp:${String(event.name)}`
+          ? `mcp:${toolName}`
           : type === 'agent.mcp_tool_result'
             ? event.is_error
               ? `ERROR ${String((event.content as { text?: string }[] | undefined)?.[0]?.text ?? '').slice(0, 120)}`
@@ -245,16 +306,27 @@ if (vendor === 'anthropic') {
               )
                 .slice(0, 100)
                 .replace(/\n/g, ' ');
+      if (type === 'agent.mcp_tool_result' && (toolName === 'start' || toolName.endsWith(':start'))) {
+        if (event.is_error) mcpStartErr += 1;
+        else mcpStartOk += 1;
+      }
       console.log(`${at.padStart(6)}s  ${type}  ${detail}`);
     }
     if (events.length === 0) console.log('(no events returned)');
+    if (mcpOnly) {
+      console.log(
+        `\nmcp:start summary  ok=${mcpStartOk} error=${mcpStartErr}${
+          mcpStartOk + mcpStartErr === 0 ? ' (no start call in transcript yet)' : ''
+        }`,
+      );
+    }
   } catch (error) {
     console.warn('could not read the transcript:', error);
   }
 }
 
 rule('cancel + cleanup');
-console.log(await backend.cancel(dispatch.ref));
+console.log(await backend.cancel(dispatch.ref, dispatch.credentialRef));
 if (flag('keep')) {
   console.log(`kept ${dispatch.ref} — inspect it in the console, then delete it yourself`);
 } else {

--- a/docs/managed-agent-backend.md
+++ b/docs/managed-agent-backend.md
@@ -234,7 +234,7 @@ selection, with a stub vendor and a printing sink:
 
 ```bash
 npm run managed:probe -w @gamedevpl/api                 # pull shape, stub vendor
-npm run managed:probe -w @gamedevpl/api -- --mcp        # MCP shape: nothing is pulled
+npm run managed:probe -w @gamedevpl/api -- --mcp        # MCP shape + vault credential (stub)
 npm run managed:probe -w @gamedevpl/api -- --prompt     # the brief each contract produces
 npm run managed:probe -w @gamedevpl/api -- --out /tmp/harvest
 ```
@@ -265,11 +265,32 @@ round-scoped vault containing the build capability for that exact URL; the agent
 capability and the vault is archived when the round ends. `MANAGED_AGENT_VAULT_ID` and
 `MANAGED_AGENT_VAULT_IDS` remain available only for probe-only static integrations.
 
-It creates an initial event, polls twice, interrupts and deletes the session. The current
-probe verifies session lifecycle and costs a real run; it does not wait for a game to finish
-or prove that the configured Agent writes the expected files. `--base-url` aims the same
-adapter at a local HTTP stub. A full creator-visible round still needs the sink, registry
-wiring and a configured MCP connection or pull workspace.
+`--mcp` now follows that production path: it mints a managed MCP opener
+(`mintManagedMcpOpener`), puts it on the brief as `mcpOpenerToken`, passes
+`mcpBearerCredential` into the backend, and sets `overrideTools` so the session's tool list
+is the MCP endpoint. After dispatch the probe prints `credentialRef` (the vault id) and
+archives it on cancel/cleanup. The MCP URL comes from `--mcp-url` or `MANAGED_AGENT_MCP_URL`
+(default `https://www.gamedev.pl/api/mcp`).
+
+```bash
+ANTHROPIC_API_KEY=... \
+MANAGED_AGENT_ID=agent_... \
+MANAGED_AGENT_ENVIRONMENT_ID=env_... \
+npm run managed:probe -w @gamedevpl/api -- --vendor anthropic --mcp --wait \
+  --wait-seconds 120 --budget-usd 1
+```
+
+That proves Anthropic accepted the per-round vault. Authenticating `mcp:start` against the
+live platform MCP still needs a real Firestore job and an opener signed with the same
+`SUBMISSION_TOKEN_SECRET` the API uses — export that secret into the probe environment when
+you have both. Without it the probe uses a local opener secret so vault creation still works
+and the transcript's `mcp:start` line will show an auth error rather than "no credential
+stored for this server URL".
+
+It creates an initial event, polls twice, interrupts and deletes the session. The bare
+(non-`--mcp`) probe verifies session lifecycle and costs a real run; it does not wait for a
+game to finish or prove that the configured Agent writes the expected files. `--base-url`
+aims the same adapter at a local HTTP stub.
 
 For a bounded live run, `--wait` requires both caps explicitly:
 
@@ -304,6 +325,7 @@ ref the round receives, rather than copied into this repository.
 | `MANAGED_AGENT_MODEL`               | Provider model label; Anthropic's actual model is on its Agent  |
 | `MANAGED_AGENT_ID`                  | Anthropic Managed Agent resource id                             |
 | `MANAGED_AGENT_ENVIRONMENT_ID`      | Anthropic Managed Environment resource id                       |
+| `MANAGED_AGENT_MCP_URL`             | MCP endpoint; triggers per-round vault + `overrideTools`        |
 | `MANAGED_AGENT_VAULT_IDS`           | Optional static vault ids for probe-only MCP integrations       |
 | `MANAGED_AGENT_EFFORT`              | `low` / `medium` / `high`                                       |
 | `MANAGED_AGENT_MAX_SECONDS`         | Hard ceiling on one session's wall clock                        |


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`--mcp` on `managed:probe` previously only set `tools.mcpEndpoints`, so a live Anthropic session hit “no credential stored for this server URL”. It now follows the production path: mint a managed MCP opener, put it on the brief, pass `mcpBearerCredential`, set `overrideTools`, print `credentialRef`, and archive the vault on cancel/cleanup.

## Probe behaviour

- MCP URL from `--mcp-url` or `MANAGED_AGENT_MCP_URL` (default `https://www.gamedev.pl/api/mcp`)
- Opener signed with `SUBMISSION_TOKEN_SECRET` when present (needed for live MCP auth against a real job); otherwise a probe-local secret so Anthropic vault creation still works
- Transcript prints an `mcp:start` ok/error summary
- Stub vendor path also exercises the bearer + `credentialRef` release

Docs in `docs/managed-agent-backend.md` updated to match.

## Test plan

- [x] `npm run managed:probe -w @gamedevpl/api -- --mcp` (stub) — prints `mcpBearer`, `credentialRef`, releases vault
- [ ] Live: `--vendor anthropic --mcp --wait --wait-seconds … --budget-usd …` — expect a real `credentialRef` (vault proof)
- [ ] Optional live MCP auth: same plus `SUBMISSION_TOKEN_SECRET` and a real `--issue` job id

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4cf2e9e5-dd15-4c3a-8323-8e026e20823b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4cf2e9e5-dd15-4c3a-8323-8e026e20823b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

