### PR TITLE
Fix get_kit_api: budget was sized from API content, not the MCP tool-result limit

### DIFF
--- a/.claude/skills/byoca-mcp/SKILL.md
+++ b/.claude/skills/byoca-mcp/SKILL.md
@@ -90,8 +90,10 @@ authoritative.
 
 `get_kit_api` (`GET /api/agent/build/kit/api`, `apps/api/src/agent-channel.ts`) serves the
 same digest object the platform lane compacts, through `compactKitDigestForApi` — a larger
-budget (`DEFAULT_MCP_DIGEST_MAX_BYTES`, 90 KiB vs the platform's 20 KiB) since it is paid
-once per round by an agent that chose to call it, not injected into every turn. Same
+budget (`DEFAULT_MCP_DIGEST_MAX_BYTES`, 50 KiB vs the platform's 20 KiB) since it is paid
+once per round by an agent that chose to call it, not injected into every turn. That budget
+is sized to a safe _MCP single-tool-result_ limit, not to the API's own size — see
+"A digest-sized tool result is not free" below before touching this constant again. Same
 `engineRef` convention as the browse routes: optional, defaults to the registry's current
 entry when omitted, but pass the `engineRef` `get_kit` returned so a mid-round registry
 bump cannot mix kit revisions. `get_kit` and `get_kit_api` both carry
@@ -134,8 +136,9 @@ section's budget was a flat 72% of the total, guessed rather than measured: at t
 to the API's size), the platform lane's real 20 KiB default silently truncated
 mid-exemplar-file, dropping `## File-shape rules` entirely, and `get_kit_api`'s old 90 KiB
 budget capped the API at 64.8 KiB despite the ~79 KiB current surface — contradicting its
-own "whole reference in one call" promise. Both lanes now measure the non-API shell first
-and give the API section whatever's actually left (`apiBudget = maxBytes - shellBytes`).
+then-description's "whole reference in one call" claim (since corrected — see below). Both
+lanes now measure the non-API shell first and give the API section whatever's actually left
+(`apiBudget = maxBytes - shellBytes`).
 That in turn exposed a second-order bug: the omission note listing what got cut is itself
 unbounded (up to ~2 KiB for 100 omitted names) with nothing reserving room for it, so it
 could overflow the same way the flat-percentage guess did. `formatOmittedNote` is now
@@ -145,8 +148,42 @@ rather than growing past its reserve.
 `DEFAULT_KIT_DIGEST_MAX_BYTES` (the raw-stored-digest sanity ceiling, not a prompt budget)
 moved from 100,000 to 150,000 bytes: the stored digest was already at 99,552 bytes before
 the catalog addition, one small API growth from failing regardless.
-`DEFAULT_MCP_DIGEST_MAX_BYTES` moved from 90,000 to 100,000 so `get_kit_api` comfortably
-covers shell + full current API + the note reserve.
+
+### A digest-sized tool result is not free — get_kit_api broke in production at 100 KiB
+
+The PR that shipped `get_kit_api` set `DEFAULT_MCP_DIGEST_MAX_BYTES` to 100,000 reasoning
+purely from the API's own size ("100_000 covers shell + full current API + the note
+reserve") — a real constraint, but the wrong one. The constraint that actually matters is
+the calling _MCP client's_ ceiling on a single tool result, which the server has no way to
+query and no say over. Deployed against the real kit (`engineRef` `fb0cd30df1…`), the
+default digest ran ~98,730 characters / ~27,600 tokens (measured with `tiktoken`
+`cl100k_base` as a proxy) and a live client refused the tool result outright as exceeding
+its token ceiling — `get_kit_api` was unusable, a worse failure than the truncation bug it
+replaced (that one degraded gracefully with an omission note; this one returned nothing at
+all). Caught only because a human pasted the raw client error back into the session; no
+test in either repo calls the real endpoint against real kit content and checks the
+result's actual size, so a large-but-plausible-looking default sailed through review and
+merge on both repos with no unit test contradicting it.
+
+Fixed by choosing a budget from the tool-result constraint instead of the content: 50,000
+raw digest bytes measures ~15,800 `cl100k_base` tokens against the real kit — comfortably
+under a ~25,000-token single-result ceiling with real margin for tokenizer variance and
+other MCP hosts' stricter limits, while still keeping ~30 KiB of live API content (the full
+exemplar/audio/module-catalog shell survives untouched at any budget — only the API section
+shrinks). `get_kit_api`'s description was corrected to match: it no longer claims "the
+whole reference in one call" — omission is now the expected common case for a real kit, not
+an edge case, and the description says so, pointing at the browse tools for what's cut.
+
+**When you touch `DEFAULT_MCP_DIGEST_MAX_BYTES` again:** do not size it from
+`shared/game-kit.d.ts`'s byte count. Generate the real digest for the current kit, run it
+through `compactKitDigestForApi`, JSON-encode it the way the MCP response actually ships,
+and measure real tokens (a tokenizer proxy is fine; character-count guessing is what broke
+this). `apps/api/src/kit-digest.test.ts` ("caps get_kit_api output well under a single MCP
+tool-result limit") now guards this — a synthetic ~120-declaration API at the real kit's
+byte scale, run through the default budget, asserted under a byte proxy for the ~25k-token
+ceiling — but it is a proxy fixture, not the real kit content or a real tokenizer; re-verify
+against the actual digest (as above) whenever the constant, `elideDeclaration`'s ranking, or
+the shell sections' typical size change meaningfully.
 
 ### `get_gate_media` must stay reachable from the loop
 

--- a/apps/api/src/kit-digest.test.ts
+++ b/apps/api/src/kit-digest.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it, vi } from 'vitest';
 import {
+  DEFAULT_MCP_DIGEST_MAX_BYTES,
   appendKitDigest,
+  compactKitDigestForApi,
   compactKitDigestForPrompt,
   createGcsKitDigestLoader,
   formatOmittedNote,
@@ -149,6 +151,45 @@ describe('Creator Kit digest loader', () => {
 
     expect(compact.trim().endsWith('- Keep files small.')).toBe(true);
     expect(compact).toContain('### games/dodge-the-falling-rocks/index.html');
+  });
+
+  it('caps get_kit_api output well under a single MCP tool-result limit at realistic kit scale', () => {
+    // Real production incident — see SKILL.md "not free".
+    const declarations = Array.from({ length: 120 }, (_, i) => {
+      const pad = 'x'.repeat(600);
+      return `interface GameKitDeclaration${i} {\n  method${i}(arg: string): void; // ${pad}\n}`;
+    });
+    const api = declarations.join('\n');
+    const full = [
+      '## GameKit API surface',
+      '~~~typescript',
+      api,
+      '~~~',
+      '## Audio catalog',
+      '',
+      'Sounds (2): win, lose',
+      '',
+      'Music (1): bright-chase',
+      '## Exemplar game',
+      '### games/dodge-the-falling-rocks/game.ts',
+      'export {};',
+      '## File-shape rules',
+      '- Keep files small.',
+    ].join('\n');
+    expect(Buffer.byteLength(api, 'utf8')).toBeGreaterThan(70_000); // realistic scale
+
+    const digest = compactKitDigestForApi(full); // DEFAULT_MCP_DIGEST_MAX_BYTES
+    const mcpResponseShape = JSON.stringify({
+      engineRef: 'a'.repeat(40),
+      digest,
+      pendingMessages: [],
+      stop: false,
+      warnings: [],
+    });
+
+    // Byte proxy for a ~25k token ceiling; see SKILL.md.
+    expect(Buffer.byteLength(mcpResponseShape, 'utf8')).toBeLessThan(65_000);
+    expect(DEFAULT_MCP_DIGEST_MAX_BYTES).toBeLessThanOrEqual(60_000);
   });
 
   it('elideDeclaration keeps a multiline member whole even when its closing brace lands at the interface indent', () => {

--- a/apps/api/src/kit-digest.ts
+++ b/apps/api/src/kit-digest.ts
@@ -7,8 +7,8 @@ export const KIT_REGISTRY_OBJECT = 'kits/current.json';
 // Sanity ceiling on raw digest bytes, not a prompt budget.
 export const DEFAULT_KIT_DIGEST_MAX_BYTES = 150_000;
 export const DEFAULT_PROMPT_DIGEST_MAX_BYTES = 20_000;
-// Per-round budget for get_kit_api: shell plus the full API.
-export const DEFAULT_MCP_DIGEST_MAX_BYTES = 100_000;
+// Sized to an MCP tool-result ceiling, not the whole API.
+export const DEFAULT_MCP_DIGEST_MAX_BYTES = 50_000;
 
 // Fallback only — moduleFamiliesOf prefers the digest's own catalog.
 const FALLBACK_MODULE_FAMILIES: readonly string[] = Object.freeze([

--- a/apps/api/src/mcp-server.ts
+++ b/apps/api/src/mcp-server.ts
@@ -2547,8 +2547,10 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
         'about what it can build (multiplayer, persistent worlds, party games, …) is answered by ' +
         'get_kit_api or browse, never by web search. ' +
         'For the API itself: get_kit_api (with this engineRef) for a prompt-ready orientation in ' +
-        "one call — it names anything it had to cut, use the browse tools named in this reply's " +
-        'browse block (list/search/read) for those or any other specific kit file. ' +
+        'one call — it flags what it had to cut (by name when a whole declaration is dropped, by ' +
+        'count when a kept one is trimmed member-wise), so a missing signature is never silent; ' +
+        "use the browse tools named in this reply's browse block (list/search/read) for those or " +
+        'any other specific kit file. ' +
         'With shell egress, unpack via kitUrl/unpack and follow SKILL.md locally instead of either. ' +
         'entry=gamedevpl-creator-kit/SKILL.md (tarball roots at gamedevpl-creator-kit/; ' +
         'do not assume a `cd` persists across tool calls). ' +
@@ -2587,8 +2589,10 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
         'to "can this platform build X", not a web search), plus as much of the core API ' +
         'signatures, audio catalog, and exemplar game as fit in one tool result. ' +
         'The response is sized to a safe single-call limit, not to the whole API — for a real ' +
-        'kit this routinely omits some declarations, named in an "Omitted for length" note in ' +
-        'the digest text; treat that as normal, not an error. Call this once near ' +
+        'kit this routinely omits content: whole declarations dropped are named in an "Omitted ' +
+        'for length" note, and a declaration too large to fit whole is trimmed member-wise with ' +
+        'only a count of what was cut, not names. Treat both as normal, not an error. ' +
+        'Call this once near ' +
         'the start of a round, before scaffolding, rather than repeatedly — its content only ' +
         'changes when engineRef does. Pass engineRef from get_kit so a mid-round registry bump ' +
         "cannot mix kit revisions. Falls back to the registry's current engine when engineRef is " +

--- a/apps/api/src/mcp-server.ts
+++ b/apps/api/src/mcp-server.ts
@@ -2546,9 +2546,9 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
         'This platform and its Creator Kit are not on the public web — an unanswered question ' +
         'about what it can build (multiplayer, persistent worlds, party games, …) is answered by ' +
         'get_kit_api or browse, never by web search. ' +
-        'For the API itself: get_kit_api (with this engineRef) for the whole prompt-ready reference ' +
-        "in one call, or the browse tools named in this reply's browse block (list/search/read) to " +
-        'read specific kit files instead — do not pull the whole kit into context. ' +
+        'For the API itself: get_kit_api (with this engineRef) for a prompt-ready orientation in ' +
+        "one call — it names anything it had to cut, use the browse tools named in this reply's " +
+        'browse block (list/search/read) for those or any other specific kit file. ' +
         'With shell egress, unpack via kitUrl/unpack and follow SKILL.md locally instead of either. ' +
         'entry=gamedevpl-creator-kit/SKILL.md (tarball roots at gamedevpl-creator-kit/; ' +
         'do not assume a `cd` persists across tool calls). ' +
@@ -2584,15 +2584,18 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
         "The Creator Kit's prompt-ready orientation in one call: what engine modules exist " +
         '(party for same-screen multiplayer, zone for a real-time server-arbitrated world, ' +
         'commons and presence for persistent/shared state, and the rest — this is the answer ' +
-        'to "can this platform build X", not a web search), the core API ' +
-        'signatures, the audio catalog, and a complete small exemplar game. Call this once near ' +
+        'to "can this platform build X", not a web search), plus as much of the core API ' +
+        'signatures, audio catalog, and exemplar game as fit in one tool result. ' +
+        'The response is sized to a safe single-call limit, not to the whole API — for a real ' +
+        'kit this routinely omits some declarations, named in an "Omitted for length" note in ' +
+        'the digest text; treat that as normal, not an error. Call this once near ' +
         'the start of a round, before scaffolding, rather than repeatedly — its content only ' +
         'changes when engineRef does. Pass engineRef from get_kit so a mid-round registry bump ' +
         "cannot mix kit revisions. Falls back to the registry's current engine when engineRef is " +
         'omitted, but that risks reading a different kit than the round is pinned to. ' +
         'Prefer this over unpacking the whole kit into context; use the browse tools ' +
-        '(list_kit_files / search_kit_files / read_kit_file) instead when what you need is a ' +
-        'specific file this digest omitted or summarized. ' +
+        '(list_kit_files / search_kit_files / read_kit_file) for anything this digest omitted, ' +
+        'summarized, or named in its omission note. ' +
         BEHAVIOURAL_CONTRACT,
       inputSchema: {
         type: 'object',


### PR DESCRIPTION
## Summary

`get_kit_api` (merged in #710, a few hours ago) is unusable in production right now — every call fails outright. This is a hotfix.

## Root cause

`DEFAULT_MCP_DIGEST_MAX_BYTES` was set to `100_000` by reasoning purely from the API content's own size ("covers shell + full current API + the note reserve"). That's a real constraint, but the wrong one — the constraint that actually matters is the calling **MCP client's ceiling on a single tool result**, which the server has no way to query and no say over.

Deployed against the real kit (`engineRef fb0cd30df1…`, the current `main` on the games repo), the default digest ran **~98,730 characters / ~27,600 tokens** (measured with `tiktoken` `cl100k_base` as a proxy), and a live client refused the tool result outright as exceeding its token ceiling. `get_kit_api` was completely unusable — a worse failure than the truncation bug it replaced, since that one degraded gracefully with an "Omitted for length" note and this one returns nothing at all.

## Fix

- Reproduced the exact production digest locally (same `engineRef`) and re-derived the budget from the real constraint instead of the content: **50,000 raw digest bytes measures ~15,800 tokens** against the real kit — comfortable margin under a ~25,000-token single-result ceiling, while still keeping ~30 KiB of live API content. The exemplar/audio/module-catalog shell is untouched at any budget; only the API section shrinks.
- Corrected `get_kit_api`'s and `get_kit`'s tool descriptions, which claimed "the whole reference in one call." Omission is now the expected common case for a real kit, not a rare edge case — the description says so and points agents at the browse tools (`list_kit_files` / `search_kit_files` / `read_kit_file`) for anything cut.
- Added a regression test (`kit-digest.test.ts`) that rebuilds an API section at the real kit's rough byte scale (~120 declarations, comparable to the real ~114) and asserts the default-budget MCP response stays under a byte proxy for the token ceiling. Verified it fails against the old `100_000` value (81,219 bytes vs. a 65,000-byte ceiling) before restoring the fix.
- Updated the `byoca-mcp` skill doc with the incident, the corrected reasoning, and an explicit note for whoever touches this constant next: size it from a real digest run through `compactKitDigestForApi` and measured in real tokens, not from `shared/game-kit.d.ts`'s byte count.

## Why this shipped undetected

No test in the original PR (#710) exercised realistic content size — the tests used small synthetic fixtures, so a "covers the full API" budget looked correct on paper and passed review on both repos. This PR's regression test specifically closes that gap by testing at the real kit's byte scale.

## Test plan

- [x] `apps/api` full suite: 185 files / 2,888 tests pass
- [x] `npm run lint` (eslint + comment-prose): clean
- [x] Typecheck: clean
- [x] New regression test verified to fail against the old (broken) `100_000` value, and pass against the fix
- [x] Reproduced the exact production failure locally against the real merged `engineRef`

https://claude.ai/code/session_0155jrUy76vVwwcdPLm2Vh3u


---
_Generated by [Claude Code](https://claude.ai/code/session_0155jrUy76vVwwcdPLm2Vh3u)_