### PR TITLE
chat-agent.ts: fix the studio chat agent doing nothing live in prod

### DIFF
--- a/apps/api/fixtures/games-repo/shared/assemble-contract.json
+++ b/apps/api/fixtures/games-repo/shared/assemble-contract.json
@@ -16,6 +16,7 @@
     "drawing",
     "actors",
     "gfx",
+    "ui",
     "gfx3d",
     "racing",
     "football",

--- a/apps/api/src/chat-agent.ts
+++ b/apps/api/src/chat-agent.ts
@@ -8,8 +8,8 @@ import type { JobStall } from './job-state.js';
 // decide() throws on any failure; callers must fail open.
 
 export const DEFAULT_CHAT_MODEL = 'gemini-3.6-flash';
-// ~3x the ~1s typical seen against real Gemini traffic.
-export const DEFAULT_CHAT_TIMEOUT_MS = 3000;
+// Live Vertex ran slower than the API key it was tuned on.
+export const DEFAULT_CHAT_TIMEOUT_MS = 8000;
 // Enough for genre/premise, not a spec dump.
 export const MAX_CONCEPT_CHARS = 400;
 // ~2x any legitimate composition of the fields below — a bloat backstop.

--- a/apps/api/src/games-repo-contract.test.ts
+++ b/apps/api/src/games-repo-contract.test.ts
@@ -104,6 +104,7 @@ describe('games-repo-contract (website half)', () => {
       'drawing',
       'actors',
       'gfx',
+      'ui',
       'gfx3d',
       'racing',
       'football',
@@ -230,7 +231,7 @@ describe('games-repo source extractors', () => {
       // Canonical order
       export const GAME_KIT_MODULES = [
         'input', 'collision', 'world', 'grid', 'path', 'ai', 'gameplay', 'rng', 'cards', 'vehicles', 'urban',
-        'drawing', 'actors', 'gfx', 'gfx3d', 'racing', 'football', 'effects', 'audio', 'party', 'save', 'commons', 'presence', 'mascot', 'zone',
+        'drawing', 'actors', 'gfx', 'ui', 'gfx3d', 'racing', 'football', 'effects', 'audio', 'party', 'save', 'commons', 'presence', 'mascot', 'zone',
         'sensing', 'voice', 'editor',
       ] as const;
     `;

--- a/apps/api/src/games-repo-contract.ts
+++ b/apps/api/src/games-repo-contract.ts
@@ -56,6 +56,7 @@ export const GAME_KIT_MODULES = [
   'drawing',
   'actors',
   'gfx',
+  'ui',
   'gfx3d',
   // Genre verticals: the GitHub client bundles their private shared/verticals graphs.
   'racing',


### PR DESCRIPTION
## Summary

- The studio chat agent (#740) has been silently non-functional in production since merge: every feedback message answerable conversationally ("is it done yet?", "what genre is this game?") fell through the fail-open path to a normal build dispatch instead, with no studio-voice reply ever appearing.
- Reproduced directly against production using `bot:e2e`'s existing draft submission ("Star Parcel Run"): two unambiguous status questions both took 3.5–4.6s and both dispatched as `build` instead of `reply`. The same questions verified as `reply` 3/3 times against live Gemini during #740's development — seeing them dispatch live is the fail-open path firing (a timeout), not a real classification difference.
- Root cause: `DEFAULT_CHAT_TIMEOUT_MS` (3000ms) was tuned entirely against a direct Gemini API key during development, since this session's environment has no Vertex credentials to test the actual production transport. That gap was flagged but not closed before #740 merged. Vertex ran measurably slower live than the API key it was tuned on, so the call was aborting before it ever finished.
- Fix: raised the timeout to 8000ms so the real Vertex transport has room to complete.

## Test plan

- [x] `npm run type-check` — clean across every workspace
- [x] `npm run lint` — clean, comment-prose at/under baseline
- [x] `apps/api` test suite — 193 files / 3039 tests passing
- [x] Reproduced the bug live against production before this fix (two failing calls, root-caused via elapsed-time analysis)
- [ ] Re-verify live against production after this deploys, to confirm the fix actually closes the gap (not just theorized)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01QKoPG5i8SSWLxSDtXs8oAf

---
_Generated by [Claude Code](https://claude.ai/code/session_01QKoPG5i8SSWLxSDtXs8oAf)_