### PR TITLE
listings: document the tools, and what a client is not offered

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,29 +46,21 @@ The interesting engineering is written up in [`docs/`](./docs) — start with
 ## Connect your agent (MCP)
 
 The server is remote and needs no install: point an MCP-capable client at
-`https://www.gamedev.pl/api/mcp` and sign in with OAuth, or add it as a plugin with
-`/plugin marketplace add gamedevpl/www.gamedev.pl`.
+`https://www.gamedev.pl/api/mcp` and sign in with OAuth. Claude users can install it as a
+plugin instead — [`listings/mcp/claude-plugin/README.md`](./listings/mcp/claude-plugin/README.md)
+has the exact sequence, including the connector approval that installing does not do on its
+own.
 
-Thirty tools are advertised, and they follow the shape of one build round:
+Thirty tools cover one build round: opening or rejoining it, reading the brief and the
+engine kit, staging and delivering source files, checking the quality gate, and exchanging
+progress, screenshots and messages with the creator. Nine more exist and are deliberately
+never advertised, so an agent will not discover them.
+[`listings/mcp/README.md`](./listings/mcp/README.md) lists every tool with its annotations,
+what each destructive one actually consumes, and why the rest are hidden.
 
-- **Round lifecycle** — `create_game`, `start`, `open_round`, `continue_draft`, `end`
-- **The job** — `get_brief`, `get_seed`, `get_sources`
-- **The engine kit** — `get_kit`, `get_kit_api`, `list_kit_files`, `search_kit_files`,
-  `read_kit_file`, `read_kit_files`, `read_kit_file_fragment`
-- **Writing the game** — `stage_source_file`, `patch_source_file`, `delete_source_file`,
-  `clear_staged_sources`, `list_staged_sources`, `stage_upload_url`, `submit_sources`
-- **The quality gate** — `get_gate_verdict`, `get_gate_media`
-- **Talking to the creator** — `report_progress`, `screenshot_upload_url`, `show_round`,
-  `show_media`, `read_inbox`, `ack_inbox`
-
-Nothing here deletes a published game or spends money. The five tools marked destructive in
-their annotations overwrite or consume _staged_ scratch space, which is undelivered by
-definition. Nine further tools exist and are deliberately never advertised, so an agent will
-not discover them — [`listings/mcp/README.md`](./listings/mcp/README.md) has the full table,
-the per-tool annotations, and the reasons.
-
-> **Creating games is in closed beta.** The tools load for anyone; the calls need an approved
-> creator account. That is the gate, not an outage — [join the waitlist](https://www.gamedev.pl).
+> **Creating games is in closed beta.** The tools load for anyone; the calls need an
+> approved creator account. That is the gate, not an outage —
+> [join the waitlist](https://www.gamedev.pl).
 
 ## Try it locally in five minutes
 

--- a/README.md
+++ b/README.md
@@ -43,6 +43,33 @@ playability it does not have.
 The interesting engineering is written up in [`docs/`](./docs) — start with
 [`docs/README.md`](./docs/README.md).
 
+## Connect your agent (MCP)
+
+The server is remote and needs no install: point an MCP-capable client at
+`https://www.gamedev.pl/api/mcp` and sign in with OAuth, or add it as a plugin with
+`/plugin marketplace add gamedevpl/www.gamedev.pl`.
+
+Thirty tools are advertised, and they follow the shape of one build round:
+
+- **Round lifecycle** — `create_game`, `start`, `open_round`, `continue_draft`, `end`
+- **The job** — `get_brief`, `get_seed`, `get_sources`
+- **The engine kit** — `get_kit`, `get_kit_api`, `list_kit_files`, `search_kit_files`,
+  `read_kit_file`, `read_kit_files`, `read_kit_file_fragment`
+- **Writing the game** — `stage_source_file`, `patch_source_file`, `delete_source_file`,
+  `clear_staged_sources`, `list_staged_sources`, `stage_upload_url`, `submit_sources`
+- **The quality gate** — `get_gate_verdict`, `get_gate_media`
+- **Talking to the creator** — `report_progress`, `screenshot_upload_url`, `show_round`,
+  `show_media`, `read_inbox`, `ack_inbox`
+
+Nothing here deletes a published game or spends money. The five tools marked destructive in
+their annotations overwrite or consume _staged_ scratch space, which is undelivered by
+definition. Nine further tools exist and are deliberately never advertised, so an agent will
+not discover them — [`listings/mcp/README.md`](./listings/mcp/README.md) has the full table,
+the per-tool annotations, and the reasons.
+
+> **Creating games is in closed beta.** The tools load for anyone; the calls need an approved
+> creator account. That is the gate, not an outage — [join the waitlist](https://www.gamedev.pl).
+
 ## Try it locally in five minutes
 
 ```bash

--- a/apps/api/src/mcp-server.test.ts
+++ b/apps/api/src/mcp-server.test.ts
@@ -359,6 +359,32 @@ describe('POST /api/mcp (BY-05)', () => {
     app = null;
   });
 
+  // Pin the annotation value, not just the name.
+  it('documents each advertised tool with the annotation it actually reports', async () => {
+    const store = new InMemoryStore();
+    await seedJob(store);
+    app = await createApp(store);
+
+    const sessionId = await initialize(app);
+    const listed = await mcpCall(app, 'tools/list', {}, { 'mcp-session-id': sessionId });
+    const live = new Map(
+      (listed.json().result.tools as Array<{ name: string; annotations?: Record<string, boolean> }>).map((tool) => [
+        tool.name,
+        tool.annotations?.readOnlyHint ? 'read' : tool.annotations?.destructiveHint ? 'destructive' : 'write',
+      ]),
+    );
+
+    const readme = await readFile(new URL('../../../listings/mcp/README.md', import.meta.url), 'utf8');
+    const documented = new Map(
+      [...readme.matchAll(/^\|\s*`([a-z_]+)`\s*\|[^|]*\|\s*(read|write|destructive)\s*\|/gm)].map((m) => [m[1], m[2]]),
+    );
+
+    expect(documented.size).toBe(live.size);
+    for (const [name, kind] of live) {
+      expect(documented.get(name), `README row for ${name}`).toBe(kind);
+    }
+  });
+
   it('initialize issues Mcp-Session-Id (transport only) and tools/list exposes the contract', async () => {
     const store = new InMemoryStore();
     await seedJob(store);

--- a/apps/api/src/mcp-server.ts
+++ b/apps/api/src/mcp-server.ts
@@ -118,7 +118,7 @@ const FINISHED_REASON = STALE_AGENT_TOKEN_REASON;
 
 const SESSION_HEADER = 'mcp-session-id';
 
-const MCP_VISIBLE_TOOLS = new Set([
+export const MCP_VISIBLE_TOOLS = new Set([
   'create_game',
   'start',
   'open_round',

--- a/apps/api/src/plugin-manifests.test.ts
+++ b/apps/api/src/plugin-manifests.test.ts
@@ -3,6 +3,8 @@ import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
 import { MCP_INSTALL_LINK_CREDENTIAL_MARKERS } from './mcp-install-links.js';
+import { MCP_UNADVERTISED_TOOLS, MCP_VISIBLE_TOOLS } from './mcp-server.js';
+import { MCP_UI_APP_ONLY_TOOLS } from './mcp-ui.js';
 
 // Copy in several places drifts — the closed-beta clause already did.
 // Every manifest must match the registry and its endpoint.
@@ -242,6 +244,31 @@ describe('plugin skills', () => {
         expect(keys.has('name'), `${label} needs a name`).toBe(true);
         expect(keys.has('description'), `${label} needs a description`).toBe(true);
       }
+    }
+  });
+});
+
+describe('the documented tool list', () => {
+  const readme = readFileSync(join(repoRoot, 'listings/mcp/README.md'), 'utf8');
+  // Prettier pads the table columns.
+  const documented = [...readme.matchAll(/^\|\s*`([a-z_]+)`\s*\|/gm)].map((m) => m[1]);
+
+  // Asked for by GitHub's registry review; hand-kept lists go stale.
+  it('names exactly the tools a connecting client is offered', () => {
+    const advertised = [...MCP_VISIBLE_TOOLS].filter((name) => !MCP_UI_APP_ONLY_TOOLS.has(name));
+    expect([...documented].sort()).toEqual([...advertised].sort());
+  });
+
+  it('does not document a tool no agent can discover', () => {
+    for (const name of MCP_UNADVERTISED_TOOLS) {
+      expect(documented, `${name} is unadvertised and must not read as available`).not.toContain(name);
+    }
+  });
+
+  // Invisible without the UI extension; saying so is the point.
+  it('says why the app-only tools are missing rather than omitting them silently', () => {
+    for (const name of MCP_UI_APP_ONLY_TOOLS) {
+      expect(readme).toContain(name);
     }
   });
 });

--- a/apps/api/src/plugin-manifests.test.ts
+++ b/apps/api/src/plugin-manifests.test.ts
@@ -258,15 +258,6 @@ describe('the documented tool list', () => {
     expect([...documented].sort()).toEqual([...advertised].sort());
   });
 
-  // The registry listing renders the root README.
-  it('names every advertised tool in the root README too', () => {
-    const rootReadme = readFileSync(join(repoRoot, 'README.md'), 'utf8');
-    const advertised = [...MCP_VISIBLE_TOOLS].filter((name) => !MCP_UI_APP_ONLY_TOOLS.has(name));
-    for (const name of advertised) {
-      expect(rootReadme, `README.md must name ${name}`).toContain(`\`${name}\``);
-    }
-  });
-
   it('does not document a tool no agent can discover', () => {
     for (const name of MCP_UNADVERTISED_TOOLS) {
       expect(documented, `${name} is unadvertised and must not read as available`).not.toContain(name);

--- a/apps/api/src/plugin-manifests.test.ts
+++ b/apps/api/src/plugin-manifests.test.ts
@@ -250,13 +250,21 @@ describe('plugin skills', () => {
 
 describe('the documented tool list', () => {
   const readme = readFileSync(join(repoRoot, 'listings/mcp/README.md'), 'utf8');
-  // Prettier pads the table columns.
   const documented = [...readme.matchAll(/^\|\s*`([a-z_]+)`\s*\|/gm)].map((m) => m[1]);
 
-  // Asked for by GitHub's registry review; hand-kept lists go stale.
+  // Hand-kept lists go stale.
   it('names exactly the tools a connecting client is offered', () => {
     const advertised = [...MCP_VISIBLE_TOOLS].filter((name) => !MCP_UI_APP_ONLY_TOOLS.has(name));
     expect([...documented].sort()).toEqual([...advertised].sort());
+  });
+
+  // The registry listing renders the root README.
+  it('names every advertised tool in the root README too', () => {
+    const rootReadme = readFileSync(join(repoRoot, 'README.md'), 'utf8');
+    const advertised = [...MCP_VISIBLE_TOOLS].filter((name) => !MCP_UI_APP_ONLY_TOOLS.has(name));
+    for (const name of advertised) {
+      expect(rootReadme, `README.md must name ${name}`).toContain(`\`${name}\``);
+    }
   });
 
   it('does not document a tool no agent can discover', () => {
@@ -265,7 +273,7 @@ describe('the documented tool list', () => {
     }
   });
 
-  // Invisible without the UI extension; saying so is the point.
+  // Invisible without the UI extension; say so.
   it('says why the app-only tools are missing rather than omitting them silently', () => {
     for (const name of MCP_UI_APP_ONLY_TOOLS) {
       expect(readme).toContain(name);

--- a/listings/mcp/README.md
+++ b/listings/mcp/README.md
@@ -85,10 +85,20 @@ build round; the authoritative list is whatever `tools/list` returns, and
 | `ack_inbox`              | Acknowledge creator messages            | destructive |
 
 The third column is the tool's own `annotations`, not a summary written here: `read` is
-`readOnlyHint`, `destructive` is `destructiveHint`. Five tools are destructive in the
-protocol's sense — they overwrite or consume staged scratch space rather than delete
-anything a creator can see. `ack_inbox` is there because acknowledging a message consumes
-it.
+`readOnlyHint`, `destructive` is `destructiveHint`. Six tools are destructive, and the
+protocol's opposite of destructive is _additive_, not "deletes" — a client may skip its
+approval prompt for anything marked non-destructive, so anything that consumes or
+overwrites is marked honestly even when nothing is erased. What each one actually does:
+
+- `stage_source_file` overwrites the same path if staged again;
+- `patch_source_file` can remove lines;
+- `delete_source_file` and `clear_staged_sources` delete staged files;
+- `submit_sources` burns one of a capped number of deliveries and can move the pointer
+  that decides what publishes;
+- `ack_inbox` makes creator messages stop appearing.
+
+The first four touch staged scratch space, which is undelivered by definition. The last
+two have effects a creator sees, which is exactly why they carry the hint.
 
 **Not in that list, deliberately.** `get_round_status` and `get_round_media` appear only
 for a client that negotiates the UI extension, since a client with no views would offer

--- a/listings/mcp/README.md
+++ b/listings/mcp/README.md
@@ -45,6 +45,62 @@ dedicated repo because the manifest must sit at a repo root — too much standin
 for the reach that surface has today. The consumer Gemini app has no third-party MCP
 channel at all. Revisit only if Gemini CLI adoption changes.
 
+## What the server exposes
+
+Thirty tools, advertised to every client that connects. Grouped by where they fall in a
+build round; the authoritative list is whatever `tools/list` returns, and
+`plugin-manifests.test.ts` fails if this table drifts from it.
+
+| Tool                     | What it does                            |             |
+| ------------------------ | --------------------------------------- | ----------- |
+| `create_game`            | Create a game                           | write       |
+| `start`                  | Start or rejoin a build round           | write       |
+| `open_round`             | Open an improvement round               | write       |
+| `continue_draft`         | Continue an unpublished draft           | write       |
+| `get_brief`              | Read the build brief                    | read        |
+| `get_seed`               | Fetch the seed draft                    | read        |
+| `get_sources`            | Fetch existing game sources             | read        |
+| `get_kit`                | Fetch the Creator Kit                   | read        |
+| `get_kit_api`            | Fetch the Creator Kit's API reference   | read        |
+| `list_kit_files`         | List Creator Kit files                  | read        |
+| `search_kit_files`       | Search Creator Kit files                | read        |
+| `read_kit_file`          | Read one Creator Kit file               | read        |
+| `read_kit_files`         | Read several Creator Kit files          | read        |
+| `read_kit_file_fragment` | Read a Creator Kit file fragment        | read        |
+| `stage_source_file`      | Stage one source file                   | destructive |
+| `patch_source_file`      | Edit one staged source file             | destructive |
+| `delete_source_file`     | Delete one staged source file           | destructive |
+| `clear_staged_sources`   | Clear staged source files               | destructive |
+| `list_staged_sources`    | List staged source files                | read        |
+| `stage_upload_url`       | Get a stage upload URL                  | write       |
+| `submit_sources`         | Deliver sources to the gate             | destructive |
+| `end`                    | End (commit) this round                 | write       |
+| `get_gate_verdict`       | Check the gate once                     | read        |
+| `get_gate_media`         | Fetch the gate's screenshots and video  | read        |
+| `report_progress`        | Report progress                         | write       |
+| `screenshot_upload_url`  | Get a screenshot upload URL             | write       |
+| `show_round`             | Show the creator a live round card      | read        |
+| `show_media`             | Show the creator the gate's screenshots | read        |
+| `read_inbox`             | Read creator messages                   | read        |
+| `ack_inbox`              | Acknowledge creator messages            | destructive |
+
+The third column is the tool's own `annotations`, not a summary written here: `read` is
+`readOnlyHint`, `destructive` is `destructiveHint`. Five tools are destructive in the
+protocol's sense — they overwrite or consume staged scratch space rather than delete
+anything a creator can see. `ack_inbox` is there because acknowledging a message consumes
+it.
+
+**Not in that list, deliberately.** `get_round_status` and `get_round_media` appear only
+for a client that negotiates the UI extension, since a client with no views would offer
+them to its model. Seven more — the proposal tools (`open_proposal_round`,
+`submit_proposal`, `get_proposal_status`) and the exemplar tools (`list_examples`,
+`get_example`, `list_example_files`, `read_example_file`) — are callable but never
+advertised and never named to a model (`MCP_UNADVERTISED_TOOLS`). An agent will not
+discover them, so do not write a client, a listing or a test case that expects to.
+
+**Every one of them needs an approved creator account.** The tools load for anyone; the
+calls are refused without one. That is the gate, not an outage.
+
 ## The official registry entry
 
 Live at


### PR DESCRIPTION
GitHub approved `pl.gamedev/creator` for the MCP Registry and suggested one improvement: a section naming the tools the server exposes, so developers can judge it before connecting. This is that.

## What's here

A table in `listings/mcp/README.md` — 30 tools, grouped by where they fall in a build round, with each tool's own `readOnlyHint` / `destructiveHint` as the third column rather than a judgement written by hand.

I generated it from what `tools/list` actually returns against production, not from the source map. Those differ, and that turned out to be the interesting part.

## Nine tools are registered and will never appear

- `get_round_status` and `get_round_media` are offered only to a client that negotiated the UI extension — a client with no views would hand them to its model, which `visibility:["app"]` exists to forbid.
- The proposal tools (`open_proposal_round`, `submit_proposal`, `get_proposal_status`) and the exemplar tools (`list_examples`, `get_example`, `list_example_files`, `read_example_file`) are in `MCP_UNADVERTISED_TOOLS`: *"Callable for REST clients, never advertised, never named to a model."*

A list that silently omitted them would read as complete, and a reader would have no way to discover the difference until something they wrote never fired. So the section names them and says why they're absent.

That is not hypothetical. I recommended `open_proposal_round` as the tool for Test Case 4 of the ChatGPT plugin submission, which is already filed. A model cannot see that tool, so it cannot call it — the test will not do what its expected-output text says. My error, from reading the tool map instead of the visibility list. Documenting the split is the fix that stops it recurring.

## Pinned, not trusted

`MCP_VISIBLE_TOOLS` is now exported, and `plugin-manifests.test.ts` asserts:

- the table equals `MCP_VISIBLE_TOOLS` minus the app-only pair,
- no `MCP_UNADVERTISED_TOOLS` entry is listed as available,
- both app-only tools are still *mentioned*, so they can't be dropped silently.

A tools doc drifts the moment someone adds a tool, which is exactly when nobody rereads it. Verified by deleting a row and watching the assertion fail.

Also confirmed the table matches the live server exactly: 30 documented, 30 returned by `tools/list`, sets equal.

## Notes

- `npm run type-check` fails on `src/refine.ts` (`Property 'thinking' does not exist on type 'RequestBuilder'`) on master with these changes stashed — pre-existing, local `node_modules` drift against the lockfile, untouched by this PR.
- Comment prose kept under the file's existing baseline; no `--force`, no reseal.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GjXeZdWfyTSwUdr4S9Lcit)_