### PR TITLE
Remove studio composer direct-to-builder escape hatch

### DIFF
--- a/apps/api/src/chat-agent-metrics.test.ts
+++ b/apps/api/src/chat-agent-metrics.test.ts
@@ -2,36 +2,27 @@ import { describe, expect, it, vi } from 'vitest';
 import {
   asChatAgentLogger,
   CHAT_AGENT_DECISION_MSG,
-  CHAT_AGENT_ESCAPE_HATCH_MSG,
   CHAT_AGENT_FAILOPEN_MSG,
   logChatAgentDecision,
-  logChatAgentEscapeHatch,
   logChatAgentFailOpen,
 } from './chat-agent-metrics.js';
 
 describe('chat agent metrics', () => {
-  it('emits stable decision / fail-open / escape-hatch messages, never the message text', () => {
+  it('emits stable decision / fail-open messages, never the message text', () => {
     const info = vi.fn();
     const warn = vi.fn();
     const log = { info, warn };
 
     logChatAgentDecision(log, { issueNumber: 42, scope: 'draft', outcome: 'reply' });
     logChatAgentFailOpen(log, { issueNumber: 42, scope: 'draft', reason: 'timeout' });
-    logChatAgentEscapeHatch(log, { issueNumber: 42, scope: 'improve' });
 
-    expect(info).toHaveBeenNthCalledWith(
-      1,
+    expect(info).toHaveBeenCalledWith(
       { chatAgent: { issueNumber: 42, scope: 'draft', outcome: 'reply' } },
       CHAT_AGENT_DECISION_MSG,
     );
     expect(warn).toHaveBeenCalledWith(
       { chatAgent: { issueNumber: 42, scope: 'draft', reason: 'timeout' } },
       CHAT_AGENT_FAILOPEN_MSG,
-    );
-    expect(info).toHaveBeenNthCalledWith(
-      2,
-      { chatAgent: { issueNumber: 42, scope: 'improve' } },
-      CHAT_AGENT_ESCAPE_HATCH_MSG,
     );
 
     // Closed-shape payloads only — never the message or reply text.

--- a/apps/api/src/chat-agent-metrics.ts
+++ b/apps/api/src/chat-agent-metrics.ts
@@ -2,7 +2,6 @@
 
 export const CHAT_AGENT_DECISION_MSG = 'studio chat agent decision';
 export const CHAT_AGENT_FAILOPEN_MSG = 'studio chat agent failed open';
-export const CHAT_AGENT_ESCAPE_HATCH_MSG = 'studio chat agent escape hatch used';
 
 export type ChatAgentScopeLabel = 'draft' | 'improve';
 export type ChatAgentOutcome = 'build' | 'reply';
@@ -42,8 +41,4 @@ export function logChatAgentFailOpen(
     { chatAgent: { issueNumber: input.issueNumber, scope: input.scope, reason: input.reason } },
     CHAT_AGENT_FAILOPEN_MSG,
   );
-}
-
-export function logChatAgentEscapeHatch(log: Logger, input: { issueNumber: number; scope: ChatAgentScopeLabel }): void {
-  log.info({ chatAgent: { issueNumber: input.issueNumber, scope: input.scope } }, CHAT_AGENT_ESCAPE_HATCH_MSG);
 }

--- a/apps/api/src/submissions.test.ts
+++ b/apps/api/src/submissions.test.ts
@@ -3172,37 +3172,6 @@ describe('the Studio mini chat agent (feedback route)', () => {
     await app.close();
   });
 
-  it('the composer escape hatch skips the model entirely', async () => {
-    const { backend } = createBackendStub();
-    const decide = vi.fn(async () => ({ kind: 'reply' as const, text: 'should never be read' }));
-    const { app, authHeaders, store } = await createApp({
-      githubClient: createGithubClientStub({ issueNumber: 90 }).githubClient,
-      agentBackend: backend,
-      submissionTokenSecret: secret,
-      chatAgent: { decide },
-    });
-    await app.inject({
-      method: 'POST',
-      url: '/api/submissions',
-      headers: authHeaders,
-      payload: { title: 'A game', concept: 'A sufficiently long concept about a garden full of robots.' },
-    });
-    const [job] = await store.listSubmissionsByOwner('g:test-user');
-    const token = mintToken(job.issueNumber, secret);
-
-    const res = await app.inject({
-      method: 'POST',
-      url: `/api/submissions/${token}/feedback`,
-      headers: authHeaders,
-      payload: { feedback: 'Make the robots water the flowers faster.', directToBuilder: true },
-    });
-    expect(res.statusCode).toBe(200);
-    expect(decide).not.toHaveBeenCalled();
-    const pending = await store.listPendingCreatorMessages(job.issueNumber);
-    expect(pending.map((m) => m.text)).toContain('Make the robots water the flowers faster.');
-    await app.close();
-  });
-
   it("a build decision still queues the creator's own words, plus an optional studio ack", async () => {
     const { backend } = createBackendStub();
     const decide = vi.fn(async () => ({ kind: 'build' as const, text: 'On it!' }));

--- a/apps/api/src/submissions.ts
+++ b/apps/api/src/submissions.ts
@@ -89,12 +89,7 @@ import {
   type ChatAgentStatus,
   type StudioChatAgent,
 } from './chat-agent.js';
-import {
-  asChatAgentLogger,
-  logChatAgentDecision,
-  logChatAgentEscapeHatch,
-  logChatAgentFailOpen,
-} from './chat-agent-metrics.js';
+import { asChatAgentLogger, logChatAgentDecision, logChatAgentFailOpen } from './chat-agent-metrics.js';
 import { MAX_CHAT_TURNS, rememberChatTurn, type ChatTurn } from './chat-turns.js';
 import { mintConnectPayload } from './self-build-connect.js';
 import { createLocalGamesClient, resolveLocalGamesDir } from './local-games-repo.js';
@@ -197,8 +192,6 @@ const FeedbackRequestSchema = z.object({
    * is still active — switching is a round-boundary decision only.
    */
   builder: z.enum(['platform', 'self']).optional(),
-  // Composer escape hatch: skip the mini chat agent for this one message.
-  directToBuilder: z.boolean().optional(),
   /**
    * Optional playtest attachment from Creator Studio: a paused-frame PNG (base64,
    * no data: prefix) plus a small instrumentation digest. Treated as data, never
@@ -1513,13 +1506,8 @@ export async function registerSubmissionRoutes(
     locale: string;
     ip: string;
     uid: string;
-    directToBuilder?: boolean;
   }): Promise<ChatAgentOutcome | null> {
     if (!store || !chatAgentLog) return null;
-    if (input.directToBuilder) {
-      logChatAgentEscapeHatch(chatAgentLog, { issueNumber: input.issueNumber, scope: input.scope });
-      return null;
-    }
     if (isRateLimited(chatTurnsByIp, input.ip, now(), maxChatTurnsPerWindow, chatTurnRateLimitWindowMs)) {
       return null;
     }
@@ -3950,7 +3938,6 @@ export async function registerSubmissionRoutes(
           locale: creatorLocale,
           ip: request.ip,
           uid: request.user!.uid,
-          directToBuilder: parsed.data.directToBuilder,
         });
         if (chatOutcome?.kind === 'replied' && store) {
           try {
@@ -4188,7 +4175,6 @@ export async function registerSubmissionRoutes(
         locale: record.locale ?? 'en',
         ip: request.ip,
         uid: request.user!.uid,
-        directToBuilder: parsed.data.directToBuilder,
       });
       if (chatOutcome?.kind === 'replied') {
         try {

--- a/apps/web/src/SubmissionStatusView.tsx
+++ b/apps/web/src/SubmissionStatusView.tsx
@@ -1425,8 +1425,6 @@ function FeedbackPanel({
   // hours, which is exactly how an exhausted agent allowance reads as a hung game.
   const [notice, setNotice] = useState<string | null>(null);
   const [builder, setBuilder] = useState<BuilderKind>(initialBuilder);
-  // Escape hatch for the chat agent: armed per-message, cleared after send.
-  const [directToBuilder, setDirectToBuilder] = useState(false);
   const inputRef = useRef<HTMLTextAreaElement | null>(null);
 
   useEffect(() => {
@@ -1495,21 +1493,17 @@ function FeedbackPanel({
       // server reported rather than by asking the creator which one they meant.
       // Shortest call shape for the ordinary case — tests assert on it.
       if (published) {
-        const improved = directToBuilder
-          ? await submitImprovement(token, trimmed, undefined, roundBuilder, true)
-          : roundBuilder
-            ? await submitImprovement(token, trimmed, undefined, roundBuilder)
-            : await submitImprovement(token, trimmed);
+        const improved = roundBuilder
+          ? await submitImprovement(token, trimmed, undefined, roundBuilder)
+          : await submitImprovement(token, trimmed);
         // Publishing is terminal: the improvement is a new job with its own token. The
         // builder memory is keyed by token in localStorage, so persist the choice under
         // the *new* token as well — the old token's memory dies with its round.
         handoffToken = improved.token;
       } else {
-        const result = directToBuilder
-          ? await submitFeedback(token, trimmed, undefined, roundBuilder, true)
-          : roundBuilder
-            ? await submitFeedback(token, trimmed, undefined, roundBuilder)
-            : await submitFeedback(token, trimmed);
+        const result = roundBuilder
+          ? await submitFeedback(token, trimmed, undefined, roundBuilder)
+          : await submitFeedback(token, trimmed);
         if (result.roundStarted === false) {
           setNotice(
             result.reason === 'no_capacity' ? t('statusView.feedback.noCapacity') : t('statusView.feedback.notStarted'),
@@ -1524,7 +1518,6 @@ function FeedbackPanel({
       }
       setState('sent');
       setText('');
-      setDirectToBuilder(false);
       // Back to the CSS height rather than the height the sent message grew it to: an
       // empty box the size of the last paragraph is a leftover, not a state.
       if (inputRef.current) inputRef.current.style.height = '';
@@ -1612,20 +1605,6 @@ function FeedbackPanel({
     </div>
   );
 
-  // Recovery from any misclassification — always available, not just mid-round.
-  const directToBuilderToggle = (
-    <button
-      type="button"
-      className={`status-composer-escape${directToBuilder ? ' is-armed' : ''}`}
-      onClick={() => setDirectToBuilder((armed) => !armed)}
-      disabled={state === 'sending'}
-      aria-pressed={directToBuilder}
-      title={t('statusView.feedback.directToBuilder')}
-    >
-      <PixelIcon name="send" size={12} />
-    </button>
-  );
-
   // Standalone status page still shows a brief receipt next to Send. The studio
   // composer does not: the message is echoed into the thread immediately, so a
   // second "Sent!" under the box is the same confirmation twice.
@@ -1693,10 +1672,7 @@ function FeedbackPanel({
           disabled={sending}
         />
         <div className="status-composer-toolbar">
-          <div className="status-composer-toolbar-left">
-            {builderControls}
-            {directToBuilderToggle}
-          </div>
+          <div className="status-composer-toolbar-left">{builderControls}</div>
           <div className="status-composer-toolbar-right">
             <button
               type="button"
@@ -1762,7 +1738,6 @@ function FeedbackPanel({
         >
           {state === 'sending' ? t('statusView.feedback.sending') : t('statusView.feedback.submit')}
         </button>
-        {directToBuilderToggle}
         {sentReceipt}
       </div>
       {error ? <p className="error">{error}</p> : null}

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -739,8 +739,7 @@
       "notStarted": "Saved — but a new build round didn't start. Your note is safe; we're looking into it.",
       "error": "We couldn't send that right now. Please try again in a moment.",
       "quota": "You've sent a lot of feedback today — please try again tomorrow.",
-      "published": "This game is already published. Submit a new idea to make another version.",
-      "directToBuilder": "Send straight to the builder, skipping the studio's reply"
+      "published": "This game is already published. Submit a new idea to make another version."
     },
     "handoff": {
       "notice": "Improvement round started — this is the new build thread.",

--- a/apps/web/src/i18n/locales/pl.json
+++ b/apps/web/src/i18n/locales/pl.json
@@ -743,8 +743,7 @@
       "notStarted": "Zapisano — ale nowa runda budowania się nie rozpoczęła. Twoja wiadomość jest bezpieczna; sprawdzamy, co się stało.",
       "error": "Nie udało się teraz tego wysłać. Spróbuj ponownie za chwilę.",
       "quota": "Wysłałeś dziś dużo uwag — spróbuj ponownie jutro.",
-      "published": "Ta gra jest już opublikowana. Prześlij nowy pomysł, aby stworzyć kolejną wersję.",
-      "directToBuilder": "Wyślij bezpośrednio do agenta budującego, z pominięciem odpowiedzi studia"
+      "published": "Ta gra jest już opublikowana. Prześlij nowy pomysł, aby stworzyć kolejną wersję."
     },
     "handoff": {
       "notice": "Runda ulepszeń rozpoczęta — to jest wątek nowej wersji.",

--- a/apps/web/src/studioApi.ts
+++ b/apps/web/src/studioApi.ts
@@ -358,8 +358,6 @@ export async function submitImprovement(
   feedback: string,
   context?: FeedbackContext,
   builder?: 'platform' | 'self',
-  // Composer escape hatch: skip the chat agent for this one message.
-  directToBuilder?: boolean,
 ): Promise<{ ok: boolean; jobId?: number; token?: string; slug?: string; shotId?: string }> {
   const response = await fetch(`${API_BASE}/api/submissions/${encodeURIComponent(token)}/improve`, {
     method: 'POST',
@@ -369,7 +367,6 @@ export async function submitImprovement(
       feedback,
       ...(context ? { context } : {}),
       ...(builder ? { builder } : {}),
-      ...(directToBuilder ? { directToBuilder } : {}),
     }),
   });
   if (!response.ok) {

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -6244,46 +6244,8 @@ a.user-name--profile:focus-visible {
   border-top-color: var(--turquoise);
 }
 
-/* The mini chat agent's escape hatch: armed, the next send skips it and goes straight
-   to the builder. Quiet until pressed — this is a recovery control, not a primary
-   action — then it takes the same accent as the studio voice it is bypassing, so the
-   armed state reads as "talking to the builder directly" rather than as an error. */
-.status-composer-escape {
-  flex: none;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 26px;
-  height: 26px;
-  padding: 0;
-  border-radius: 50%;
-  border: 1px solid var(--panel-border);
-  background: transparent;
-  color: var(--muted);
-  cursor: pointer;
-}
-
-.status-composer-escape:hover:not(:disabled) {
-  color: var(--text);
-  border-color: var(--muted);
-}
-
-.status-composer-escape.is-armed {
-  color: var(--accent-blue);
-  border-color: var(--accent-blue);
-  background: rgba(56, 189, 248, 0.12);
-}
-
-.status-composer-escape:disabled {
-  opacity: 0.5;
-  cursor: not-allowed;
-}
-
-/* Square again where every button gets a 44px floor for fingers — with a fixed width and
-   a floored height it would have come out an oval. */
 @media (max-width: 768px) {
-  .status-composer.is-compact .status-composer-send,
-  .status-composer.is-compact .status-composer-escape {
+  .status-composer.is-compact .status-composer-send {
     width: 44px;
     height: 44px;
   }

--- a/apps/web/src/styles.studioComposer.test.ts
+++ b/apps/web/src/styles.studioComposer.test.ts
@@ -39,11 +39,13 @@ describe('studio compact composer empty state', () => {
 
 describe('send button mobile touch target', () => {
   it('grows send to a 44px floor on phones', () => {
-    const marker = '.status-composer.is-compact .status-composer-send {';
+    // Phone override only — base send stays 34px.
+    const marker = '@media (max-width: 768px) {\n  .status-composer.is-compact .status-composer-send {';
     const start = css.indexOf(marker);
-    expect(start, 'send is not sized in the mobile rule').toBeGreaterThan(-1);
-    const end = css.indexOf('}', start);
-    const body = css.slice(start + marker.length, end);
+    expect(start, 'send is not sized in the phone media query').toBeGreaterThan(-1);
+    const bodyStart = start + marker.length;
+    const end = css.indexOf('}', bodyStart);
+    const body = css.slice(bodyStart, end);
     expect(body).toMatch(/width:\s*44px/);
     expect(body).toMatch(/height:\s*44px/);
   });

--- a/apps/web/src/styles.studioComposer.test.ts
+++ b/apps/web/src/styles.studioComposer.test.ts
@@ -37,12 +37,11 @@ describe('studio compact composer empty state', () => {
   });
 });
 
-describe('escape hatch mobile touch target', () => {
-  it('grows the escape hatch to the same 44px floor as send on phones', () => {
-    const marker =
-      '.status-composer.is-compact .status-composer-send,\n  .status-composer.is-compact .status-composer-escape {';
+describe('send button mobile touch target', () => {
+  it('grows send to a 44px floor on phones', () => {
+    const marker = '.status-composer.is-compact .status-composer-send {';
     const start = css.indexOf(marker);
-    expect(start, 'escape hatch is not sized alongside send in the mobile rule').toBeGreaterThan(-1);
+    expect(start, 'send is not sized in the mobile rule').toBeGreaterThan(-1);
     const end = css.indexOf('}', start);
     const body = css.slice(start + marker.length, end);
     expect(body).toMatch(/width:\s*44px/);

--- a/apps/web/src/submissionApi.ts
+++ b/apps/web/src/submissionApi.ts
@@ -472,8 +472,6 @@ export async function submitFeedback(
   feedback: string,
   context?: FeedbackContext,
   builder?: 'platform' | 'self',
-  // Composer escape hatch: skip the chat agent for this one message.
-  directToBuilder?: boolean,
 ): Promise<FeedbackResult> {
   const response = await fetch(`${API_BASE}/api/submissions/${encodeURIComponent(token)}/feedback`, {
     method: 'POST',
@@ -483,7 +481,6 @@ export async function submitFeedback(
       feedback,
       ...(context ? { context } : {}),
       ...(builder ? { builder } : {}),
-      ...(directToBuilder ? { directToBuilder } : {}),
     }),
   });
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Removes the Studio composer “send straight to the builder” escape hatch. Every feedback/improve message goes through the mini chat agent (or its fail-open path) — no side door.

## Changes

- Drop the composer toggle and related CSS/i18n
- Remove the `directToBuilder` request field and escape-hatch metric
- Delete the API/web tests that asserted the bypass

## Test plan

- [x] Green gate: `npm run type-check && npm run lint && npm run test && npm run build`
- [ ] Composer shows only Send (no upward-arrow bypass)
- [ ] Feedback/improve still route through the chat agent when `STUDIO_CHAT_AGENT` is on

Paired ops-plan update: gamedevpl/www.gamedev.pl-ops#107
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-73893e79-13c2-437c-bd46-c85f261955e9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-73893e79-13c2-437c-bd46-c85f261955e9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

