### PR TITLE
Fix overlapping Studio chat actions

### DIFF
--- a/apps/web/src/StudioChatRail.test.tsx
+++ b/apps/web/src/StudioChatRail.test.tsx
@@ -1,0 +1,53 @@
+// @vitest-environment jsdom
+
+import { act } from 'react';
+import { createRoot } from 'react-dom/client';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import i18n from './i18n/index.js';
+import { StudioChatRail } from './StudioChatRail.js';
+
+describe('StudioChatRail', () => {
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('separates and names both icon actions', async () => {
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    await i18n.changeLanguage('en');
+    const onOpenChange = vi.fn();
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    const root = createRoot(host);
+
+    await act(async () => {
+      root.render(
+        <StudioChatRail
+          title="Sky Dodge"
+          open
+          onOpenChange={onOpenChange}
+          unreadCount={0}
+          standaloneHref="/status/sky-dodge"
+        >
+          <p>Thread</p>
+        </StudioChatRail>,
+      );
+    });
+
+    const popout = host.querySelector<HTMLAnchorElement>('.studio-chat-rail-popout');
+    const close = host.querySelector<HTMLButtonElement>('.studio-chat-rail-close');
+    expect(host.querySelectorAll('.studio-chat-rail-head-action')).toHaveLength(2);
+    expect(popout?.getAttribute('aria-label')).toBe('Open as page');
+    expect(popout?.dataset.tooltip).toBe('Open as page');
+    expect(popout?.querySelector('svg')?.getAttribute('width')).toBe('14');
+    expect(close?.getAttribute('aria-label')).toBe('Close chat');
+    expect(close?.dataset.tooltip).toBe('Close chat');
+    expect(close?.querySelector('svg')?.getAttribute('width')).toBe('14');
+
+    await act(async () => {
+      close?.click();
+    });
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+
+    await act(async () => root.unmount());
+  });
+});

--- a/apps/web/src/StudioChatRail.tsx
+++ b/apps/web/src/StudioChatRail.tsx
@@ -69,6 +69,8 @@ export function StudioChatRail({
   }, [open, isSheet]);
 
   const visiblyOpen = open && !(isSheet && detent === 'peek');
+  const popOutLabel = t('studioPanel.rail.popOut', { defaultValue: 'Open as page' });
+  const closeLabel = t('studioPanel.rail.closeThread', { defaultValue: 'Close chat' });
   useEffect(() => {
     onVisiblyOpenChange?.(visiblyOpen);
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -167,18 +169,20 @@ export function StudioChatRail({
           <div className="studio-chat-rail-head-actions">
             {standaloneHref ? (
               <a
-                className="studio-chat-rail-popout"
+                className="studio-chat-rail-head-action studio-chat-rail-popout"
                 href={standaloneHref}
-                title={t('studioPanel.rail.popOut', { defaultValue: 'Open as page' })}
+                aria-label={popOutLabel}
+                data-tooltip={popOutLabel}
               >
-                <PixelIcon name="expand" size={12} />
+                <PixelIcon name="expand" size={14} />
               </a>
             ) : null}
             <button
               type="button"
-              className="modal-close-btn"
+              className="studio-chat-rail-head-action studio-chat-rail-close"
               onClick={() => onOpenChange(false)}
-              aria-label={t('studioPanel.close')}
+              aria-label={closeLabel}
+              data-tooltip={closeLabel}
             >
               <PixelIcon name="close" size={14} />
             </button>

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -410,6 +410,7 @@
       "collapse": "Collapse",
       "expand": "Expand",
       "popOut": "Open as page",
+      "closeThread": "Close chat",
       "peekEmpty": "No updates yet"
     },
     "share": {

--- a/apps/web/src/i18n/locales/pl.json
+++ b/apps/web/src/i18n/locales/pl.json
@@ -412,6 +412,7 @@
       "collapse": "Zwiń",
       "expand": "Rozwiń",
       "popOut": "Otwórz jako stronę",
+      "closeThread": "Zamknij czat",
       "peekEmpty": "Brak nowości"
     },
     "share": {

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -11777,23 +11777,77 @@ button.builder-mode-selector:disabled {
 .studio-chat-rail-head-actions {
   display: inline-flex;
   align-items: center;
-  gap: 4px;
+  gap: 6px;
   flex: none;
 }
 
-.studio-chat-rail-popout {
+.studio-chat-rail-head-action {
+  position: relative;
+  z-index: 3;
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 30px;
-  height: 30px;
-  border-radius: 8px;
+  width: 36px;
+  height: 36px;
+  padding: 0;
+  border: 1px solid transparent;
+  border-radius: 9px;
+  background: transparent;
   color: var(--muted);
+  text-decoration: none;
+  cursor: pointer;
+  transition:
+    color 140ms ease,
+    background 140ms ease,
+    border-color 140ms ease;
 }
 
-.studio-chat-rail-popout:hover {
+.studio-chat-rail-head-action:hover,
+.studio-chat-rail-head-action:focus-visible {
   color: var(--text);
   background: rgba(148, 163, 184, 0.1);
+  border-color: rgba(148, 163, 184, 0.22);
+}
+
+.studio-chat-rail-head-action:focus-visible {
+  outline: 2px solid var(--turquoise);
+  outline-offset: 2px;
+}
+
+.studio-chat-rail-head-action::after {
+  content: attr(data-tooltip);
+  position: absolute;
+  top: calc(100% + 7px);
+  right: 0;
+  width: max-content;
+  max-width: 190px;
+  padding: 6px 8px;
+  border: 1px solid var(--panel-border);
+  border-radius: 7px;
+  background: rgba(5, 9, 13, 0.98);
+  color: var(--text);
+  box-shadow: 0 8px 22px rgba(0, 0, 0, 0.42);
+  font-size: 0.72rem;
+  font-weight: 600;
+  line-height: 1.2;
+  white-space: normal;
+  text-align: center;
+  pointer-events: none;
+  opacity: 0;
+  visibility: hidden;
+  transform: translateY(-3px);
+  transition:
+    opacity 120ms ease,
+    transform 120ms ease,
+    visibility 0s linear 120ms;
+}
+
+.studio-chat-rail-head-action:hover::after,
+.studio-chat-rail-head-action:focus-visible::after {
+  opacity: 1;
+  visibility: visible;
+  transform: translateY(0);
+  transition-delay: 0s;
 }
 
 .studio-chat-rail-body {

--- a/apps/web/src/styles.studioChatRail.test.ts
+++ b/apps/web/src/styles.studioChatRail.test.ts
@@ -1,0 +1,30 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const css = readFileSync(fileURLToPath(new URL('./styles.css', import.meta.url)), 'utf8');
+
+function declarations(selector: string): string {
+  const start = css.indexOf(`${selector} {`);
+  expect(start, `missing ${selector} rule`).toBeGreaterThan(-1);
+  const end = css.indexOf('}', start);
+  expect(end, `unclosed ${selector} rule`).toBeGreaterThan(start);
+  return css.slice(start, end);
+}
+
+describe('Studio chat rail header', () => {
+  it('keeps both actions in one separated flex row', () => {
+    expect(declarations('.studio-chat-rail-head-actions')).toMatch(/display:\s*inline-flex/);
+    expect(declarations('.studio-chat-rail-head-actions')).toMatch(/gap:\s*6px/);
+    expect(declarations('.studio-chat-rail-head-action')).toMatch(/position:\s*relative/);
+    expect(declarations('.studio-chat-rail-head-action')).toMatch(/width:\s*36px/);
+    expect(declarations('.studio-chat-rail-head-action')).toMatch(/height:\s*36px/);
+  });
+
+  it('reveals localized tooltips on hover and keyboard focus', () => {
+    expect(declarations('.studio-chat-rail-head-action::after')).toMatch(/content:\s*attr\(data-tooltip\)/);
+    expect(css).toMatch(
+      /\.studio-chat-rail-head-action:hover::after,\s*\.studio-chat-rail-head-action:focus-visible::after\s*{[^}]*opacity:\s*1[^}]*visibility:\s*visible/s,
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- keep the Studio chat pop-out and close controls in one explicit flex action row
- add consistent sizing, spacing, hover/focus treatment, and localized tooltips
- add component and stylesheet regression coverage

## Root cause

The chat close button reused the generic `.modal-close-btn` class, which positions controls absolutely. The neighboring pop-out link stayed in normal flex flow, so both controls tried to occupy the same top-right space.

## Impact

The two actions are now distinct and legible, including with long Polish titles, compact phone layouts, keyboard-height viewports, and bottom update banners. Both controls expose localized accessible names and visible hover/keyboard-focus tooltips.

Existing navigation and close behavior is unchanged. None of the product instrumentation questions are affected, so no telemetry event was added.

## Validation

- `npm run type-check`
- `npm run lint`
- `npm exec --workspace @gamedevpl/web -- vitest run src/StudioChatRail.test.tsx src/styles.studioChatRail.test.ts`
- `npm run build`
- browser checks at desktop, phone, and keyboard-height viewports, including long Polish copy and an update banner
