### PR TITLE
fix(e2e): studio-shell gate for open chat rail after #739

### DIFF
--- a/apps/e2e/src/studio-shell.test.ts
+++ b/apps/e2e/src/studio-shell.test.ts
@@ -121,9 +121,8 @@ async function stubStudioThreadData(page: Page) {
     }
     const path = new URL(route.request().url()).pathname.replace(/\/$/, '');
     if (path.endsWith(`/api/submissions/${FIXTURE_TOKEN}`)) {
-      // Terminal status so the view stops polling; composer still mounts for any
-      // non-abandoned state (SubmissionStatusView, embedded + compact).
-      await fulfillJson(route, { status: 'published', slug: FIXTURE_SLUG });
+      // needs_changes: rail stays open; published collapses it (#739).
+      await fulfillJson(route, { status: 'needs_changes', slug: FIXTURE_SLUG });
       return;
     }
     await route.fulfill({ status: 404, contentType: 'application/json', body: '{"error":"not found"}' });
@@ -204,9 +203,9 @@ describe.skipIf(!prereq.ok)('the studio thread as an app screen', () => {
       await page.setViewportSize({ width: viewport.width, height: viewport.height });
       await visit(page, '/studio', 4_000);
 
-      // The fixture must put a composer on screen. If it does not, the shell CSS under
-      // test never ran — fail loudly rather than green-ticking an empty assertion.
+      // Expanded rail + composer — collapsed 1px clip makes stick checks nonsense.
       try {
+        await page.waitForSelector('.studio-chat-rail:not(.is-collapsed)', { state: 'attached', timeout: 15_000 });
         await page.waitForSelector('.status-composer.is-compact', { state: 'visible', timeout: 15_000 });
       } catch {
         expect.fail(
@@ -220,6 +219,7 @@ describe.skipIf(!prereq.ok)('the studio thread as an app screen', () => {
         const body = document.querySelector('.studio-thread-scroll-body');
         const detail = document.querySelector('.studio-detail');
         const layout = document.querySelector('.studio-layout');
+        const rail = document.querySelector('.studio-chat-rail');
         // The fixture thread is empty/short. A pad sized as a fraction of the
         // scrollport cannot create overflow by itself (percentage of H is ≤ H),
         // so "scrollHeight - clientHeight" is the wrong signal here — it would
@@ -236,8 +236,9 @@ describe.skipIf(!prereq.ok)('the studio thread as an app screen', () => {
           scrollerClientHeight = scroller.clientHeight;
           const turn = document.createElement('div');
           turn.dataset.e2eInjected = 'true';
-          // Taller than the 4.5rem the pad leaves, so max-scroll is non-trivial.
-          turn.style.cssText = 'height:200px;flex:none;';
+          // Probe must fit the scrollport (phone half-sheet is ~150px tall).
+          const turnHeight = Math.min(200, Math.max(48, Math.floor(scrollerClientHeight * 0.3) || 48));
+          turn.style.cssText = `height:${turnHeight}px;flex:none;`;
           const mount = body ?? pad.parentElement;
           if (mount && body) {
             body.appendChild(turn);
@@ -272,10 +273,20 @@ describe.skipIf(!prereq.ok)('the studio thread as an app screen', () => {
           viewportWidth: window.innerWidth,
           hasSwitcher: Boolean(document.querySelector('.studio-game-switcher')),
           hasShelf: Boolean(document.querySelector('.studio-shelf')),
+          railCollapsed: Boolean(rail?.classList.contains('is-collapsed')),
+          railHeight: rail?.getBoundingClientRect().height ?? 0,
         };
       });
 
       expect(shell.gameOpen, 'the studio should mark a game open so the shell CSS applies').toBe(true);
+      expect(shell.railCollapsed, 'chat rail must stay expanded so stick/runway can be measured').toBe(false);
+      expect(shell.railHeight, 'expanded chat rail needs a real height, not the 1px collapsed clip').toBeGreaterThan(
+        120,
+      );
+      expect(
+        shell.scrollerClientHeight,
+        'transcript scrollport must be tall enough to measure stick geometry',
+      ).toBeGreaterThan(80);
       expect(shell.compactShelf, 'the fixture shelf must be large enough to enter compact-rail mode').toBe(true);
       expect(shell.shelfOpen, 'compact shelf should start collapsed/closed').toBe(false);
       expect(shell.hasSwitcher, 'the switch-game combo must stay gone').toBe(false);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Deploy CI ([run 31437499780](https://github.com/gamedevpl/www.gamedev.pl/actions/runs/31437499780)) failed the browser gate: `studio-shell.test.ts` asserted that content-end stick keeps the last turn in the lower half of the pane, and got nonsense ratios (including negatives) at every width.

Root cause was the game-first studio (#739), not a broken stick formula:

1. The fixture stubbed `status: 'published'`. `defaultRailOpen` collapses the floating chat rail for quiet rounds, so stick/runway geometry was measured on a 1px clipped scroller.
2. On phone / narrow tablet the half-sheet transcript is ~150px tall; the fixed 200px stand-in turn was taller than the scrollport, so even a correct stick put the turn top above the fold.

## Fix

- Stub `needs_changes` so the rail stays open (composer still mounts; poll stays quiet enough).
- Wait for `.studio-chat-rail:not(.is-collapsed)` and assert a real rail/scrollport height before stick checks.
- Size the stand-in turn to ~30% of the scrollport (capped at 200px).

Verified: all 8 `studio-shell` e2e tests pass against the failed deploy's candidate URL (`candidate---gamedev-app-…`), which still serves the #739 build. Green gate (`type-check`, `lint`, `test`, `build`) is clean.

## Test plan

- [x] `npm run type-check && npm run lint && npm run test && npm run build`
- [x] `apps/e2e` studio-shell suite against the candidate revision
- [ ] Deploy workflow browser gate on this PR / after merge

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-11022d60-8b67-4cdf-be4b-1092001808c7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-11022d60-8b67-4cdf-be4b-1092001808c7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

