### PR TITLE
fix(seed): type-check generated GameKit calls

### DIFF
--- a/apps/api/src/game-seed.test.ts
+++ b/apps/api/src/game-seed.test.ts
@@ -273,6 +273,7 @@ function stubContext(overrides: Partial<SeedContext> = {}): SeedContextSource {
   const context: SeedContext = {
     catalogIndex: 'apex-sprint — Apex Sprint — arcade racing\nword-forge — Word Forge — word puzzle',
     scaffold: '--- games/<slug>/game.ts ---\nexport {};',
+    kitDeclaration: null,
     hasGame: (slug) => ['apex-sprint', 'word-forge'].includes(slug),
     renderReferences: (slugs) => slugs.map((slug) => `--- games/${slug}/game.ts ---\nexport {};`).join('\n'),
     ...overrides,
@@ -303,6 +304,27 @@ function stubClient(responses: { text: string; inputTokens?: number; outputToken
     return chain;
   };
   return builder as unknown as ConstructorParameters<typeof VertexGameSeeder>[0]['client'];
+}
+
+function stubClientWithPrompts(responses: { text: string }[]) {
+  const prompts: string[] = [];
+  let call = 0;
+  const builder = ((prompt: string) => {
+    prompts.push(prompt);
+    const response = responses[Math.min(call++, responses.length - 1)];
+    const chain = {
+      temperature: () => chain,
+      maxOutputTokens: () => chain,
+      signal: () => chain,
+      run: async () => ({
+        parts: [{ type: 'text' as const, text: response.text }],
+        model: 'gemini-3.6-flash',
+        usage: { inputTokens: 100, outputTokens: 50 },
+      }),
+    };
+    return chain;
+  }) as unknown as ConstructorParameters<typeof VertexGameSeeder>[0]['client'];
+  return { client: builder, prompts };
 }
 
 const draftFor = (slug: string) =>
@@ -340,6 +362,20 @@ const GOOD_DRAFT = [
   'The trace still needs recording.',
 ].join('\n');
 
+const KIT = `
+interface GameKitDraw {
+  circle(x: number, y: number, r: number): void;
+  ellipse(x: number, y: number, rx: number, ry: number): void;
+}
+interface GameKitSensing {
+  createVoiceMeter(): unknown;
+}
+interface GameKitGameContext {
+  draw: GameKitDraw;
+  sensing: GameKitSensing;
+}
+`;
+
 describe('VertexGameSeeder', () => {
   const request = { slug: 'my-game', title: 'My Game', spec: 'A game about tanks' };
 
@@ -358,8 +394,46 @@ describe('VertexGameSeeder', () => {
     expect(draft!.references).toEqual(['apex-sprint', 'word-forge']);
     expect(draft!.files.map((file) => file.path)).toEqual(['SPEC.md', 'game.ts', 'game/model.ts']);
     expect(draft!.notes).toBe('The trace still needs recording.');
+    expect(draft!.typeChecked).toBe(false);
+    expect(draft!.typeErrors).toBe(0);
     // Both calls are billed to the job, not just the expensive one.
     expect(draft!.usage).toEqual({ inputTokens: 30_400, outputTokens: 8_010, model: 'gemini-3.6-flash' });
+  });
+
+  it('combines bundle and GameKit validation errors into one repair round', async () => {
+    const bundleVerdicts = [
+      { ok: false as const, errors: ['bundle: missing game/render.ts'] },
+      { ok: true as const },
+    ];
+    const typeCheckVerdicts = [
+      { ok: false as const, errors: ['game.ts:1: error TS2339: draw.flash'] },
+      { ok: true as const },
+    ];
+    const { client, prompts } = stubClientWithPrompts([
+      { text: '{"picks":["apex-sprint"]}' },
+      { text: GOOD_DRAFT },
+      { text: '--- games/my-game/game.ts ---\n// repaired\n' },
+    ]);
+
+    const seeder = new VertexGameSeeder({
+      context: stubContext({ kitDeclaration: KIT }),
+      client,
+      bundleCheck: async () => bundleVerdicts.shift()!,
+      typeCheck: (_sources, kitDeclaration) => {
+        expect(kitDeclaration).toBe(KIT);
+        return typeCheckVerdicts.shift()!;
+      },
+    });
+
+    const draft = await seeder.seed(request);
+
+    expect(draft).not.toBeNull();
+    expect(draft!.repaired).toBe(true);
+    expect(draft!.compiles).toBe(true);
+    expect(draft!.typeChecked).toBe(true);
+    expect(draft!.typeErrors).toBe(0);
+    expect(prompts[2]).toContain('bundle: missing game/render.ts');
+    expect(prompts[2]).toContain('game.ts:1: error TS2339: draw.flash');
   });
 
   it('drops hallucinated slugs and keeps the real ones', async () => {
@@ -511,7 +585,7 @@ describe('VertexGameSeeder', () => {
     expect(draft!.files.some((file) => file.path.includes('shared'))).toBe(false);
   });
 
-  const ENV_KEYS = ['SEED_REFERENCES', 'SEED_PICK_TIMEOUT_MS', 'SEED_GENERATE_TIMEOUT_MS'] as const;
+  const ENV_KEYS = ['SEED_REFERENCES', 'SEED_PICK_TIMEOUT_MS', 'SEED_GENERATE_TIMEOUT_MS', 'SEED_TYPECHECK_TIMEOUT_MS'] as const;
   const saved: Record<string, string | undefined> = {};
 
   beforeEach(() => {
@@ -590,6 +664,7 @@ describe('knowledge context injection (KQ-11)', () => {
     const context: SeedContext = {
       catalogIndex: 'apex-sprint — Apex Sprint — arcade racing',
       scaffold: '--- games/<slug>/game.ts ---\nexport {};',
+      kitDeclaration: null,
       hasGame: (slug) => slug === 'apex-sprint',
       renderReferences: (slugs, byteBudget) => {
         budgets.push(byteBudget);

--- a/apps/api/src/game-seed.ts
+++ b/apps/api/src/game-seed.ts
@@ -34,6 +34,9 @@ import type { GenAIClient, GenerationResult } from 'genaicode';
 import { createVertexClient, type VertexGenerationConfig } from './genai.js';
 import { checkSeedBundles, type SeedBundleResult } from './seed-bundle.js';
 import type { SeedContext, SeedContextSource } from './seed-context.js';
+import { typeCheckGame } from './type-check.js';
+import type { TypeCheckResult } from './type-check.js';
+import { TYPECHECK_PREFLIGHT_BUDGET_MS } from './typecheck-preflight.js';
 import type { QueryKnowledgeFn } from './knowledge-search.js';
 
 /**
@@ -76,6 +79,7 @@ const MAX_SEED_TOTAL_BYTES = 400_000;
 /** A seed that has not arrived by now has stopped being an optimization. */
 export const DEFAULT_SEED_PICK_TIMEOUT_MS = 30_000;
 export const DEFAULT_SEED_GENERATE_TIMEOUT_MS = 180_000;
+export const DEFAULT_SEED_TYPECHECK_TIMEOUT_MS = TYPECHECK_PREFLIGHT_BUDGET_MS;
 
 /** Same model family as the rest of our Vertex call sites; flash is the measured choice. */
 const DEFAULT_SEED_MODEL = 'gemini-3.6-flash';
@@ -117,6 +121,8 @@ export interface SeedDraft {
   compiles: boolean;
   /** Whether a repair round ran, so the rate of first-try-correct drafts is measurable. */
   repaired: boolean;
+  typeChecked: boolean;
+  typeErrors: number;
 }
 
 export interface SeedRequest {
@@ -365,9 +371,9 @@ export function renderKnowledgeContext(
  */
 export function buildRepairPrompt(input: { slug: string; errors: string[]; files: SeedFile[] }): string {
   return [
-    'The game draft below fails to compile. Fix it.',
+    'The game draft below fails validation. Fix it.',
     '',
-    'Compiler errors:',
+    'Validation errors:',
     ...input.errors.map((error) => `- ${error}`),
     '',
     'Rules:',
@@ -403,12 +409,14 @@ export interface VertexGameSeederOptions {
   references?: number;
   pickTimeoutMs?: number;
   generateTimeoutMs?: number;
+  typeCheckTimeoutMs?: number;
   log?: { warn: (context: object, message: string) => void; info: (context: object, message: string) => void };
   /** Test seam, mirroring VertexChecker/VertexSpecRefiner: a prebuilt client. */
   client?: GenAIClient;
   // knowledge-search.ts, called server-internally (chunks mode).
   knowledgeSearch?: QueryKnowledgeFn;
   knowledgeTimeoutMs?: number;
+  typeCheck?: (sources: Record<string, string>, kitDeclaration: string | null) => TypeCheckResult;
   /**
    * Test seam for the bundle check. Defaults to the real esbuild pass; tests substitute
    * verdicts so the repair flow is exercised without esbuild's opinion in the loop.
@@ -429,6 +437,7 @@ export class VertexGameSeeder implements GameSeeder {
   private readonly references: number;
   private readonly pickTimeoutMs: number;
   private readonly generateTimeoutMs: number;
+  private readonly typeCheckTimeoutMs: number;
   private readonly model: string;
   private pickClient?: GenAIClient;
   private generateClient?: GenAIClient;
@@ -442,6 +451,10 @@ export class VertexGameSeeder implements GameSeeder {
     this.generateTimeoutMs = positiveNumber(
       options.generateTimeoutMs ?? process.env.SEED_GENERATE_TIMEOUT_MS,
       DEFAULT_SEED_GENERATE_TIMEOUT_MS,
+    );
+    this.typeCheckTimeoutMs = positiveNumber(
+      options.typeCheckTimeoutMs ?? process.env.SEED_TYPECHECK_TIMEOUT_MS,
+      DEFAULT_SEED_TYPECHECK_TIMEOUT_MS,
     );
     this.model = options.model ?? process.env.SEED_MODEL?.trim() ?? DEFAULT_SEED_MODEL;
   }
@@ -501,6 +514,27 @@ export class VertexGameSeeder implements GameSeeder {
     }
   }
 
+  private typeCheck(
+    files: SeedFile[],
+    kitDeclaration: string | null,
+  ): { verdict: TypeCheckResult; checked: boolean } {
+    if (!kitDeclaration) return { verdict: { ok: true }, checked: false };
+
+    const startedAt = Date.now();
+    try {
+      const verdict = (this.options.typeCheck ?? typeCheckGame)(
+        Object.fromEntries(files.map((file) => [file.path, file.content])),
+        kitDeclaration,
+      );
+      if (Date.now() - startedAt > this.typeCheckTimeoutMs) {
+        return { verdict: { ok: true }, checked: false };
+      }
+      return { verdict, checked: true };
+    } catch {
+      return { verdict: { ok: true }, checked: false };
+    }
+  }
+
   async seed(request: SeedRequest): Promise<SeedDraft | null> {
     const startedAt = Date.now();
     try {
@@ -556,11 +590,26 @@ export class VertexGameSeeder implements GameSeeder {
       // One round, not a loop — a draft two rounds from compiling is better finished by
       // the agent, which was going to read it anyway.
       const bundleCheck = this.options.bundleCheck ?? checkSeedBundles;
-      let verdict = await bundleCheck(slug, files);
+      const checkDraft = async (candidate: SeedFile[]) => {
+        const [bundleVerdict, typeCheckResult] = await Promise.all([
+          bundleCheck(slug, candidate),
+          Promise.resolve(this.typeCheck(candidate, context.kitDeclaration)),
+        ]);
+        return { bundleVerdict, typeCheckResult };
+      };
+
+      let checks = await checkDraft(files);
       let repaired = false;
-      if (!verdict.ok) {
+      const validationErrors = () => [
+        ...(checks.bundleVerdict.ok ? [] : checks.bundleVerdict.errors),
+        ...(checks.typeCheckResult.verdict.ok ? [] : checks.typeCheckResult.verdict.errors),
+      ];
+
+      if (validationErrors().length > 0) {
         repaired = true;
-        const repairResult = await this.client('generate')(buildRepairPrompt({ slug, errors: verdict.errors, files }))
+        const repairResult = await this.client('generate')(
+          buildRepairPrompt({ slug, errors: validationErrors(), files }),
+        )
           .maxOutputTokens(65_536)
           .signal(AbortSignal.timeout(this.generateTimeoutMs))
           .run();
@@ -579,8 +628,11 @@ export class VertexGameSeeder implements GameSeeder {
           // still exists and is still a usable head start for the agent.
           if (isUsableSeed(candidate)) files = candidate;
         }
-        verdict = await bundleCheck(slug, files);
+        checks = await checkDraft(files);
       }
+      const typeErrors = checks.typeCheckResult.verdict.ok
+        ? 0
+        : checks.typeCheckResult.verdict.errors.length;
 
       const draft: SeedDraft = {
         slug,
@@ -589,8 +641,10 @@ export class VertexGameSeeder implements GameSeeder {
         ...(parsed.notes ? { notes: parsed.notes } : {}),
         usage,
         elapsedMs: Date.now() - startedAt,
-        compiles: verdict.ok,
+        compiles: checks.bundleVerdict.ok,
         repaired,
+        typeChecked: checks.typeCheckResult.checked,
+        typeErrors,
       };
       this.options.log?.info(
         {
@@ -601,6 +655,8 @@ export class VertexGameSeeder implements GameSeeder {
           tokens: draft.usage,
           compiles: draft.compiles,
           repaired: draft.repaired,
+          typeChecked: draft.typeChecked,
+          typeErrors: draft.typeErrors,
         },
         'seed generated',
       );

--- a/apps/api/src/seed-context.test.ts
+++ b/apps/api/src/seed-context.test.ts
@@ -13,6 +13,8 @@ const CATALOG = JSON.stringify([
 
 const FILES: Record<string, string> = {
   'catalog.json': CATALOG,
+  'shared/game-kit.d.ts': 'interface GameKitDraw { circle(x: number, y: number, r: number): void; }\n',
+  'shared/modules/core.ts': 'export const core = true;\n',
   'templates/game/SPEC.md': '---\ntitle: __TITLE__\n---\n',
   'templates/game/game.ts': "import { startGame } from './game/runtime.ts';\n",
   'templates/game/game/runtime.ts': 'export function startGame() {}\n',
@@ -33,6 +35,7 @@ describe('buildSeedContext', () => {
     expect(context.catalogIndex).toBe(
       'apex-sprint — Apex Sprint — arcade racing\nword-forge — Word Forge — word puzzle',
     );
+    expect(context.kitDeclaration).toContain('interface GameKitDraw');
   });
 
   it('excludes games that are not published', () => {
@@ -54,6 +57,7 @@ describe('buildSeedContext', () => {
     // to run makes any comparison between runs meaningless.
     expect(rendered.indexOf('game/model.ts')).toBeLessThan(rendered.indexOf('game/render.ts'));
     expect(rendered).toContain('export const SPEED = 1;');
+    expect(rendered).not.toContain('game-kit.d.ts');
   });
 
   it('spends the byte budget across games in pick order', () => {
@@ -148,6 +152,7 @@ describe('createArchiveSeedContextSource', () => {
     const second = await source.load();
 
     expect(first?.hasGame('apex-sprint')).toBe(true);
+    expect(first?.kitDeclaration).toContain('interface GameKitDraw');
     expect(second).toBe(first);
     expect(downloads).toBe(1);
   });

--- a/apps/api/src/seed-context.ts
+++ b/apps/api/src/seed-context.ts
@@ -24,12 +24,12 @@ const TEXT_EXTENSIONS = ['.ts', '.json', '.md', '.css', '.html'];
  *
  * Media is the whole reason the games repo is large and none of it can enter a text
  * prompt, so it is dropped at the tar boundary rather than downloaded into memory and
- * ignored. `shared/` is excluded too: GameKit's own source is far larger than the
- * reference budget, and a game's *use* of the engine — which is what the model needs to
- * copy — is visible in the reference games themselves.
+ * ignored. `shared/` stays excluded for prompt budget, except `shared/game-kit.d.ts`,
+ * which the checker reads without rendering.
  */
 function seedInclude(relativePath: string): boolean {
   if (relativePath === 'catalog.json') return true;
+  if (relativePath === 'shared/game-kit.d.ts') return true;
   const inScope = relativePath.startsWith('games/') || relativePath.startsWith('templates/');
   return inScope && TEXT_EXTENSIONS.some((extension) => relativePath.endsWith(extension));
 }
@@ -48,6 +48,8 @@ export interface SeedContext {
   catalogIndex: string;
   /** The `templates/game` skeleton, rendered in the same fence format as references. */
   scaffold: string;
+  /** GameKit declarations for validation, never rendered into a prompt. */
+  kitDeclaration: string | null;
   hasGame(slug: string): boolean;
   /** Full source of the picked games, in fence format, truncated to a byte budget. */
   renderReferences(slugs: string[], byteBudget: number): string;
@@ -126,6 +128,7 @@ export function buildSeedContext(index: SeedFileIndex): SeedContext | null {
   return {
     catalogIndex: published.map((entry) => `${entry.slug} — ${entry.title} — ${entry.genre}`).join('\n'),
     scaffold: renderTree('templates/game', 'games/<slug>', { remaining: CONTEXT_SCAFFOLD_BUDGET }),
+    kitDeclaration: index.read('shared/game-kit.d.ts'),
     hasGame: (slug: string) => slugs.has(slug),
     renderReferences(picks: string[], byteBudget: number): string {
       const budget = { remaining: byteBudget };


### PR DESCRIPTION
## Summary

- Keep `shared/game-kit.d.ts` available to the seed validator without rendering it into model prompts.
- Run the esbuild bundle check and in-process TypeScript check together.
- Combine bundle and type diagnostics into one bounded repair round.
- Preserve `compiles` as the esbuild-only preview flag and expose `typeChecked`/`typeErrors` for observability.
- Fail open when the declaration is absent, the checker errors, or the post-check budget is exceeded.

## Why

The seed pipeline previously treated transpilation as sufficient validation, so incorrect GameKit calls could reach the generated preview. The checker now validates against the real GameKit declaration while keeping prompt context and seed behavior backend-agnostic.

## Validation

Run locally before publishing:

- `npm run type-check`
- `npm run lint`
- `npm run test`
- `npm run build`
- Focused seed/context tests
