### PR TITLE
readme: stop counting the tools in prose

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,10 +51,10 @@ plugin instead — [`listings/mcp/claude-plugin/README.md`](./listings/mcp/claud
 has the exact sequence, including the connector approval that installing does not do on its
 own.
 
-Thirty tools cover one build round: opening or rejoining it, reading the brief and the
-engine kit, staging and delivering source files, checking the quality gate, and exchanging
-progress, screenshots and messages with the creator. Nine more exist and are deliberately
-never advertised, so an agent will not discover them.
+The tools cover one build round: opening or rejoining it, reading the brief and the engine
+kit, asking the kit and docs a question, staging and delivering source files, checking the
+quality gate, and exchanging progress, screenshots and messages with the creator. Several
+more exist and are deliberately never advertised, so an agent will not discover them.
 [`listings/mcp/README.md`](./listings/mcp/README.md) lists every tool with its annotations,
 what each destructive one actually consumes, and why the rest are hidden.
 

--- a/listings/mcp/README.md
+++ b/listings/mcp/README.md
@@ -47,7 +47,7 @@ channel at all. Revisit only if Gemini CLI adoption changes.
 
 ## What the server exposes
 
-Thirty-one tools, advertised to every client that connects. Grouped by where they fall in a
+Every tool advertised to a connecting client, grouped by where it falls in a
 build round; the authoritative list is whatever `tools/list` returns, and
 `plugin-manifests.test.ts` fails if this table drifts from it.
 


### PR DESCRIPTION
Small follow-up to #742, prompted by watching its guard work.

`knowledge_query` landed in #743 and the table guard did exactly what it was built for — the row and the tool arrived together, and `plugin-manifests.test.ts` stayed green.

The sentence above the table did not, because a numeral in prose is pinned to nothing. The root README still read *"Thirty tools cover one build round"* and *"Nine more exist"*, against a live thirty-one.

Both counts removed rather than corrected. They carry no information the table doesn't, they were wrong within days of being written, and the next tool would have made them wrong again. The table stays pinned; the prose now describes what the tools do instead of how many there are.

Verified against production while checking: `tools/list` returns 31, the table has 31 rows, the sets match.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GjXeZdWfyTSwUdr4S9Lcit)_