### PR TITLE
Reject non-compliant shipped index.html files in favor of generated markup

### DIFF
--- a/apps/api/src/github-client.test.ts
+++ b/apps/api/src/github-client.test.ts
@@ -964,6 +964,46 @@ describe('getGameSources', () => {
     expect(sources?.styleCss).not.toContain('.wrap h1');
   });
 
+  it('falls back to generated markup when a shipped index.html references external game.ts/style.css', async () => {
+    // Regression: this scaffold's script/link tags never survive assembly's CSP.
+    const files = new Map<string, string | Uint8Array>([
+      [
+        'games/arena-brawlers/index.html',
+        '<div id="app"></div><link rel="stylesheet" href="./style.css">' +
+          '<script type="module" src="./game.ts"></script>',
+      ],
+      ['games/arena-brawlers/game.ts', 'GameKit.mount({ update() {} });'],
+      ['games/arena-brawlers/style.css', '.game { color: red; }'],
+      ['games/arena-brawlers/SPEC.md', specMd({ title: 'Arena Brawlers' })],
+      [
+        'games/arena-brawlers/GAME.json',
+        JSON.stringify({
+          engine: { modules: [] },
+          howToPlay: {
+            goal: { en: 'Defeat opponents', pl: 'Pokonaj przeciwników' },
+            hint: { en: 'Use WASD', pl: 'Użyj WASD' },
+          },
+        }),
+      ],
+      ['shared/game-shell.css', '.shell {}'],
+      ['shared/modules/core.ts', 'window.GameKit = { mount() {} };'],
+    ]);
+    const fetchImpl = vi.fn(async (input: RequestInfo | URL) => {
+      const pathname = new URL(String(input)).pathname;
+      const marker = '/contents/';
+      const path = decodeURIComponent(pathname.slice(pathname.indexOf(marker) + marker.length));
+      const value = files.get(path);
+      return value === undefined ? new Response('not found', { status: 404 }) : new Response(value, { status: 200 });
+    }) as unknown as typeof fetch;
+    const client = createGitHubClient({ token: 'test-token', repo, fetchImpl });
+
+    const sources = await client.getGameSources('main', 'arena-brawlers');
+
+    expect(sources?.indexHtml).toContain('id="game"');
+    expect(sources?.indexHtml).not.toContain('<script');
+    expect(sources?.indexHtml).not.toContain('<link');
+  });
+
   it('accepts the post-draw-surface module order including gfx and actors', async () => {
     const files = new Map<string, string | Uint8Array>([
       ['games/squad/index.html', '<canvas id="game"></canvas>'],

--- a/apps/api/src/github-client.ts
+++ b/apps/api/src/github-client.ts
@@ -1367,9 +1367,7 @@ export function createGitHubClient(options: GitHubClientOptions): GitHubClient {
 
       const title = specMd ? parseSpecTitle(specMd) : null;
 
-      // Empty counts as absent: staging writes the path before the content. A
-      // non-compliant shipped index.html (see isCompliantIndexHtml) is treated the
-      // same way — the generated markup is always assembly-safe.
+      // Empty counts as absent: staging writes the path before the content.
       const resolvedIndexHtml =
         indexHtml?.trim() && isCompliantIndexHtml(indexHtml)
           ? indexHtml

--- a/apps/api/src/github-client.ts
+++ b/apps/api/src/github-client.ts
@@ -107,6 +107,13 @@ function generateStyleCssFromManifest(manifestSource: string): string | null {
   return generateStyleCss(manifest.theme);
 }
 
+// External script/link tags never survive the assembler's inline-only CSP.
+function isCompliantIndexHtml(html: string): boolean {
+  if (/<script[^>]*\bsrc=/i.test(html)) return false;
+  if (/<link[^>]*\bhref=/i.test(html)) return false;
+  return true;
+}
+
 // GAME_KIT_MODULES lives in games-repo-contract.ts — CI re-checks the live
 // games repo copy when GAMES_REPO_TOKEN is set (issue #247).
 const MAX_SOURCE_GRAPH_MODULES = 64;
@@ -1360,10 +1367,13 @@ export function createGitHubClient(options: GitHubClientOptions): GitHubClient {
 
       const title = specMd ? parseSpecTitle(specMd) : null;
 
-      // Empty counts as absent: staging writes the path before the content.
-      const resolvedIndexHtml = indexHtml?.trim()
-        ? indexHtml
-        : generateIndexHtmlFromManifest(manifestSource, title ?? slug);
+      // Empty counts as absent: staging writes the path before the content. A
+      // non-compliant shipped index.html (see isCompliantIndexHtml) is treated the
+      // same way — the generated markup is always assembly-safe.
+      const resolvedIndexHtml =
+        indexHtml?.trim() && isCompliantIndexHtml(indexHtml)
+          ? indexHtml
+          : generateIndexHtmlFromManifest(manifestSource, title ?? slug);
       if (resolvedIndexHtml === null) {
         return null;
       }


### PR DESCRIPTION
## Summary
This change adds validation to reject shipped `index.html` files that contain external script or stylesheet references, which would fail silently in the assembled game environment. Such files are now replaced with generated markup that is guaranteed to work under the assembly's Content Security Policy.

## Key Changes
- Added `isCompliantIndexHtml()` function that validates shipped `index.html` files by rejecting those containing `<script src=...>` or `<link href=...>` references
- Updated `getGameSources()` to use this validation when deciding whether to use a shipped `index.html` or fall back to generated markup
- Added comprehensive test case demonstrating the regression scenario: a game with external references that would fail silently in the browser

## Implementation Details
The assembler inlines `game.ts` and `style.css` into a single `<script>` and `<style>` tag pair, and serves the result under a restrictive CSP (`default-src 'none'; script-src 'unsafe-inline'; style-src 'unsafe-inline'`). Any external script or stylesheet references in the shipped `index.html` are blocked by this CSP and unresolvable from a `srcdoc` document, causing silent failures in the browser.

By validating and rejecting non-compliant `index.html` files at upload time, games that would otherwise fail to render are caught early and replaced with assembly-safe generated markup.

https://claude.ai/code/session_01Da5G4wkP9XQ4C7Y41GaCUa