### PR TITLE
Auto-allow MCP tools on managed Anthropic sessions

### DIFF
--- a/apps/api/src/managed-provider-anthropic.test.ts
+++ b/apps/api/src/managed-provider-anthropic.test.ts
@@ -167,7 +167,11 @@ describe('anthropic managed provider', () => {
     expect(body.agent.mcp_servers).toEqual([{ type: 'url', name: 'gamedevpl', url: 'https://example.test/mcp' }]);
     expect(body.agent.tools).toEqual([
       { type: 'agent_toolset_20260401' },
-      { type: 'mcp_toolset', mcp_server_name: 'gamedevpl' },
+      {
+        type: 'mcp_toolset',
+        mcp_server_name: 'gamedevpl',
+        default_config: { permission_policy: { type: 'always_allow' } },
+      },
     ]);
   });
 

--- a/apps/api/src/managed-provider-anthropic.ts
+++ b/apps/api/src/managed-provider-anthropic.ts
@@ -145,7 +145,8 @@ export function createAnthropicManagedProvider(config: ManagedProviderConfig): M
           }),
         }),
       );
-      if (!credential.success) throw new ManagedAgentError('anthropic vault credential creation returned no credential');
+      if (!credential.success)
+        throw new ManagedAgentError('anthropic vault credential creation returned no credential');
     } catch (error) {
       await call(`/v1/vaults/${encodeURIComponent(vault.data.id)}/archive`, { method: 'POST' }).catch(() => undefined);
       throw error;
@@ -197,9 +198,16 @@ export function createAnthropicManagedProvider(config: ManagedProviderConfig): M
           ...(mcpServers?.length
             ? {
                 mcp_servers: mcpServers,
+                // MCP defaults to always_ask; managed rounds need always_allow.
                 tools: [
                   { type: 'agent_toolset_20260401' },
-                  ...mcpServers.map((server) => ({ type: 'mcp_toolset', mcp_server_name: server.name })),
+                  ...mcpServers.map((server) => ({
+                    type: 'mcp_toolset',
+                    mcp_server_name: server.name,
+                    default_config: {
+                      permission_policy: { type: 'always_allow' },
+                    },
+                  })),
                 ],
               }
             : {}),

--- a/apps/api/src/visit-telemetry.test.ts
+++ b/apps/api/src/visit-telemetry.test.ts
@@ -143,9 +143,15 @@ describe('POST /api/telemetry/visit', () => {
       ],
     });
 
-    const events = await store.listVisitEvents(today());
+    // 60s backdate can put event 0 on yesterday near UTC midnight.
+    const yesterday = new Date(Date.now() - 86_400_000).toISOString().slice(0, 10);
+    const events = [
+      ...(await store.listVisitEvents(today(), { visitId })),
+      ...(await store.listVisitEvents(yesterday, { visitId })),
+    ];
+    expect(events).toHaveLength(2);
     const [first, second] = events.sort((a, b) => a.msSinceStart - b.msSinceStart);
-    expect(Date.parse(second.at) - Date.parse(first.at)).toBe(60_000);
+    expect(Date.parse(second!.at) - Date.parse(first!.at)).toBe(60_000);
   });
 
   it('rejects a malformed visit id', async () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Managed Anthropic sessions override the agent toolset with our MCP server URL. The `mcp_toolset` entry had no `permission_policy`, and Anthropic’s default for MCP is `always_ask`.

That matches the stuck round (`sesn_015k5…`, mistrz-trampoliny): first `start` shows **awaiting approval**, session goes **Idle**, and nobody is watching the console to click Approve. Turn-one ~58k tokens is the usual cold context (tool schemas + prompt); the acute failure is the idle wait.

Fix: set `default_config.permission_policy.type = always_allow` on every session-overridden MCP toolset. Our MCP endpoint is ours; there is no HITL approver on this path.

Also hardens a UTC-midnight flake in `visit-telemetry.test.ts` that failed CI (~00:01Z) when a 60s backdated event landed on yesterday’s partition.

## Test plan

- [x] Unit test asserts the session create body includes `always_allow`
- [x] Visit offset test covers today+yesterday partitions
- [x] Local green gate
- [ ] CI green
- [ ] After merge: re-run a managed round and confirm `start` executes without Approve
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4cf2e9e5-dd15-4c3a-8323-8e026e20823b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4cf2e9e5-dd15-4c3a-8323-8e026e20823b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

