### PR TITLE
fix(contract): mirror cards module order

### DIFF
--- a/apps/api/fixtures/games-repo/shared/assemble-contract.json
+++ b/apps/api/fixtures/games-repo/shared/assemble-contract.json
@@ -10,6 +10,7 @@
     "ai",
     "gameplay",
     "rng",
+    "cards",
     "vehicles",
     "urban",
     "drawing",

--- a/apps/api/src/games-repo-contract-check.ts
+++ b/apps/api/src/games-repo-contract-check.ts
@@ -301,6 +301,7 @@ export async function runGamesRepoContractCheck(options: ContractCheckOptions): 
     ['football', Date.parse('2026-08-10T00:00:00.000Z')],
     ['vehicles', Date.parse('2026-09-01T00:00:00.000Z')],
     ['urban', Date.parse('2026-08-11T00:00:00.000Z')],
+    ['cards', Date.parse('2026-08-15T00:00:00.000Z')],
   ]);
   const websiteExtras = localModules.filter((m) => !remoteModules.includes(m));
   const now = options.now?.() ?? Date.now();

--- a/apps/api/src/games-repo-contract.test.ts
+++ b/apps/api/src/games-repo-contract.test.ts
@@ -98,6 +98,7 @@ describe('games-repo-contract (website half)', () => {
       'ai',
       'gameplay',
       'rng',
+      'cards',
       'vehicles',
       'urban',
       'drawing',
@@ -228,7 +229,7 @@ describe('games-repo source extractors', () => {
     const source = `
       // Canonical order
       export const GAME_KIT_MODULES = [
-        'input', 'collision', 'world', 'grid', 'path', 'ai', 'gameplay', 'rng', 'vehicles', 'urban',
+        'input', 'collision', 'world', 'grid', 'path', 'ai', 'gameplay', 'rng', 'cards', 'vehicles', 'urban',
         'drawing', 'actors', 'gfx', 'gfx3d', 'racing', 'football', 'effects', 'audio', 'party', 'save', 'commons', 'presence', 'mascot', 'zone',
         'sensing', 'voice', 'editor',
       ] as const;

--- a/apps/api/src/games-repo-contract.ts
+++ b/apps/api/src/games-repo-contract.ts
@@ -48,6 +48,7 @@ export const GAME_KIT_MODULES = [
   'ai',
   'gameplay',
   'rng',
+  'cards',
   // Top-down arcade vehicle paint/lights — pairs with gameplay.driveArcadeVehicle.
   'vehicles',
   // Genre vertical: deterministic street topology and routing for 2D urban games.


### PR DESCRIPTION
Paired with gamedevpl/www.gamedev.pl-games#677; merge both together.

Updates the website-side GameKit module order and assemble-contract fixture for the new shared `cards` module, keeping the games and website contracts in lockstep. Adds a short-lived `cards` website-ahead expiry guard so CI stays green during rollout; remove it after the paired games PR lands.

Validation:
- `npm run test -w @gamedevpl/api -- src/games-repo-contract.test.ts` (28 passed)
- `npm run build:packages`
- `npm run type-check -w @gamedevpl/api`
- Copilot rollout feedback addressed with the temporary expiry guard.