### PR TITLE
Generate index.html/style.css in getGameDeliverySources when absent

### DIFF
--- a/apps/api/src/github-client.test.ts
+++ b/apps/api/src/github-client.test.ts
@@ -1266,6 +1266,34 @@ describe('getGameSourceMap', () => {
     expect(sources?.['TRACE.json']).toBeUndefined();
   });
 
+  it('generates index.html and style.css when the game ships neither, like every current game', async () => {
+    const files = new Map<string, string | Uint8Array>([
+      ['games/gilded-run/game.ts', 'GameKit.mount({ ok: true });\n'],
+      ['games/gilded-run/SPEC.md', '---\ntitle: Gilded Run\n---\n'],
+      [
+        'games/gilded-run/GAME.json',
+        JSON.stringify({
+          engine: { modules: [] },
+          howToPlay: { goal: { en: 'Win', pl: 'Wygraj' }, hint: { en: 'Go', pl: 'Idź' } },
+          theme: { accent: '#ffd56a' },
+        }),
+      ],
+    ]);
+    const fetchImpl = vi.fn(async (input: RequestInfo | URL) => {
+      const pathname = new URL(String(input)).pathname;
+      const marker = '/contents/';
+      const path = decodeURIComponent(pathname.slice(pathname.indexOf(marker) + marker.length));
+      const value = files.get(path);
+      return value === undefined ? new Response('not found', { status: 404 }) : new Response(value, { status: 200 });
+    }) as unknown as typeof fetch;
+    const client = createGitHubClient({ token: 'test-token', repo, fetchImpl });
+
+    const sources = await client.getGameDeliverySources('main', 'gilded-run');
+
+    expect(sources?.['index.html']).toContain('Win');
+    expect(sources?.['style.css']).toContain('color: #ffd56a');
+  });
+
   it('refuses a slug that could address anything but a game directory', async () => {
     const fetchImpl = vi.fn(async () => new Response('', { status: 200 })) as unknown as typeof fetch;
     const client = createGitHubClient({ token: 'test-token', repo, fetchImpl });

--- a/apps/api/src/github-client.ts
+++ b/apps/api/src/github-client.ts
@@ -1308,6 +1308,19 @@ export function createGitHubClient(options: GitHubClientOptions): GitHubClient {
       for (const entry of fixedEntries) {
         if (entry) sources[entry[0]] = entry[1];
       }
+      // Every game relies on this — neither file is ever committed anymore.
+      const manifestSource = sources['GAME.json'];
+      if (manifestSource) {
+        if (!sources['index.html']?.trim()) {
+          const title = sources['SPEC.md'] ? parseSpecTitle(sources['SPEC.md']) : null;
+          const generated = generateIndexHtmlFromManifest(manifestSource, title ?? slug);
+          if (generated !== null) sources['index.html'] = generated;
+        }
+        if (!sources['style.css']?.trim()) {
+          const generated = generateStyleCssFromManifest(manifestSource);
+          if (generated !== null) sources['style.css'] = generated;
+        }
+      }
       return sources;
     },
 

--- a/docs/games-repo.md
+++ b/docs/games-repo.md
@@ -15,13 +15,11 @@ games/
     SPEC.md          ← source of truth, including catalog frontmatter
     GAME.json        ← shared-engine module selection
     CAPTURE.json     ← deterministic play, assertion, and capture scenario
-    index.html
     game.ts          ← lean composition root
     game/
       model.ts
       runtime.ts
       render.ts      ← optional, for games with substantial rendering logic
-    style.css
     media/
       opening.png
       <named-moment>.png


### PR DESCRIPTION
## Summary

**Fixes a live bug.** `getGameDeliverySources` (used by `remix.ts`'s "save remix as a Studio draft" flow, `remix-save.ts`) reads `DELIVERY_FIXED_FILES` straight from GitHub with no generation fallback, unlike `getGameSources` (#701, #728). `index.html` and `style.css` are never committed anymore — every game in the catalog is in exactly this shape today — so the raw read always came back empty for both. `remix-save.ts`'s `incomplete_sources` check requires an `index.html` entry, so saving a remix as a draft has been failing for every repo-era game.

Reuses the same `generateIndexHtmlFromManifest` / `generateStyleCssFromManifest` fallbacks `getGameSources` already has, keyed off the `GAME.json` and `SPEC.md` this function already reads as fixed files.

Found this while auditing for leftover `index.html`/`style.css` assumptions after the `style.css` → theme migration (#728) — it predates that PR (the `index.html` half of the gap has existed since #701), but every game hitting the missing-file case simultaneously is what makes it unmissable now.

## Test plan

- [x] `npx tsc -p apps/api/tsconfig.json --noEmit` — clean
- [x] New regression test in `github-client.test.ts`: confirmed it fails against the pre-fix code (`git stash`) and passes after
- [x] `npx vitest run` (full `apps/api` suite) — 188 files, 2936 tests, all pass
- [x] `npm run lint` — clean

---
_Generated by [Claude Code](https://claude.ai/code/session_0169CPTPTdXZHpN7PeEcuwMF)_