### PR TITLE
Auto-resolve builder handoffs no agent ever acks

### DIFF
--- a/apps/api/src/self-build.test.ts
+++ b/apps/api/src/self-build.test.ts
@@ -840,6 +840,71 @@ describe('self builder (BY-02)', () => {
     expect(staleReport.json().error).toBe(STALE_AGENT_TOKEN_REASON);
   });
 
+  it('force-acknowledges a builder handoff nobody ever acked once it goes stale', async () => {
+    const { backend, briefs } = platformStub();
+    const { gamesStore } = stubGamesStore();
+    const opened = Date.parse('2026-08-01T00:00:00Z');
+    let clock = opened;
+    const created = await createApp({
+      platform: backend,
+      gamesStore,
+      now: () => clock,
+      internalAuthVerifier: { verify: async () => true },
+    });
+    app = created.app;
+    const { store } = created;
+
+    const submit = await app.inject({
+      method: 'POST',
+      url: '/api/submissions',
+      headers: authHeaders(),
+      payload: { title: 'Wedged Handoff', concept: CONCEPT, builder: 'platform' },
+    });
+    expect(submit.statusCode).toBe(200);
+    let issueNumber = 0;
+    await vi.waitFor(async () => {
+      issueNumber = (await store.listSubmissionsByOwner('g:creator'))[0]!.issueNumber;
+      expect((await store.getSubmission(issueNumber))?.state).toBe('dispatched');
+    });
+    await store.touchLastAgentSignalAt(issueNumber, new Date(clock).toISOString());
+
+    const token = mintToken(issueNumber, secret);
+    const handoff = await app.inject({
+      method: 'POST',
+      url: `/api/submissions/${token}/handoff`,
+      headers: authHeaders(),
+      payload: { builder: 'self', stopActivePlatformAgent: true },
+    });
+    expect(handoff.statusCode).toBe(202);
+    expect(handoff.json()).toMatchObject({ pending: true, target: 'self' });
+    expect((await store.getSubmission(issueNumber))?.builderHandoff?.to).toBe('self');
+
+    // The platform agent that was supposed to ack via MCP `end` never does — crashed,
+    // wedged, gone. A sweep just past the stall window must not still be waiting on it.
+    clock = opened + 9 * 60 * 1000;
+    const tooSoon = await app.inject({
+      method: 'POST',
+      url: '/api/internal/notify-sweep',
+      headers: { authorization: 'Bearer internal' },
+    });
+    expect(tooSoon.statusCode).toBe(200);
+    expect((await store.getSubmission(issueNumber))?.builderHandoff?.to).toBe('self');
+    expect((await store.getSubmission(issueNumber))?.builder).toBe('platform');
+
+    clock = opened + 11 * 60 * 1000;
+    const sweep = await app.inject({
+      method: 'POST',
+      url: '/api/internal/notify-sweep',
+      headers: { authorization: 'Bearer internal' },
+    });
+    expect(sweep.statusCode).toBe(200);
+    await vi.waitFor(async () => {
+      const record = await store.getSubmission(issueNumber);
+      expect(record?.builder).toBe('self');
+      expect(record?.builderHandoff).toBeUndefined();
+    });
+  });
+
   it('hands a quiet self round to platform, bumps generation, and seeds from the candidate', async () => {
     const { backend, briefs } = platformStub();
     const { gamesStore } = stubGamesStore();

--- a/apps/api/src/self-build.test.ts
+++ b/apps/api/src/self-build.test.ts
@@ -841,7 +841,7 @@ describe('self builder (BY-02)', () => {
   });
 
   it('force-acknowledges a builder handoff nobody ever acked once it goes stale', async () => {
-    const { backend, briefs } = platformStub();
+    const { backend } = platformStub();
     const { gamesStore } = stubGamesStore();
     const opened = Date.parse('2026-08-01T00:00:00Z');
     let clock = opened;
@@ -879,8 +879,7 @@ describe('self builder (BY-02)', () => {
     expect(handoff.json()).toMatchObject({ pending: true, target: 'self' });
     expect((await store.getSubmission(issueNumber))?.builderHandoff?.to).toBe('self');
 
-    // The platform agent that was supposed to ack via MCP `end` never does — crashed,
-    // wedged, gone. A sweep just past the stall window must not still be waiting on it.
+    // The platform agent never acks via MCP `end` — crashed or wedged.
     clock = opened + 9 * 60 * 1000;
     const tooSoon = await app.inject({
       method: 'POST',

--- a/apps/api/src/submissions.ts
+++ b/apps/api/src/submissions.ts
@@ -201,6 +201,11 @@ const FeedbackRequestSchema = z.object({
 
 const PNG_SIGNATURE = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
 const MAX_CREATOR_SHOT_BYTES = 300 * 1024;
+// A creator-forced handoff (`stopActivePlatformAgent` / `stopActiveSelfAgent`) waits for
+// the currently active agent to call MCP `end` and acknowledge the stop. If that agent is
+// gone or wedged, nothing ever acks and the Studio UI would wait forever — the sweep below
+// force-acknowledges a request that's sat this long unanswered.
+const HANDOFF_ACK_STALL_MS = 10 * 60 * 1000;
 
 /** Fenced playtest context block + optional stored screenshot id for agent fetch. */
 function formatPlaytestContextBlock(
@@ -1300,6 +1305,43 @@ export async function registerSubmissionRoutes(
       input.log.error({ err: error, issueNumber: input.issueNumber, reason }, 'agent resume failed');
       return { started: false, reason };
     }
+  }
+
+  /**
+   * Acknowledges a pending builder handoff and starts the target builder's round.
+   *
+   * Shared by the agent's own MCP `end` call (the happy path: the outgoing agent hits a
+   * checkpoint and acks its own stop) and the sweep's stale-handoff fallback below (the
+   * outgoing agent never acks — gone, crashed, or wedged — so the sweep acks on its
+   * behalf rather than leaving the creator staring at a "waiting for the agent" spinner
+   * forever).
+   */
+  async function acknowledgeBuilderHandoff(input: {
+    issueNumber: number;
+    acknowledgedAt: string;
+    log: { error: (context: object, message: string) => void };
+  }): Promise<ResumeOutcome | { started: false; reason: string }> {
+    if (!store) return { started: false, reason: 'not_configured' };
+    const current = await store.getSubmission(input.issueNumber);
+    const requested = current?.builderHandoff;
+    if (!requested) return { started: false, reason: 'handoff_not_pending' };
+    const acknowledged = await store.acknowledgeBuilderHandoff(input.issueNumber, input.acknowledgedAt);
+    if (!acknowledged) return { started: false, reason: 'handoff_already_acknowledged' };
+    const outcome = await resumeBuild({
+      issueNumber: input.issueNumber,
+      feedback: current?.spec ?? `Continue building "${current?.title ?? 'this game'}" for gamedev.pl.`,
+      locale: current?.locale ?? 'en',
+      log: input.log,
+      builder: acknowledged.to,
+      preserveRoundBudget: true,
+      transition: {
+        by: 'creator',
+        reason: acknowledged.to === 'self' ? 'platform_builder_handoff' : 'self_builder_handoff',
+      },
+    });
+    if (outcome.started) await store.clearBuilderHandoff(input.issueNumber);
+    invalidateStatusCache(input.issueNumber);
+    return outcome;
   }
 
   /**
@@ -4304,6 +4346,24 @@ export async function registerSubmissionRoutes(
             continue;
           }
 
+          // A creator-forced builder handoff waits for the outgoing agent to ack via MCP
+          // `end`. If that agent is gone or wedged, the ack never arrives and Studio would
+          // show "waiting for the current agent" forever — force it through once it's sat
+          // unanswered past the stall window.
+          if (
+            record.builderHandoff &&
+            record.builderHandoff.awaitsAgentAck !== false &&
+            !record.builderHandoff.acknowledgedAt &&
+            now() - Date.parse(record.builderHandoff.requestedAt) > HANDOFF_ACK_STALL_MS
+          ) {
+            await acknowledgeBuilderHandoff({
+              issueNumber: record.issueNumber,
+              acknowledgedAt: new Date(now()).toISOString(),
+              log: request.log,
+            });
+            continue;
+          }
+
           // Unread-request detection. A creator's change request is dispatched to the
           // agent and queued here; the queue is what an agent already mid-session
           // drains. If dispatch succeeded but no agent ever collects — a dead session,
@@ -5244,28 +5304,7 @@ export async function registerSubmissionRoutes(
       // minute-old stall next to fresh progress (submit auto-end + continue loop).
       invalidateStatusCache(issueNumber);
     },
-    onBuilderHandoffAcknowledged: async ({ issueNumber, acknowledgedAt, log }) => {
-      const current = await store!.getSubmission(issueNumber);
-      const requested = current?.builderHandoff;
-      if (!requested) return { started: false, reason: 'handoff_not_pending' };
-      const acknowledged = await store!.acknowledgeBuilderHandoff(issueNumber, acknowledgedAt);
-      if (!acknowledged) return { started: false, reason: 'handoff_already_acknowledged' };
-      const outcome = await resumeBuild({
-        issueNumber,
-        feedback: current?.spec ?? `Continue building "${current?.title ?? 'this game'}" for gamedev.pl.`,
-        locale: current?.locale ?? 'en',
-        log,
-        builder: acknowledged.to,
-        preserveRoundBudget: true,
-        transition: {
-          by: 'creator',
-          reason: acknowledged.to === 'self' ? 'platform_builder_handoff' : 'self_builder_handoff',
-        },
-      });
-      if (outcome.started) await store!.clearBuilderHandoff(issueNumber);
-      invalidateStatusCache(issueNumber);
-      return outcome;
-    },
+    onBuilderHandoffAcknowledged: (input) => acknowledgeBuilderHandoff(input),
     ...(stagedPreviews
       ? { onSourcesStaged: ({ issueNumber }: { issueNumber: number }) => stagedPreviews.schedule(issueNumber) }
       : {}),

--- a/apps/api/src/submissions.ts
+++ b/apps/api/src/submissions.ts
@@ -201,10 +201,7 @@ const FeedbackRequestSchema = z.object({
 
 const PNG_SIGNATURE = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
 const MAX_CREATOR_SHOT_BYTES = 300 * 1024;
-// A creator-forced handoff (`stopActivePlatformAgent` / `stopActiveSelfAgent`) waits for
-// the currently active agent to call MCP `end` and acknowledge the stop. If that agent is
-// gone or wedged, nothing ever acks and the Studio UI would wait forever — the sweep below
-// force-acknowledges a request that's sat this long unanswered.
+// Max wait for a handoff ack before the sweep forces it.
 const HANDOFF_ACK_STALL_MS = 10 * 60 * 1000;
 
 /** Fenced playtest context block + optional stored screenshot id for agent fetch. */
@@ -1307,15 +1304,7 @@ export async function registerSubmissionRoutes(
     }
   }
 
-  /**
-   * Acknowledges a pending builder handoff and starts the target builder's round.
-   *
-   * Shared by the agent's own MCP `end` call (the happy path: the outgoing agent hits a
-   * checkpoint and acks its own stop) and the sweep's stale-handoff fallback below (the
-   * outgoing agent never acks — gone, crashed, or wedged — so the sweep acks on its
-   * behalf rather than leaving the creator staring at a "waiting for the agent" spinner
-   * forever).
-   */
+  // Acks a pending handoff and starts the target builder.
   async function acknowledgeBuilderHandoff(input: {
     issueNumber: number;
     acknowledgedAt: string;
@@ -4346,10 +4335,7 @@ export async function registerSubmissionRoutes(
             continue;
           }
 
-          // A creator-forced builder handoff waits for the outgoing agent to ack via MCP
-          // `end`. If that agent is gone or wedged, the ack never arrives and Studio would
-          // show "waiting for the current agent" forever — force it through once it's sat
-          // unanswered past the stall window.
+          // Stale handoff ack: outgoing agent may be gone.
           if (
             record.builderHandoff &&
             record.builderHandoff.awaitsAgentAck !== false &&


### PR DESCRIPTION
## Summary
- A creator-forced builder handoff (stop the active platform/self agent and switch) waits for the outgoing agent to call MCP `end` and acknowledge the stop. If that agent is gone, crashed, or wedged (e.g. no BYOCA ever connected), the ack never arrives and Studio shows "waiting for the current agent" indefinitely.
- Extracted the ack-and-resume logic shared by the agent's own `end` call into `acknowledgeBuilderHandoff()`.
- The `/api/internal/notify-sweep` loop now force-acknowledges a pending handoff once it's sat unacknowledged for more than 10 minutes, so the requested builder starts anyway instead of hanging forever.

## Test plan
- [x] `npx vitest run` in `apps/api` — 188 files, 2943 tests pass
- [x] New regression test in `self-build.test.ts` covering both "too soon, still waiting" and "past the stall window, force-progresses"
- [x] `tsc --noEmit` clean

---
_Generated by [Claude Code](https://claude.ai/code/session_012JhZL3bFXVMUaeURYhyfsP)_