### PR TITLE
Refuse missing cross-file symbols at delivery time (MR-05)

### DIFF
--- a/apps/api/src/games-store.test.ts
+++ b/apps/api/src/games-store.test.ts
@@ -143,6 +143,54 @@ describe('validateSourceUpload — the delivery contract', () => {
     });
   });
 
+  describe('cross-file symbol link check', () => {
+    const brokenPair: SourceFile[] = [
+      {
+        path: 'game/runtime.ts',
+        content: `import { WIN_SCORE, spawnDebris } from './model.js';\nexport function tick() {\n  return WIN_SCORE + spawnDebris();\n}\n`,
+      },
+      {
+        path: 'game/model.ts',
+        content: `export type Round = { score: number };\nexport const START = 0;\n`,
+      },
+    ];
+
+    it('refuses the WIN_SCORE/spawnDebris delivery on preview and publish', () => {
+      for (const mode of ['preview', 'publish'] as const) {
+        expect(() => validateSourceUpload([...MINIMAL, ...brokenPair], mode)).toThrow(
+          /game\/model\.ts does not export `WIN_SCORE`, `spawnDebris`/,
+        );
+      }
+    });
+
+    it('still accepts a valid multi-file delivery', () => {
+      const delivery = [
+        ...MINIMAL.filter((f) => f.path !== 'game.ts'),
+        {
+          path: 'game.ts',
+          content: `import { publicName, Helper } from './lib.js';\nexport { publicName, Helper };\n`,
+        },
+        {
+          path: 'lib.ts',
+          content: `const localName = 1;\nexport { localName as publicName };\nexport class Helper {}\n`,
+        },
+      ];
+      expect(validateSourceUpload(delivery)).toHaveLength(delivery.length);
+      expect(validateSourceUpload(delivery, 'preview')).toHaveLength(delivery.length);
+    });
+
+    it('does not refuse bare engine imports', () => {
+      const delivery = [
+        ...MINIMAL.filter((f) => f.path !== 'game.ts'),
+        {
+          path: 'game.ts',
+          content: `import { createGame } from '@gamedevpl/game-kit';\nexport const g = createGame;\n`,
+        },
+      ];
+      expect(validateSourceUpload(delivery)).toHaveLength(delivery.length);
+    });
+  });
+
   it('catches an enabled audio module without selected sounds before the gate', () => {
     expect(() =>
       validateSourceUpload(

--- a/apps/api/src/games-store.ts
+++ b/apps/api/src/games-store.ts
@@ -30,6 +30,7 @@ import type { GateProgress } from './gate-progress.js';
 import { hasPlayableHowToPlay } from './index-html-generator.js';
 import { parseKitSidecar } from './kit-registry.js';
 import { KIT_REGISTRY_OBJECT, parseKitRegistry, type KitRegistry } from './kit-window.js';
+import { findUnresolvedSourceLinks, formatSourceLinkError, sourceFilesToMap } from './source-link-check.js';
 
 export type { GateProgress } from './gate-progress.js';
 
@@ -326,10 +327,18 @@ export function validateSourceUpload(files: SourceFile[], mode: DeliveryMode = '
       );
     }
   }
+
+  // Refuse missing cross-file symbols before the async gate.
+  const normalized = files.map((file) => ({ path: file.path.trim(), content: file.content }));
+  const linkFindings = findUnresolvedSourceLinks(sourceFilesToMap(normalized));
+  if (linkFindings.length > 0) {
+    throw new InvalidUploadError(formatSourceLinkError(linkFindings));
+  }
+
   // AGENT.json is allowed above but deliberately not required here yet — see the
   // ALLOWED_SOURCE_FILES note. Missing file → Check 28 on the gate, not a 400 at upload.
 
-  return files.map((file) => ({ path: file.path.trim(), content: file.content }));
+  return normalized;
 }
 
 /** Provenance for one stored version. Answers "where did this come from?" years later. */

--- a/apps/api/src/source-link-check.test.ts
+++ b/apps/api/src/source-link-check.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, it } from 'vitest';
+import {
+  collectExports,
+  findUnresolvedSourceLinks,
+  formatSourceLinkError,
+  parseRelativeImports,
+  resolveRelativeImport,
+  sourceFilesToMap,
+} from './source-link-check.js';
+
+describe('source-link-check', () => {
+  it('collects named exports, default, renames, and export *', () => {
+    const info = collectExports(`
+      export const WIN_SCORE = 10;
+      export function spawnDebris() {}
+      export type Round = { lane: number };
+      export { localName as publicName };
+      export default class Game {}
+      export * from './other.js';
+    `);
+    expect(info.named.has('WIN_SCORE')).toBe(true);
+    expect(info.named.has('spawnDebris')).toBe(true);
+    expect(info.named.has('Round')).toBe(true);
+    expect(info.named.has('publicName')).toBe(true);
+    expect(info.hasDefault).toBe(true);
+    expect(info.reexportsAll).toBe(true);
+  });
+
+  it('parses relative named and default imports; skips type and namespace', () => {
+    const imports = parseRelativeImports(`
+      import { WIN_SCORE, spawnDebris } from './model.js';
+      import Game from './game.js';
+      import type { Round } from './model.js';
+      import { type Lane } from './model.js';
+      import * as ns from './model.js';
+      import { ok } from 'gamekit';
+    `);
+    expect(imports).toHaveLength(5);
+    expect(imports[0]!.names.map((n) => n.imported)).toEqual(['WIN_SCORE', 'spawnDebris']);
+    expect(imports[1]!.hasDefault).toBe(true);
+    expect(imports[2]!.isTypeOnly).toBe(true);
+    expect(imports[3]!.names).toEqual([]); // inline type binding skipped
+    expect(imports[4]!.isNamespace).toBe(true);
+  });
+
+  it('resolves .js imports onto .ts delivery keys', () => {
+    const files = new Map([['game/model.ts', 'export const X = 1;']]);
+    expect(resolveRelativeImport('game/runtime.ts', './model.js', files)).toBe('game/model.ts');
+  });
+
+  it('flags the WIN_SCORE / spawnDebris transcript failure as one grouped message', () => {
+    const files = sourceFilesToMap([
+      {
+        path: 'game/runtime.ts',
+        content: `import { WIN_SCORE, spawnDebris } from './model.js';\nexport function tick() { return WIN_SCORE + spawnDebris(); }\n`,
+      },
+      {
+        path: 'game/model.ts',
+        content: `export type Round = { score: number };\nexport const START = 0;\n`,
+      },
+    ]);
+    const findings = findUnresolvedSourceLinks(files);
+    expect(findings.map((f) => f.symbol).sort()).toEqual(['WIN_SCORE', 'spawnDebris']);
+    const msg = formatSourceLinkError(findings);
+    expect(msg).toMatch(/game\/model\.ts does not export `WIN_SCORE`, `spawnDebris`/);
+    expect(msg).toMatch(/imported by game\/runtime\.ts/);
+    // One grouped finding, not six separate diagnostics.
+    expect(msg.split('\n').length).toBeLessThanOrEqual(3);
+  });
+
+  it('accepts a valid multi-file delivery with export * and renames', () => {
+    const files = sourceFilesToMap([
+      {
+        path: 'game.ts',
+        content: `import { publicName, Helper } from './barrel.js';\nexport { publicName, Helper };\n`,
+      },
+      { path: 'barrel.ts', content: `export * from './lib.js';\n` },
+      {
+        path: 'lib.ts',
+        content: `const localName = 1;\nexport { localName as publicName };\nexport class Helper {}\n`,
+      },
+    ]);
+    // Direct rename/class import must stay clean.
+    const direct = sourceFilesToMap([
+      {
+        path: 'game.ts',
+        content: `import { publicName, Helper } from './lib.js';\nexport { publicName, Helper };\n`,
+      },
+      {
+        path: 'lib.ts',
+        content: `const localName = 1;\nexport { localName as publicName };\nexport class Helper {}\n`,
+      },
+    ]);
+    expect(findUnresolvedSourceLinks(direct)).toEqual([]);
+    expect(findUnresolvedSourceLinks(files)).toEqual([]);
+  });
+
+  it('never refuses bare / engine imports', () => {
+    const files = sourceFilesToMap([
+      {
+        path: 'game.ts',
+        content: `import { GameKit } from '@gamedevpl/game-kit';\nimport fs from 'node:fs';\nexport const g = GameKit;\n`,
+      },
+    ]);
+    expect(findUnresolvedSourceLinks(files)).toEqual([]);
+  });
+
+  it('reports a missing target module', () => {
+    const files = sourceFilesToMap([
+      { path: 'game.ts', content: `import { x } from './missing.js';\nexport { x };\n` },
+    ]);
+    const findings = findUnresolvedSourceLinks(files);
+    expect(findings).toEqual([{ from: 'game.ts', target: null, importPath: './missing.js', symbol: null }]);
+    expect(formatSourceLinkError(findings)).toMatch(/missing from the delivery/);
+  });
+
+  it('caps grouped findings and reports how many were suppressed', () => {
+    const entries: { path: string; content: string }[] = [];
+    for (let i = 0; i < 12; i += 1) {
+      entries.push({
+        path: `mod${i}.ts`,
+        content: `export const keep${i} = ${i};\n`,
+      });
+      entries.push({
+        path: `use${i}.ts`,
+        content: `import { missing${i} } from './mod${i}.js';\nexport const u = missing${i};\n`,
+      });
+    }
+    const findings = findUnresolvedSourceLinks(sourceFilesToMap(entries));
+    expect(findings.length).toBe(12);
+    const msg = formatSourceLinkError(findings);
+    expect(msg).toMatch(/\d+ more target files? suppressed/);
+    expect(msg.length).toBeLessThanOrEqual(800);
+    // At most 8 grouped findings appear before the footer.
+    const groupLines = msg.split('\n').filter((line) => line.includes('does not export'));
+    expect(groupLines.length).toBeLessThanOrEqual(8);
+  });
+
+  it('holds the binding scan budget when 30 symbols are missing from one import', () => {
+    const names = Array.from({ length: 30 }, (_, i) => `sym${i}`);
+    const files = sourceFilesToMap([
+      {
+        path: 'game.ts',
+        content: `import { ${names.join(', ')} } from './model.js';\nexport const n = ${names[0]};\n`,
+      },
+      { path: 'model.ts', content: `export const only = 1;\n` },
+    ]);
+    const findings = findUnresolvedSourceLinks(files);
+    expect(findings.length).toBe(30);
+    const msg = formatSourceLinkError(findings);
+    expect(msg).toMatch(/model\.ts does not export/);
+    expect(msg.length).toBeLessThanOrEqual(800);
+  });
+});

--- a/apps/api/src/source-link-check.ts
+++ b/apps/api/src/source-link-check.ts
@@ -1,0 +1,407 @@
+// Cross-file symbol link check; prefer false negatives.
+
+export type SourceLinkFinding = {
+  // Importer path, posix, no leading ./.
+  from: string;
+  // Resolved delivery path, or null if missing.
+  target: string | null;
+  // Import specifier as written in source.
+  importPath: string;
+  // Missing symbol, or null when the module is absent.
+  symbol: string | null;
+};
+
+const RELATIVE_IMPORT_RE = /^\s*import\s+(?:type\s+)?([\s\S]*?)\s+from\s+['"](\.[^'"]+)['"]\s*;?\s*$/gm;
+const EXPORT_NAMED_RE =
+  /^\s*export\s+(?:async\s+)?(?:function|class|const|let|var|type|interface|enum)\s+([A-Za-z_$][\w$]*)/gm;
+const EXPORT_LIST_RE = /^\s*export\s*\{([^}]+)\}/gm;
+const EXPORT_DEFAULT_RE = /^\s*export\s+default\b/m;
+const MAX_GROUPED_FINDINGS = 8;
+const MAX_ERROR_BYTES = 800;
+// Cap bindings scanned per file for pathological sources.
+const MAX_IMPORT_BINDINGS_PER_FILE = 40;
+
+// Strip line and block comments before parsing.
+export function stripComments(source: string): string {
+  let out = '';
+  let i = 0;
+  while (i < source.length) {
+    const c = source[i];
+    const n = source[i + 1];
+    if (c === '/' && n === '/') {
+      i += 2;
+      while (i < source.length && source[i] !== '\n') i += 1;
+      continue;
+    }
+    if (c === '/' && n === '*') {
+      i += 2;
+      while (i + 1 < source.length && !(source[i] === '*' && source[i + 1] === '/')) {
+        i += 1;
+      }
+      i = Math.min(source.length, i + 2);
+      continue;
+    }
+    if (c === '"' || c === "'" || c === '`') {
+      const quote = c;
+      out += c;
+      i += 1;
+      while (i < source.length) {
+        const ch = source[i];
+        out += ch;
+        if (ch === '\\') {
+          i += 1;
+          if (i < source.length) {
+            out += source[i];
+            i += 1;
+          }
+          continue;
+        }
+        if (ch === quote) {
+          i += 1;
+          break;
+        }
+        if (quote === '`' && ch === '$' && source[i + 1] === '{') {
+          out += '{';
+          i += 2;
+          let depth = 1;
+          while (i < source.length && depth > 0) {
+            const t = source[i];
+            out += t;
+            if (t === '{') depth += 1;
+            else if (t === '}') depth -= 1;
+            i += 1;
+          }
+          continue;
+        }
+        i += 1;
+      }
+      continue;
+    }
+    out += c;
+    i += 1;
+  }
+  return out;
+}
+
+type NamedBinding = { imported: string };
+
+type ParsedImport = {
+  names: NamedBinding[];
+  hasDefault: boolean;
+  // Namespace import — skip symbol checks.
+  isNamespace: boolean;
+  // Type-only import — skip (prefer false negative).
+  isTypeOnly: boolean;
+  path: string;
+};
+
+function parseNamedBindings(clause: string): NamedBinding[] {
+  const out: NamedBinding[] = [];
+  for (const part of clause.split(',')) {
+    const bit = part.trim();
+    if (!bit) continue;
+    // Skip inline type bindings (false-negative ok).
+    if (/^type\b/.test(bit)) continue;
+    const asMatch = /^([A-Za-z_$][\w$]*)\s+as\s+([A-Za-z_$][\w$]*)$/.exec(bit);
+    if (asMatch) {
+      out.push({ imported: asMatch[1]! });
+      continue;
+    }
+    if (/^[A-Za-z_$][\w$]*$/.test(bit)) {
+      out.push({ imported: bit });
+    }
+  }
+  return out;
+}
+
+// Parse relative ESM import statements from source.
+export function parseRelativeImports(source: string): ParsedImport[] {
+  const text = stripComments(source);
+  const out: ParsedImport[] = [];
+  RELATIVE_IMPORT_RE.lastIndex = 0;
+  let m: RegExpExecArray | null;
+  while ((m = RELATIVE_IMPORT_RE.exec(text)) !== null) {
+    const rawClause = m[1]!.trim();
+    const path = m[2]!;
+    const isTypeOnly = /^\s*import\s+type\b/.test(m[0]!);
+    if (rawClause.startsWith('*')) {
+      out.push({
+        names: [],
+        hasDefault: false,
+        isNamespace: true,
+        isTypeOnly,
+        path,
+      });
+      continue;
+    }
+    let hasDefault = false;
+    let names: NamedBinding[] = [];
+    const brace = rawClause.indexOf('{');
+    if (brace === -1) {
+      if (/^[A-Za-z_$][\w$]*$/.test(rawClause)) {
+        hasDefault = true;
+      } else {
+        continue;
+      }
+    } else {
+      const before = rawClause.slice(0, brace).trim().replace(/,$/, '').trim();
+      if (before && /^[A-Za-z_$][\w$]*$/.test(before)) {
+        hasDefault = true;
+      }
+      const end = rawClause.lastIndexOf('}');
+      if (end > brace) {
+        names = parseNamedBindings(rawClause.slice(brace + 1, end));
+      }
+    }
+    out.push({ names, hasDefault, isNamespace: false, isTypeOnly, path });
+  }
+  return out;
+}
+
+type ExportInfo = {
+  named: Set<string>;
+  hasDefault: boolean;
+  // Opaque barrel — skip symbol checks on importers.
+  reexportsAll: boolean;
+};
+
+// Collect export names from a module source.
+export function collectExports(source: string): ExportInfo {
+  const text = stripComments(source);
+  const named = new Set<string>();
+  let hasDefault = EXPORT_DEFAULT_RE.test(text);
+  const reexportsAll = /^\s*export\s*\*\s+(?:as\s+[A-Za-z_$][\w$]*\s+)?from\s+/m.test(text);
+
+  EXPORT_NAMED_RE.lastIndex = 0;
+  let m: RegExpExecArray | null;
+  while ((m = EXPORT_NAMED_RE.exec(text)) !== null) {
+    named.add(m[1]!);
+  }
+
+  EXPORT_LIST_RE.lastIndex = 0;
+  while ((m = EXPORT_LIST_RE.exec(text)) !== null) {
+    for (const part of m[1]!.split(',')) {
+      const bit = part.trim().replace(/^type\s+/, '');
+      if (!bit) continue;
+      const asMatch = /^([A-Za-z_$][\w$]*)\s+as\s+([A-Za-z_$][\w$]*)$/.exec(bit);
+      if (asMatch) {
+        // Importers see the exported name, not local.
+        named.add(asMatch[2]!);
+        continue;
+      }
+      if (/^[A-Za-z_$][\w$]*$/.test(bit)) named.add(bit);
+    }
+  }
+
+  if (named.has('default')) hasDefault = true;
+
+  return { named, hasDefault, reexportsAll };
+}
+
+function dirnamePosix(path: string): string {
+  const i = path.lastIndexOf('/');
+  return i === -1 ? '' : path.slice(0, i);
+}
+
+function joinPosix(dir: string, rel: string): string {
+  const base = dir ? dir.split('/') : [];
+  for (const part of rel.split('/')) {
+    if (!part || part === '.') continue;
+    if (part === '..') {
+      if (base.length === 0) return '';
+      base.pop();
+      continue;
+    }
+    base.push(part);
+  }
+  return base.join('/');
+}
+
+// Resolve a relative import against delivery keys.
+export function resolveRelativeImport(
+  fromPath: string,
+  importPath: string,
+  files: ReadonlyMap<string, string>,
+): string | null {
+  if (!importPath.startsWith('./') && !importPath.startsWith('../')) return null;
+  const joined = joinPosix(dirnamePosix(fromPath), importPath);
+  if (!joined) return null;
+  if (files.has(joined)) return joined;
+  if (joined.endsWith('.js')) {
+    const ts = joined.slice(0, -3) + '.ts';
+    if (files.has(ts)) return ts;
+    const tsx = joined.slice(0, -3) + '.tsx';
+    if (files.has(tsx)) return tsx;
+  }
+  if (joined.endsWith('.ts') || joined.endsWith('.tsx')) {
+    const js = joined.replace(/\.tsx?$/, '.js');
+    if (files.has(js)) return js;
+  }
+  if (!/\.[a-zA-Z0-9]+$/.test(joined)) {
+    for (const ext of ['.ts', '.tsx', '.js', '.jsx', '/index.ts', '/index.js']) {
+      const candidate = joined + ext;
+      if (files.has(candidate)) return candidate;
+    }
+  }
+  return null;
+}
+
+function isCheckableSourcePath(path: string): boolean {
+  return /\.(?:[cm]?[jt]s|tsx|jsx)$/.test(path);
+}
+
+// Find unresolved relative imports across a source map.
+export function findUnresolvedSourceLinks(files: ReadonlyMap<string, string>): SourceLinkFinding[] {
+  const findings: SourceLinkFinding[] = [];
+  const exportCache = new Map<string, ExportInfo>();
+
+  const sortedPaths = [...files.keys()].filter(isCheckableSourcePath).sort();
+  for (const from of sortedPaths) {
+    const source = files.get(from);
+    if (source == null) continue;
+    let imports: ParsedImport[];
+    try {
+      imports = parseRelativeImports(source);
+    } catch {
+      continue;
+    }
+    let bindingBudget = MAX_IMPORT_BINDINGS_PER_FILE;
+    for (const imp of imports) {
+      if (imp.isTypeOnly || imp.isNamespace) continue;
+      const resolved = resolveRelativeImport(from, imp.path, files);
+      if (resolved == null) {
+        if (/\.(?:[cm]?[jt]s|tsx|jsx)$/.test(imp.path) || !/\.[a-zA-Z0-9]+$/.test(imp.path)) {
+          findings.push({ from, target: null, importPath: imp.path, symbol: null });
+        }
+        continue;
+      }
+      let exports = exportCache.get(resolved);
+      if (!exports) {
+        try {
+          exports = collectExports(files.get(resolved) ?? '');
+        } catch {
+          continue;
+        }
+        exportCache.set(resolved, exports);
+      }
+      // Opaque export-* barrel: skip symbol checks.
+      if (exports.reexportsAll) continue;
+
+      if (imp.hasDefault) {
+        bindingBudget -= 1;
+        if (bindingBudget < 0) break;
+        if (!exports.hasDefault && !exports.named.has('default')) {
+          findings.push({
+            from,
+            target: resolved,
+            importPath: imp.path,
+            symbol: 'default',
+          });
+        }
+      }
+      for (const binding of imp.names) {
+        bindingBudget -= 1;
+        if (bindingBudget < 0) break;
+        if (!exports.named.has(binding.imported)) {
+          findings.push({
+            from,
+            target: resolved,
+            importPath: imp.path,
+            symbol: binding.imported,
+          });
+        }
+      }
+    }
+  }
+  return findings;
+}
+
+type GroupedFinding = {
+  targetLabel: string;
+  symbols: string[];
+  importers: string[];
+  missingModule: boolean;
+};
+
+function groupFindings(findings: SourceLinkFinding[]): GroupedFinding[] {
+  const byKey = new Map<string, GroupedFinding>();
+  for (const f of findings) {
+    const targetLabel = f.target ?? f.importPath;
+    const key = f.symbol == null ? `missing:${targetLabel}` : `syms:${targetLabel}`;
+    let group = byKey.get(key);
+    if (!group) {
+      group = {
+        targetLabel,
+        symbols: [],
+        importers: [],
+        missingModule: f.symbol == null,
+      };
+      byKey.set(key, group);
+    }
+    if (f.symbol != null && !group.symbols.includes(f.symbol)) {
+      group.symbols.push(f.symbol);
+    }
+    if (!group.importers.includes(f.from)) {
+      group.importers.push(f.from);
+    }
+  }
+  // Most missing symbols first, then importer count.
+  return [...byKey.values()].sort((a, b) => {
+    const sa = a.missingModule ? 0 : a.symbols.length;
+    const sb = b.missingModule ? 0 : b.symbols.length;
+    if (sb !== sa) return sb - sa;
+    return b.importers.length - a.importers.length;
+  });
+}
+
+function formatGroup(g: GroupedFinding): string {
+  const importers = g.importers.join(', ');
+  if (g.missingModule) {
+    return (
+      `${g.targetLabel} is missing from the delivery — imported by ${importers}. ` +
+      'Add the file or change the import; both paths are yours to edit.'
+    );
+  }
+  const syms = g.symbols.map((s) => `\`${s}\``).join(', ');
+  return (
+    `${g.targetLabel} does not export ${syms} — imported by ${importers}. ` +
+    'Add the exports or change the imports; both files are yours to edit.'
+  );
+}
+
+// Group findings; cap groups and total message bytes.
+export function formatSourceLinkError(findings: SourceLinkFinding[]): string {
+  if (findings.length === 0) return '';
+  const groups = groupFindings(findings);
+  let shownCount = Math.min(groups.length, MAX_GROUPED_FINDINGS);
+
+  const build = (count: number): string => {
+    const shown = groups.slice(0, count);
+    const suppressed = groups.length - shown.length;
+    const header = 'Source link check failed — fix missing imports/exports before submitting:\n';
+    let body = header + shown.map(formatGroup).join('\n');
+    if (suppressed > 0) {
+      body += `\n(${suppressed} more target file${suppressed === 1 ? '' : 's'} suppressed)`;
+    }
+    return body;
+  };
+
+  let body = build(shownCount);
+  while (body.length > MAX_ERROR_BYTES && shownCount > 1) {
+    shownCount -= 1;
+    body = build(shownCount);
+  }
+  if (body.length > MAX_ERROR_BYTES) {
+    body = body.slice(0, MAX_ERROR_BYTES - 1) + '…';
+  }
+  return body;
+}
+
+// Build a path→content map from delivery files.
+export function sourceFilesToMap(files: ReadonlyArray<{ path: string; content: string }>): Map<string, string> {
+  const map = new Map<string, string>();
+  for (const file of files) {
+    map.set(file.path.trim(), file.content);
+  }
+  return map;
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

Managed rounds can deliver sources that import symbols the target file never exported. The async gate catches that only after the agent has called `end`, so the verdict lands with nobody in the session. This is the `WIN_SCORE` / `spawnDebris` failure class from the managed transcript.

## What

A **link check, not a typecheck**, inside `validateSourceUpload` for both `preview` and `publish`:

- Collect relative imports and exports across staged `.ts`/`.js` files
- Refuse when a symbol is not exported by its target, or the target file is missing
- Group by target file (one line naming all missing symbols + importers)
- Cap: ≤8 grouped findings, ~800 bytes of message

Bare / engine imports are ignored. Prefer false negatives when the parser is unsure.

### Ceiling (honest)

This catches missing **symbols**, not missing **members**. It would not catch `runtime.ts` reading a `Round` field `model.ts` never declared — that needs a real typecheck (MR-06).

### Cases intentionally skipped (false negatives)

- bare / package imports (engine)
- `import type` / inline `type` bindings
- `import * as ns`
- targets that only `export * from` (opaque barrels)
- dynamic `import()`, deep re-export chains, unparseable syntax

## Tests

- Reproduces the `WIN_SCORE`/`spawnDebris` refusal with one grouped message
- Valid multi-file delivery with `export { x as y }` and `export *` still passes
- Bare imports never refuse; 30-symbol / many-target caps hold
- Both preview and publish run the check

## Follow-ups

- MR-06: `tsc --noEmit` preflight on `submit_sources` (pinned kit)
- MR-07: instrument whether preflights actually reduce async-gate failures

No change to the async gate — this is an earlier copy of a subset, not a replacement.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4cf2e9e5-dd15-4c3a-8323-8e026e20823b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4cf2e9e5-dd15-4c3a-8323-8e026e20823b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

