### PR TITLE
Instrument delivery preflight and gate effectiveness (MR-07)

### DIFF
--- a/.claude/skills/product-instrumentation/SKILL.md
+++ b/.claude/skills/product-instrumentation/SKILL.md
@@ -166,6 +166,11 @@ adjacent flow, close the gap in the same change or flag it explicitly in the PR:
     series (`selfChosen` / `connected` / `signaled` / `gateVerdicts`) on
     `GET /api/admin/telemetry/trends`, rendered on the Trends strip of the operator
     telemetry tab beside visits/plays/creations.
+  - ~~Managed delivery preflight / gate effectiveness unmeasured~~ — **closed (MR-07)**:
+    server log metrics in `delivery-metrics.ts` (`delivery preflight refused`,
+    `delivery accepted`, `delivery gate verdict`) answer whether audio/symbols/typecheck
+    preflights catch bad submits, how many attempts a caught round needs, and whether
+    async gate failure rates fall. No visit-stream join; no source/prompt/uid in payloads.
 - ~~How-to-play opens recorded but unreadable~~ — **closed 2026-07-31** for the read
   path that [#395](https://github.com/gamedevpl/www.gamedev.pl/issues/395) needs:
   `how_to_play_opened` carries `via: 'bar' | 'more'` and optional `reopen: true` (same

--- a/apps/api/src/delivery-metrics.test.ts
+++ b/apps/api/src/delivery-metrics.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 import {
+  asDeliveryLogger,
   builderLabelFromRecord,
   DELIVERY_ACCEPTED_MSG,
   DELIVERY_GATE_VERDICT_MSG,
@@ -68,9 +69,49 @@ describe('delivery metrics', () => {
   it('maps builders and failed stages to closed sets', () => {
     expect(builderLabelFromRecord('self')).toBe('self');
     expect(builderLabelFromRecord('platform')).toBe('platform');
+    // Managed keeps builder=platform; backend wins.
+    expect(builderLabelFromRecord('platform', 'managed:anthropic')).toBe('managed');
     expect(builderLabelFromRecord(undefined, 'managed:anthropic')).toBe('managed');
+    // Self wins over a managed backend string.
+    expect(builderLabelFromRecord('self', 'managed:anthropic')).toBe('self');
     expect(failedStageFromProgress('smoke')).toBe('smoke');
     expect(failedStageFromProgress('preparing')).toBe('other');
     expect(failedStageFromProgress(undefined)).toBeUndefined();
+  });
+
+  it('binds info to the logger receiver', () => {
+    const calls: unknown[] = [];
+    const log = {
+      tag: 'pino-like',
+      info(this: { tag: string }, context: object, message: string) {
+        calls.push({ thisTag: this.tag, context, message });
+      },
+    };
+    const bound = asDeliveryLogger(log);
+    expect(bound).not.toBeNull();
+    logDeliveryPreflightRefused(bound!, {
+      issueNumber: 1,
+      roundGeneration: 1,
+      builder: 'platform',
+      mode: 'publish',
+      kind: 'audio',
+      attempt: 1,
+    });
+    expect(calls).toEqual([
+      {
+        thisTag: 'pino-like',
+        context: {
+          delivery: {
+            issueNumber: 1,
+            roundGeneration: 1,
+            builder: 'platform',
+            mode: 'publish',
+            kind: 'audio',
+            attempt: 1,
+          },
+        },
+        message: DELIVERY_PREFLIGHT_REFUSED_MSG,
+      },
+    ]);
   });
 });

--- a/apps/api/src/delivery-metrics.test.ts
+++ b/apps/api/src/delivery-metrics.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  builderLabelFromRecord,
+  DELIVERY_ACCEPTED_MSG,
+  DELIVERY_GATE_VERDICT_MSG,
+  DELIVERY_PREFLIGHT_REFUSED_MSG,
+  failedStageFromProgress,
+  logDeliveryAccepted,
+  logDeliveryGateVerdict,
+  logDeliveryPreflightRefused,
+} from './delivery-metrics.js';
+
+describe('delivery metrics', () => {
+  it('emits stable refusal / accept / gate messages with closed labels', () => {
+    const info = vi.fn();
+    const log = { info };
+
+    logDeliveryPreflightRefused(log, {
+      issueNumber: 42,
+      roundGeneration: 1,
+      builder: 'managed',
+      mode: 'preview',
+      kind: 'symbols',
+      attempt: 1,
+    });
+    logDeliveryAccepted(log, {
+      issueNumber: 42,
+      roundGeneration: 1,
+      builder: 'managed',
+      mode: 'preview',
+      submitAttempts: 2,
+      refusals: { audio: 0, symbols: 1, typecheck: 0 },
+      msFromRoundStart: 12_000,
+      typecheckBypass: false,
+    });
+    logDeliveryGateVerdict(log, {
+      issueNumber: 42,
+      roundGeneration: 1,
+      builder: 'managed',
+      mode: 'preview',
+      outcome: 'failed',
+      status: 'preview_failed',
+      failedStage: 'typecheck',
+    });
+
+    expect(info.mock.calls.map((c) => c[1])).toEqual([
+      DELIVERY_PREFLIGHT_REFUSED_MSG,
+      DELIVERY_ACCEPTED_MSG,
+      DELIVERY_GATE_VERDICT_MSG,
+    ]);
+    expect(info.mock.calls[0]![0]).toEqual({
+      delivery: {
+        issueNumber: 42,
+        roundGeneration: 1,
+        builder: 'managed',
+        mode: 'preview',
+        kind: 'symbols',
+        attempt: 1,
+      },
+    });
+    // Privacy: no slug, source, prompt, or uid.
+    for (const [payload] of info.mock.calls) {
+      const json = JSON.stringify(payload);
+      expect(json).not.toMatch(/slug|prompt|uid|game\.ts|SPEC/);
+    }
+  });
+
+  it('maps builders and failed stages to closed sets', () => {
+    expect(builderLabelFromRecord('self')).toBe('self');
+    expect(builderLabelFromRecord('platform')).toBe('platform');
+    expect(builderLabelFromRecord(undefined, 'managed:anthropic')).toBe('managed');
+    expect(failedStageFromProgress('smoke')).toBe('smoke');
+    expect(failedStageFromProgress('preparing')).toBe('other');
+    expect(failedStageFromProgress(undefined)).toBeUndefined();
+  });
+});

--- a/apps/api/src/delivery-metrics.ts
+++ b/apps/api/src/delivery-metrics.ts
@@ -1,0 +1,118 @@
+// Delivery preflight + gate metrics (stable log messages).
+
+export const DELIVERY_PREFLIGHT_REFUSED_MSG = 'delivery preflight refused';
+export const DELIVERY_ACCEPTED_MSG = 'delivery accepted';
+export const DELIVERY_GATE_VERDICT_MSG = 'delivery gate verdict';
+
+export type DeliveryPreflightKind = 'audio' | 'symbols' | 'typecheck';
+export type DeliveryBuilderLabel = 'platform' | 'self' | 'managed' | 'other';
+export type DeliveryModeLabel = 'preview' | 'publish';
+
+export type DeliveryGateStatus = 'preview_passed' | 'preview_failed' | 'green' | 'red' | 'kit_outdated';
+
+export type DeliveryFailedStage = 'typecheck' | 'smoke' | 'build' | 'trace' | 'capture' | 'validate' | 'other';
+
+interface Logger {
+  info: (context: object, message: string) => void;
+}
+
+export function builderLabelFromRecord(builder: string | undefined, backend?: string): DeliveryBuilderLabel {
+  if (builder === 'self') return 'self';
+  if (builder === 'platform') return 'platform';
+  if (backend?.startsWith('managed:')) return 'managed';
+  if (builder) return 'other';
+  if (backend?.startsWith('managed:')) return 'managed';
+  return 'other';
+}
+
+export function logDeliveryPreflightRefused(
+  log: Logger,
+  input: {
+    issueNumber: number;
+    roundGeneration: number;
+    builder: DeliveryBuilderLabel;
+    mode: DeliveryModeLabel;
+    kind: DeliveryPreflightKind;
+    attempt: number;
+  },
+): void {
+  log.info(
+    {
+      delivery: {
+        issueNumber: input.issueNumber,
+        roundGeneration: input.roundGeneration,
+        builder: input.builder,
+        mode: input.mode,
+        kind: input.kind,
+        attempt: input.attempt,
+      },
+    },
+    DELIVERY_PREFLIGHT_REFUSED_MSG,
+  );
+}
+
+export function logDeliveryAccepted(
+  log: Logger,
+  input: {
+    issueNumber: number;
+    roundGeneration: number;
+    builder: DeliveryBuilderLabel;
+    mode: DeliveryModeLabel;
+    submitAttempts: number;
+    refusals: { audio: number; symbols: number; typecheck: number };
+    msFromRoundStart: number | null;
+    typecheckBypass: boolean;
+  },
+): void {
+  log.info(
+    {
+      delivery: {
+        issueNumber: input.issueNumber,
+        roundGeneration: input.roundGeneration,
+        builder: input.builder,
+        mode: input.mode,
+        submitAttempts: input.submitAttempts,
+        refusals: input.refusals,
+        msFromRoundStart: input.msFromRoundStart,
+        typecheckBypass: input.typecheckBypass,
+      },
+    },
+    DELIVERY_ACCEPTED_MSG,
+  );
+}
+
+export function logDeliveryGateVerdict(
+  log: Logger,
+  input: {
+    issueNumber: number;
+    roundGeneration: number;
+    builder: DeliveryBuilderLabel;
+    mode: DeliveryModeLabel;
+    outcome: 'passed' | 'failed';
+    status: DeliveryGateStatus;
+    failedStage?: DeliveryFailedStage;
+  },
+): void {
+  log.info(
+    {
+      delivery: {
+        issueNumber: input.issueNumber,
+        roundGeneration: input.roundGeneration,
+        builder: input.builder,
+        mode: input.mode,
+        outcome: input.outcome,
+        status: input.status,
+        ...(input.failedStage ? { failedStage: input.failedStage } : {}),
+      },
+    },
+    DELIVERY_GATE_VERDICT_MSG,
+  );
+}
+
+// Map progress stage to a closed failed-stage label.
+export function failedStageFromProgress(stage: string | undefined): DeliveryFailedStage | undefined {
+  if (!stage) return undefined;
+  if (stage === 'typecheck' || stage === 'smoke' || stage === 'build') return stage;
+  if (stage === 'trace' || stage === 'capture' || stage === 'validate') return stage;
+  return 'other';
+}

--- a/apps/api/src/delivery-metrics.ts
+++ b/apps/api/src/delivery-metrics.ts
@@ -17,12 +17,18 @@ interface Logger {
 }
 
 export function builderLabelFromRecord(builder: string | undefined, backend?: string): DeliveryBuilderLabel {
+  // Managed keeps builder=platform; prefer managed:* backend.
   if (builder === 'self') return 'self';
+  if (backend?.startsWith('managed:')) return 'managed';
   if (builder === 'platform') return 'platform';
-  if (backend?.startsWith('managed:')) return 'managed';
   if (builder) return 'other';
-  if (backend?.startsWith('managed:')) return 'managed';
   return 'other';
+}
+
+// Bind info so Pino keeps its receiver.
+export function asDeliveryLogger(log: { info?: (context: object, message: string) => void }): Logger | null {
+  if (typeof log.info !== 'function') return null;
+  return { info: log.info.bind(log) };
 }
 
 export function logDeliveryPreflightRefused(

--- a/apps/api/src/games-store.ts
+++ b/apps/api/src/games-store.ts
@@ -129,10 +129,16 @@ export function isPublishableMode(mode: DeliveryMode | undefined): boolean {
   return mode !== 'preview' && mode !== 'proposal';
 }
 
+// Preflight kinds counted by delivery metrics.
+export type PreflightRefusalKind = 'audio' | 'symbols' | 'typecheck';
+
 export class InvalidUploadError extends Error {
-  constructor(message: string) {
+  readonly kind?: PreflightRefusalKind;
+
+  constructor(message: string, kind?: PreflightRefusalKind) {
     super(message);
     this.name = 'InvalidUploadError';
+    this.kind = kind;
   }
 }
 
@@ -292,6 +298,7 @@ export function validateSourceUpload(files: SourceFile[], mode: DeliveryMode = '
             'reuse them as they are; the exemplar GAME.json selects ui-toggle, win and lose. ' +
             'Dropping the audio module only defers the failure: the publish gate requires it, ' +
             'with at least three sounds including ui-toggle and a music track.',
+          'audio',
         );
       }
     } catch (error) {
@@ -332,7 +339,7 @@ export function validateSourceUpload(files: SourceFile[], mode: DeliveryMode = '
   const normalized = files.map((file) => ({ path: file.path.trim(), content: file.content }));
   const linkFindings = findUnresolvedSourceLinks(sourceFilesToMap(normalized));
   if (linkFindings.length > 0) {
-    throw new InvalidUploadError(formatSourceLinkError(linkFindings));
+    throw new InvalidUploadError(formatSourceLinkError(linkFindings), 'symbols');
   }
 
   // AGENT.json is allowed above but deliberately not required here yet — see the

--- a/apps/api/src/source-delivery.test.ts
+++ b/apps/api/src/source-delivery.test.ts
@@ -4,6 +4,7 @@ import { InvalidUploadError } from './games-store.js';
 import type { KitFileStore, KitTree } from './kit-files.js';
 import { KIT_ROOT_DIR } from './kit-registry.js';
 import { InMemoryStore } from './store.js';
+import { DELIVERY_ACCEPTED_MSG, DELIVERY_PREFLIGHT_REFUSED_MSG } from './delivery-metrics.js';
 import {
   createSourceDeliveryService,
   SourceDeliveryAuthorityError,
@@ -83,19 +84,21 @@ async function setup(opts?: { kitFileStore?: KitFileStore | null }) {
   });
   const gamesStore = { putCandidateSources } as unknown as GamesStore;
   const gate = vi.fn(async () => ({ buildId: 'build-managed-1' }));
+  const log = { info: vi.fn(), error: vi.fn(), warn: vi.fn() };
   const service = createSourceDeliveryService({
     store,
     gamesStore,
     kitFileStore: opts?.kitFileStore,
     onSourcesDelivered: gate,
     onEvent: vi.fn(),
+    log,
   });
   const authority: SourceDeliveryAuthority = {
     backend: BACKEND,
     sessionRef: SESSION,
     roundGeneration: 1,
   };
-  return { store, putCandidateSources, gate, service, authority };
+  return { store, putCandidateSources, gate, service, authority, log };
 }
 
 describe('shared source delivery', () => {
@@ -234,7 +237,7 @@ export function tick(round: Round) {
 
     it('refuses a typed Round-field failure before storing', async () => {
       const kitFileStore = fakeKitStore({ [PINNED]: treeFor(PINNED, KIT_DTS) });
-      const { store, putCandidateSources, service, authority } = await setup({ kitFileStore });
+      const { store, putCandidateSources, service, authority, log } = await setup({ kitFileStore });
       await store.pinRoundKitEngineRef(ISSUE, PINNED);
 
       await expect(
@@ -249,6 +252,34 @@ export function tick(round: Round) {
       ).rejects.toBeInstanceOf(InvalidUploadError);
       expect(putCandidateSources).not.toHaveBeenCalled();
       expect((await store.getSubmission(ISSUE))?.roundTypecheckPreflightRefusals).toBe(1);
+      expect(log.info).toHaveBeenCalledWith(
+        expect.objectContaining({
+          delivery: expect.objectContaining({ kind: 'typecheck', attempt: 1 }),
+        }),
+        DELIVERY_PREFLIGHT_REFUSED_MSG,
+      );
+    });
+
+    it('logs an accepted delivery with submitAttempts and refusals', async () => {
+      const { store, service, authority, log } = await setup();
+      await service.deliver({
+        issueNumber: ISSUE,
+        slug: SLUG,
+        files: PREVIEW_FILES,
+        mode: 'preview',
+        backend: BACKEND,
+        authority,
+      });
+      expect(log.info).toHaveBeenCalledWith(
+        expect.objectContaining({
+          delivery: expect.objectContaining({
+            submitAttempts: 1,
+            refusals: { audio: 0, symbols: 0, typecheck: 0 },
+          }),
+        }),
+        DELIVERY_ACCEPTED_MSG,
+      );
+      expect((await store.getSubmission(ISSUE))?.roundSubmitAttempts).toBe(1);
     });
 
     it('loads the pinned kit even after the registry pointer moves', async () => {

--- a/apps/api/src/source-delivery.ts
+++ b/apps/api/src/source-delivery.ts
@@ -1,4 +1,5 @@
 import { selfBuildDeliveryCap } from './builder.js';
+import { builderLabelFromRecord, logDeliveryAccepted, logDeliveryPreflightRefused } from './delivery-metrics.js';
 import { InvalidUploadError, type GamesStore, type SourceFile } from './games-store.js';
 import { parseSpecTitle } from './github-client.js';
 import { canTransition, resolveJobState, TERMINAL_JOB_STATES, type JobState } from './job-state.js';
@@ -96,6 +97,7 @@ export interface SourceDeliveryServiceOptions {
   }) => Promise<{ buildId?: string; accepted?: boolean } | void> | void;
   onEvent?: (issueNumber: number) => void;
   log?: {
+    info?: (context: object, message: string) => void;
     error: (context: object, message: string) => void;
     warn?: (context: object, message: string) => void;
   };
@@ -235,8 +237,32 @@ export function createSourceDeliveryService(options: SourceDeliveryServiceOption
         );
       }
 
+      const attempt = await options.store.incrementRoundSubmitAttempts(input.issueNumber);
+      const builderLabel = builderLabelFromRecord(record.builder, record.dispatch?.backend ?? input.backend);
+      const roundGeneration = record.roundGeneration ?? 1;
+
+      const emitRefusal = async (kind: 'audio' | 'symbols' | 'typecheck') => {
+        if (kind === 'audio' || kind === 'symbols') {
+          await options.store.incrementRoundPreflightRefusal(input.issueNumber, kind);
+        }
+        if (options.log?.info) {
+          logDeliveryPreflightRefused(
+            { info: options.log.info },
+            {
+              issueNumber: input.issueNumber,
+              roundGeneration,
+              builder: builderLabel,
+              mode: input.mode,
+              kind,
+              attempt,
+            },
+          );
+        }
+      };
+
       // Typecheck preflight uses the pinned kit; skip if unavailable.
       const engineRefForCheck = pinnedEngineRef ?? input.kitEngineRef;
+      let typecheckBypass = Boolean(record.roundTypecheckPreflightBypassErrors);
       if (options.kitFileStore && engineRefForCheck) {
         try {
           const tree = await options.kitFileStore.loadTree(engineRefForCheck);
@@ -254,9 +280,12 @@ export function createSourceDeliveryService(options: SourceDeliveryServiceOption
             const prior = record.roundTypecheckPreflightRefusals ?? 0;
             if (prior < TYPECHECK_PREFLIGHT_MAX_REFUSALS) {
               await options.store.incrementRoundTypecheckPreflightRefusals(input.issueNumber);
-              throw new InvalidUploadError(check.message);
+              await emitRefusal('typecheck');
+              throw new InvalidUploadError(check.message, 'typecheck');
             }
-            // Third submit accepts; attach diagnostics on the round.
+            // Soft bypass: still count as a refusal for MR-07, then accept.
+            await emitRefusal('typecheck');
+            typecheckBypass = true;
             await options.store.setRoundTypecheckPreflightBypassErrors(input.issueNumber, check.message);
             options.log?.warn?.(
               {
@@ -269,6 +298,7 @@ export function createSourceDeliveryService(options: SourceDeliveryServiceOption
             );
           } else {
             if (record.roundTypecheckPreflightBypassErrors) {
+              typecheckBypass = false;
               await options.store.setRoundTypecheckPreflightBypassErrors(input.issueNumber, null);
             }
             if (check.skipped === 'timeout') {
@@ -308,14 +338,22 @@ export function createSourceDeliveryService(options: SourceDeliveryServiceOption
       }
 
       const stateAfterSignal = await markBuilding(input.issueNumber, record);
-      const { version } = await options.gamesStore.putCandidateSources({
-        slug: input.slug,
-        issueNumber: input.issueNumber,
-        files: input.files,
-        backend: input.backend ?? record.dispatch?.backend ?? record.builder,
-        mode: input.mode,
-        ...(input.kitEngineRef ? { kitEngineRef: input.kitEngineRef } : {}),
-      });
+      let version: string;
+      try {
+        ({ version } = await options.gamesStore.putCandidateSources({
+          slug: input.slug,
+          issueNumber: input.issueNumber,
+          files: input.files,
+          backend: input.backend ?? record.dispatch?.backend ?? record.builder,
+          mode: input.mode,
+          ...(input.kitEngineRef ? { kitEngineRef: input.kitEngineRef } : {}),
+        }));
+      } catch (error) {
+        if (error instanceof InvalidUploadError && (error.kind === 'audio' || error.kind === 'symbols')) {
+          await emitRefusal(error.kind);
+        }
+        throw error;
+      }
 
       if (input.mode === 'preview') {
         await options.store.setSubmissionPreviewVersion(input.issueNumber, version);
@@ -324,6 +362,28 @@ export function createSourceDeliveryService(options: SourceDeliveryServiceOption
       }
       if (record.builder === 'self') {
         await options.store.incrementRoundDeliveryCount(input.issueNumber);
+      }
+
+      if (options.log?.info) {
+        const latest = (await options.store.getSubmission(input.issueNumber)) ?? record;
+        const startedMs = latest.roundStartedAt ? Date.parse(latest.roundStartedAt) : NaN;
+        logDeliveryAccepted(
+          { info: options.log.info },
+          {
+            issueNumber: input.issueNumber,
+            roundGeneration,
+            builder: builderLabel,
+            mode: input.mode,
+            submitAttempts: latest.roundSubmitAttempts ?? attempt,
+            refusals: {
+              audio: latest.roundPreflightRefusalsAudio ?? 0,
+              symbols: latest.roundPreflightRefusalsSymbols ?? 0,
+              typecheck: latest.roundTypecheckPreflightRefusals ?? 0,
+            },
+            msFromRoundStart: Number.isFinite(startedMs) ? Math.max(0, now() - startedMs) : null,
+            typecheckBypass,
+          },
+        );
       }
 
       const spec = input.files.find((file) => file.path === 'SPEC.md')?.content;

--- a/apps/api/src/source-delivery.ts
+++ b/apps/api/src/source-delivery.ts
@@ -1,5 +1,10 @@
 import { selfBuildDeliveryCap } from './builder.js';
-import { builderLabelFromRecord, logDeliveryAccepted, logDeliveryPreflightRefused } from './delivery-metrics.js';
+import {
+  asDeliveryLogger,
+  builderLabelFromRecord,
+  logDeliveryAccepted,
+  logDeliveryPreflightRefused,
+} from './delivery-metrics.js';
 import { InvalidUploadError, type GamesStore, type SourceFile } from './games-store.js';
 import { parseSpecTitle } from './github-client.js';
 import { canTransition, resolveJobState, TERMINAL_JOB_STATES, type JobState } from './job-state.js';
@@ -240,23 +245,21 @@ export function createSourceDeliveryService(options: SourceDeliveryServiceOption
       const attempt = await options.store.incrementRoundSubmitAttempts(input.issueNumber);
       const builderLabel = builderLabelFromRecord(record.builder, record.dispatch?.backend ?? input.backend);
       const roundGeneration = record.roundGeneration ?? 1;
+      const deliveryLog = options.log ? asDeliveryLogger(options.log) : null;
 
       const emitRefusal = async (kind: 'audio' | 'symbols' | 'typecheck') => {
         if (kind === 'audio' || kind === 'symbols') {
           await options.store.incrementRoundPreflightRefusal(input.issueNumber, kind);
         }
-        if (options.log?.info) {
-          logDeliveryPreflightRefused(
-            { info: options.log.info },
-            {
-              issueNumber: input.issueNumber,
-              roundGeneration,
-              builder: builderLabel,
-              mode: input.mode,
-              kind,
-              attempt,
-            },
-          );
+        if (deliveryLog) {
+          logDeliveryPreflightRefused(deliveryLog, {
+            issueNumber: input.issueNumber,
+            roundGeneration,
+            builder: builderLabel,
+            mode: input.mode,
+            kind,
+            attempt,
+          });
         }
       };
 
@@ -364,26 +367,23 @@ export function createSourceDeliveryService(options: SourceDeliveryServiceOption
         await options.store.incrementRoundDeliveryCount(input.issueNumber);
       }
 
-      if (options.log?.info) {
+      if (deliveryLog) {
         const latest = (await options.store.getSubmission(input.issueNumber)) ?? record;
         const startedMs = latest.roundStartedAt ? Date.parse(latest.roundStartedAt) : NaN;
-        logDeliveryAccepted(
-          { info: options.log.info },
-          {
-            issueNumber: input.issueNumber,
-            roundGeneration,
-            builder: builderLabel,
-            mode: input.mode,
-            submitAttempts: latest.roundSubmitAttempts ?? attempt,
-            refusals: {
-              audio: latest.roundPreflightRefusalsAudio ?? 0,
-              symbols: latest.roundPreflightRefusalsSymbols ?? 0,
-              typecheck: latest.roundTypecheckPreflightRefusals ?? 0,
-            },
-            msFromRoundStart: Number.isFinite(startedMs) ? Math.max(0, now() - startedMs) : null,
-            typecheckBypass,
+        logDeliveryAccepted(deliveryLog, {
+          issueNumber: input.issueNumber,
+          roundGeneration,
+          builder: builderLabel,
+          mode: input.mode,
+          submitAttempts: latest.roundSubmitAttempts ?? attempt,
+          refusals: {
+            audio: latest.roundPreflightRefusalsAudio ?? 0,
+            symbols: latest.roundPreflightRefusalsSymbols ?? 0,
+            typecheck: latest.roundTypecheckPreflightRefusals ?? 0,
           },
-        );
+          msFromRoundStart: Number.isFinite(startedMs) ? Math.max(0, now() - startedMs) : null,
+          typecheckBypass,
+        });
       }
 
       const spec = input.files.find((file) => file.path === 'SPEC.md')?.content;

--- a/apps/api/src/store.ts
+++ b/apps/api/src/store.ts
@@ -373,6 +373,15 @@ export interface SubmissionRecord {
   roundTypecheckPreflightRefusals?: number;
   // Grouped diagnostics when accepting past that cap.
   roundTypecheckPreflightBypassErrors?: string;
+  // When this round opened (ISO); used for ms-to-first-accept.
+  roundStartedAt?: string;
+  // Submit attempts this round (refusals + accepts).
+  roundSubmitAttempts?: number;
+  // Audio / symbol preflight refusals this round.
+  roundPreflightRefusalsAudio?: number;
+  roundPreflightRefusalsSymbols?: number;
+  // Last `${version}:${status}` already logged for gate metrics.
+  roundLastGateMetricKey?: string;
   /**
    * Creator concept text (sanitized), without the QA clarifications block.
    *
@@ -1808,6 +1817,12 @@ export interface Store {
   incrementRoundTypecheckPreflightRefusals(issueNumber: number): Promise<number>;
   // Store or clear bypass diagnostics after the refusal cap.
   setRoundTypecheckPreflightBypassErrors(issueNumber: number, message: string | null): Promise<void>;
+  // Bump submit attempts (every deliver call that reaches preflight).
+  incrementRoundSubmitAttempts(issueNumber: number): Promise<number>;
+  // Bump audio or symbols preflight refusal count.
+  incrementRoundPreflightRefusal(issueNumber: number, kind: 'audio' | 'symbols'): Promise<number>;
+  // Record that a gate metric was logged for this version/status key.
+  setRoundLastGateMetricKey(issueNumber: number, key: string): Promise<void>;
   /** Appends a dispatch ref, recording which backend is building this job and where. */
   recordDispatch(
     issueNumber: number,
@@ -2950,14 +2965,16 @@ export class InMemoryStore implements Store {
   }
 
   async createSubmission(issueNumber: number, ownerUid: string, title: string): Promise<SubmissionRecord> {
+    const createdAt = new Date().toISOString();
     const record: SubmissionRecord = {
       issueNumber,
       ownerUid,
-      createdAt: new Date().toISOString(),
+      createdAt,
       title,
       // New jobs are generation-scoped from the first mint; legacy records created
       // before this field existed stay unset until their current round closes.
       roundGeneration: 1,
+      roundStartedAt: createdAt,
     };
     this.submissions.set(issueNumber, record);
     return { ...record };
@@ -3002,6 +3019,10 @@ export class InMemoryStore implements Store {
             roundGeneration: nextRoundGeneration(sub.roundGeneration),
             roundDeliveryCount: 0,
             roundTypecheckPreflightRefusals: 0,
+            roundSubmitAttempts: 0,
+            roundPreflightRefusalsAudio: 0,
+            roundPreflightRefusalsSymbols: 0,
+            roundStartedAt: transition.at,
           }
         : {}),
     };
@@ -3015,6 +3036,7 @@ export class InMemoryStore implements Store {
       delete next.agentEndedAt;
       delete next.roundKitEngineRef;
       delete next.roundTypecheckPreflightBypassErrors;
+      delete next.roundLastGateMetricKey;
     }
     this.submissions.set(issueNumber, next);
     return true;
@@ -3029,6 +3051,10 @@ export class InMemoryStore implements Store {
       roundGeneration,
       roundDeliveryCount: 0,
       roundTypecheckPreflightRefusals: 0,
+      roundSubmitAttempts: 0,
+      roundPreflightRefusalsAudio: 0,
+      roundPreflightRefusalsSymbols: 0,
+      roundStartedAt: new Date().toISOString(),
     };
     delete next.seed;
     delete next.seedStatus;
@@ -3037,6 +3063,7 @@ export class InMemoryStore implements Store {
     delete next.agentEndedAt;
     delete next.roundKitEngineRef;
     delete next.roundTypecheckPreflightBypassErrors;
+    delete next.roundLastGateMetricKey;
     this.submissions.set(issueNumber, next);
     return roundGeneration;
   }
@@ -3110,7 +3137,12 @@ export class InMemoryStore implements Store {
       delete next.seedStatus;
       next.roundDeliveryCount = 0;
       next.roundTypecheckPreflightRefusals = 0;
+      next.roundSubmitAttempts = 0;
+      next.roundPreflightRefusalsAudio = 0;
+      next.roundPreflightRefusalsSymbols = 0;
+      next.roundStartedAt = new Date().toISOString();
       delete next.roundTypecheckPreflightBypassErrors;
+      delete next.roundLastGateMetricKey;
     }
     this.submissions.set(issueNumber, next);
   }
@@ -3164,6 +3196,33 @@ export class InMemoryStore implements Store {
       return;
     }
     this.submissions.set(issueNumber, { ...sub, roundTypecheckPreflightBypassErrors: message });
+  }
+
+  async incrementRoundSubmitAttempts(issueNumber: number): Promise<number> {
+    const sub = this.submissions.get(issueNumber);
+    if (!sub) return 0;
+    const roundSubmitAttempts = (sub.roundSubmitAttempts ?? 0) + 1;
+    this.submissions.set(issueNumber, { ...sub, roundSubmitAttempts });
+    return roundSubmitAttempts;
+  }
+
+  async incrementRoundPreflightRefusal(issueNumber: number, kind: 'audio' | 'symbols'): Promise<number> {
+    const sub = this.submissions.get(issueNumber);
+    if (!sub) return 0;
+    if (kind === 'audio') {
+      const roundPreflightRefusalsAudio = (sub.roundPreflightRefusalsAudio ?? 0) + 1;
+      this.submissions.set(issueNumber, { ...sub, roundPreflightRefusalsAudio });
+      return roundPreflightRefusalsAudio;
+    }
+    const roundPreflightRefusalsSymbols = (sub.roundPreflightRefusalsSymbols ?? 0) + 1;
+    this.submissions.set(issueNumber, { ...sub, roundPreflightRefusalsSymbols });
+    return roundPreflightRefusalsSymbols;
+  }
+
+  async setRoundLastGateMetricKey(issueNumber: number, key: string): Promise<void> {
+    const sub = this.submissions.get(issueNumber);
+    if (!sub) return;
+    this.submissions.set(issueNumber, { ...sub, roundLastGateMetricKey: key });
   }
 
   async allocateJobId(): Promise<number> {
@@ -5195,14 +5254,16 @@ export class FirestoreStore implements Store {
   }
 
   async createSubmission(issueNumber: number, ownerUid: string, title: string): Promise<SubmissionRecord> {
+    const createdAt = new Date().toISOString();
     const record: SubmissionRecord = {
       issueNumber,
       ownerUid,
-      createdAt: new Date().toISOString(),
+      createdAt,
       title,
       // New jobs are generation-scoped from the first mint; legacy records created
       // before this field existed stay unset until their current round closes.
       roundGeneration: 1,
+      roundStartedAt: createdAt,
     };
     await this.db.collection('submissions').doc(String(issueNumber)).set(record);
     return record;
@@ -5254,6 +5315,10 @@ export class FirestoreStore implements Store {
           roundGeneration: nextRoundGeneration(current.roundGeneration),
           roundDeliveryCount: 0,
           roundTypecheckPreflightRefusals: 0,
+          roundSubmitAttempts: 0,
+          roundPreflightRefusalsAudio: 0,
+          roundPreflightRefusalsSymbols: 0,
+          roundStartedAt: transition.at,
         };
         delete next.seed;
         delete next.seedStatus;
@@ -5262,6 +5327,7 @@ export class FirestoreStore implements Store {
         delete next.agentEndedAt;
         delete next.roundKitEngineRef;
         delete next.roundTypecheckPreflightBypassErrors;
+        delete next.roundLastGateMetricKey;
         tx.set(ref, next);
       } else {
         tx.set(
@@ -5290,6 +5356,10 @@ export class FirestoreStore implements Store {
         roundGeneration,
         roundDeliveryCount: 0,
         roundTypecheckPreflightRefusals: 0,
+        roundSubmitAttempts: 0,
+        roundPreflightRefusalsAudio: 0,
+        roundPreflightRefusalsSymbols: 0,
+        roundStartedAt: new Date().toISOString(),
       };
       delete next.seed;
       delete next.seedStatus;
@@ -5298,6 +5368,7 @@ export class FirestoreStore implements Store {
       delete next.agentEndedAt;
       delete next.roundKitEngineRef;
       delete next.roundTypecheckPreflightBypassErrors;
+      delete next.roundLastGateMetricKey;
       tx.set(ref, next);
       return roundGeneration;
     });
@@ -5398,10 +5469,15 @@ export class FirestoreStore implements Store {
         defaultBuilder: builder,
         roundDeliveryCount: 0,
         roundTypecheckPreflightRefusals: 0,
+        roundSubmitAttempts: 0,
+        roundPreflightRefusalsAudio: 0,
+        roundPreflightRefusalsSymbols: 0,
+        roundStartedAt: new Date().toISOString(),
       };
       delete next.seed;
       delete next.seedStatus;
       delete next.roundTypecheckPreflightBypassErrors;
+      delete next.roundLastGateMetricKey;
       tx.set(ref, next);
     });
   }
@@ -5467,6 +5543,42 @@ export class FirestoreStore implements Store {
       return;
     }
     await ref.set({ roundTypecheckPreflightBypassErrors: message }, { merge: true });
+  }
+
+  async incrementRoundSubmitAttempts(issueNumber: number): Promise<number> {
+    const ref = this.db.collection('submissions').doc(String(issueNumber));
+    return this.db.runTransaction(async (tx) => {
+      const snap = await tx.get(ref);
+      if (!snap.exists) return 0;
+      const current = snap.data() as SubmissionRecord;
+      const roundSubmitAttempts = (current.roundSubmitAttempts ?? 0) + 1;
+      tx.set(ref, { roundSubmitAttempts }, { merge: true });
+      return roundSubmitAttempts;
+    });
+  }
+
+  async incrementRoundPreflightRefusal(issueNumber: number, kind: 'audio' | 'symbols'): Promise<number> {
+    const ref = this.db.collection('submissions').doc(String(issueNumber));
+    return this.db.runTransaction(async (tx) => {
+      const snap = await tx.get(ref);
+      if (!snap.exists) return 0;
+      const current = snap.data() as SubmissionRecord;
+      if (kind === 'audio') {
+        const roundPreflightRefusalsAudio = (current.roundPreflightRefusalsAudio ?? 0) + 1;
+        tx.set(ref, { roundPreflightRefusalsAudio }, { merge: true });
+        return roundPreflightRefusalsAudio;
+      }
+      const roundPreflightRefusalsSymbols = (current.roundPreflightRefusalsSymbols ?? 0) + 1;
+      tx.set(ref, { roundPreflightRefusalsSymbols }, { merge: true });
+      return roundPreflightRefusalsSymbols;
+    });
+  }
+
+  async setRoundLastGateMetricKey(issueNumber: number, key: string): Promise<void> {
+    await this.db
+      .collection('submissions')
+      .doc(String(issueNumber))
+      .set({ roundLastGateMetricKey: key }, { merge: true });
   }
 
   async allocateJobId(): Promise<number> {

--- a/apps/api/src/submissions.test.ts
+++ b/apps/api/src/submissions.test.ts
@@ -11,6 +11,7 @@ import { mintToken, verifyToken } from './submission-token.js';
 import { canTransition } from './job-state.js';
 import type { AgentBackend, BuildBrief } from './agent-backend.js';
 import type { GamesStore } from './games-store.js';
+import { DELIVERY_GATE_VERDICT_MSG } from './delivery-metrics.js';
 import { JOB_ID_FLOOR } from './store.js';
 import { createManagedAvailabilityGate, type ManagedAvailabilityGate } from './managed-availability.js';
 
@@ -1615,6 +1616,85 @@ describe('submission routes', () => {
     // `phase` is the raw job state; `status` is the public projection.
     expect(status.json().phase).toBe('submitted');
     expect(status.json().status).toBe('building');
+
+    await app.close();
+  });
+
+  it('emits a stable delivery gate verdict once per version/status', async () => {
+    // Green preview stays submitted so dedupe can re-poll.
+    const { githubClient } = createGithubClientStub({ issueNumber: 727 });
+    const { backend } = createBackendStub();
+    const gamesStore = {
+      getManifest: async () => ({
+        slug: 'space-parcels',
+        version: 'v3',
+        createdAt: '2026-08-09T22:00:00.000Z',
+        issueNumber: 727,
+        sourceFiles: [],
+        previewGate: { green: true, ranAt: '2026-08-09T22:30:00.000Z' },
+      }),
+    } as unknown as GamesStore;
+    const clock = { t: Date.UTC(2026, 7, 9, 22, 0, 0) };
+
+    const { app, authHeaders, store } = await createApp({
+      githubClient,
+      agentBackend: backend,
+      submissionTokenSecret: secret,
+      agentChannel: { gamesStore },
+      now: () => clock.t,
+    });
+    const infoSpy = vi.spyOn(app.log, 'info');
+
+    await app.inject({
+      method: 'POST',
+      url: '/api/submissions',
+      headers: authHeaders,
+      payload: { title: 'A game', concept: 'A sufficiently long concept about delivering parcels in space.' },
+    });
+    const [job] = await store.listSubmissionsByOwner('g:test-user');
+    await store.setSubmissionSlug(job.issueNumber, 'space-parcels');
+    await store.setSubmissionPreviewVersion(job.issueNumber, 'v3');
+    await store.recordDispatch(job.issueNumber, { backend: 'managed:anthropic', ref: 'sess-1' });
+    await store.recordJobTransition(job.issueNumber, {
+      to: 'submitted',
+      at: '2026-08-09T22:00:00.000Z',
+      by: 'agent',
+      reason: 'sources_delivered',
+    });
+
+    const token = mintToken(job.issueNumber, secret);
+    const first = await app.inject({
+      method: 'GET',
+      url: `/api/submissions/${token}`,
+      headers: authHeaders,
+    });
+    expect(first.statusCode).toBe(200);
+    expect(first.json().phase).toBe('submitted');
+
+    const gateCalls = infoSpy.mock.calls.filter((call) => call[1] === DELIVERY_GATE_VERDICT_MSG);
+    expect(gateCalls).toHaveLength(1);
+    expect(gateCalls[0]![0]).toEqual({
+      delivery: {
+        issueNumber: job.issueNumber,
+        roundGeneration: 1,
+        builder: 'managed',
+        mode: 'preview',
+        outcome: 'passed',
+        status: 'preview_passed',
+      },
+    });
+    expect(JSON.stringify(gateCalls[0]![0])).not.toMatch(/slug|prompt|uid|game\.ts|SPEC/);
+
+    // Past the 60s status cache so reconcile runs again.
+    clock.t += 61_000;
+    const second = await app.inject({
+      method: 'GET',
+      url: `/api/submissions/${token}`,
+      headers: authHeaders,
+    });
+    expect(second.statusCode).toBe(200);
+    expect(infoSpy.mock.calls.filter((call) => call[1] === DELIVERY_GATE_VERDICT_MSG)).toHaveLength(1);
+    expect((await store.getSubmission(job.issueNumber))?.roundLastGateMetricKey).toBe('v3:preview_passed');
 
     await app.close();
   });

--- a/apps/api/src/submissions.ts
+++ b/apps/api/src/submissions.ts
@@ -70,6 +70,12 @@ import {
 } from './job-state.js';
 import { isMcpPresenceEventText } from './mcp-presence.js';
 import { logSeedStagingFailure } from './seed-metrics.js';
+import {
+  builderLabelFromRecord,
+  failedStageFromProgress,
+  logDeliveryGateVerdict,
+  type DeliveryGateStatus,
+} from './delivery-metrics.js';
 import { mintConnectPayload } from './self-build-connect.js';
 import { createLocalGamesClient, resolveLocalGamesDir } from './local-games-repo.js';
 import { createMailerFromEnv, type Mailer } from './mailer.js';
@@ -2558,13 +2564,46 @@ export async function registerSubmissionRoutes(
    */
   async function reconcileGateVerdict(record: SubmissionRecord): Promise<JobTransition | null> {
     const gamesStore = options.agentChannel?.gamesStore;
-    if (!gamesStore || !store || !record.deliveredVersion || !record.slug) return null;
+    const version = record.deliveredVersion ?? record.previewVersion;
+    if (!gamesStore || !store || !version || !record.slug) return null;
     const state = record.state ?? 'queued';
-    if (state !== 'submitted' && state !== 'gating') return null;
+    if (state !== 'building' && state !== 'submitted' && state !== 'gating') return null;
     try {
-      const manifest = await gamesStore.getManifest(record.slug, record.deliveredVersion);
+      const manifest = await gamesStore.getManifest(record.slug, version);
+      const emitGateMetric = async (input: {
+        mode: 'preview' | 'publish';
+        outcome: 'passed' | 'failed';
+        status: DeliveryGateStatus;
+        failedStage?: ReturnType<typeof failedStageFromProgress>;
+      }) => {
+        const key = `${version}:${input.status}`;
+        if (record.roundLastGateMetricKey === key) return;
+        await store.setRoundLastGateMetricKey(record.issueNumber, key);
+        record.roundLastGateMetricKey = key;
+        logDeliveryGateVerdict(app.log, {
+          issueNumber: record.issueNumber,
+          roundGeneration: record.roundGeneration ?? 1,
+          builder: builderLabelFromRecord(record.builder, record.dispatch?.backend),
+          mode: input.mode,
+          outcome: input.outcome,
+          status: input.status,
+          ...(input.failedStage ? { failedStage: input.failedStage } : {}),
+        });
+      };
+
       const verdict = manifest?.gate;
-      if (verdict) {
+      if (verdict && record.deliveredVersion) {
+        const status: DeliveryGateStatus = verdict.green
+          ? 'green'
+          : verdict.status === 'kit_outdated'
+            ? 'kit_outdated'
+            : 'red';
+        await emitGateMetric({
+          mode: 'publish',
+          outcome: verdict.green ? 'passed' : 'failed',
+          status,
+          ...(verdict.green ? {} : { failedStage: failedStageFromProgress(manifest?.gateProgress?.stage) }),
+        });
         // Green means publishable, never published: the human review this waits for is the
         // moderation boundary, and a gate that promoted past it would quietly delete it.
         const to = verdict.green ? 'ready_for_review' : 'needs_changes';
@@ -2593,9 +2632,18 @@ export async function registerSubmissionRoutes(
         }
         return transition;
       }
-      // mode=preview never writes manifest.gate — red still needs a transition too.
+      // mode=preview never writes manifest.gate — still emit metrics for green/red.
       const preview = manifest?.previewGate;
-      if (!preview || preview.green) return null;
+      if (!preview) return null;
+      const previewStatus: DeliveryGateStatus =
+        preview.status === 'kit_outdated' ? 'kit_outdated' : preview.green ? 'preview_passed' : 'preview_failed';
+      await emitGateMetric({
+        mode: 'preview',
+        outcome: preview.green ? 'passed' : 'failed',
+        status: previewStatus,
+        ...(preview.green ? {} : { failedStage: failedStageFromProgress(manifest?.gateProgress?.stage) }),
+      });
+      if (preview.green) return null;
       const to = 'needs_changes' as const;
       if (!canTransition(state, to)) return null;
       const transition: JobTransition = {
@@ -2612,7 +2660,7 @@ export async function registerSubmissionRoutes(
           gamesStore,
           issueNumber: record.issueNumber,
           slug: record.slug,
-          version: record.deliveredVersion,
+          version,
           screenshotPath: preview.screenshot,
         }).catch((error) => {
           app.log.warn({ err: error, issueNumber: record.issueNumber }, 'could not post gate screenshot');


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Telemetry-only follow-up to MR-05 (symbol link check) and MR-06 (typecheck preflight). Stable Cloud Logging messages answer whether delivery preflights help — without source, prompt, or uid in the payloads, and without creator-facing UI.

### Log events (`apps/api/src/delivery-metrics.ts`)

| Message | When | Closed fields |
| --- | --- | --- |
| `delivery preflight refused` | audio / symbols / typecheck refuse (incl. soft typecheck bypass) | `kind`, `attempt`, `builder`, `mode`, `roundGeneration`, `issueNumber` |
| `delivery accepted` | sources stored after preflights | `submitAttempts`, `refusals.{audio,symbols,typecheck}`, `msFromRoundStart`, `typecheckBypass` |
| `delivery gate verdict` | preview/publish gate settles (deduped per version+status) | `outcome`, `status`, optional `failedStage` |

### How the three MR-07 questions become answerable

1. **Do preflights catch bad submits?** — count `delivery preflight refused` by `delivery.kind` (and optionally by `builder` / `mode`).
2. **How many submits until accept on a caught round?** — on `delivery accepted`, read `submitAttempts` and `refusals.*` (rounds that never refused show `submitAttempts: 1` and zero refusals).
3. **Do async gate failure rates fall?** — count `delivery gate verdict` by `outcome` / `status` / `failedStage` over time; join to prior refusals via `issueNumber` + `roundGeneration` when needed.

Round counters (`roundStartedAt`, `roundSubmitAttempts`, audio/symbol refusal counts, last gate metric key) reset when a round bumps or closes. Typecheck refusals continue to use the existing `roundTypecheckPreflightRefusals` field.

### Copilot review

- Prefer `managed:*` backend over `builder === 'platform'` so managed rounds are not labeled platform.
- Bind Pino `info` via `asDeliveryLogger` so the logger keeps its receiver.
- Cover gate-verdict payload shape, privacy, and per-`${version}:${status}` dedupe in `submissions.test.ts`.

## Test plan

- [x] Unit tests for stable log messages and privacy (no slug/prompt/uid)
- [x] Source-delivery tests assert refuse + accept log shapes
- [x] Gate-verdict emit + dedupe test
- [x] Green gate: `npm run type-check && npm run lint && npm run test && npm run build`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4cf2e9e5-dd15-4c3a-8323-8e026e20823b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4cf2e9e5-dd15-4c3a-8323-8e026e20823b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

