### PR TITLE
Typecheck preflight on submit_sources (MR-06)

### DIFF
--- a/apps/api/src/source-delivery.test.ts
+++ b/apps/api/src/source-delivery.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it, vi } from 'vitest';
 import type { GamesStore, SourceFile, VersionManifest } from './games-store.js';
+import { InvalidUploadError } from './games-store.js';
+import type { KitFileStore, KitTree } from './kit-files.js';
+import { KIT_ROOT_DIR } from './kit-registry.js';
 import { InMemoryStore } from './store.js';
 import {
   createSourceDeliveryService,
@@ -34,7 +37,33 @@ function manifest(files: SourceFile[], version: string): VersionManifest {
   };
 }
 
-async function setup() {
+const KIT_DTS = `
+interface GameKitGameContext { width: number; height: number; }
+declare const GameKit: { defineGame(): unknown };
+`;
+
+function fakeKitStore(trees: Record<string, KitTree>): KitFileStore {
+  return {
+    loadRegistry: async () => ({ engineRef: Object.keys(trees)[0]!, previous: null, sha256: 'a'.repeat(64) }),
+    loadTree: async (engineRef?: string) => {
+      const ref = engineRef ?? Object.keys(trees)[0]!;
+      const tree = trees[ref];
+      if (!tree) throw new Error(`missing kit ${ref}`);
+      return tree;
+    },
+    loadCurrentTree: async () => trees[Object.keys(trees)[0]!]!,
+  };
+}
+
+function treeFor(engineRef: string, kitDts: string): KitTree {
+  return {
+    engineRef,
+    sha256: 'a'.repeat(64),
+    files: new Map([[`${KIT_ROOT_DIR}/shared/game-kit.d.ts`, Buffer.from(kitDts, 'utf8')]]),
+  };
+}
+
+async function setup(opts?: { kitFileStore?: KitFileStore | null }) {
   const store = new InMemoryStore();
   await store.createSubmission(ISSUE, 'owner', 'Original title');
   await store.setSubmissionSlug(ISSUE, SLUG);
@@ -57,6 +86,7 @@ async function setup() {
   const service = createSourceDeliveryService({
     store,
     gamesStore,
+    kitFileStore: opts?.kitFileStore,
     onSourcesDelivered: gate,
     onEvent: vi.fn(),
   });
@@ -179,5 +209,123 @@ describe('shared source delivery', () => {
       }),
     ).rejects.toMatchObject({ reason: 'round_closed' });
     expect(putCandidateSources).not.toHaveBeenCalled();
+  });
+
+  describe('typecheck preflight', () => {
+    const PINNED = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+    const CURRENT = 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+    const brokenFiles: SourceFile[] = [
+      { path: 'SPEC.md', content: '---\ntitle: Broken\n---\n' },
+      { path: 'index.html', content: '<!doctype html>' },
+      {
+        path: 'game/model.ts',
+        content: 'export type Round = { score: number };\n',
+      },
+      {
+        path: 'game.ts',
+        content: `
+import type { Round } from './game/model.ts';
+export function tick(round: Round) {
+  return round.lane + round.speed;
+}
+`,
+      },
+    ];
+
+    it('refuses a typed Round-field failure before storing', async () => {
+      const kitFileStore = fakeKitStore({ [PINNED]: treeFor(PINNED, KIT_DTS) });
+      const { store, putCandidateSources, service, authority } = await setup({ kitFileStore });
+      await store.pinRoundKitEngineRef(ISSUE, PINNED);
+
+      await expect(
+        service.deliver({
+          issueNumber: ISSUE,
+          slug: SLUG,
+          files: brokenFiles,
+          mode: 'preview',
+          backend: BACKEND,
+          authority,
+        }),
+      ).rejects.toBeInstanceOf(InvalidUploadError);
+      expect(putCandidateSources).not.toHaveBeenCalled();
+      expect((await store.getSubmission(ISSUE))?.roundTypecheckPreflightRefusals).toBe(1);
+    });
+
+    it('loads the pinned kit even after the registry pointer moves', async () => {
+      let loaded: string | undefined;
+      const kitFileStore: KitFileStore = {
+        loadRegistry: async () => ({ engineRef: CURRENT, previous: PINNED, sha256: 'a'.repeat(64) }),
+        loadTree: async (engineRef?: string) => {
+          loaded = engineRef ?? CURRENT;
+          // Empty current kit would skip if pin ignored.
+          if (loaded === PINNED) return treeFor(PINNED, KIT_DTS);
+          return treeFor(CURRENT, '');
+        },
+        loadCurrentTree: async () => treeFor(CURRENT, ''),
+      };
+      const { store, putCandidateSources, service, authority } = await setup({ kitFileStore });
+      await store.pinRoundKitEngineRef(ISSUE, PINNED);
+
+      await expect(
+        service.deliver({
+          issueNumber: ISSUE,
+          slug: SLUG,
+          files: brokenFiles,
+          mode: 'preview',
+          backend: BACKEND,
+          authority,
+        }),
+      ).rejects.toThrow(/Typecheck preflight failed/);
+      expect(loaded).toBe(PINNED);
+      expect(putCandidateSources).not.toHaveBeenCalled();
+    });
+
+    it('accepts on the third submit and attaches diagnostics to the round', async () => {
+      const kitFileStore = fakeKitStore({ [PINNED]: treeFor(PINNED, KIT_DTS) });
+      const { store, putCandidateSources, service, authority } = await setup({ kitFileStore });
+      await store.pinRoundKitEngineRef(ISSUE, PINNED);
+
+      for (let i = 0; i < 2; i += 1) {
+        await expect(
+          service.deliver({
+            issueNumber: ISSUE,
+            slug: SLUG,
+            files: brokenFiles,
+            mode: 'preview',
+            backend: BACKEND,
+            authority,
+          }),
+        ).rejects.toBeInstanceOf(InvalidUploadError);
+      }
+      expect(putCandidateSources).not.toHaveBeenCalled();
+
+      const result = await service.deliver({
+        issueNumber: ISSUE,
+        slug: SLUG,
+        files: brokenFiles,
+        mode: 'preview',
+        backend: BACKEND,
+        authority,
+      });
+      expect(result.accepted).toBe(true);
+      expect(putCandidateSources).toHaveBeenCalledOnce();
+      const record = await store.getSubmission(ISSUE);
+      expect(record?.roundTypecheckPreflightRefusals).toBe(2);
+      expect(record?.roundTypecheckPreflightBypassErrors).toMatch(/Typecheck preflight failed/);
+    });
+
+    it('does not refuse when no kit store is configured', async () => {
+      const { putCandidateSources, service, authority } = await setup({ kitFileStore: null });
+      const result = await service.deliver({
+        issueNumber: ISSUE,
+        slug: SLUG,
+        files: brokenFiles,
+        mode: 'preview',
+        backend: BACKEND,
+        authority,
+      });
+      expect(result.accepted).toBe(true);
+      expect(putCandidateSources).toHaveBeenCalledOnce();
+    });
   });
 });

--- a/apps/api/src/source-delivery.test.ts
+++ b/apps/api/src/source-delivery.test.ts
@@ -327,5 +327,28 @@ export function tick(round: Round) {
       expect(result.accepted).toBe(true);
       expect(putCandidateSources).toHaveBeenCalledOnce();
     });
+
+    it('clears bypass diagnostics after a later clean delivery', async () => {
+      const kitFileStore = fakeKitStore({ [PINNED]: treeFor(PINNED, KIT_DTS) });
+      const { store, service, authority } = await setup({ kitFileStore });
+      await store.pinRoundKitEngineRef(ISSUE, PINNED);
+      await store.setRoundTypecheckPreflightBypassErrors(ISSUE, 'stale diagnostics');
+
+      const clean: SourceFile[] = [
+        { path: 'SPEC.md', content: '---\ntitle: Clean\n---\n' },
+        { path: 'index.html', content: '<!doctype html>' },
+        { path: 'game.ts', content: 'export const n = 1;\n' },
+      ];
+      const result = await service.deliver({
+        issueNumber: ISSUE,
+        slug: SLUG,
+        files: clean,
+        mode: 'preview',
+        backend: BACKEND,
+        authority,
+      });
+      expect(result.accepted).toBe(true);
+      expect((await store.getSubmission(ISSUE))?.roundTypecheckPreflightBypassErrors).toBeUndefined();
+    });
   });
 });

--- a/apps/api/src/source-delivery.ts
+++ b/apps/api/src/source-delivery.ts
@@ -267,11 +267,16 @@ export function createSourceDeliveryService(options: SourceDeliveryServiceOption
               },
               'typecheck preflight bypassed after refusal cap',
             );
-          } else if (check.skipped === 'timeout') {
-            options.log?.warn?.(
-              { issueNumber: input.issueNumber, slug: input.slug, durationMs: check.durationMs },
-              'typecheck preflight skipped: budget exceeded',
-            );
+          } else {
+            if (record.roundTypecheckPreflightBypassErrors) {
+              await options.store.setRoundTypecheckPreflightBypassErrors(input.issueNumber, null);
+            }
+            if (check.skipped === 'timeout') {
+              options.log?.warn?.(
+                { issueNumber: input.issueNumber, slug: input.slug, durationMs: check.durationMs },
+                'typecheck preflight skipped: budget exceeded',
+              );
+            }
           }
         } catch (error) {
           if (error instanceof InvalidUploadError) throw error;

--- a/apps/api/src/source-delivery.ts
+++ b/apps/api/src/source-delivery.ts
@@ -2,8 +2,14 @@ import { selfBuildDeliveryCap } from './builder.js';
 import { InvalidUploadError, type GamesStore, type SourceFile } from './games-store.js';
 import { parseSpecTitle } from './github-client.js';
 import { canTransition, resolveJobState, TERMINAL_JOB_STATES, type JobState } from './job-state.js';
+import type { KitFileStore } from './kit-files.js';
 import { sanitizeCreatorText } from './submission-status.js';
 import type { Store, SubmissionRecord } from './store.js';
+import {
+  runTypecheckPreflight,
+  sharedSourcesFromKitTree,
+  TYPECHECK_PREFLIGHT_MAX_REFUSALS,
+} from './typecheck-preflight.js';
 
 export interface SourceDeliveryAuthority {
   // Backend identity recorded at dispatch time.
@@ -78,6 +84,8 @@ export interface SourceDeliveryService {
 export interface SourceDeliveryServiceOptions {
   store: Store;
   gamesStore: GamesStore;
+  // Optional: typecheck against the round's pinned kit.
+  kitFileStore?: KitFileStore | null;
   now?: () => number;
   maxSubmitsPerWindow?: number;
   onSourcesDelivered?: (input: {
@@ -89,6 +97,7 @@ export interface SourceDeliveryServiceOptions {
   onEvent?: (issueNumber: number) => void;
   log?: {
     error: (context: object, message: string) => void;
+    warn?: (context: object, message: string) => void;
   };
 }
 
@@ -224,6 +233,53 @@ export function createSourceDeliveryService(options: SourceDeliveryServiceOption
           `This round is pinned to Creator Kit engine ${pinnedEngineRef}, not ${input.kitEngineRef}. ` +
             'Call get_kit and submit with the engineRef it returns.',
         );
+      }
+
+      // Typecheck preflight uses the pinned kit; skip if unavailable.
+      const engineRefForCheck = pinnedEngineRef ?? input.kitEngineRef;
+      if (options.kitFileStore && engineRefForCheck) {
+        try {
+          const tree = await options.kitFileStore.loadTree(engineRefForCheck);
+          const kitShared = sharedSourcesFromKitTree(tree);
+          const sources: Record<string, string> = {};
+          for (const file of input.files) {
+            sources[file.path.trim()] = file.content;
+          }
+          const check = await runTypecheckPreflight({
+            slug: input.slug,
+            sources,
+            kitShared,
+          });
+          if (!check.ok) {
+            const prior = record.roundTypecheckPreflightRefusals ?? 0;
+            if (prior < TYPECHECK_PREFLIGHT_MAX_REFUSALS) {
+              await options.store.incrementRoundTypecheckPreflightRefusals(input.issueNumber);
+              throw new InvalidUploadError(check.message);
+            }
+            // Third submit accepts; attach diagnostics on the round.
+            await options.store.setRoundTypecheckPreflightBypassErrors(input.issueNumber, check.message);
+            options.log?.warn?.(
+              {
+                issueNumber: input.issueNumber,
+                slug: input.slug,
+                engineRef: engineRefForCheck,
+                durationMs: check.durationMs,
+              },
+              'typecheck preflight bypassed after refusal cap',
+            );
+          } else if (check.skipped === 'timeout') {
+            options.log?.warn?.(
+              { issueNumber: input.issueNumber, slug: input.slug, durationMs: check.durationMs },
+              'typecheck preflight skipped: budget exceeded',
+            );
+          }
+        } catch (error) {
+          if (error instanceof InvalidUploadError) throw error;
+          options.log?.warn?.(
+            { err: error, issueNumber: input.issueNumber, engineRef: engineRefForCheck },
+            'typecheck preflight skipped: kit load failed',
+          );
+        }
       }
 
       if (record.slug && record.slug !== input.slug) {

--- a/apps/api/src/store.ts
+++ b/apps/api/src/store.ts
@@ -369,6 +369,10 @@ export interface SubmissionRecord {
    * (`SELF_BUILD_DELIVERY_CAP`); resets when a new round opens.
    */
   roundDeliveryCount?: number;
+  // Typecheck preflight refusals this round (cap 2).
+  roundTypecheckPreflightRefusals?: number;
+  // Grouped diagnostics when accepting past that cap.
+  roundTypecheckPreflightBypassErrors?: string;
   /**
    * Creator concept text (sanitized), without the QA clarifications block.
    *
@@ -1800,6 +1804,10 @@ export interface Store {
   setSeedStatus(issueNumber: number, status: 'pending' | 'unavailable'): Promise<void>;
   /** Increments and returns the per-round sources-delivery count. */
   incrementRoundDeliveryCount(issueNumber: number): Promise<number>;
+  // Bump typecheck-preflight refusal count for this round.
+  incrementRoundTypecheckPreflightRefusals(issueNumber: number): Promise<number>;
+  // Store or clear bypass diagnostics after the refusal cap.
+  setRoundTypecheckPreflightBypassErrors(issueNumber: number, message: string | null): Promise<void>;
   /** Appends a dispatch ref, recording which backend is building this job and where. */
   recordDispatch(
     issueNumber: number,
@@ -2989,7 +2997,13 @@ export class InMemoryStore implements Store {
       state: transition.to,
       stateSince: transition.at,
       transitions: [...(sub.transitions ?? []), transition].slice(-MAX_JOB_TRANSITIONS),
-      ...(closes ? { roundGeneration: nextRoundGeneration(sub.roundGeneration), roundDeliveryCount: 0 } : {}),
+      ...(closes
+        ? {
+            roundGeneration: nextRoundGeneration(sub.roundGeneration),
+            roundDeliveryCount: 0,
+            roundTypecheckPreflightRefusals: 0,
+          }
+        : {}),
     };
     if (closes) {
       delete next.seed;
@@ -3000,6 +3014,7 @@ export class InMemoryStore implements Store {
       delete next.lastAgentPresence;
       delete next.agentEndedAt;
       delete next.roundKitEngineRef;
+      delete next.roundTypecheckPreflightBypassErrors;
     }
     this.submissions.set(issueNumber, next);
     return true;
@@ -3009,13 +3024,19 @@ export class InMemoryStore implements Store {
     const sub = this.submissions.get(issueNumber);
     if (!sub) return null;
     const roundGeneration = nextRoundGeneration(sub.roundGeneration);
-    const next: SubmissionRecord = { ...sub, roundGeneration, roundDeliveryCount: 0 };
+    const next: SubmissionRecord = {
+      ...sub,
+      roundGeneration,
+      roundDeliveryCount: 0,
+      roundTypecheckPreflightRefusals: 0,
+    };
     delete next.seed;
     delete next.seedStatus;
     delete next.lastAgentSignalAt;
     delete next.lastAgentPresence;
     delete next.agentEndedAt;
     delete next.roundKitEngineRef;
+    delete next.roundTypecheckPreflightBypassErrors;
     this.submissions.set(issueNumber, next);
     return roundGeneration;
   }
@@ -3088,6 +3109,8 @@ export class InMemoryStore implements Store {
       delete next.seed;
       delete next.seedStatus;
       next.roundDeliveryCount = 0;
+      next.roundTypecheckPreflightRefusals = 0;
+      delete next.roundTypecheckPreflightBypassErrors;
     }
     this.submissions.set(issueNumber, next);
   }
@@ -3121,6 +3144,26 @@ export class InMemoryStore implements Store {
     const roundDeliveryCount = (sub.roundDeliveryCount ?? 0) + 1;
     this.submissions.set(issueNumber, { ...sub, roundDeliveryCount });
     return roundDeliveryCount;
+  }
+
+  async incrementRoundTypecheckPreflightRefusals(issueNumber: number): Promise<number> {
+    const sub = this.submissions.get(issueNumber);
+    if (!sub) return 0;
+    const roundTypecheckPreflightRefusals = (sub.roundTypecheckPreflightRefusals ?? 0) + 1;
+    this.submissions.set(issueNumber, { ...sub, roundTypecheckPreflightRefusals });
+    return roundTypecheckPreflightRefusals;
+  }
+
+  async setRoundTypecheckPreflightBypassErrors(issueNumber: number, message: string | null): Promise<void> {
+    const sub = this.submissions.get(issueNumber);
+    if (!sub) return;
+    if (message == null) {
+      const next = { ...sub };
+      delete next.roundTypecheckPreflightBypassErrors;
+      this.submissions.set(issueNumber, next);
+      return;
+    }
+    this.submissions.set(issueNumber, { ...sub, roundTypecheckPreflightBypassErrors: message });
   }
 
   async allocateJobId(): Promise<number> {
@@ -5210,6 +5253,7 @@ export class FirestoreStore implements Store {
           transitions: [...(current.transitions ?? []), transition].slice(-MAX_JOB_TRANSITIONS),
           roundGeneration: nextRoundGeneration(current.roundGeneration),
           roundDeliveryCount: 0,
+          roundTypecheckPreflightRefusals: 0,
         };
         delete next.seed;
         delete next.seedStatus;
@@ -5217,6 +5261,7 @@ export class FirestoreStore implements Store {
         delete next.lastAgentPresence;
         delete next.agentEndedAt;
         delete next.roundKitEngineRef;
+        delete next.roundTypecheckPreflightBypassErrors;
         tx.set(ref, next);
       } else {
         tx.set(
@@ -5240,13 +5285,19 @@ export class FirestoreStore implements Store {
       if (!snap.exists) return null;
       const current = snap.data() as SubmissionRecord;
       const roundGeneration = nextRoundGeneration(current.roundGeneration);
-      const next: SubmissionRecord = { ...current, roundGeneration, roundDeliveryCount: 0 };
+      const next: SubmissionRecord = {
+        ...current,
+        roundGeneration,
+        roundDeliveryCount: 0,
+        roundTypecheckPreflightRefusals: 0,
+      };
       delete next.seed;
       delete next.seedStatus;
       delete next.lastAgentSignalAt;
       delete next.lastAgentPresence;
       delete next.agentEndedAt;
       delete next.roundKitEngineRef;
+      delete next.roundTypecheckPreflightBypassErrors;
       tx.set(ref, next);
       return roundGeneration;
     });
@@ -5346,9 +5397,11 @@ export class FirestoreStore implements Store {
         builder,
         defaultBuilder: builder,
         roundDeliveryCount: 0,
+        roundTypecheckPreflightRefusals: 0,
       };
       delete next.seed;
       delete next.seedStatus;
+      delete next.roundTypecheckPreflightBypassErrors;
       tx.set(ref, next);
     });
   }
@@ -5393,6 +5446,34 @@ export class FirestoreStore implements Store {
       tx.set(ref, { roundDeliveryCount }, { merge: true });
       return roundDeliveryCount;
     });
+  }
+
+  async incrementRoundTypecheckPreflightRefusals(issueNumber: number): Promise<number> {
+    const ref = this.db.collection('submissions').doc(String(issueNumber));
+    return this.db.runTransaction(async (tx) => {
+      const snap = await tx.get(ref);
+      if (!snap.exists) return 0;
+      const current = snap.data() as SubmissionRecord;
+      const roundTypecheckPreflightRefusals = (current.roundTypecheckPreflightRefusals ?? 0) + 1;
+      tx.set(ref, { roundTypecheckPreflightRefusals }, { merge: true });
+      return roundTypecheckPreflightRefusals;
+    });
+  }
+
+  async setRoundTypecheckPreflightBypassErrors(issueNumber: number, message: string | null): Promise<void> {
+    const ref = this.db.collection('submissions').doc(String(issueNumber));
+    if (message == null) {
+      await this.db.runTransaction(async (tx) => {
+        const snap = await tx.get(ref);
+        if (!snap.exists) return;
+        const current = snap.data() as SubmissionRecord;
+        const next = { ...current };
+        delete next.roundTypecheckPreflightBypassErrors;
+        tx.set(ref, next);
+      });
+      return;
+    }
+    await ref.set({ roundTypecheckPreflightBypassErrors: message }, { merge: true });
   }
 
   async allocateJobId(): Promise<number> {

--- a/apps/api/src/store.ts
+++ b/apps/api/src/store.ts
@@ -5463,14 +5463,7 @@ export class FirestoreStore implements Store {
   async setRoundTypecheckPreflightBypassErrors(issueNumber: number, message: string | null): Promise<void> {
     const ref = this.db.collection('submissions').doc(String(issueNumber));
     if (message == null) {
-      await this.db.runTransaction(async (tx) => {
-        const snap = await tx.get(ref);
-        if (!snap.exists) return;
-        const current = snap.data() as SubmissionRecord;
-        const next = { ...current };
-        delete next.roundTypecheckPreflightBypassErrors;
-        tx.set(ref, next);
-      });
+      await ref.set({ roundTypecheckPreflightBypassErrors: FieldValue.delete() }, { merge: true });
       return;
     }
     await ref.set({ roundTypecheckPreflightBypassErrors: message }, { merge: true });

--- a/apps/api/src/submissions.ts
+++ b/apps/api/src/submissions.ts
@@ -54,6 +54,7 @@ import type { GameSeeder, SeedDraft } from './game-seed.js';
 import { ManagedOutputRejectedError } from './managed-agent.js';
 import { createManagedDeliveryLock } from './managed-backend.js';
 import { createSourceDeliveryService, SourceDeliveryAuthorityError } from './source-delivery.js';
+import { createKitFileStore } from './kit-files.js';
 import { InvalidUploadError } from './games-store.js';
 import {
   canTransition,
@@ -590,11 +591,15 @@ export async function registerSubmissionRoutes(
     eventsCache.delete(issueNumber);
     invalidateStatusCache(issueNumber);
   }
+  const kitFileStoreForDelivery = options.agentChannel?.objectStore
+    ? createKitFileStore(options.agentChannel.objectStore)
+    : null;
   const sourceDelivery =
     store && gamesStoreForSeed
       ? createSourceDeliveryService({
           store,
           gamesStore: gamesStoreForSeed,
+          kitFileStore: kitFileStoreForDelivery,
           now,
           maxSubmitsPerWindow: options.agentChannel?.maxSubmitsPerWindow,
           onSourcesDelivered: options.agentChannel?.onSourcesDelivered,

--- a/apps/api/src/typecheck-preflight.test.ts
+++ b/apps/api/src/typecheck-preflight.test.ts
@@ -1,0 +1,162 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import { KIT_ROOT_DIR } from './kit-registry.js';
+import type { KitTree } from './kit-files.js';
+import { sharedSourcesFromKitTree, typecheckDeliverySources } from './typecheck-preflight.js';
+
+const KIT_DTS = `
+interface GameKitGameContext {
+  draw: { circle(x: number, y: number, r: number): void };
+  width: number;
+  height: number;
+}
+declare const GameKit: { defineGame(): unknown };
+`;
+
+function kitTree(files: Record<string, string>): KitTree {
+  const map = new Map<string, Buffer>();
+  for (const [rel, body] of Object.entries(files)) {
+    map.set(`${KIT_ROOT_DIR}/${rel}`, Buffer.from(body, 'utf8'));
+  }
+  return { engineRef: 'abc', sha256: 'a'.repeat(64), files: map };
+}
+
+describe('typecheck preflight', () => {
+  it('extracts shared declarations from a kit tree', () => {
+    const shared = sharedSourcesFromKitTree(
+      kitTree({
+        'shared/game-kit.d.ts': KIT_DTS,
+        'shared/modules/core.ts': 'export const core = 1;\n',
+        'SKILL.md': '# ignore\n',
+        'shared/audio/beep.wav': 'not-text',
+      }),
+    );
+    expect(Object.keys(shared).sort()).toEqual(['shared/game-kit.d.ts', 'shared/modules/core.ts']);
+  });
+
+  it('refuses the Round-field transcript failure with one grouped line', () => {
+    const result = typecheckDeliverySources({
+      slug: 'comet',
+      kitShared: { 'shared/game-kit.d.ts': KIT_DTS },
+      sources: {
+        'game/model.ts': `export type Round = { score: number };\n`,
+        'game/runtime.ts': `
+import type { Round } from './model.ts';
+export function tick(round: Round) {
+  return round.lane + round.speed + round.combo + round.heat;
+}
+`,
+      },
+    });
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.message).toMatch(/type `Round` has no properties/);
+    expect(result.message).toMatch(/`lane`/);
+    expect(result.message).toMatch(/`speed`/);
+    expect(result.message).toMatch(/`combo`/);
+    expect(result.message).toMatch(/`heat`/);
+    // One grouped finding, not four separate property lines.
+    expect(result.message.split('\n').filter((l) => l.includes('has no propert')).length).toBe(1);
+  });
+
+  it('accepts a consistent multi-file delivery', () => {
+    const result = typecheckDeliverySources({
+      slug: 'ok-game',
+      kitShared: {
+        'shared/game-kit.d.ts': KIT_DTS,
+        'shared/modules/core.ts': 'export function clamp(n: number): number { return n; }\n',
+      },
+      sources: {
+        'game.ts': `import { start } from './game/runtime.ts';\nexport const g = start;\n`,
+        'game/model.ts': `export type Round = { score: number };\n`,
+        'game/runtime.ts': `
+import type { Round } from './model.ts';
+export function start(): Round { return { score: 0 }; }
+`,
+      },
+    });
+    expect(result.ok).toBe(true);
+  });
+
+  it('skips when the kit declaration is absent', () => {
+    const result = typecheckDeliverySources({
+      slug: 'x',
+      kitShared: {},
+      sources: { 'game.ts': 'export const n: number = "no";\n' },
+    });
+    expect(result).toMatchObject({ ok: true, skipped: 'no_kit' });
+  });
+
+  it('uses kit shared modules for resolution, not only ambient dts', () => {
+    const result = typecheckDeliverySources({
+      slug: 'mod-game',
+      kitShared: {
+        'shared/game-kit.d.ts': KIT_DTS,
+        'shared/modules/util.ts': 'export function twice(n: number): number { return n * 2; }\n',
+      },
+      sources: {
+        'game.ts': `
+import { twice } from '../../shared/modules/util.ts';
+export const n = twice(2);
+`,
+      },
+    });
+    expect(result.ok).toBe(true);
+  });
+});
+
+describe('typecheck preflight latency (measured)', () => {
+  it('reports duration for a staged-sized tree against real game-kit.d.ts', () => {
+    // Prefer the games-repo checkout when present; else the tiny fixture above.
+    let kitDts = KIT_DTS;
+    try {
+      const gamesShared = path.resolve(
+        path.dirname(fileURLToPath(import.meta.url)),
+        '../../../../www.gamedev.pl-games/shared/game-kit.d.ts',
+      );
+      kitDts = readFileSync(gamesShared, 'utf8');
+    } catch {
+      try {
+        kitDts = readFileSync('/agent/repos/www.gamedev.pl-games/shared/game-kit.d.ts', 'utf8');
+      } catch {
+        // Fixture kit is enough for a lower-bound measurement.
+      }
+    }
+
+    const model = `export type Round = {\n  score: number;\n  lane: number;\n};\n`;
+    const runtime = `
+import type { Round } from './model.ts';
+export function tick(round: Round, kit: GameKitGameContext) {
+  kit.draw.circle(round.lane, round.score, 4);
+  return round.score;
+}
+`;
+    const sources: Record<string, string> = {
+      'game.ts': `import { tick } from './game/runtime.ts';\nexport { tick };\n`,
+      'game/model.ts': model,
+      'game/runtime.ts': runtime,
+    };
+    // Warm lib cache once, then measure.
+    typecheckDeliverySources({
+      slug: 'bench',
+      kitShared: { 'shared/game-kit.d.ts': kitDts },
+      sources,
+    });
+    const samples: number[] = [];
+    for (let i = 0; i < 11; i += 1) {
+      const result = typecheckDeliverySources({
+        slug: 'bench',
+        kitShared: { 'shared/game-kit.d.ts': kitDts },
+        sources,
+      });
+      expect(result.ok).toBe(true);
+      samples.push(result.durationMs);
+    }
+    samples.sort((a, b) => a - b);
+    const p95 = samples[Math.floor(samples.length * 0.95)]!;
+    expect(p95).toBeLessThan(10_000);
+    expect(p95, `measured p95=${p95}ms`).toBeGreaterThanOrEqual(0);
+  });
+});

--- a/apps/api/src/typecheck-preflight.test.ts
+++ b/apps/api/src/typecheck-preflight.test.ts
@@ -89,6 +89,38 @@ export function start(): Round { return { score: 0 }; }
     expect(result).toMatchObject({ ok: true, skipped: 'no_kit' });
   });
 
+  it('pluralizes a single missing property correctly', () => {
+    const result = typecheckDeliverySources({
+      slug: 'one',
+      kitShared: { 'shared/game-kit.d.ts': KIT_DTS },
+      sources: {
+        'game/model.ts': 'export type Round = { score: number };\n',
+        'game.ts': `
+import type { Round } from './game/model.ts';
+export function tick(round: Round) { return round.lane; }
+`,
+      },
+    });
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.message).toMatch(/has no property `lane`/);
+    expect(result.message).not.toMatch(/has no properties/);
+  });
+
+  it('does not read arbitrary host filesystem paths from delivery imports', () => {
+    const result = typecheckDeliverySources({
+      slug: 'escape',
+      kitShared: { 'shared/game-kit.d.ts': KIT_DTS },
+      sources: {
+        'game.ts': `import secret from '/etc/passwd';\nexport const s = secret;\n`,
+      },
+    });
+    // Must not surface file contents; missing-module / resolve failure is fine.
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.message).not.toMatch(/root:|daemon:|nobody:/);
+  });
+
   it('uses kit shared modules for resolution, not only ambient dts', () => {
     const result = typecheckDeliverySources({
       slug: 'mod-game',

--- a/apps/api/src/typecheck-preflight.ts
+++ b/apps/api/src/typecheck-preflight.ts
@@ -1,5 +1,6 @@
 // In-process tsc preflight for submit_sources.
 
+import path from 'node:path';
 import ts from 'typescript';
 import type { KitTree } from './kit-files.js';
 import { KIT_ROOT_DIR } from './kit-registry.js';
@@ -27,6 +28,12 @@ export const TYPECHECK_PREFLIGHT_BUDGET_MS = 10_000;
 export const TYPECHECK_PREFLIGHT_MAX_REFUSALS = 2;
 
 const libCache = new Map<string, ts.SourceFile | undefined>();
+const TS_LIB_DIR = path.dirname(ts.getDefaultLibFilePath(COMPILER_OPTIONS));
+
+function isAllowedDiskPath(name: string): boolean {
+  const resolved = path.resolve(name);
+  return resolved === TS_LIB_DIR || resolved.startsWith(`${TS_LIB_DIR}${path.sep}`);
+}
 
 export type TypecheckPreflightResult =
   | { ok: true; skipped?: 'no_kit' | 'timeout' | 'checker_failed'; durationMs: number }
@@ -35,9 +42,9 @@ export type TypecheckPreflightResult =
 export function sharedSourcesFromKitTree(tree: KitTree): Record<string, string> {
   const out: Record<string, string> = {};
   const prefix = `${KIT_ROOT_DIR}/`;
-  for (const [path, buf] of tree.files) {
-    if (!path.startsWith(prefix)) continue;
-    const rel = path.slice(prefix.length);
+  for (const [filePath, buf] of tree.files) {
+    if (!filePath.startsWith(prefix)) continue;
+    const rel = filePath.slice(prefix.length);
     const isKitDts = rel === 'shared/game-kit.d.ts';
     const isModule = rel.startsWith('shared/modules/') && rel.endsWith('.ts');
     const isVertical = rel.startsWith('shared/verticals/') && rel.endsWith('.ts');
@@ -117,10 +124,10 @@ function formatFindings(findings: RawFinding[]): string {
   const lines: string[] = [];
   for (const g of groups.values()) {
     if (g.kind === 'props') {
-      const props = g.props.map((p) => `\`${p}\``).join(', ');
+      const listed = g.props.map((p) => `\`${p}\``).join(', ');
+      const noun = g.props.length === 1 ? 'property' : 'properties';
       lines.push(
-        `${g.file}: type \`${g.typeName}\` has no ${props.length === 1 ? 'property' : 'properties'} ${props}. ` +
-          'Add them to the type or stop reading them.',
+        `${g.file}: type \`${g.typeName}\` has no ${noun} ${listed}. ` + 'Add them to the type or stop reading them.',
       );
     } else {
       lines.push(g.line);
@@ -167,13 +174,23 @@ export function typecheckDeliverySources(input: {
   }
   const roots = [...files.keys()];
 
+  // Disk reads: TypeScript lib only (delivery is untrusted).
   const host: ts.CompilerHost = {
-    fileExists: (name) => files.has(name) || ts.sys.fileExists(name),
-    readFile: (name) => files.get(name) ?? ts.sys.readFile(name),
+    fileExists: (name) => files.has(name) || (isAllowedDiskPath(name) && ts.sys.fileExists(name)),
+    readFile: (name) => {
+      const own = files.get(name);
+      if (own !== undefined) return own;
+      if (!isAllowedDiskPath(name)) return undefined;
+      return ts.sys.readFile(name);
+    },
     getSourceFile: (name, languageVersion) => {
       const own = files.get(name);
       if (own !== undefined) return ts.createSourceFile(name, own, languageVersion, true);
       if (libCache.has(name)) return libCache.get(name);
+      if (!isAllowedDiskPath(name)) {
+        libCache.set(name, undefined);
+        return undefined;
+      }
       const text = ts.sys.readFile(name);
       const parsed = text === undefined ? undefined : ts.createSourceFile(name, text, languageVersion, true);
       libCache.set(name, parsed);
@@ -185,8 +202,8 @@ export function typecheckDeliverySources(input: {
     getCanonicalFileName: (name) => name,
     useCaseSensitiveFileNames: () => true,
     getNewLine: () => '\n',
-    directoryExists: (dir) => dir.startsWith(ROOT) || ts.sys.directoryExists(dir),
-    getDirectories: (dir) => (dir.startsWith(ROOT) ? [] : ts.sys.getDirectories(dir)),
+    directoryExists: (dir) => dir.startsWith(ROOT) || (isAllowedDiskPath(dir) && ts.sys.directoryExists(dir)),
+    getDirectories: (dir) => (isAllowedDiskPath(dir) ? ts.sys.getDirectories(dir) : []),
   };
 
   let program: ts.Program;
@@ -203,6 +220,7 @@ export function typecheckDeliverySources(input: {
   return { ok: false, message: formatFindings(findings), durationMs };
 }
 
+// Post-check budget: sync tsc cannot be preempted mid-run.
 export async function runTypecheckPreflight(input: {
   slug: string;
   sources: Record<string, string>;
@@ -211,27 +229,13 @@ export async function runTypecheckPreflight(input: {
 }): Promise<TypecheckPreflightResult> {
   const budgetMs = input.budgetMs ?? TYPECHECK_PREFLIGHT_BUDGET_MS;
   const started = Date.now();
-  return await new Promise((resolve) => {
-    let settled = false;
-    const timer = setTimeout(() => {
-      if (settled) return;
-      settled = true;
-      resolve({ ok: true, skipped: 'timeout', durationMs: Date.now() - started });
-    }, budgetMs);
-    setImmediate(() => {
-      if (settled) return;
-      try {
-        const result = typecheckDeliverySources(input);
-        if (settled) return;
-        settled = true;
-        clearTimeout(timer);
-        resolve(result);
-      } catch {
-        if (settled) return;
-        settled = true;
-        clearTimeout(timer);
-        resolve({ ok: true, skipped: 'checker_failed', durationMs: Date.now() - started });
-      }
-    });
-  });
+  try {
+    const result = typecheckDeliverySources(input);
+    if (Date.now() - started > budgetMs) {
+      return { ok: true, skipped: 'timeout', durationMs: Date.now() - started };
+    }
+    return result;
+  } catch {
+    return { ok: true, skipped: 'checker_failed', durationMs: Date.now() - started };
+  }
 }

--- a/apps/api/src/typecheck-preflight.ts
+++ b/apps/api/src/typecheck-preflight.ts
@@ -1,0 +1,237 @@
+// In-process tsc preflight for submit_sources.
+
+import ts from 'typescript';
+import type { KitTree } from './kit-files.js';
+import { KIT_ROOT_DIR } from './kit-registry.js';
+
+const COMPILER_OPTIONS: ts.CompilerOptions = {
+  noEmit: true,
+  strict: true,
+  noImplicitAny: false,
+  strictPropertyInitialization: false,
+  useUnknownInCatchVariables: false,
+  skipLibCheck: true,
+  target: ts.ScriptTarget.ES2022,
+  module: ts.ModuleKind.ESNext,
+  moduleResolution: ts.ModuleResolutionKind.Bundler,
+  allowImportingTsExtensions: true,
+  lib: ['lib.es2022.d.ts', 'lib.dom.d.ts'],
+};
+
+const ROOT = '/preflight';
+const MAX_GROUPED = 8;
+const MAX_ERROR_BYTES = 800;
+// Soft wall; over budget → skip (accept).
+export const TYPECHECK_PREFLIGHT_BUDGET_MS = 10_000;
+// Cap refusals; further submits accept.
+export const TYPECHECK_PREFLIGHT_MAX_REFUSALS = 2;
+
+const libCache = new Map<string, ts.SourceFile | undefined>();
+
+export type TypecheckPreflightResult =
+  | { ok: true; skipped?: 'no_kit' | 'timeout' | 'checker_failed'; durationMs: number }
+  | { ok: false; message: string; durationMs: number };
+
+export function sharedSourcesFromKitTree(tree: KitTree): Record<string, string> {
+  const out: Record<string, string> = {};
+  const prefix = `${KIT_ROOT_DIR}/`;
+  for (const [path, buf] of tree.files) {
+    if (!path.startsWith(prefix)) continue;
+    const rel = path.slice(prefix.length);
+    const isKitDts = rel === 'shared/game-kit.d.ts';
+    const isModule = rel.startsWith('shared/modules/') && rel.endsWith('.ts');
+    const isVertical = rel.startsWith('shared/verticals/') && rel.endsWith('.ts');
+    if (isKitDts || isModule || isVertical) {
+      out[rel] = buf.toString('utf8');
+    }
+  }
+  return out;
+}
+
+function gameRelativePath(virtualPath: string, slug: string): string {
+  const prefix = `${ROOT}/games/${slug}/`;
+  return virtualPath.startsWith(prefix) ? virtualPath.slice(prefix.length) : virtualPath;
+}
+
+type RawFinding = {
+  file: string;
+  code: number;
+  message: string;
+  property?: string;
+  typeName?: string;
+};
+
+function parseMissingProperty(message: string): { property: string; typeName: string } | null {
+  const m = /Property '([^']+)' does not exist on type '([^']+)'/.exec(message);
+  if (!m) return null;
+  return { property: m[1]!, typeName: m[2]! };
+}
+
+function collectFindings(diagnostics: readonly ts.Diagnostic[], slug: string): RawFinding[] {
+  const gamePrefix = `${ROOT}/games/${slug}/`;
+  const out: RawFinding[] = [];
+  for (const diagnostic of diagnostics) {
+    if (!diagnostic.file?.fileName.startsWith(gamePrefix)) continue;
+    const message = ts.flattenDiagnosticMessageText(diagnostic.messageText, ' ');
+    const file = gameRelativePath(diagnostic.file.fileName, slug);
+    const missing = diagnostic.code === 2339 ? parseMissingProperty(message) : null;
+    out.push({
+      file,
+      code: diagnostic.code,
+      message,
+      ...(missing ? { property: missing.property, typeName: missing.typeName } : {}),
+    });
+  }
+  return out;
+}
+
+function formatFindings(findings: RawFinding[]): string {
+  if (findings.length === 0) return '';
+
+  const groups = new Map<
+    string,
+    { kind: 'props' | 'other'; file: string; typeName?: string; props: string[]; line: string }
+  >();
+  for (const f of findings) {
+    if (f.property && f.typeName) {
+      const key = `props:${f.file}:${f.typeName}`;
+      let g = groups.get(key);
+      if (!g) {
+        g = { kind: 'props', file: f.file, typeName: f.typeName, props: [], line: '' };
+        groups.set(key, g);
+      }
+      if (!g.props.includes(f.property)) g.props.push(f.property);
+      continue;
+    }
+    const key = `other:${f.file}:${f.code}:${f.message}`;
+    if (!groups.has(key)) {
+      groups.set(key, {
+        kind: 'other',
+        file: f.file,
+        props: [],
+        line: `${f.file}: error TS${f.code}: ${f.message}`,
+      });
+    }
+  }
+
+  const lines: string[] = [];
+  for (const g of groups.values()) {
+    if (g.kind === 'props') {
+      const props = g.props.map((p) => `\`${p}\``).join(', ');
+      lines.push(
+        `${g.file}: type \`${g.typeName}\` has no ${props.length === 1 ? 'property' : 'properties'} ${props}. ` +
+          'Add them to the type or stop reading them.',
+      );
+    } else {
+      lines.push(g.line);
+    }
+  }
+
+  lines.sort((a, b) => b.length - a.length);
+  let shown = lines.slice(0, MAX_GROUPED);
+  let suppressed = lines.length - shown.length;
+  const header = 'Typecheck preflight failed — fix these before submitting:\n';
+  const footer = (n: number) => (n > 0 ? `\n(${n} more finding${n === 1 ? '' : 's'} suppressed)` : '');
+
+  let body = header + shown.join('\n') + footer(suppressed);
+  while (body.length > MAX_ERROR_BYTES && shown.length > 1) {
+    shown = shown.slice(0, -1);
+    suppressed = lines.length - shown.length;
+    body = header + shown.join('\n') + footer(suppressed);
+  }
+  if (body.length > MAX_ERROR_BYTES) {
+    body = body.slice(0, MAX_ERROR_BYTES - 1) + '…';
+  }
+  return body;
+}
+
+export function typecheckDeliverySources(input: {
+  slug: string;
+  sources: Record<string, string>;
+  kitShared: Record<string, string>;
+}): TypecheckPreflightResult {
+  const started = Date.now();
+  if (!input.kitShared['shared/game-kit.d.ts']) {
+    return { ok: true, skipped: 'no_kit', durationMs: Date.now() - started };
+  }
+
+  const files = new Map<string, string>();
+  for (const [rel, source] of Object.entries(input.kitShared)) {
+    files.set(`${ROOT}/${rel}`, source);
+  }
+  const gameRoot = `${ROOT}/games/${input.slug}`;
+  for (const [rel, source] of Object.entries(input.sources)) {
+    if (rel.endsWith('.ts') || rel.endsWith('.tsx')) {
+      files.set(`${gameRoot}/${rel}`, source);
+    }
+  }
+  const roots = [...files.keys()];
+
+  const host: ts.CompilerHost = {
+    fileExists: (name) => files.has(name) || ts.sys.fileExists(name),
+    readFile: (name) => files.get(name) ?? ts.sys.readFile(name),
+    getSourceFile: (name, languageVersion) => {
+      const own = files.get(name);
+      if (own !== undefined) return ts.createSourceFile(name, own, languageVersion, true);
+      if (libCache.has(name)) return libCache.get(name);
+      const text = ts.sys.readFile(name);
+      const parsed = text === undefined ? undefined : ts.createSourceFile(name, text, languageVersion, true);
+      libCache.set(name, parsed);
+      return parsed;
+    },
+    getDefaultLibFileName: (options) => ts.getDefaultLibFilePath(options),
+    writeFile: () => undefined,
+    getCurrentDirectory: () => ROOT,
+    getCanonicalFileName: (name) => name,
+    useCaseSensitiveFileNames: () => true,
+    getNewLine: () => '\n',
+    directoryExists: (dir) => dir.startsWith(ROOT) || ts.sys.directoryExists(dir),
+    getDirectories: (dir) => (dir.startsWith(ROOT) ? [] : ts.sys.getDirectories(dir)),
+  };
+
+  let program: ts.Program;
+  try {
+    program = ts.createProgram(roots, COMPILER_OPTIONS, host);
+  } catch {
+    return { ok: true, skipped: 'checker_failed', durationMs: Date.now() - started };
+  }
+
+  const diagnostics = [...program.getSemanticDiagnostics(), ...program.getSyntacticDiagnostics()];
+  const findings = collectFindings(diagnostics, input.slug);
+  const durationMs = Date.now() - started;
+  if (findings.length === 0) return { ok: true, durationMs };
+  return { ok: false, message: formatFindings(findings), durationMs };
+}
+
+export async function runTypecheckPreflight(input: {
+  slug: string;
+  sources: Record<string, string>;
+  kitShared: Record<string, string>;
+  budgetMs?: number;
+}): Promise<TypecheckPreflightResult> {
+  const budgetMs = input.budgetMs ?? TYPECHECK_PREFLIGHT_BUDGET_MS;
+  const started = Date.now();
+  return await new Promise((resolve) => {
+    let settled = false;
+    const timer = setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      resolve({ ok: true, skipped: 'timeout', durationMs: Date.now() - started });
+    }, budgetMs);
+    setImmediate(() => {
+      if (settled) return;
+      try {
+        const result = typecheckDeliverySources(input);
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        resolve(result);
+      } catch {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        resolve({ ok: true, skipped: 'checker_failed', durationMs: Date.now() - started });
+      }
+    });
+  });
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

MR-05 catches missing *symbols*. The managed transcript also shipped missing *members* (`Round` fields never declared) — that needs a real typecheck, and today that only runs in the async gate after the agent has called `end`.

## Approach (trade stated)

**In-process `tsc` via `typescript.createProgram`** against a virtual tree (delivery sources + pinned kit `shared/`), not a synchronous Cloud Build typecheck stage.

| Option | Latency | Logic reuse |
| --- | --- | --- |
| Reuse gate Cloud Build typecheck sync | Cold start blows the ~10s reply budget | Identical to gate |
| In-process program (this PR) | Warm p95 **~29ms** on a staged multi-file tree + real `game-kit.d.ts` (21 samples; cold first call in suite ~0.4–0.6s) | Mirrors games-repo compiler options; kit modules materialised from the pin |

**Budget honesty:** sync `createProgram` cannot be preempted on the request thread. The soft 10s wall is applied *after* the check — if it took longer, the submit is accepted (`skipped: 'timeout'`) rather than refused. Kit-load failure also fail-opens. The async gate still runs unchanged.

## Behaviour

- Hook: `createSourceDeliveryService.deliver` **before** `putCandidateSources` (covers MCP, channel, and managed harvest).
- Kit resolution: `record.roundKitEngineRef` (pin) — proven by a test that moves the registry “current” pointer between pin and submit; the check still loads the pin.
- Compiler host: virtual `/preflight` tree + TypeScript `lib/` only (no arbitrary host filesystem reads from delivery imports).
- Error shape: collapse `Property '…' does not exist on type 'Round'` ×N into one line naming all properties; ≤8 groups / ~800 bytes.
- Loop guard: **max two refusals per round**; third submit accepts, starts the gate, and stores grouped diagnostics on `roundTypecheckPreflightBypassErrors`. A later clean submit clears that field.
- No shell egress required — entirely server-side.

## Tests

- Round-field refusal with one grouped message (and singular “property”)
- Pin holds after registry pointer move
- Third submit accepts + attaches diagnostics; clean submit clears them
- Host lockdown against `/etc/passwd`-style imports
- No kit store → no refusal (fail-open)
- Measured warm p95 assertion (<10s) in `typecheck-preflight.test.ts`

## Follow-up

MR-07: instrument whether preflight refusals actually reduce async-gate failures.

## Copilot review

Addressed: pluralization, host FS lockdown, timeout semantics, bypass-error clearing, `FieldValue.delete` for Firestore clear.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4cf2e9e5-dd15-4c3a-8323-8e026e20823b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4cf2e9e5-dd15-4c3a-8323-8e026e20823b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

