### PR TITLE
Log managed vault mint/revoke with issueNumber and slug

### DIFF
--- a/apps/api/src/managed-backend.test.ts
+++ b/apps/api/src/managed-backend.test.ts
@@ -119,6 +119,7 @@ describe('managed backend', () => {
 
   it('mints a vault-only MCP credential and revokes it after agent end', async () => {
     const released: string[] = [];
+    const info = vi.fn();
     const { provider, started, setState } = fakeProvider({
       startSession: async (request) => {
         started.push(request);
@@ -133,6 +134,7 @@ describe('managed backend', () => {
       tools: { mcpEndpoints: [{ url: 'https://www.gamedev.pl/api/mcp', name: 'gamedevpl' }] },
       mcpBearerCredential: (input) => ({ url: 'https://www.gamedev.pl/api/mcp', token: input.channelToken }),
       readSignals: async () => ({ agentEndedAt: '2026-08-09T18:00:00.000Z' }),
+      log: { warn: vi.fn(), info },
     });
 
     const result = await backend.dispatch(brief({ channelToken: 'round-token' }));
@@ -142,6 +144,20 @@ describe('managed backend', () => {
     expect(started[0].mcpBearerCredential).toEqual({ url: 'https://www.gamedev.pl/api/mcp', token: 'round-token' });
     expect(result.credentialRef).toBe('lease-1');
     expect(released).toEqual(['lease-1']);
+    expect(info).toHaveBeenCalledWith(
+      {
+        issueNumber: ISSUE,
+        slug: SLUG,
+        ref: 'session-1',
+        credentialRef: 'lease-1',
+        mcpUrl: 'https://www.gamedev.pl/api/mcp',
+      },
+      'managed round credential minted',
+    );
+    expect(info).toHaveBeenCalledWith(
+      { issueNumber: ISSUE, slug: SLUG, ref: 'session-1', credentialRef: 'lease-1' },
+      'managed round credential revoked',
+    );
   });
 
   it('sends the seed as workspace files and the digest as a cacheable prefix', async () => {
@@ -502,16 +518,28 @@ describe('managed backend', () => {
 
   it('archives round credentials even when interrupt fails', async () => {
     const releaseCredential = vi.fn(async () => undefined);
+    const info = vi.fn();
     const { provider } = fakeProvider({
+      startSession: async () => ({ id: 'session-1', state: 'queued', credentialRef: 'vault-1' }),
       cancelSession: async () => {
         throw new Error('interrupt unavailable');
       },
       releaseCredential,
     });
-    const backend = createManagedBackend({ provider, deliver: async () => ({ version: 'v1' }) });
+    const backend = createManagedBackend({
+      provider,
+      deliver: async () => ({ version: 'v1' }),
+      log: { warn: vi.fn(), info },
+    });
 
-    await expect(backend.cancel('session-1', 'vault-1')).rejects.toThrow(/interrupt unavailable/);
+    await backend.dispatch(brief());
+    await expect(backend.cancel('session-1')).rejects.toThrow(/interrupt unavailable/);
     expect(releaseCredential).toHaveBeenCalledWith('vault-1');
+    // Cancel has no issueNumber arg; sessionJobs still correlates the revoke log.
+    expect(info).toHaveBeenCalledWith(
+      { issueNumber: ISSUE, slug: SLUG, ref: 'session-1', credentialRef: 'vault-1' },
+      'managed round credential revoked',
+    );
   });
 
   it('answers null for a session the vendor has forgotten', async () => {

--- a/apps/api/src/managed-backend.ts
+++ b/apps/api/src/managed-backend.ts
@@ -124,17 +124,31 @@ export function createManagedBackend(options: ManagedBackendOptions): AgentBacke
   const sessionGenerations = new Map<string, number>();
   const credentialRefs = new Map<string, string>();
   const releasedCredentials = new Set<string>();
+  // So cancel/cleanup can still log issueNumber/slug without a caller hint.
+  const sessionJobs = new Map<string, { issueNumber: number; slug?: string }>();
+
+  function jobContext(ref: string, issueNumber?: number): { issueNumber?: number; slug?: string } {
+    const job = sessionJobs.get(ref);
+    const resolvedIssue = issueNumber ?? job?.issueNumber;
+    return {
+      ...(resolvedIssue !== undefined ? { issueNumber: resolvedIssue } : {}),
+      ...(job?.slug ? { slug: job.slug } : {}),
+    };
+  }
 
   async function releaseCredential(ref: string, issueNumber?: number): Promise<void> {
+    const context = jobContext(ref, issueNumber);
     const credentialRef =
-      credentialRefs.get(ref) ?? (issueNumber ? await options.readCredentialRef?.(issueNumber, ref) : undefined);
+      credentialRefs.get(ref) ??
+      (context.issueNumber !== undefined ? await options.readCredentialRef?.(context.issueNumber, ref) : undefined);
     if (!credentialRef || releasedCredentials.has(credentialRef) || !options.provider.releaseCredential) return;
     releasedCredentials.add(credentialRef);
     try {
       await options.provider.releaseCredential(credentialRef);
+      options.log?.info?.({ ...context, ref, credentialRef }, 'managed round credential revoked');
     } catch (error) {
       releasedCredentials.delete(credentialRef);
-      options.log?.warn({ err: error, ref }, 'could not revoke managed round credential');
+      options.log?.warn({ err: error, ...context, ref, credentialRef }, 'could not revoke managed round credential');
     }
   }
 
@@ -173,7 +187,23 @@ export function createManagedBackend(options: ManagedBackendOptions): AgentBacke
     });
     startedAt.set(session.id, Date.now());
     sessionGenerations.set(session.id, brief.roundGeneration ?? 1);
-    if (session.credentialRef) credentialRefs.set(session.id, session.credentialRef);
+    sessionJobs.set(session.id, {
+      issueNumber: brief.issueNumber,
+      ...(brief.slug ? { slug: brief.slug } : {}),
+    });
+    if (session.credentialRef) {
+      credentialRefs.set(session.id, session.credentialRef);
+      options.log?.info?.(
+        {
+          issueNumber: brief.issueNumber,
+          ...(brief.slug ? { slug: brief.slug } : {}),
+          ref: session.id,
+          credentialRef: session.credentialRef,
+          ...(mcpBearerCredential ? { mcpUrl: mcpBearerCredential.url } : {}),
+        },
+        'managed round credential minted',
+      );
+    }
     return { ref: session.id, ...(session.credentialRef ? { credentialRef: session.credentialRef } : {}) };
   }
 
@@ -383,6 +413,7 @@ export function createManagedBackend(options: ManagedBackendOptions): AgentBacke
       if (previous.credentialRef) credentialRefs.set(previous.ref, previous.credentialRef);
       await releaseCredential(previous.ref);
       credentialRefs.delete(previous.ref);
+      sessionJobs.delete(previous.ref);
       await options.provider.deleteSession?.(previous.ref);
     },
   };


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

After the live managed-agent smoke (`issueNumber=1000051`), the round succeeded end-to-end but vault mint/teardown could only be inferred from gate outcomes — those log lines carried no job identity.

This adds greppable success-path logs:

- `managed round credential minted` — `issueNumber`, `slug`, `ref`, `credentialRef`, `mcpUrl`
- `managed round credential revoked` — same job fields on successful archive
- warn-on-failure already existed; it now also includes `issueNumber` / `slug` / `credentialRef`

Session job identity is retained so `cancel` / `cleanup` (no `issueNumber` arg) still correlate.

## Test plan

- [x] `vitest run apps/api/src/managed-backend.test.ts`
- [ ] After deploy: grep Cloud Run for `managed round credential minted` + a known `issueNumber`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4cf2e9e5-dd15-4c3a-8323-8e026e20823b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4cf2e9e5-dd15-4c3a-8323-8e026e20823b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

