### PR TITLE
test(knowledge-search): lock in the live Discovery Engine response shape

### DIFF
--- a/apps/api/src/knowledge-search.test.ts
+++ b/apps/api/src/knowledge-search.test.ts
@@ -203,6 +203,84 @@ describe('queryKnowledge — mode=chunks', () => {
   });
 });
 
+describe('live API shape (captured 2026-08-10 against the real gamedevpl-knowledge engine)', () => {
+  it('parses a real :search response verbatim', async () => {
+    const realSearchResponse = {
+      results: [
+        {
+          chunk: {
+            name: 'projects/334141807880/locations/eu/collections/default_collection/dataStores/gamedevpl-knowledge/branches/0/documents/shared-modules-party-ts/chunks/c1',
+            id: 'c1',
+            content: '# shared/modules/party.ts\n\n```ts\nfunction createParty(config) { /* ... */ }\n```',
+            documentMetadata: {
+              uri: 'gs://gamedevpl-games-store/knowledge/fe4d2aa9f46136e56a4d125b17c102475fa6e5bc/shared/modules/party.ts.md',
+              title: 'party.ts',
+              structData: {
+                sourceCommit: 'fe4d2aa9f46136e56a4d125b17c102475fa6e5bc',
+                repoPath: 'shared/modules/party.ts',
+                kitVersion: 'fe4d2aa9f46136e56a4d125b17c102475fa6e5bc',
+                corpus: 'module',
+              },
+            },
+            relevanceScore: 0.7711970806121826,
+          },
+        },
+      ],
+    };
+    const fetchImpl = vi.fn(async () => jsonResponse(realSearchResponse));
+    const queryKnowledge = testClient({ engineId: 'gamedevpl-knowledge', fetchImpl });
+
+    const result = await queryKnowledge({ query: 'how do parties work in gamekit', mode: 'chunks' });
+
+    expect(result.chunks).toEqual([
+      { repoPath: 'shared/modules/party.ts', corpus: 'module', snippet: realSearchResponse.results[0].chunk.content },
+    ]);
+    expect(result.repoPaths).toEqual(['shared/modules/party.ts']);
+    expect(result.indexedCommit).toBe('fe4d2aa9f46136e56a4d125b17c102475fa6e5bc');
+  });
+
+  it('parses a real :answer response verbatim', async () => {
+    const realAnswerResponse = {
+      answer: {
+        state: 'SUCCEEDED',
+        answerText: 'In GameKit, parties are designed for shared-screen multiplayer experiences.',
+        citations: [],
+        references: [
+          {
+            chunkInfo: {
+              content: '## Party (shared-screen + phone controllers)\n\n- Select `party` in `GAME.json` ...',
+              relevanceScore: 0.8,
+              documentMetadata: {
+                document:
+                  'projects/334141807880/locations/eu/collections/default_collection/dataStores/gamedevpl-knowledge/branches/0/documents/github-skills-develop-canvas-game-references-game-kit-md',
+                uri: 'gs://gamedevpl-games-store/knowledge/fe4d2aa9f46136e56a4d125b17c102475fa6e5bc/.github/skills/develop-canvas-game/references/game-kit.md',
+                title: 'game-kit',
+                pageIdentifier: '0',
+                structData: {
+                  kitVersion: 'fe4d2aa9f46136e56a4d125b17c102475fa6e5bc',
+                  corpus: 'skill',
+                  sourceCommit: 'fe4d2aa9f46136e56a4d125b17c102475fa6e5bc',
+                  repoPath: '.github/skills/develop-canvas-game/references/game-kit.md',
+                },
+              },
+            },
+          },
+        ],
+        steps: [],
+      },
+    };
+    const fetchImpl = vi.fn(async () => jsonResponse(realAnswerResponse));
+    const queryKnowledge = testClient({ engineId: 'gamedevpl-knowledge', fetchImpl });
+
+    const result = await queryKnowledge({ query: 'how do parties work in gamekit', mode: 'answer' });
+
+    expect(result.answer).toBe(realAnswerResponse.answer.answerText);
+    expect(result.repoPaths).toEqual(['.github/skills/develop-canvas-game/references/game-kit.md']);
+    expect(result.indexedCommit).toBe('fe4d2aa9f46136e56a4d125b17c102475fa6e5bc');
+    expect(result.chunks[0].snippet).toBe(realAnswerResponse.answer.references[0].chunkInfo.content);
+  });
+});
+
 describe('empty-answer detection and fallback', () => {
   it('falls back to chunks and labels the result, per invariant 2', async () => {
     const fetchImpl = vi

--- a/apps/api/src/knowledge-search.ts
+++ b/apps/api/src/knowledge-search.ts
@@ -155,7 +155,7 @@ function dedupeChunkKey(repoPath: string, content: string): string {
   return JSON.stringify([repoPath, content]);
 }
 
-// UNVERIFIED against a live call: parsing tolerates several plausible :search shapes.
+// Verified against the live Discovery Engine API — matches this shape exactly.
 function extractChunksFromSearchResponse(json: unknown): ExtractedSource {
   const results = isObject(json) && Array.isArray(json.results) ? json.results : [];
   const chunks: KnowledgeChunk[] = [];
@@ -183,7 +183,7 @@ function extractChunksFromSearchResponse(json: unknown): ExtractedSource {
   return { chunks, repoPaths: [...repoPaths], indexedCommit };
 }
 
-// UNVERIFIED against a live call: parsing tolerates several plausible :answer reference shapes.
+// Verified against the live Discovery Engine API — matches this shape exactly.
 function extractFromAnswerResponse(json: unknown): ExtractedSource & { answerText: string; state?: string } {
   const answerObj = isObject(json) && isObject(json.answer) ? json.answer : {};
   const answerText = asString(answerObj.answerText) ?? '';


### PR DESCRIPTION
## Summary
- Part of bringing `knowledge_query` live (#743, KQ-01..KQ-12) — step 3 of the six-step activation plan.
- Verified both `:search` (CHUNKS mode) and `:answer` directly against the real `gamedevpl-knowledge` Discovery Engine after the first successful corpus import (238/238 documents, `fe4d2aa9`).
- Both response shapes match `extractChunksFromSearchResponse`/`extractFromAnswerResponse`'s primary parse path exactly: `results[].chunk.content` + `documentMetadata.{uri,structData.{repoPath,corpus,sourceCommit}}` for search, `answer.references[].chunkInfo.content` + `documentMetadata.structData` for answer.
- No parser changes needed — the previously-`UNVERIFIED` comments are updated to record verification, and two regression tests pin the exact captured real shape so a future API change is caught.

## Rebased 2026-08-12
This branch had gone stale (day-old base, ~40 commits behind) and its "Games-repo contract" check was failing — caused by an unrelated one-line comment this branch had also picked up in `games-repo-contract.ts` (`// Shared card deck/hand primitives (games-repo tip).` above `'cards'`), which broke the cross-repo array-literal scraper. Rebased onto current `master` and dropped that unrelated line entirely; it wasn't needed for this PR's actual purpose. The two knowledge-search.ts comment updates and the two new regression tests are otherwise unchanged.

Note: master has since merged #771 (chunk dedup), which is unrelated to and compatible with this PR — both touch `knowledge-search.ts`/`.test.ts` but in different, non-overlapping regions.

## Test plan
- [x] `npx vitest run apps/api/src/knowledge-search.test.ts` — 27/27 pass (25 existing + 2 new)
- [x] `npm run type-check -w @gamedevpl/api` — clean
- [x] `npx eslint apps/api/src/knowledge-search.ts apps/api/src/knowledge-search.test.ts --max-warnings 0` — clean
- [x] `npm run comment-prose` — clean
- [x] `npx vitest run apps/api/src/games-repo-contract.test.ts apps/api/src/games-repo-contract-check.test.ts` — 66/66 pass (confirms `games-repo-contract.ts` is untouched and clean)

Co-Authored-By: Claude Sonnet 5