### PR TITLE
Fix compact composer vertical alignment

### DIFF
--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -6101,8 +6101,8 @@ a.user-name--profile:focus-visible {
 .status-composer.is-compact.is-empty .status-feedback-input {
   grid-column: 1;
   grid-row: auto;
-  padding: 2px 0;
-  /* Match send height so the placeholder centers. */
+  padding: 6px 0;
+  /* Center the placeholder line inside the send button's height. */
   min-height: 34px;
   line-height: 1.35;
 }
@@ -6233,6 +6233,7 @@ a.user-name--profile:focus-visible {
 
   .status-composer.is-compact.is-empty .status-feedback-input {
     min-height: 44px;
+    padding-block: 11px;
   }
 }
 

--- a/apps/web/src/styles.studioComposer.test.ts
+++ b/apps/web/src/styles.studioComposer.test.ts
@@ -24,6 +24,7 @@ describe('studio compact composer empty state', () => {
     const input = firstRuleBody('.status-composer.is-compact.is-empty .status-feedback-input');
     expect(input).toMatch(/grid-column:\s*1/);
     expect(input).toMatch(/min-height:\s*34px/);
+    expect(input).toMatch(/padding:\s*6px\s+0/);
 
     const toolbar = firstRuleBody('.status-composer.is-compact.is-empty .status-composer-toolbar');
     expect(toolbar).toMatch(/grid-column:\s*2/);


### PR DESCRIPTION
## Summary

- Vertically centers the empty compact composer placeholder with the builder status and send control.
- Adds the matching padding for the 44px mobile control.
- Extends the stylesheet regression test to guard the desktop alignment rule.

## Root cause

The textarea and toolbar boxes were centered together, but the textarea's single line was top-aligned inside its fixed-height box.

## Validation

- Targeted `styles.studioComposer.test.ts` passed.
- Type-check, lint, and production build passed.
- Full-suite attempts also exposed unrelated existing socket/network test failures outside this change.