### PR TITLE
docs: remove stale index.html/style.css lines from games-repo.md

### DIFF
--- a/docs/games-repo.md
+++ b/docs/games-repo.md
@@ -15,13 +15,11 @@ games/
     SPEC.md          ← source of truth, including catalog frontmatter
     GAME.json        ← shared-engine module selection
     CAPTURE.json     ← deterministic play, assertion, and capture scenario
-    index.html
     game.ts          ← lean composition root
     game/
       model.ts
       runtime.ts
       render.ts      ← optional, for games with substantial rendering logic
-    style.css
     media/
       opening.png
       <named-moment>.png


### PR DESCRIPTION
## Summary

Follow-up to #728. `docs/games-repo.md`'s example file tree still listed `index.html` and `style.css` as committed files under `games/<slug>/`. Both are generated (`howToPlay` → `index.html`, `theme` → `style.css`) and never committed — this doc predates that and is already stale in a lot of other ways (it's marked "Status: Design agreed, not built" and doesn't mention half the files a game actually ships today), so this is a narrow fix for the two specific lines this session's work made newly inaccurate, not a full doc refresh.

Docs-only change, no code touched.

---
_Generated by [Claude Code](https://claude.ai/code/session_0169CPTPTdXZHpN7PeEcuwMF)_