### PR TITLE
Float the Studio removal toast below the top navigation

### DIFF
--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -10775,19 +10775,21 @@ button.builder-mode-selector:disabled {
   color: var(--muted);
 }
 
-/* Match the app-update toast instead of pushing Studio down below the top bar. */
+/* Keep the removal result visible without pushing Studio down or competing with
+   the bottom install/update toast. The top offset clears the sticky app header
+   (including its safe-area inset) before the card begins. */
 .studio-abandon-notice {
   position: fixed;
-  left: 12px;
-  right: 12px;
-  bottom: max(12px, env(safe-area-inset-bottom));
+  top: calc(max(12px, env(safe-area-inset-top)) + 69px);
+  right: 24px;
+  left: auto;
   z-index: 900;
   display: flex;
   align-items: center;
   gap: 12px;
-  width: auto;
+  width: min(560px, calc(100vw - 48px));
   max-width: 560px;
-  margin: 0 auto;
+  margin: 0;
   padding: 12px 14px;
   border: 1px solid var(--panel-border);
   border-radius: 14px;
@@ -10798,13 +10800,18 @@ button.builder-mode-selector:disabled {
   animation: install-prompt-in 220ms ease-out;
 }
 
-.app:has(:is(.install-prompt, .app-update)) .studio-abandon-notice {
-  bottom: max(88px, calc(76px + env(safe-area-inset-bottom)));
-}
-
 @media (prefers-reduced-motion: reduce) {
   .studio-abandon-notice {
     animation: none;
+  }
+}
+
+@media (max-width: 768px) {
+  .studio-abandon-notice {
+    top: calc(max(8px, env(safe-area-inset-top)) + 65px);
+    right: 12px;
+    left: 12px;
+    width: auto;
   }
 }
 

--- a/apps/web/src/styles.studioAbandonNotice.test.ts
+++ b/apps/web/src/styles.studioAbandonNotice.test.ts
@@ -5,19 +5,26 @@ import { describe, expect, it } from 'vitest';
 const css = readFileSync(fileURLToPath(new URL('./styles.css', import.meta.url)), 'utf8');
 
 describe('Studio removal notice', () => {
-  it('floats like the app update toast without spanning the workspace', () => {
+  it('floats below the top navigation without spanning the workspace', () => {
     const start = css.indexOf('.studio-abandon-notice {');
     const end = css.indexOf('}', start);
     const rule = css.slice(start, end);
 
     expect(start).toBeGreaterThan(-1);
     expect(rule).toMatch(/position:\s*fixed/);
-    expect(rule).toMatch(/bottom:\s*max\(12px, env\(safe-area-inset-bottom\)\)/);
+    expect(rule).toMatch(/top:\s*calc\(max\(12px, env\(safe-area-inset-top\)\) \+ 69px\)/);
+    expect(rule).toMatch(/right:\s*24px/);
+    expect(rule).toMatch(/left:\s*auto/);
     expect(rule).toMatch(/max-width:\s*560px/);
     expect(rule).toMatch(/box-shadow:/);
   });
 
-  it('stacks above another bottom toast', () => {
-    expect(css).toMatch(/\.app:has\(:is\(\.install-prompt, \.app-update\)\) \.studio-abandon-notice\s*{[^}]*bottom:/s);
+  it('uses safe mobile spacing below the compact top navigation', () => {
+    expect(css).toMatch(
+      /@media \(max-width: 768px\)\s*{\s*\.studio-abandon-notice\s*{[^}]*top:\s*calc\(max\(8px, env\(safe-area-inset-top\)\) \+ 65px\)/s,
+    );
+    expect(css).toMatch(
+      /@media \(max-width: 768px\)\s*{\s*\.studio-abandon-notice\s*{[^}]*left:\s*12px;[^}]*width:\s*auto;/s,
+    );
   });
 });


### PR DESCRIPTION
## What changed

Move the Studio removal notice from the bottom-centered toast position to a top-right floating card below the sticky top navigation.

## Why

The bottom placement felt disconnected from the related Studio context and competed with the install/update notification area. The new placement keeps the notice visible without covering bottom chrome or pushing the Studio layout.

## Validation

- Targeted `styles.studioAbandonNotice.test.ts` — 2 tests passed
- `git diff --check` passed

Mobile layouts use full-width spacing with safe-area-aware offsets below the compact top navigation.