### PR TITLE
feat(api): add Copilot managed driver

### DIFF
--- a/apps/api/scripts/managed-probe.ts
+++ b/apps/api/scripts/managed-probe.ts
@@ -13,6 +13,7 @@ import {
   type ManagedSession,
 } from '../src/managed-agent.js';
 import '../src/managed-provider-anthropic.js';
+import '../src/managed-provider-copilot.js';
 import { createManagedBackend, type ManagedDeliveryInput } from '../src/managed-backend.js';
 import { createFileKitDigestLoader } from '../src/kit-digest.js';
 
@@ -33,11 +34,13 @@ const apiBaseUrl = (value('base-url') ?? 'https://api.anthropic.com').replace(/\
 const wait = flag('wait');
 const waitSeconds = Number(value('wait-seconds') ?? process.env.MANAGED_AGENT_MAX_SECONDS ?? '');
 const budgetUsd = Number(value('budget-usd') ?? process.env.MANAGED_AGENT_MAX_LIST_BUDGET_USD ?? '');
+const budgetCredits = Number(value('budget-credits') ?? process.env.MANAGED_AGENT_COPILOT_MAX_CREDITS ?? '');
 const vaultIds = (process.env.MANAGED_AGENT_VAULT_IDS ?? process.env.MANAGED_AGENT_VAULT_ID)
   ?.split(',')
   .map((id) => id.trim())
   .filter(Boolean);
 const mcpOnly = flag('mcp');
+const vendor = value('vendor');
 const mcpUrl = (value('mcp-url') ?? process.env.MANAGED_AGENT_MCP_URL ?? 'https://www.gamedev.pl/api/mcp').replace(
   /\/$/,
   '',
@@ -56,6 +59,10 @@ if (mcpOnly && (!Number.isSafeInteger(ISSUE) || ISSUE <= 0)) {
 }
 if (mcpOnly && (!Number.isSafeInteger(roundGeneration) || roundGeneration < 1)) {
   console.error('--round-generation must be a positive integer');
+  process.exit(1);
+}
+if (vendor === 'copilot' && (mcpOnly || flag('override-tools') || args.includes('--mcp-url'))) {
+  console.error('Copilot uses the harness prompt lane; MCP-lane flags are not valid for --vendor copilot');
   process.exit(1);
 }
 
@@ -97,6 +104,7 @@ function stubProvider(): ManagedAgentProvider {
   return {
     vendor: 'stub',
     model: 'stub-model',
+    promptLane: 'outputs',
     async startSession(request) {
       rule('startSession');
       console.log(`model            ${request.model}`);
@@ -122,7 +130,13 @@ function stubProvider(): ManagedAgentProvider {
         id: 'stub-session-1',
         state: polls === 1 ? 'in_progress' : 'idle',
         vendorState: polls === 1 ? 'running' : 'status_idle',
-        usage: { inputTokens: 1_240_000, outputTokens: 18_400, model: 'stub-model' },
+        usage: {
+          unit: 'tokens',
+          vendor: 'stub',
+          inputTokens: 1_240_000,
+          outputTokens: 18_400,
+          model: 'stub-model',
+        },
       };
     },
     async listOutputs(): Promise<ManagedOutputRef[]> {
@@ -148,18 +162,34 @@ function stubProvider(): ManagedAgentProvider {
   };
 }
 
-const vendor = value('vendor');
 const apiKey =
   process.env.MANAGED_AGENT_API_KEY?.trim() ??
-  (vendor === 'anthropic' ? process.env.ANTHROPIC_API_KEY?.trim() : undefined);
+  (vendor === 'anthropic'
+    ? process.env.ANTHROPIC_API_KEY?.trim()
+    : vendor === 'copilot'
+      ? process.env.AGENT_TASKS_TOKEN?.trim()
+      : undefined);
 const model =
-  value('model') ?? process.env.MANAGED_AGENT_MODEL?.trim() ?? (vendor === 'anthropic' ? 'claude-sonnet-5' : undefined);
+  value('model') ??
+  (vendor === 'copilot' ? process.env.AGENT_TASKS_MODEL?.trim() : process.env.MANAGED_AGENT_MODEL?.trim()) ??
+  (vendor === 'anthropic' ? 'claude-sonnet-5' : vendor === 'copilot' ? 'claude-sonnet-4.6' : undefined);
 if (vendor && (!apiKey || !model)) {
   console.error(`--vendor ${vendor} needs an API key and model`);
   process.exit(1);
 }
-if (wait && (!Number.isInteger(waitSeconds) || waitSeconds <= 0 || !Number.isFinite(budgetUsd) || budgetUsd <= 0)) {
-  console.error('--wait requires positive --wait-seconds and --budget-usd values');
+if (
+  wait &&
+  (!Number.isInteger(waitSeconds) ||
+    waitSeconds <= 0 ||
+    (vendor === 'copilot'
+      ? !Number.isFinite(budgetCredits) || budgetCredits <= 0
+      : !Number.isFinite(budgetUsd) || budgetUsd <= 0))
+) {
+  console.error(
+    vendor === 'copilot'
+      ? '--wait requires positive --wait-seconds and --budget-credits values'
+      : '--wait requires positive --wait-seconds and --budget-usd values',
+  );
   process.exit(1);
 }
 // MCP rounds override the Agent tool list, like production.
@@ -168,6 +198,14 @@ const provider = vendor
   ? createManagedProvider(vendor, {
       apiKey: apiKey!,
       model: model!,
+      ...(vendor === 'copilot'
+        ? {
+            repo: process.env.GAMES_REPO?.trim() ?? 'gamedevpl/www.gamedev.pl-games',
+            baseRef: process.env.GAMES_PUBLISHED_REF?.trim() || 'main',
+            customAgent: process.env.AGENT_CUSTOM_AGENT?.trim() || 'game-builder',
+            createPullRequest: false,
+          }
+        : {}),
       ...(process.env.MANAGED_AGENT_ID ? { agentId: process.env.MANAGED_AGENT_ID.trim() } : {}),
       ...(process.env.MANAGED_AGENT_ENVIRONMENT_ID
         ? { environmentId: process.env.MANAGED_AGENT_ENVIRONMENT_ID.trim() }
@@ -206,6 +244,9 @@ const backend = createManagedBackend({
   ...(manifest?.agent?.system ? { systemPrompt: async () => manifest.agent!.system } : {}),
   ...(digestPath ? { kitDigest: createFileKitDigestLoader(digestPath) } : {}),
   ...(wait ? { maxDurationSeconds: waitSeconds } : {}),
+  ...(vendor === 'copilot' && Number.isFinite(budgetCredits) && budgetCredits > 0
+    ? { budget: { unit: 'credits' as const, max: budgetCredits } }
+    : {}),
   // The probe cannot see MCP deliveries, so nudging would mislead.
   ...(mcpOnly && !flag('nudge') ? { nudgeIdle: false } : {}),
 });
@@ -232,6 +273,7 @@ if (mcpOnly && vendor === 'anthropic' && !dispatch.credentialRef) {
 }
 
 const pollCount = wait ? Math.ceil((waitSeconds * 1000) / 5000) + 1 : 2;
+const timeline: Array<{ at: string; state: string; candidate: boolean }> = [];
 for (let attempt = 1; attempt <= pollCount; attempt += 1) {
   if (attempt > 1) await new Promise((resolve) => setTimeout(resolve, 5000));
   rule(`observe #${attempt}`);
@@ -241,13 +283,23 @@ for (let attempt = 1; attempt <= pollCount; attempt += 1) {
     slug: SLUG,
     roundGeneration,
   });
-  console.log(observation ?? '(vendor has forgotten this session)');
+  if (observation) {
+    const entry = { at: new Date().toISOString(), state: observation.state, candidate: observation.hasCandidate };
+    timeline.push(entry);
+    console.log(`${entry.at}  ${entry.state}  candidate=${entry.candidate}`);
+    console.log(observation);
+  } else {
+    console.log('(vendor has forgotten this session)');
+  }
   if (
     observation &&
     (observation.hasCandidate || ['idle', 'failed', 'timed_out', 'cancelled'].includes(observation.state))
   )
     break;
 }
+
+rule('state-transition timeline');
+for (const entry of timeline) console.log(`${entry.at}  ${entry.state}  candidate=${entry.candidate}`);
 
 rule('what the platform would store');
 if (delivered.length === 0) {

--- a/apps/api/src/agent-backend-env.test.ts
+++ b/apps/api/src/agent-backend-env.test.ts
@@ -10,7 +10,12 @@ const ENV_KEYS = [
   'MANAGED_AGENT_MAX_SECONDS',
   'MANAGED_AGENT_MAX_LIST_COST_CENTS',
   'MANAGED_AGENT_MCP_URL',
+  'MANAGED_AGENT_COPILOT_MAX_CREDITS',
   'AGENT_TASKS_TOKEN',
+  'AGENT_TASKS_MODEL',
+  'GAMES_REPO',
+  'GAMES_PUBLISHED_REF',
+  'AGENT_CUSTOM_AGENT',
 ] as const;
 
 describe('createAgentBackendRegistryFromEnv', () => {
@@ -75,5 +80,24 @@ describe('createAgentBackendRegistryFromEnv', () => {
     });
     const registry = createAgentBackendRegistryFromEnv({ info: vi.fn(), warn: vi.fn() });
     expect(registry.platform?.name).toBe('managed:anthropic');
+  });
+
+  it('builds Copilot from its own token and model configuration', () => {
+    setEnv({
+      MANAGED_AGENT_VENDOR: 'copilot',
+      AGENT_TASKS_TOKEN: 'ghp_managed_copilot',
+      AGENT_TASKS_MODEL: undefined,
+      MANAGED_AGENT_COPILOT_MAX_CREDITS: '25',
+    });
+    const info = vi.fn();
+    const registry = createAgentBackendRegistryFromEnv({ info, warn: vi.fn() }, undefined, {
+      deliver: async () => ({ version: 'v1' }),
+    });
+
+    expect(registry.platform?.name).toBe('managed:copilot');
+    expect(info).toHaveBeenCalledWith(
+      expect.objectContaining({ vendor: 'copilot', model: 'claude-sonnet-4.6' }),
+      'managed agent dispatch enabled',
+    );
   });
 });

--- a/apps/api/src/agent-backend-env.ts
+++ b/apps/api/src/agent-backend-env.ts
@@ -12,6 +12,7 @@ import { VertexGameSeeder, type GameSeeder } from './game-seed.js';
 import { createGitHubClient } from './github-client.js';
 import { createManagedProvider, type ManagedAgentEffort } from './managed-agent.js';
 import './managed-provider-anthropic.js';
+import './managed-provider-copilot.js';
 import {
   createManagedBackend,
   type ManagedDeliveryLock,
@@ -61,16 +62,25 @@ export function createManagedPlatformBackendFromEnv(deps?: ManagedBackendDeps, l
   const vendor = process.env.MANAGED_AGENT_VENDOR?.trim();
   if (!vendor) return undefined;
 
-  const apiKey = process.env.MANAGED_AGENT_API_KEY?.trim();
-  const model = process.env.MANAGED_AGENT_MODEL?.trim();
+  const isCopilot = vendor === 'copilot';
+  const apiKey = (isCopilot ? process.env.AGENT_TASKS_TOKEN : process.env.MANAGED_AGENT_API_KEY)?.trim();
+  const model = (
+    isCopilot ? process.env.AGENT_TASKS_MODEL?.trim() || 'claude-sonnet-4.6' : process.env.MANAGED_AGENT_MODEL?.trim()
+  )?.trim();
   if (!apiKey || !model) {
-    log?.warn({ vendor }, 'managed agent vendor is set but MANAGED_AGENT_API_KEY / MANAGED_AGENT_MODEL are missing');
+    log?.warn(
+      { vendor },
+      isCopilot
+        ? 'copilot managed agent requires AGENT_TASKS_TOKEN'
+        : 'managed agent vendor requires MANAGED_AGENT_API_KEY / MANAGED_AGENT_MODEL',
+    );
     return undefined;
   }
   const agentId = process.env.MANAGED_AGENT_ID?.trim();
   const environmentId = process.env.MANAGED_AGENT_ENVIRONMENT_ID?.trim();
   const maxDurationSeconds = Number(process.env.MANAGED_AGENT_MAX_SECONDS ?? '');
   const maxListCostCents = Number(process.env.MANAGED_AGENT_MAX_LIST_COST_CENTS ?? '');
+  const maxCopilotCredits = Number(process.env.MANAGED_AGENT_COPILOT_MAX_CREDITS ?? '');
   const vaultIds = (process.env.MANAGED_AGENT_VAULT_IDS ?? process.env.MANAGED_AGENT_VAULT_ID)
     ?.split(',')
     .map((id) => id.trim())
@@ -92,10 +102,16 @@ export function createManagedPlatformBackendFromEnv(deps?: ManagedBackendDeps, l
     );
     return undefined;
   }
+  if (isCopilot && process.env.MANAGED_AGENT_COPILOT_MAX_CREDITS !== undefined) {
+    if (!Number.isFinite(maxCopilotCredits) || maxCopilotCredits <= 0) {
+      log?.warn({ vendor }, 'copilot managed agent credit ceiling must be positive');
+      return undefined;
+    }
+  }
   // An MCP agent submits for itself, so it needs no sink.
-  const mcpUrl = process.env.MANAGED_AGENT_MCP_URL?.trim();
-  if (!deps?.deliver && !mcpUrl) {
-    log?.warn({ vendor }, 'managed agent vendor is set but neither a delivery sink nor MANAGED_AGENT_MCP_URL exists');
+  const mcpUrl = isCopilot ? undefined : process.env.MANAGED_AGENT_MCP_URL?.trim();
+  if (!isCopilot && !mcpUrl) {
+    log?.warn({ vendor }, 'managed agent vendor is set but MANAGED_AGENT_MCP_URL is missing');
     return undefined;
   }
 
@@ -113,6 +129,14 @@ export function createManagedPlatformBackendFromEnv(deps?: ManagedBackendDeps, l
         : {}),
       ...(Number.isInteger(maxListCostCents) && maxListCostCents > 0 ? { maxListCostCents } : {}),
       ...(vaultIds?.length ? { vaultIds } : {}),
+      ...(isCopilot
+        ? {
+            repo: process.env.GAMES_REPO?.trim() ?? 'gamedevpl/www.gamedev.pl-games',
+            baseRef: process.env.GAMES_PUBLISHED_REF?.trim() || 'main',
+            customAgent: process.env.AGENT_CUSTOM_AGENT?.trim() || 'game-builder',
+            createPullRequest: false,
+          }
+        : {}),
       ...(mcpUrl ? { overrideTools: true } : {}),
       ...(process.env.MANAGED_AGENT_BASE_URL?.trim() ? { baseUrl: process.env.MANAGED_AGENT_BASE_URL.trim() } : {}),
     });
@@ -140,6 +164,9 @@ export function createManagedPlatformBackendFromEnv(deps?: ManagedBackendDeps, l
     ...(deps?.kitDigest ? { kitDigest: deps.kitDigest } : {}),
     ...(effort ? { effort } : {}),
     ...(Number.isFinite(maxDurationSeconds) && maxDurationSeconds > 0 ? { maxDurationSeconds } : {}),
+    ...(isCopilot && Number.isFinite(maxCopilotCredits) && maxCopilotCredits > 0
+      ? { budget: { unit: 'credits' as const, max: maxCopilotCredits } }
+      : {}),
     deliveryMode,
     ...(log ? { log } : {}),
   });

--- a/apps/api/src/job-state.test.ts
+++ b/apps/api/src/job-state.test.ts
@@ -195,6 +195,16 @@ describe('reconcileAgentObservation', () => {
     });
   });
 
+  it('keeps a budget stop visible in the round transition', () => {
+    expect(
+      reconcileAgentObservation('building', {
+        state: 'cancelled',
+        hasCandidate: false,
+        stopReason: 'budget_reached',
+      }),
+    ).toEqual({ to: 'canceled', reason: 'budget_reached' });
+  });
+
   it('ignores agent lifecycle once the work has been delivered', () => {
     // A session reporting failure after a successful upload must not snatch the
     // candidate back from the gate or the reviewer.

--- a/apps/api/src/job-state.ts
+++ b/apps/api/src/job-state.ts
@@ -12,6 +12,7 @@
 // reconciler sweep, and the operator surface alike.
 
 import type { AgentTaskState } from './agent-state.js';
+import type { ManagedBudgetStop, ManagedSessionUsage } from './managed-agent.js';
 import type { SubmissionStatus } from './submission-status.js';
 
 /**
@@ -341,6 +342,9 @@ export interface AgentObservation {
   sessionCredits?: number;
   // Tokens, for token-billed backends; not convertible to credits.
   sessionTokens?: { input: number; output: number };
+  sessionUsage?: ManagedSessionUsage;
+  stopReason?: string;
+  budgetStop?: ManagedBudgetStop;
 }
 
 export interface ReconcileResult {
@@ -385,7 +389,7 @@ export function reconcileAgentObservation(current: JobState, observation: AgentO
       case 'timed_out':
         return { to: 'failed', reason: 'task_timed_out' };
       case 'cancelled':
-        return { to: 'canceled', reason: 'task_cancelled' };
+        return { to: 'canceled', reason: observation.stopReason ?? 'task_cancelled' };
     }
   })();
 

--- a/apps/api/src/managed-agent.test.ts
+++ b/apps/api/src/managed-agent.test.ts
@@ -129,6 +129,7 @@ describe('provider registry', () => {
     const stub: ManagedAgentProvider = {
       vendor: 'test-vendor',
       model: 'test-model',
+      promptLane: 'outputs',
       startSession: async () => ({ id: 's1', state: 'queued' }),
       getSession: async () => null,
       listOutputs: async () => [],

--- a/apps/api/src/managed-agent.ts
+++ b/apps/api/src/managed-agent.ts
@@ -4,6 +4,8 @@ import type { AgentTaskState } from './agent-state.js';
 // Coarse reasoning budget; vendors name it differently.
 export type ManagedAgentEffort = 'low' | 'medium' | 'high';
 
+export type ManagedPromptLane = 'mcp' | 'harness' | 'outputs';
+
 export interface ManagedWorkspaceFile {
   path: string;
   content: string;
@@ -22,20 +24,40 @@ export interface ManagedOutputRef {
   handle?: string;
 }
 
-// Tokens: the only unit every vendor reports.
 export interface ManagedTokenUsage {
+  unit: 'tokens';
+  vendor: string;
   inputTokens: number;
   outputTokens: number;
   model?: string;
+}
+
+export interface ManagedCreditUsage {
+  unit: 'credits';
+  vendor: string;
+  credits: number;
+  model?: string;
+}
+
+export type ManagedSessionUsage = ManagedTokenUsage | ManagedCreditUsage;
+
+export type ManagedUsageBudget = { unit: 'credits'; max: number } | { unit: 'cents'; max: number };
+
+export interface ManagedBudgetStop {
+  unit: ManagedUsageBudget['unit'];
+  observed: number;
+  max: number;
+  enforced: boolean;
 }
 
 export interface ManagedSession {
   id: string;
   state: AgentTaskState;
   credentialRef?: string;
+  workspace?: string;
   // The vendor's own word, kept for operator views.
   vendorState?: string;
-  usage?: ManagedTokenUsage;
+  usage?: ManagedSessionUsage;
   startedAt?: string;
   endedAt?: string;
   stopReason?: string;
@@ -71,6 +93,7 @@ export interface ManagedSessionRequest {
 export interface ManagedAgentProvider {
   readonly vendor: string;
   readonly model: string;
+  readonly promptLane: ManagedPromptLane;
   startSession(request: ManagedSessionRequest): Promise<ManagedSession>;
   getSession(sessionId: string): Promise<ManagedSession | null>;
   // Paths are relative to the request's outputPath.
@@ -80,6 +103,7 @@ export interface ManagedAgentProvider {
   sendMessage?(sessionId: string, message: string): Promise<void>;
   cancelSession(sessionId: string): Promise<{ enforced: boolean }>;
   deleteSession?(sessionId: string): Promise<void>;
+  deleteWorkspace?(workspace: string): Promise<void>;
   releaseCredential?(credentialRef: string): Promise<void>;
 }
 
@@ -263,6 +287,10 @@ export function selectManagedOutputs(refs: readonly ManagedOutputRef[], slug: st
 export interface ManagedProviderConfig {
   apiKey: string;
   model: string;
+  repo?: string;
+  baseRef?: string;
+  customAgent?: string;
+  createPullRequest?: boolean;
   agentId?: string;
   environmentId?: string;
   maxListCostCents?: number;

--- a/apps/api/src/managed-backend.test.ts
+++ b/apps/api/src/managed-backend.test.ts
@@ -32,6 +32,7 @@ function fakeProvider(overrides: Partial<ManagedAgentProvider> = {}) {
   const provider: ManagedAgentProvider = {
     vendor: 'fake',
     model: 'fake-model',
+    promptLane: 'outputs',
     startSession: async (request) => {
       started.push(request);
       return { id: 'session-1', state: 'queued' };
@@ -40,7 +41,7 @@ function fakeProvider(overrides: Partial<ManagedAgentProvider> = {}) {
       id: 'session-1',
       // Adapters normalize before returning; the fake honours that contract.
       state: normalizeManagedState(state),
-      usage: { inputTokens: 1_000, outputTokens: 250 },
+      usage: { unit: 'tokens', vendor: 'fake', inputTokens: 1_000, outputTokens: 250, model: 'fake-model' },
       ...(stopReason ? { stopReason } : {}),
     }),
     listOutputs: async () =>
@@ -89,7 +90,7 @@ describe('managed backend', () => {
   });
 
   it('accepts an MCP-only configuration, where the agent submits for itself', async () => {
-    const { provider, setState, setOutputs, read } = fakeProvider();
+    const { provider, setState, setOutputs, read } = fakeProvider({ promptLane: 'mcp' });
     const backend = createManagedBackend({
       provider,
       tools: { mcpEndpoints: [{ url: 'https://www.gamedev.pl/api/mcp', name: 'gamedevpl' }] },
@@ -105,7 +106,7 @@ describe('managed backend', () => {
   });
 
   it('prefers the MCP delivery contract when both delivery paths are configured', async () => {
-    const { provider, started, setState, setOutputs, read } = fakeProvider();
+    const { provider, started, setState, setOutputs, read } = fakeProvider({ promptLane: 'mcp' });
     const backend = createManagedBackend({
       provider,
       deliver: async () => ({ version: 'v1' }),
@@ -126,6 +127,7 @@ describe('managed backend', () => {
     const released: string[] = [];
     const info = vi.fn();
     const { provider, started, setState } = fakeProvider({
+      promptLane: 'mcp',
       startSession: async (request) => {
         started.push(request);
         return { id: 'session-1', state: 'queued', credentialRef: 'lease-1' };
@@ -403,6 +405,105 @@ describe('managed backend', () => {
     }
   });
 
+  it('stops a Copilot round once summed credits exceed its ceiling', async () => {
+    const cancel = vi.fn(async () => ({ enforced: false }));
+    const start = vi.fn();
+    const { provider } = fakeProvider({
+      promptLane: 'harness',
+      startSession: async (request) => {
+        start(request);
+        return { id: 'copilot-task', state: 'queued' };
+      },
+      getSession: async () => ({
+        id: 'copilot-task',
+        state: 'in_progress',
+        usage: { unit: 'credits', vendor: 'copilot', credits: 3.5, model: 'gpt-5.4' },
+      }),
+      cancelSession: cancel,
+    });
+    const backend = createManagedBackend({
+      provider,
+      budget: { unit: 'credits', max: 3 },
+      deliver: async () => ({ version: 'v1' }),
+    });
+
+    await backend.dispatch(brief());
+    const first = await backend.observe('copilot-task', { hasCandidate: false, issueNumber: ISSUE, slug: SLUG });
+    const second = await backend.observe('copilot-task', { hasCandidate: false, issueNumber: ISSUE, slug: SLUG });
+
+    expect(first).toMatchObject({
+      state: 'cancelled',
+      stopReason: 'budget_reached',
+      sessionCredits: 3.5,
+      budgetStop: { unit: 'credits', observed: 3.5, max: 3, enforced: false },
+    });
+    expect(second).toMatchObject({ state: 'cancelled', stopReason: 'budget_reached' });
+    expect(cancel).toHaveBeenCalledTimes(1);
+    expect(start).toHaveBeenCalledTimes(1);
+  });
+
+  it('prioritizes budget exhaustion before action-block handling', async () => {
+    const cancel = vi.fn(async () => ({ enforced: false }));
+    const readSignals = vi.fn(async () => ({}));
+    const { provider } = fakeProvider({
+      promptLane: 'mcp',
+      getSession: async () => ({
+        id: 'session-1',
+        state: 'idle',
+        stopReason: 'requires_action',
+        usage: { unit: 'credits', vendor: 'fake', credits: 3.5, model: 'synthetic' },
+      }),
+      cancelSession: cancel,
+    });
+    const backend = createManagedBackend({
+      provider,
+      budget: { unit: 'credits', max: 3 },
+      readSignals,
+      tools: { mcpEndpoints: [{ url: 'https://example.test/api/mcp', name: 'gamedevpl' }] },
+      deliver: async () => ({ version: 'v1' }),
+    });
+
+    const first = await backend.observe('session-1', { hasCandidate: false, issueNumber: ISSUE, slug: SLUG });
+    const second = await backend.observe('session-1', { hasCandidate: false, issueNumber: ISSUE, slug: SLUG });
+
+    expect(first).toMatchObject({
+      state: 'cancelled',
+      stopReason: 'budget_reached',
+      budgetStop: { unit: 'credits', observed: 3.5, max: 3, enforced: false },
+    });
+    expect(second).toMatchObject({ state: 'cancelled', stopReason: 'budget_reached' });
+    expect(readSignals).not.toHaveBeenCalled();
+    expect(cancel).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not generalize Anthropic action handling to Copilot', async () => {
+    const { provider, setState, setStopReason } = fakeProvider({
+      vendor: 'copilot',
+      promptLane: 'harness',
+    });
+    const backend = createManagedBackend({ provider, deliver: async () => ({ version: 'v1' }) });
+
+    await backend.dispatch(brief());
+    setState('idle');
+    setStopReason('requires_action');
+
+    const observation = await backend.observe('session-1', { hasCandidate: false, issueNumber: ISSUE, slug: SLUG });
+
+    expect(observation).toMatchObject({ state: 'idle', hasCandidate: false });
+  });
+
+  it('does not nudge the Copilot harness lane', async () => {
+    const { provider, setState } = fakeProvider({ promptLane: 'harness' });
+    const backend = createManagedBackend({ provider, deliver: async () => ({ version: 'v1' }) });
+
+    await backend.dispatch(brief());
+    setState('idle');
+
+    const observation = await backend.observe('session-1', { hasCandidate: false, issueNumber: ISSUE, slug: SLUG });
+
+    expect(observation).toMatchObject({ state: 'idle', hasCandidate: false });
+  });
+
   it('nudges an idle session once, then spends the round if still idle without delivery', async () => {
     const sendMessage = vi.fn(async () => undefined);
     const { provider, setState } = fakeProvider({ sendMessage });
@@ -422,7 +523,7 @@ describe('managed backend', () => {
 
   it('does not nudge a round that delivered a preview but has no sealed version yet', async () => {
     const sendMessage = vi.fn(async () => undefined);
-    const { provider, setState } = fakeProvider({ sendMessage });
+    const { provider, setState } = fakeProvider({ promptLane: 'mcp', sendMessage });
     const backend = createManagedBackend({
       provider,
       tools: { mcpEndpoints: [{ url: 'https://example.test/api/mcp', name: 'gamedevpl' }] },
@@ -438,7 +539,7 @@ describe('managed backend', () => {
 
   it('does not re-enter a session the agent deliberately ended', async () => {
     const sendMessage = vi.fn(async () => undefined);
-    const { provider, setState } = fakeProvider({ sendMessage });
+    const { provider, setState } = fakeProvider({ promptLane: 'mcp', sendMessage });
     const backend = createManagedBackend({
       provider,
       tools: { mcpEndpoints: [{ url: 'https://example.test/api/mcp', name: 'gamedevpl' }] },
@@ -455,7 +556,7 @@ describe('managed backend', () => {
 
   it('still nudges a session that went idle without delivering or ending', async () => {
     const sendMessage = vi.fn(async () => undefined);
-    const { provider, setState } = fakeProvider({ sendMessage });
+    const { provider, setState } = fakeProvider({ promptLane: 'mcp', sendMessage });
     const backend = createManagedBackend({
       provider,
       tools: { mcpEndpoints: [{ url: 'https://example.test/api/mcp', name: 'gamedevpl' }] },
@@ -476,7 +577,7 @@ describe('managed backend', () => {
   it('ends a round blocked on tool confirmation instead of leaving Studio on building', async () => {
     const sendMessage = vi.fn(async () => undefined);
     const warn = vi.fn();
-    const { provider, setState, setStopReason } = fakeProvider({ sendMessage });
+    const { provider, setState, setStopReason } = fakeProvider({ vendor: 'anthropic', promptLane: 'mcp', sendMessage });
     const backend = createManagedBackend({
       provider,
       tools: { mcpEndpoints: [{ url: 'https://example.test/api/mcp', name: 'gamedevpl' }] },
@@ -504,7 +605,7 @@ describe('managed backend', () => {
         'anthropic managed agents /v1/sessions/x/events failed: 400 only user.tool_confirmation events are allowed',
       );
     });
-    const { provider, setState } = fakeProvider({ sendMessage });
+    const { provider, setState } = fakeProvider({ vendor: 'anthropic', promptLane: 'mcp', sendMessage });
     const backend = createManagedBackend({
       provider,
       tools: { mcpEndpoints: [{ url: 'https://example.test/api/mcp', name: 'gamedevpl' }] },
@@ -523,7 +624,7 @@ describe('managed backend', () => {
 
   it('does not spend a nudged idle round that delivered a preview between polls', async () => {
     const sendMessage = vi.fn(async () => undefined);
-    const { provider, setState } = fakeProvider({ sendMessage });
+    const { provider, setState } = fakeProvider({ promptLane: 'mcp', sendMessage });
     const signals: { previewVersion?: string } = {};
     const backend = createManagedBackend({
       provider,
@@ -630,5 +731,15 @@ describe('managed backend', () => {
     const backend = createManagedBackend({ provider, deliver: async () => ({ version: 'v1' }) });
     await backend.cleanup?.({ ref: 'session-1' });
     expect(deleteSession).toHaveBeenCalledWith('session-1');
+  });
+
+  it('deletes provider workspaces on cleanup', async () => {
+    const deleteWorkspace = vi.fn(async () => undefined);
+    const { provider } = fakeProvider({ deleteWorkspace });
+    const backend = createManagedBackend({ provider, deliver: async () => ({ version: 'v1' }) });
+
+    await backend.cleanup?.({ ref: 'session-1', workspace: 'copilot/spent' });
+
+    expect(deleteWorkspace).toHaveBeenCalledWith('copilot/spent');
   });
 });

--- a/apps/api/src/managed-backend.ts
+++ b/apps/api/src/managed-backend.ts
@@ -13,10 +13,12 @@ import {
   selectManagedOutputs,
   type ManagedAgentEffort,
   type ManagedAgentProvider,
+  type ManagedBudgetStop,
   type ManagedOutputCaps,
   type ManagedOutputFile,
   type ManagedOutputPlan,
   type ManagedMcpBearerCredential,
+  type ManagedUsageBudget,
   type ManagedToolAccess,
 } from './managed-agent.js';
 
@@ -91,6 +93,7 @@ export interface ManagedBackendOptions {
   outputPath?: string;
   effort?: ManagedAgentEffort;
   maxDurationSeconds?: number;
+  budget?: ManagedUsageBudget;
   outputCaps?: ManagedOutputCaps;
   tools?: ManagedToolAccess;
   mcpBearerCredential?: (brief: BuildBrief) => ManagedMcpBearerCredential | undefined;
@@ -119,17 +122,21 @@ export function isUnnudgeableManagedIdleError(error: unknown): boolean {
 
 export function createManagedBackend(options: ManagedBackendOptions): AgentBackend {
   const deliver = options.deliver;
-  if (!deliver && !options.tools?.mcpEndpoints?.length) {
-    throw new ManagedAgentError(
-      'a managed backend needs either a delivery sink or an MCP endpoint the agent can submit through',
-    );
+  const promptLane = options.provider.promptLane;
+  const channelMode = promptLane === 'mcp' || promptLane === 'harness';
+  if (promptLane === 'outputs' && !deliver) {
+    throw new ManagedAgentError('a managed backend needs either a delivery sink or an MCP endpoint');
+  }
+  if (promptLane === 'mcp' && !options.tools?.mcpEndpoints?.length) {
+    throw new ManagedAgentError('the MCP prompt lane needs an MCP endpoint');
   }
   const outputPath = options.outputPath ?? DEFAULT_MANAGED_OUTPUT_PATH;
   const deliveryMode = options.deliveryMode ?? 'preview';
-  const channelMode = Boolean(options.tools?.mcpEndpoints?.length);
   const backendName = `managed:${options.provider.vendor}`;
+  const handlesAnthropicToolConfirmation = options.provider.vendor === 'anthropic';
   // At-most-once per session; a re-poll cannot duplicate.
   const harvested = new Set<string>();
+  const budgetStops = new Map<string, ManagedBudgetStop>();
   const startedAt = new Map<string, number>();
   const idleNudged = new Set<string>();
   const sessionGenerations = new Map<string, number>();
@@ -176,7 +183,9 @@ export function createManagedBackend(options: ManagedBackendOptions): AgentBacke
       prompt: buildPrompt(
         brief,
         channelMode
-          ? { kind: 'channel', fast: true }
+          ? promptLane === 'mcp'
+            ? { kind: 'channel', fast: true }
+            : { kind: 'channel' }
           : deliver
             ? { kind: 'outputs', path: outputPath }
             : { kind: 'channel', fast: true },
@@ -215,7 +224,11 @@ export function createManagedBackend(options: ManagedBackendOptions): AgentBacke
         'managed round credential minted',
       );
     }
-    return { ref: session.id, ...(session.credentialRef ? { credentialRef: session.credentialRef } : {}) };
+    return {
+      ref: session.id,
+      ...(session.workspace ? { workspace: session.workspace } : {}),
+      ...(session.credentialRef ? { credentialRef: session.credentialRef } : {}),
+    };
   }
 
   // `pending` means ask again, so the round is not spent.
@@ -314,6 +327,53 @@ export function createManagedBackend(options: ManagedBackendOptions): AgentBacke
       const session = await options.provider.getSession(ref);
       if (!session) return null;
 
+      const usage = session.usage;
+      const usageFields = usage
+        ? usage.unit === 'tokens'
+          ? {
+              sessionTokens: { input: usage.inputTokens, output: usage.outputTokens },
+              sessionUsage: usage,
+            }
+          : { sessionCredits: usage.credits, sessionUsage: usage }
+        : {};
+      const stopped = budgetStops.get(ref);
+      if (stopped) {
+        return {
+          state: 'cancelled',
+          hasCandidate: observeOptions.hasCandidate,
+          stopReason: 'budget_reached',
+          budgetStop: stopped,
+          ...(session.workspace ? { workspace: session.workspace } : {}),
+          ...usageFields,
+        };
+      }
+
+      const observedBudget =
+        options.budget?.unit === 'credits' && usage?.unit === 'credits' ? usage.credits : undefined;
+      if (observedBudget !== undefined && observedBudget > options.budget!.max) {
+        const cancellation = await options.provider.cancelSession(ref);
+        const budgetStop: ManagedBudgetStop = {
+          unit: options.budget!.unit,
+          observed: observedBudget,
+          max: options.budget!.max,
+          enforced: cancellation.enforced,
+        };
+        budgetStops.set(ref, budgetStop);
+        await releaseCredential(ref, observeOptions.issueNumber);
+        options.log?.warn(
+          { ref, observed: observedBudget, max: options.budget!.max, enforced: cancellation.enforced },
+          'managed round stopped at its usage budget',
+        );
+        return {
+          state: 'cancelled',
+          hasCandidate: observeOptions.hasCandidate,
+          stopReason: 'budget_reached',
+          budgetStop,
+          ...(session.workspace ? { workspace: session.workspace } : {}),
+          ...usageFields,
+        };
+      }
+
       const started = startedAt.get(ref) ?? (session.startedAt ? Date.parse(session.startedAt) : NaN);
       const expired =
         options.maxDurationSeconds !== undefined &&
@@ -326,9 +386,8 @@ export function createManagedBackend(options: ManagedBackendOptions): AgentBacke
         return {
           state: 'timed_out',
           hasCandidate: observeOptions.hasCandidate,
-          ...(session.usage
-            ? { sessionTokens: { input: session.usage.inputTokens, output: session.usage.outputTokens } }
-            : {}),
+          ...(session.workspace ? { workspace: session.workspace } : {}),
+          ...usageFields,
         };
       }
 
@@ -363,7 +422,7 @@ export function createManagedBackend(options: ManagedBackendOptions): AgentBacke
         !hasCandidate &&
         options.nudgeIdle !== false &&
         session.stopReason !== 'budget_reached' &&
-        !isManagedIdleBlockedOnAction(session.stopReason) &&
+        !(handlesAnthropicToolConfirmation && isManagedIdleBlockedOnAction(session.stopReason)) &&
         Boolean(options.provider.sendMessage) &&
         !idleNudged.has(ref);
       // Re-read signals after a spent nudge.
@@ -372,7 +431,7 @@ export function createManagedBackend(options: ManagedBackendOptions): AgentBacke
         credentialRefs.has(ref) ||
         Boolean(options.readCredentialRef && session.state === 'idle') ||
         (session.state === 'idle' && !hasCandidate && idleNudged.has(ref)) ||
-        isManagedIdleBlockedOnAction(session.stopReason);
+        (handlesAnthropicToolConfirmation && isManagedIdleBlockedOnAction(session.stopReason));
       const signals =
         needsSignals && options.readSignals && observeOptions.issueNumber !== undefined
           ? await options.readSignals(observeOptions.issueNumber)
@@ -387,6 +446,7 @@ export function createManagedBackend(options: ManagedBackendOptions): AgentBacke
         !hasCandidate &&
         !roundDelivered &&
         !agentEnded &&
+        handlesAnthropicToolConfirmation &&
         isManagedIdleBlockedOnAction(session.stopReason)
       ) {
         // Tool confirmation: Studio cannot Approve — spend the round.
@@ -407,7 +467,7 @@ export function createManagedBackend(options: ManagedBackendOptions): AgentBacke
           options.log?.info?.({ ref }, 'nudged idle managed session to continue');
         } catch (error) {
           // Transient: retry next poll. Confirmation: spend the round.
-          if (isUnnudgeableManagedIdleError(error)) {
+          if (handlesAnthropicToolConfirmation && isUnnudgeableManagedIdleError(error)) {
             idleNudged.add(ref);
             spentWithoutDelivery = true;
           }
@@ -432,9 +492,8 @@ export function createManagedBackend(options: ManagedBackendOptions): AgentBacke
       return {
         state,
         hasCandidate,
-        ...(session.usage
-          ? { sessionTokens: { input: session.usage.inputTokens, output: session.usage.outputTokens } }
-          : {}),
+        ...(session.workspace ? { workspace: session.workspace } : {}),
+        ...usageFields,
       };
     },
 
@@ -453,10 +512,12 @@ export function createManagedBackend(options: ManagedBackendOptions): AgentBacke
       idleNudged.delete(previous.ref);
       harvested.delete(previous.ref);
       sessionGenerations.delete(previous.ref);
+      budgetStops.delete(previous.ref);
       if (previous.credentialRef) credentialRefs.set(previous.ref, previous.credentialRef);
       await releaseCredential(previous.ref);
       credentialRefs.delete(previous.ref);
       sessionJobs.delete(previous.ref);
+      if (previous.workspace) await options.provider.deleteWorkspace?.(previous.workspace);
       await options.provider.deleteSession?.(previous.ref);
     },
   };

--- a/apps/api/src/managed-provider-anthropic.test.ts
+++ b/apps/api/src/managed-provider-anthropic.test.ts
@@ -23,7 +23,7 @@ describe('anthropic managed provider', () => {
       fetchImpl: fetchImpl as unknown as typeof fetch,
     });
     expect(await provider.getSession('sess_0')).toMatchObject({
-      usage: { inputTokens: 0, outputTokens: 0 },
+      usage: { unit: 'tokens', vendor: 'anthropic', inputTokens: 0, outputTokens: 0 },
     });
   });
 
@@ -195,7 +195,7 @@ describe('anthropic managed provider', () => {
     expect(session).toMatchObject({
       state: 'completed',
       vendorState: 'completed',
-      usage: { inputTokens: 1_050, outputTokens: 25, model: 'test-model' },
+      usage: { unit: 'tokens', vendor: 'anthropic', inputTokens: 1_050, outputTokens: 25, model: 'test-model' },
     });
   });
 

--- a/apps/api/src/managed-provider-anthropic.ts
+++ b/apps/api/src/managed-provider-anthropic.ts
@@ -69,7 +69,17 @@ function toSession(parsed: z.infer<typeof SessionSchema>): ManagedSession {
     id: parsed.id,
     state: normalizeManagedState(parsed.status),
     ...(parsed.status ? { vendorState: parsed.status } : {}),
-    ...(hasUsage ? { usage: { inputTokens, outputTokens, ...(parsed.model ? { model: parsed.model } : {}) } } : {}),
+    ...(hasUsage
+      ? {
+          usage: {
+            unit: 'tokens' as const,
+            vendor: ANTHROPIC_VENDOR,
+            inputTokens,
+            outputTokens,
+            ...(parsed.model ? { model: parsed.model } : {}),
+          },
+        }
+      : {}),
     ...(parsed.created_at ? { startedAt: parsed.created_at } : {}),
     ...(parsed.ended_at ? { endedAt: parsed.ended_at } : {}),
     ...(parsed.stop_reason?.type ? { stopReason: parsed.stop_reason.type } : {}),
@@ -157,6 +167,7 @@ export function createAnthropicManagedProvider(config: ManagedProviderConfig): M
   return {
     vendor: ANTHROPIC_VENDOR,
     model: config.model,
+    promptLane: 'mcp',
 
     async startSession(request: ManagedSessionRequest): Promise<ManagedSession> {
       if (!agentId || !environmentId) {

--- a/apps/api/src/managed-provider-copilot.test.ts
+++ b/apps/api/src/managed-provider-copilot.test.ts
@@ -1,0 +1,177 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { AgentTask, AgentTaskInput, AgentTasksClient } from './agent-tasks.js';
+import { buildPrompt } from './build-prompt.js';
+import type { BuildBrief } from './agent-backend.js';
+import { createCopilotManagedProvider } from './managed-provider-copilot.js';
+
+const BRIEF: BuildBrief = {
+  issueNumber: 42,
+  slug: 'comet-courier',
+  spec: 'Deliver parcels between comets.',
+  channelToken: 'tok_abc',
+  apiBaseUrl: 'https://www.gamedev.pl',
+};
+
+function task(overrides: Partial<AgentTask> = {}): AgentTask {
+  return { id: 'task-1', state: 'queued', sessionCount: 0, sessions: [], ...overrides };
+}
+
+function tasks(result: AgentTask = task()) {
+  const startTask = vi.fn(async (_input: AgentTaskInput) => result);
+  const getTask = vi.fn(async () => result);
+  return {
+    client: { startTask, getTask, listTasks: vi.fn(async () => []) } as unknown as AgentTasksClient,
+    startTask,
+    getTask,
+  };
+}
+
+describe('Copilot managed provider', () => {
+  it('declares the harness lane and preserves the legacy task payload', async () => {
+    const stub = tasks(task({ branch: { baseRef: 'main', headRef: 'copilot/courier' } }));
+    const provider = createCopilotManagedProvider(
+      { apiKey: 'token', model: 'gpt-5.4', repo: 'gamedevpl/www.gamedev.pl-games' },
+      { tasks: stub.client, github: { deleteBranch: vi.fn(), createBranchWithFiles: vi.fn() } },
+    );
+
+    await provider.startSession({
+      correlationId: '42',
+      prompt: buildPrompt(BRIEF),
+      model: 'gpt-5.4',
+      outputPath: 'outputs',
+    });
+
+    expect(provider.promptLane).toBe('harness');
+    expect(stub.startTask).toHaveBeenCalledWith({
+      prompt: buildPrompt(BRIEF),
+      baseRef: 'main',
+      model: 'gpt-5.4',
+      createPullRequest: false,
+      customAgent: 'game-builder',
+    });
+  });
+
+  it('stages a seed on the same disposable branch as legacy Copilot', async () => {
+    const stub = tasks();
+    const github = { deleteBranch: vi.fn(async () => undefined), createBranchWithFiles: vi.fn(async () => undefined) };
+    const provider = createCopilotManagedProvider(
+      { apiKey: 'token', model: 'gpt-5.4', repo: 'gamedevpl/www.gamedev.pl-games' },
+      { tasks: stub.client, github },
+    );
+
+    const session = await provider.startSession({
+      correlationId: '42',
+      prompt: buildPrompt({
+        ...BRIEF,
+        seed: { slug: 'comet-courier', files: [{ path: 'game.ts', content: 'x' }], references: [] },
+      }),
+      model: 'gpt-5.4',
+      outputPath: 'outputs',
+      workspaceFiles: [{ path: 'games/comet-courier/game.ts', content: 'x' }],
+    });
+
+    expect(github.deleteBranch).toHaveBeenCalledWith('seed/job-42');
+    expect(github.createBranchWithFiles).toHaveBeenCalledWith({
+      branch: 'seed/job-42',
+      baseRef: 'main',
+      message: 'Seed round 0 for comet-courier (job 42)',
+      files: [{ path: 'game.ts', content: 'x' }],
+    });
+    expect(stub.startTask.mock.calls[0]?.[0].baseRef).toBe('seed/job-42');
+    expect(session.workspace).toBe('seed/job-42');
+  });
+
+  it('fails open to an unseeded prompt when the seed branch cannot be written', async () => {
+    const stub = tasks();
+    const github = {
+      deleteBranch: vi.fn(async () => undefined),
+      createBranchWithFiles: vi.fn(async () => {
+        throw new Error('branch unavailable');
+      }),
+    };
+    const provider = createCopilotManagedProvider(
+      { apiKey: 'token', model: 'gpt-5.4', repo: 'gamedevpl/www.gamedev.pl-games' },
+      { tasks: stub.client, github },
+    );
+    const prompt = buildPrompt({
+      ...BRIEF,
+      seed: { slug: 'comet-courier', files: [{ path: 'game.ts', content: 'x' }], references: [] },
+    });
+
+    await provider.startSession({
+      correlationId: '42',
+      prompt,
+      model: 'gpt-5.4',
+      outputPath: 'outputs',
+      workspaceFiles: [{ path: 'games/comet-courier/game.ts', content: 'x' }],
+    });
+
+    expect(stub.startTask.mock.calls[0]?.[0].baseRef).toBe('main');
+    expect(stub.startTask.mock.calls[0]?.[0].prompt).not.toContain('already contains a generated first draft');
+  });
+
+  it('sums every Copilot session into credits without inventing tokens', async () => {
+    const stub = tasks(
+      task({
+        state: 'completed',
+        sessions: [
+          { id: 's1', state: 'completed', usage: { amount: 1_250_000_000, type: 'ai_credits' } },
+          { id: 's2', state: 'completed', usage: { amount: 2_200_000_000, type: 'ai_credits' } },
+        ],
+      }),
+    );
+    const provider = createCopilotManagedProvider(
+      { apiKey: 'token', model: 'gpt-5.4', repo: 'gamedevpl/www.gamedev.pl-games' },
+      { tasks: stub.client, github: { deleteBranch: vi.fn(), createBranchWithFiles: vi.fn() } },
+    );
+
+    const session = await provider.getSession('task-1');
+
+    expect(session).toMatchObject({
+      state: 'completed',
+      usage: { unit: 'credits', vendor: 'copilot', credits: 3.45, model: 'gpt-5.4' },
+    });
+    expect(session?.usage?.unit).toBe('credits');
+  });
+
+  it('maps the task branch into the managed workspace field', async () => {
+    const stub = tasks(task({ state: 'in_progress', branch: { headRef: 'copilot/tv-tycoon' } }));
+    const provider = createCopilotManagedProvider(
+      { apiKey: 'token', model: 'gpt-5.4', repo: 'gamedevpl/www.gamedev.pl-games' },
+      { tasks: stub.client, github: { deleteBranch: vi.fn(), createBranchWithFiles: vi.fn() } },
+    );
+
+    await expect(provider.getSession('task-1')).resolves.toMatchObject({
+      state: 'in_progress',
+      workspace: 'copilot/tv-tycoon',
+    });
+  });
+
+  it('does not expose outputs or a message channel', async () => {
+    const stub = tasks();
+    const provider = createCopilotManagedProvider(
+      { apiKey: 'token', model: 'gpt-5.4', repo: 'gamedevpl/www.gamedev.pl-games' },
+      { tasks: stub.client, github: { deleteBranch: vi.fn(), createBranchWithFiles: vi.fn() } },
+    );
+
+    expect(await provider.listOutputs('task-1')).toEqual([]);
+    expect(provider.sendMessage).toBeUndefined();
+    await expect(provider.readOutput('task-1', { path: 'game.ts' })).rejects.toThrow(/does not expose session output/);
+    expect(await provider.cancelSession('task-1')).toEqual({ enforced: false });
+    await expect(provider.deleteSession?.('task-1')).resolves.toBeUndefined();
+    await expect(provider.releaseCredential?.('channel-token')).resolves.toBeUndefined();
+  });
+
+  it('deletes the disposable workspace branch during backend cleanup', async () => {
+    const stub = tasks();
+    const deleteBranch = vi.fn(async () => undefined);
+    const provider = createCopilotManagedProvider(
+      { apiKey: 'token', model: 'gpt-5.4', repo: 'gamedevpl/www.gamedev.pl-games' },
+      { tasks: stub.client, github: { deleteBranch, createBranchWithFiles: vi.fn() } },
+    );
+
+    await provider.deleteWorkspace?.('copilot/spent');
+
+    expect(deleteBranch).toHaveBeenCalledWith('copilot/spent');
+  });
+});

--- a/apps/api/src/managed-provider-copilot.ts
+++ b/apps/api/src/managed-provider-copilot.ts
@@ -1,0 +1,165 @@
+import {
+  createAgentTasksClient,
+  creditsFromUsageAmount,
+  resolveTaskBranch,
+  type AgentTask,
+  type AgentTasksClient,
+  type AgentTaskModel,
+} from './agent-tasks.js';
+import { createGitHubClient, type GitHubClient } from './github-client.js';
+import {
+  ManagedAgentError,
+  normalizeManagedState,
+  registerManagedProvider,
+  type ManagedAgentProvider,
+  type ManagedOutputRef,
+  type ManagedProviderConfig,
+  type ManagedSession,
+  type ManagedSessionRequest,
+} from './managed-agent.js';
+
+export const COPILOT_VENDOR = 'copilot';
+
+const DEFAULT_BASE_REF = 'main';
+const DEFAULT_CUSTOM_AGENT = 'game-builder';
+
+export interface CopilotManagedProviderDeps {
+  tasks?: AgentTasksClient;
+  github?: Pick<GitHubClient, 'deleteBranch' | 'createBranchWithFiles'>;
+}
+
+function seedSlug(files: ManagedSessionRequest['workspaceFiles']): string | undefined {
+  const path = files?.[0]?.path ?? '';
+  const match = /^games\/([^/]+)\//.exec(path);
+  return match?.[1];
+}
+
+function withoutSeedPrompt(prompt: string): string {
+  const withoutIntro = prompt.replace(
+    /^(Build a new browser game in `games\/[^`]+\/`). \*\*A first draft of it is already in your checkout\*\* — see below\.$/m,
+    '$1.',
+  );
+  return withoutIntro.replace(
+    /\n## The draft you are starting from\n[\s\S]*?\n## Scope — this is enforced, not advisory\n/,
+    '\n## Scope — this is enforced, not advisory\n',
+  );
+}
+
+function seedBranchName(correlationId: string): string {
+  return `seed/job-${correlationId}`;
+}
+
+async function stageSeed(
+  request: ManagedSessionRequest,
+  baseRef: string,
+  github: Pick<GitHubClient, 'deleteBranch' | 'createBranchWithFiles'>,
+): Promise<string | null> {
+  const files = request.workspaceFiles;
+  const slug = seedSlug(files);
+  if (!files?.length || !slug) return null;
+  const prefix = `games/${slug}/`;
+  const branch = seedBranchName(request.correlationId);
+  try {
+    await github.deleteBranch(branch).catch(() => undefined);
+    await github.createBranchWithFiles({
+      branch,
+      baseRef,
+      message: `Seed round 0 for ${slug} (job ${request.correlationId})`,
+      files: files.map((file) => ({ path: file.path.slice(prefix.length), content: file.content })),
+    });
+    return branch;
+  } catch {
+    return null;
+  }
+}
+
+function taskSession(task: AgentTask, model: string): ManagedSession {
+  const usageTotal = task.sessions.reduce((sum, session) => (session.usage ? sum + session.usage.amount : sum), 0);
+  const hasUsage = task.sessions.some((session) => session.usage);
+  const sessionModel = task.sessions[task.sessions.length - 1]?.model ?? model;
+  return {
+    id: task.id,
+    state: normalizeManagedState(task.state),
+    vendorState: task.state,
+    ...(resolveTaskBranch(task) ? { workspace: resolveTaskBranch(task)! } : {}),
+    ...(hasUsage
+      ? {
+          usage: {
+            unit: 'credits' as const,
+            vendor: COPILOT_VENDOR,
+            credits: creditsFromUsageAmount(usageTotal),
+            model: sessionModel,
+          },
+        }
+      : {}),
+    ...(task.createdAt ? { startedAt: task.createdAt } : {}),
+    ...(task.updatedAt ? { endedAt: task.updatedAt } : {}),
+  };
+}
+
+export function createCopilotManagedProvider(
+  config: ManagedProviderConfig,
+  deps: CopilotManagedProviderDeps = {},
+): ManagedAgentProvider {
+  const repo = config.repo?.trim();
+  if (!repo) throw new ManagedAgentError('copilot managed provider requires a games repo');
+  const baseRef = config.baseRef?.trim() || DEFAULT_BASE_REF;
+  const customAgent = config.customAgent?.trim() || DEFAULT_CUSTOM_AGENT;
+  const createPullRequest = config.createPullRequest ?? false;
+  const tasks =
+    deps.tasks ??
+    createAgentTasksClient({
+      token: config.apiKey,
+      repo,
+      ...(config.fetchImpl ? { fetchImpl: config.fetchImpl } : {}),
+      ...(config.timeoutMs ? { timeoutMs: config.timeoutMs } : {}),
+    });
+  const github = deps.github ?? createGitHubClient({ token: config.apiKey, repo });
+
+  return {
+    vendor: COPILOT_VENDOR,
+    model: config.model,
+    promptLane: 'harness',
+
+    async startSession(request: ManagedSessionRequest): Promise<ManagedSession> {
+      if (request.tools?.mcpEndpoints?.length) {
+        throw new ManagedAgentError('copilot managed provider uses the harness prompt lane, not MCP');
+      }
+      const seedBranch = await stageSeed(request, baseRef, github);
+      const task = await tasks.startTask({
+        prompt: seedBranch ? request.prompt : withoutSeedPrompt(request.prompt),
+        baseRef: seedBranch ?? baseRef,
+        model: request.model as AgentTaskModel,
+        createPullRequest,
+        customAgent,
+      });
+      return { ...taskSession(task, request.model), ...(seedBranch ? { workspace: seedBranch } : {}) };
+    },
+
+    async getSession(sessionId: string): Promise<ManagedSession | null> {
+      const task = await tasks.getTask(sessionId);
+      return task ? taskSession(task, config.model) : null;
+    },
+
+    async listOutputs(): Promise<ManagedOutputRef[]> {
+      return [];
+    },
+
+    async readOutput(_sessionId: string, ref: ManagedOutputRef): Promise<string> {
+      throw new ManagedAgentError(`copilot does not expose session output ${ref.path}`);
+    },
+
+    async cancelSession(): Promise<{ enforced: boolean }> {
+      return { enforced: false };
+    },
+
+    async deleteWorkspace(workspace: string): Promise<void> {
+      await github.deleteBranch(workspace);
+    },
+
+    async deleteSession(): Promise<void> {},
+    async releaseCredential(): Promise<void> {},
+  };
+}
+
+registerManagedProvider(COPILOT_VENDOR, (config) => createCopilotManagedProvider(config));

--- a/docs/managed-agent-backend.md
+++ b/docs/managed-agent-backend.md
@@ -1,11 +1,9 @@
 # Managed agent backend — running the builder ourselves, on a swappable vendor
 
-> Status: ✅ **MCP shape live when selected.** With a valid managed configuration and the
-> environment registry selected, the managed Anthropic adapter occupies the platform
-> builder slot. A round mints a per-round vault for `MANAGED_AGENT_MCP_URL`, the agent
-> delivers through `submit_sources`, and preview mode lands at `ready_for_review`. The
-> remaining gap is the **pull-shape** delivery sink — see
-> [What is not wired yet](#what-is-not-wired-yet).
+> Status: ✅ **MCP and Copilot drivers are implemented.** Anthropic uses the MCP lane;
+> Copilot uses the existing repository harness and build channel. Both run through the
+> managed lifecycle and record their native usage units. Production cutover remains gated
+> by the MP-04 owner approval described in the migration brief.
 >
 > **Why this is not the execution model that was removed for legal reasons.** The thing
 > [`games-repo.md`](./games-repo.md) abandoned was agent compute _we operate_ — containers
@@ -35,7 +33,7 @@ else:
 | Capability | Method                       | Why it is the whole surface                           |
 | ---------- | ---------------------------- | ----------------------------------------------------- |
 | Start      | `startSession`               | A prompt, a model, a workspace, an output directory   |
-| Observe    | `getSession`                 | One normalized state plus token usage                 |
+| Observe    | `getSession`                 | One normalized state plus native usage                |
 | Harvest    | `listOutputs` / `readOutput` | The delivery, pulled — never pushed through the model |
 | Stop       | `cancelSession`              | With an honest `enforced` answer                      |
 
@@ -57,10 +55,8 @@ a second vendor would spell differently belongs in its adapter.
    onto the `AgentTaskState` the job machine already understands. An unknown word reads as
    `in_progress`, never `failed`: a vendor adding a state is not a reason to abandon a live
    build.
-2. **Usage is tokens.** Credits are one vendor's billing unit and cannot be converted to
-   another's at any published rate, so `sessionTokens` is its own field beside
-   `sessionCredits` rather than a reinterpretation of it. A cost report stays honest
-   because each backend reports the only unit it actually knows.
+2. **Usage keeps native units.** Token and credit observations are discriminated and carry
+   their vendor/model identity. No driver converts one unit into another.
 3. **The shared parts are shared, and live in neutral files.** The state vocabulary is
    `agent-state.ts`, not GitHub's client; the brief is `build-prompt.ts`, not Copilot's
    backend. Both used to sit inside the first backend that needed them, which made a second
@@ -69,33 +65,19 @@ a second vendor would spell differently belongs in its adapter.
    Adding one is a `registerManagedProvider` line and a file; replacing one is an
    environment change and a deploy.
 
-## Why Copilot does not move under this seam
+## Copilot under the seam
 
-The obvious tidying — make architecture A a `ManagedAgentProvider` too, so there is one
-abstraction instead of two — makes both worse, and it is worth writing down why before
-someone tries it.
-
-`AgentBackend` is already the shared abstraction, and it is the one carrying its weight:
-Copilot, self and managed all implement it, and the job machine, gate, store, review and
-publication cannot tell them apart. `ManagedAgentProvider` is a deliberately narrower seam
-one level down, for vendors that share the hosted-session shape. Copilot does not share it:
+Copilot now implements `ManagedAgentProvider` while keeping its harness-specific answers:
 
 | Seam capability          | Copilot's answer                                                                     |
 | ------------------------ | ------------------------------------------------------------------------------------ |
 | `startSession` workspace | A **branch**, staged with git writes — not a list of files                           |
-| `getSession` usage       | **Credits**, never tokens. The seam's "tokens are universal" claim is not true of it |
+| `getSession` usage       | **Credits**, never tokens                                                            |
 | `listOutputs`            | Nothing to list. Delivery is a push over the build channel                           |
 | `cancelSession`          | Fits — cooperative, `enforced: false`                                                |
 
-One of four fits. Bending the rest means either a lowest-common-denominator seam where
-every capability is optional — which stops constraining anything and stops being an
-abstraction — or a fat one carrying branches, credits and output directories so that each
-implementation ignores two thirds of it.
-
-What is genuinely shared was shared instead: the state vocabulary (`agent-state.ts`), the
-brief (`build-prompt.ts`), the observation shape, and — once the sink is extracted — one
-definition of "delivered". That is convergence where the two architectures actually agree,
-rather than a common interface over two things that differ.
+The driver declares the harness prompt lane. The backend selects the lane from that
+declaration, so vendor names do not choose prompt behavior.
 
 ## Two delivery shapes, and the one guard that covers both
 
@@ -310,6 +292,18 @@ variable keeps its explicit cents name for server configuration. The backend int
 session when the wall-clock cap expires. Omitting either value makes the probe refuse to start
 rather than run unbounded.
 
+Copilot uses the harness lane and its own Agent Tasks credential:
+
+```bash
+AGENT_TASKS_TOKEN=... \
+npm run managed:probe -w @gamedevpl/api -- --vendor copilot --create --wait \
+  --wait-seconds 120 --budget-credits 25
+```
+
+`--vendor copilot` rejects `--mcp`, `--mcp-url`, and `--override-tools`. A standalone
+Copilot probe can print task transitions and usage, but the production channel signals and
+gate verdict require the app's configured store and delivery wiring.
+
 The probe can inject a digest file while exercising this path:
 
 ```bash
@@ -344,8 +338,13 @@ With `MANAGED_AGENT_DELIVERY_MODE=preview` (the default), a successful delivery 
 | Variable                            | Meaning                                                          |
 | ----------------------------------- | ---------------------------------------------------------------- |
 | `MANAGED_AGENT_VENDOR`              | Registered adapter id; required configuration must also be valid |
-| `MANAGED_AGENT_API_KEY`             | Vendor credential. Never logged, never persisted                 |
-| `MANAGED_AGENT_MODEL`               | Provider model label; Anthropic's actual model is on its Agent   |
+| `MANAGED_AGENT_API_KEY`             | Anthropic credential. Never logged, never persisted              |
+| `MANAGED_AGENT_MODEL`               | Anthropic model label; the actual model is on its Agent          |
+| `AGENT_TASKS_TOKEN`                 | Copilot Agent Tasks credential                                   |
+| `AGENT_TASKS_MODEL`                 | Copilot model label; defaults to the existing Copilot model     |
+| `GAMES_REPO`                        | Games repository targeted by Copilot                            |
+| `GAMES_PUBLISHED_REF`               | Copilot harness base ref                                        |
+| `AGENT_CUSTOM_AGENT`                | Copilot custom agent name                                       |
 | `MANAGED_AGENT_ID`                  | Anthropic Managed Agent resource id                              |
 | `MANAGED_AGENT_ENVIRONMENT_ID`      | Anthropic Managed Environment resource id                        |
 | `MANAGED_AGENT_MCP_URL`             | MCP endpoint; triggers per-round vault + `overrideTools`         |
@@ -353,6 +352,7 @@ With `MANAGED_AGENT_DELIVERY_MODE=preview` (the default), a successful delivery 
 | `MANAGED_AGENT_EFFORT`              | `low` / `medium` / `high`                                        |
 | `MANAGED_AGENT_MAX_SECONDS`         | Hard ceiling on one session's wall clock                         |
 | `MANAGED_AGENT_MAX_LIST_COST_CENTS` | Anthropic session budget, in whole cents                         |
+| `MANAGED_AGENT_COPILOT_MAX_CREDITS` | Optional Copilot per-round credit ceiling                        |
 | `MANAGED_AGENT_DELIVERY_MODE`       | `preview` (default) or `publish`                                 |
 | `MANAGED_AGENT_BASE_URL`            | Override the API origin — gateways, tests                        |
 
@@ -363,11 +363,12 @@ agent we happen to run.
 ## Adding a vendor
 
 1. Write `managed-provider-<vendor>.ts` implementing `ManagedAgentProvider`.
-2. Normalize states with `normalizeManagedState`; report usage in tokens.
-3. Return paths relative to the request's `outputPath`.
-4. Answer `cancelSession` honestly — `enforced: false` if the stop is cooperative.
-5. `registerManagedProvider('<vendor>', factory)` at the bottom of the file.
-6. Import it once where adapters are registered.
+2. Normalize states; report usage in the vendor's native unit.
+3. Declare the prompt lane (`mcp`, `harness`, or `outputs`).
+4. Return paths relative to the request's `outputPath`.
+5. Answer `cancelSession` honestly — `enforced: false` if the stop is cooperative.
+6. `registerManagedProvider('<vendor>', factory)` at the bottom of the file.
+7. Import it once where adapters are registered.
 
 The test suite for the Anthropic adapter is the shape to copy: an injected `fetchImpl`,
 no network, and assertions that the credential never reaches a URL.


### PR DESCRIPTION
## What changed

- Added a Copilot Agent Tasks driver for the managed backend.
- Kept Copilot on the harness prompt lane and Anthropic on the MCP lane.
- Preserved seed staging, task state mapping, workspace cleanup, and cooperative cancellation.
- Added native token/credit usage records and backend budget-stop governance.
- Added environment wiring, probe lane validation, transition timelines, and focused tests.
- Updated the managed backend documentation.

## Why

The legacy Copilot backend and managed backend duplicated lifecycle, stall, cancellation, and cost handling. This makes Copilot another managed driver while preserving its repository harness, build-channel delivery, credential shape, and native usage units.

## #734 rebase resolution

- Rebased onto current `master`, including #734.
- `requires_action` and tool-confirmation handling is explicitly Anthropic-only; Copilot remains harness-only and has no nudge path.
- Budget enforcement runs before signal rereads or nudge handling.
- Added a regression test proving a budget stop wins over an action-blocked observation, cancels once, records `budget_reached`, and does not reread signals.

## Validation

- `npm run lint` passes.
- Managed backend plus Copilot provider focused suite passes: 43 tests.
- Local managed probe smoke test passes.
- Copilot MCP-lane flags reject with an explicit harness-lane error.
- The original pre-rebase gate was green. After rebasing, `npm run type-check` is blocked by an existing current-master error in `apps/api/src/refine.ts` (`RequestBuilder.thinking` is missing from the installed type); this branch has no diff there.
- A post-rebase full test run reached the managed suites successfully, but unrelated baseline tests fail on restricted local socket permissions and an existing grounding expectation.

## Legacy parity audit

Compared `apps/api/src/copilot-backend.test.ts` with the managed-driver coverage:

| Legacy behavior | Managed coverage |
| --- | --- |
| Pinned model, custom agent, no PR, and base targeting | Direct task-payload test |
| State normalization, branch/workspace mapping, and usage summing | Provider mapping plus shared state tests; credit aggregation has a dedicated test |
| Seed branch creation, stale-branch deletion, and fail-open dispatch | Seed staging and fallback tests |
| Cooperative cancellation | Provider and backend cancellation tests |
| Workspace cleanup | Provider workspace deletion and backend cleanup tests |
| Prompt safety, revision framing, credentials, and truncation | Existing shared `buildPrompt` and backend tests |
| Submission/store dispatch bookkeeping | Existing application-layer tests; unchanged by the driver seam |

Intentional seam differences: managed providers expose `startSession` rather than legacy `dispatch`/`resume`, Copilot has no output harvest or message channel, and Copilot does not have an enforced cancel endpoint. The managed backend supplies the shared lifecycle and resume path.

## Scope and rollout

- The legacy Copilot backend remains in place.
- MP-04 cutover and retirement were intentionally not started.
- Live Copilot/Anthropic parity rounds were not run because Agent Tasks credentials were unavailable; the probe and local lifecycle paths are covered.
- The driver, backend governance, probe wiring, and docs remain separable review concerns, kept in one spike commit for now.
