### PR TITLE
Show the gamedev.pl mascot on the "build in progress" stage card

### DIFF
--- a/apps/web/src/Mascot.tsx
+++ b/apps/web/src/Mascot.tsx
@@ -59,12 +59,7 @@ type MascotProps = {
    * every other instance.
    */
   scrolling?: boolean;
-  /**
-   * When true, mounts the stockpot prop and stirs it — the "still working on it"
-   * gag for build/loading moments. Unlike `scrolling` this one is a plain boolean
-   * used only where it's set (loading cards), so it can default to `false` instead
-   * of needing `undefined` reserved as an off state.
-   */
+  /** Mounts the stirring-stockpot prop for busy/loading moments. */
   cooking?: boolean;
 };
 
@@ -364,13 +359,7 @@ function ScrollPhone({ clipId }: { clipId: string }) {
   );
 }
 
-/**
- * Stockpot the mascot stirs for build/loading moments (`cooking` prop). Same
- * arm-plus-prop shape as `ScrollPhone` — an arm fades in reaching toward the pot,
- * the pot rig pops in behind it — but the payoff is a spoon rotating around the
- * rim instead of a thumb scrolling a feed, with steam wisps rising and fading on
- * a staggered loop so the three don't read as one blob of motion.
- */
+// Stirring stockpot for the `cooking` gag.
 function CookingPot() {
   return (
     <g className="mascot__pot" aria-hidden="true">
@@ -383,7 +372,6 @@ function CookingPot() {
         strokeLinecap="round"
       />
       <g className="mascot__pot-rig">
-        {/* Rocks on its own — the pan-toss half of the gag, independent of the spoon's stir. */}
         <g className="mascot__pot-shake">
           <path
             className="mascot__pot-handle mascot__pot-handle--left"
@@ -427,12 +415,7 @@ function CookingPot() {
   );
 }
 
-/**
- * Toque perched on top of the head — the other half of the `cooking` costume.
- * The idle silhouette's top row starts at y=1, and the face cutouts (eyes) sit
- * around y=3–8, so the band has to rest above y=1 rather than dip onto the head
- * proper — any lower and it swallows the eyes instead of crowning them.
- */
+// Toque above the head, clear of the eye cutouts.
 function ChefHat() {
   return (
     <g className="mascot__chef-hat" aria-hidden="true">

--- a/apps/web/src/Mascot.tsx
+++ b/apps/web/src/Mascot.tsx
@@ -59,6 +59,13 @@ type MascotProps = {
    * every other instance.
    */
   scrolling?: boolean;
+  /**
+   * When true, mounts the stockpot prop and stirs it — the "still working on it"
+   * gag for build/loading moments. Unlike `scrolling` this one is a plain boolean
+   * used only where it's set (loading cards), so it can default to `false` instead
+   * of needing `undefined` reserved as an off state.
+   */
+  cooking?: boolean;
 };
 
 type Span = readonly [number, number, number];
@@ -357,6 +364,66 @@ function ScrollPhone({ clipId }: { clipId: string }) {
   );
 }
 
+/**
+ * Stockpot the mascot stirs for build/loading moments (`cooking` prop). Same
+ * arm-plus-prop shape as `ScrollPhone` — an arm fades in reaching toward the pot,
+ * the pot rig pops in behind it — but the payoff is a spoon rotating around the
+ * rim instead of a thumb scrolling a feed, with steam wisps rising and fading on
+ * a staggered loop so the three don't read as one blob of motion.
+ */
+function CookingPot() {
+  return (
+    <g className="mascot__pot" aria-hidden="true">
+      <path
+        className="mascot__pot-arm"
+        d="M46 48 Q52 42 55 38"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="3.2"
+        strokeLinecap="round"
+      />
+      <g className="mascot__pot-rig">
+        <path
+          className="mascot__pot-handle mascot__pot-handle--left"
+          d="M45 41 Q40 41 41 45"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="1.6"
+          strokeLinecap="round"
+        />
+        <path
+          className="mascot__pot-handle mascot__pot-handle--right"
+          d="M65 41 Q70 41 69 45"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="1.6"
+          strokeLinecap="round"
+        />
+        <rect className="mascot__pot-belly" x="45" y="40" width="20" height="9" rx="2.4" fill="#241a12" />
+        <ellipse
+          className="mascot__pot-rim"
+          cx="55"
+          cy="40"
+          rx="10.5"
+          ry="3.2"
+          fill="#2f2216"
+          stroke="currentColor"
+          strokeWidth="1.4"
+        />
+        <g className="mascot__pot-steam" fill="none" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round">
+          <path className="mascot__pot-steam-a" d="M50 37 q-2 -4 0 -8 q2 -4 0 -8" />
+          <path className="mascot__pot-steam-b" d="M55 36 q-2 -4 0 -8 q2 -4 0 -8" />
+          <path className="mascot__pot-steam-c" d="M60 37 q-2 -4 0 -8 q2 -4 0 -8" />
+        </g>
+        <g className="mascot__pot-spoon">
+          <path d="M55 40 L57 26" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" fill="none" />
+          <ellipse cx="57.4" cy="24.6" rx="1.9" ry="2.7" fill="currentColor" />
+        </g>
+      </g>
+    </g>
+  );
+}
+
 export function Mascot({
   emotion = 'idle',
   size = 48,
@@ -365,6 +432,7 @@ export function Mascot({
   staticPose = false,
   look,
   scrolling,
+  cooking = false,
 }: MascotProps) {
   const reactId = useId().replace(/:/g, '');
   const maskId = `mascot-mask-${reactId}`;
@@ -375,6 +443,7 @@ export function Mascot({
     `mascot--${emotion}`,
     staticPose ? 'mascot--static' : null,
     scrolling ? 'mascot--scrolling' : null,
+    cooking ? 'mascot--cooking' : null,
     className,
   ]
     .filter(Boolean)
@@ -437,6 +506,7 @@ export function Mascot({
         ) : null}
 
         {showPhone ? <ScrollPhone clipId={phoneClipId} /> : null}
+        {cooking ? <CookingPot /> : null}
       </g>
     </svg>
   );

--- a/apps/web/src/Mascot.tsx
+++ b/apps/web/src/Mascot.tsx
@@ -383,33 +383,36 @@ function CookingPot() {
         strokeLinecap="round"
       />
       <g className="mascot__pot-rig">
-        <path
-          className="mascot__pot-handle mascot__pot-handle--left"
-          d="M45 41 Q40 41 41 45"
-          fill="none"
-          stroke="currentColor"
-          strokeWidth="1.6"
-          strokeLinecap="round"
-        />
-        <path
-          className="mascot__pot-handle mascot__pot-handle--right"
-          d="M65 41 Q70 41 69 45"
-          fill="none"
-          stroke="currentColor"
-          strokeWidth="1.6"
-          strokeLinecap="round"
-        />
-        <rect className="mascot__pot-belly" x="45" y="40" width="20" height="9" rx="2.4" fill="#241a12" />
-        <ellipse
-          className="mascot__pot-rim"
-          cx="55"
-          cy="40"
-          rx="10.5"
-          ry="3.2"
-          fill="#2f2216"
-          stroke="currentColor"
-          strokeWidth="1.4"
-        />
+        {/* Rocks on its own — the pan-toss half of the gag, independent of the spoon's stir. */}
+        <g className="mascot__pot-shake">
+          <path
+            className="mascot__pot-handle mascot__pot-handle--left"
+            d="M45 41 Q40 41 41 45"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="1.6"
+            strokeLinecap="round"
+          />
+          <path
+            className="mascot__pot-handle mascot__pot-handle--right"
+            d="M65 41 Q70 41 69 45"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="1.6"
+            strokeLinecap="round"
+          />
+          <rect className="mascot__pot-belly" x="45" y="40" width="20" height="9" rx="2.4" fill="#241a12" />
+          <ellipse
+            className="mascot__pot-rim"
+            cx="55"
+            cy="40"
+            rx="10.5"
+            ry="3.2"
+            fill="#2f2216"
+            stroke="currentColor"
+            strokeWidth="1.4"
+          />
+        </g>
         <g className="mascot__pot-steam" fill="none" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round">
           <path className="mascot__pot-steam-a" d="M50 37 q-2 -4 0 -8 q2 -4 0 -8" />
           <path className="mascot__pot-steam-b" d="M55 36 q-2 -4 0 -8 q2 -4 0 -8" />
@@ -420,6 +423,37 @@ function CookingPot() {
           <ellipse cx="57.4" cy="24.6" rx="1.9" ry="2.7" fill="currentColor" />
         </g>
       </g>
+    </g>
+  );
+}
+
+/**
+ * Toque perched on top of the head — the other half of the `cooking` costume.
+ * The idle silhouette's top row starts at y=1, and the face cutouts (eyes) sit
+ * around y=3–8, so the band has to rest above y=1 rather than dip onto the head
+ * proper — any lower and it swallows the eyes instead of crowning them.
+ */
+function ChefHat() {
+  return (
+    <g className="mascot__chef-hat" aria-hidden="true">
+      <path
+        className="mascot__chef-hat-poof"
+        d="M23 -4 C21 -16 29 -22 35 -22 C41 -22 49 -16 47 -4 C44 -8 40 -5 35 -5 C30 -5 26 -8 23 -4 Z"
+        fill="#f4f4f4"
+        stroke="#c9c9c9"
+        strokeWidth="1"
+      />
+      <rect
+        className="mascot__chef-hat-band"
+        x="24"
+        y="-4.4"
+        width="22"
+        height="4.4"
+        rx="1.6"
+        fill="#f4f4f4"
+        stroke="#c9c9c9"
+        strokeWidth="1"
+      />
     </g>
   );
 }
@@ -506,6 +540,7 @@ export function Mascot({
         ) : null}
 
         {showPhone ? <ScrollPhone clipId={phoneClipId} /> : null}
+        {cooking ? <ChefHat /> : null}
         {cooking ? <CookingPot /> : null}
       </g>
     </svg>

--- a/apps/web/src/StudioStageCard.tsx
+++ b/apps/web/src/StudioStageCard.tsx
@@ -1,4 +1,5 @@
 import { useTranslation } from 'react-i18next';
+import { Mascot } from './Mascot.js';
 
 /**
  * Round 0, staging incomplete (Workstream C): the no-API fallback. Naming the missing
@@ -12,7 +13,7 @@ export function StudioStageCard() {
   const { t } = useTranslation();
   return (
     <div className="studio-stage-card is-assembling" role="status" aria-live="polite">
-      <div className="studio-stage-card-spinner" aria-hidden="true" />
+      <Mascot emotion="busy" size={56} title={t('mascot.busyAlt')} />
       <p className="studio-stage-card-title">{t('studioPanel.stage.assembling')}</p>
       <p className="studio-stage-card-detail">{t('studioPanel.stage.assemblingHint')}</p>
     </div>

--- a/apps/web/src/StudioStageCard.tsx
+++ b/apps/web/src/StudioStageCard.tsx
@@ -13,7 +13,7 @@ export function StudioStageCard() {
   const { t } = useTranslation();
   return (
     <div className="studio-stage-card is-assembling" role="status" aria-live="polite">
-      <Mascot emotion="busy" size={56} title={t('mascot.busyAlt')} />
+      <Mascot emotion="busy" size={72} cooking title={t('mascot.busyAlt')} />
       <p className="studio-stage-card-title">{t('studioPanel.stage.assembling')}</p>
       <p className="studio-stage-card-detail">{t('studioPanel.stage.assemblingHint')}</p>
     </div>

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -11118,15 +11118,6 @@ button.builder-mode-selector:disabled {
   justify-content: center;
 }
 
-.studio-stage-card.is-assembling .studio-stage-card-spinner {
-  width: 22px;
-  height: 22px;
-  border-radius: 50%;
-  border: 2.5px solid rgba(0, 228, 172, 0.22);
-  border-top-color: var(--turquoise);
-  animation: status-spin 0.8s linear infinite;
-}
-
 /* Version ribbon (the honesty organ) — bottom-center, non-dismissible. */
 .studio-version-ribbon {
   position: absolute;

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -10166,6 +10166,10 @@ button.builder-mode-selector:disabled {
   transform-origin: 55px 40px;
 }
 
+.mascot__pot-shake {
+  transform-origin: 55px 44px;
+}
+
 .mascot__pot-steam-a,
 .mascot__pot-steam-b,
 .mascot__pot-steam-c {
@@ -10184,6 +10188,11 @@ button.builder-mode-selector:disabled {
 
 .mascot:not(.mascot--static).mascot--cooking .mascot__pot-spoon {
   animation: mascot-pot-stir 0.9s ease-in-out infinite;
+}
+
+/* The pan-toss half of the gag — the pot itself rocks, on its own beat from the spoon. */
+.mascot:not(.mascot--static).mascot--cooking .mascot__pot-shake {
+  animation: mascot-pot-rock 0.6s ease-in-out infinite;
 }
 
 .mascot:not(.mascot--static).mascot--cooking .mascot__pot-steam-a {
@@ -10208,6 +10217,32 @@ button.builder-mode-selector:disabled {
   50% {
     transform: rotate(14deg);
   }
+}
+
+@keyframes mascot-pot-rock {
+  0%,
+  100% {
+    transform: rotate(-3deg) translateY(0);
+  }
+  50% {
+    transform: rotate(3deg) translateY(-1px);
+  }
+}
+
+/* Chef's hat — worn only while cooking, sits still above the head. */
+.mascot__chef-hat {
+  opacity: 0;
+  transform: translateY(4px) scale(0.8);
+  transform-origin: 35px 0px;
+  transition:
+    opacity 0.2s ease,
+    transform 0.3s cubic-bezier(0.34, 1.45, 0.64, 1);
+}
+
+.mascot:not(.mascot--static).mascot--cooking .mascot__chef-hat {
+  opacity: 1;
+  transform: translateY(0) scale(1);
+  transition-delay: 0.06s;
 }
 
 @keyframes mascot-pot-steam {
@@ -10612,7 +10647,8 @@ button.builder-mode-selector:disabled {
   .mascot .mascot__phone-arm,
   .mascot .mascot__phone-device,
   .mascot .mascot__pot-arm,
-  .mascot .mascot__pot-rig {
+  .mascot .mascot__pot-rig,
+  .mascot .mascot__chef-hat {
     transition: none !important;
     opacity: 0 !important;
     transform: none !important;
@@ -10620,6 +10656,7 @@ button.builder-mode-selector:disabled {
 
   /* Cooking prop is motion by definition too — same treatment as the phone mime. */
   .mascot__pot-spoon,
+  .mascot__pot-shake,
   .mascot__pot-steam > path {
     animation: none !important;
   }

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -10129,6 +10129,92 @@ button.builder-mode-selector:disabled {
   }
 }
 
+/*
+ * Cooking mime — a stockpot the mascot stirs for build/loading moments
+ * (`cooking` prop). Same fade-in-arm + pop-in-prop shape as the scroll phone
+ * above; put-away is a CSS transition so the pot can tuck away when `cooking`
+ * drops rather than vanishing.
+ */
+.mascot__pot {
+  pointer-events: none;
+}
+
+.mascot__pot-arm {
+  opacity: 0;
+  transition: opacity 0.2s ease;
+}
+
+.mascot__pot-rig {
+  opacity: 0;
+  transform: translate(4px, 18px) scale(0.55);
+  transform-origin: 55px 46px;
+  transition:
+    opacity 0.2s ease,
+    transform 0.42s cubic-bezier(0.34, 1.45, 0.64, 1);
+}
+
+.mascot__pot-spoon {
+  transform-origin: 55px 40px;
+}
+
+.mascot__pot-steam-a,
+.mascot__pot-steam-b,
+.mascot__pot-steam-c {
+  opacity: 0;
+}
+
+.mascot:not(.mascot--static).mascot--cooking .mascot__pot-arm {
+  opacity: 1;
+  transition-delay: 0.06s;
+}
+
+.mascot:not(.mascot--static).mascot--cooking .mascot__pot-rig {
+  opacity: 1;
+  transform: translate(0, 0) scale(1);
+}
+
+.mascot:not(.mascot--static).mascot--cooking .mascot__pot-spoon {
+  animation: mascot-pot-stir 0.9s ease-in-out infinite;
+}
+
+.mascot:not(.mascot--static).mascot--cooking .mascot__pot-steam-a {
+  animation: mascot-pot-steam 1.8s ease-out infinite;
+}
+
+.mascot:not(.mascot--static).mascot--cooking .mascot__pot-steam-b {
+  animation: mascot-pot-steam 1.8s ease-out infinite;
+  animation-delay: 0.5s;
+}
+
+.mascot:not(.mascot--static).mascot--cooking .mascot__pot-steam-c {
+  animation: mascot-pot-steam 1.8s ease-out infinite;
+  animation-delay: 1s;
+}
+
+@keyframes mascot-pot-stir {
+  0%,
+  100% {
+    transform: rotate(-18deg);
+  }
+  50% {
+    transform: rotate(14deg);
+  }
+}
+
+@keyframes mascot-pot-steam {
+  0% {
+    transform: translateY(0);
+    opacity: 0;
+  }
+  15% {
+    opacity: 0.7;
+  }
+  100% {
+    transform: translateY(-10px);
+    opacity: 0;
+  }
+}
+
 .mascot-moment {
   display: flex;
   flex-direction: column;
@@ -10515,10 +10601,18 @@ button.builder-mode-selector:disabled {
   }
 
   .mascot .mascot__phone-arm,
-  .mascot .mascot__phone-device {
+  .mascot .mascot__phone-device,
+  .mascot .mascot__pot-arm,
+  .mascot .mascot__pot-rig {
     transition: none !important;
     opacity: 0 !important;
     transform: none !important;
+  }
+
+  /* Cooking prop is motion by definition too — same treatment as the phone mime. */
+  .mascot__pot-spoon,
+  .mascot__pot-steam > path {
+    animation: none !important;
   }
 }
 

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -9916,6 +9916,15 @@ button.builder-mode-selector:disabled {
   animation: mascot-hustle 0.45s ease-in-out infinite;
 }
 
+/*
+ * The stir is the "busy" tell while cooking — a full-body hustle on top of it reads as
+ * two animations fighting instead of one. Same specificity as the busy rule above, so
+ * source order alone decides; this has to stay below it to win.
+ */
+.mascot:not(.mascot--static).mascot--cooking .mascot__body-group {
+  animation: mascot-breathe 2.8s ease-in-out infinite;
+}
+
 .mascot:not(.mascot--static).mascot--sad .mascot__body-group {
   animation: mascot-sigh 3.6s ease-in-out infinite;
 }

--- a/eslint-rules/comment-prose-baseline.json
+++ b/eslint-rules/comment-prose-baseline.json
@@ -456,7 +456,7 @@
     "apps/web/src/LegalPage.tsx": 192,
     "apps/web/src/main.tsx": 278,
     "apps/web/src/Mascot.test.tsx": 314,
-    "apps/web/src/Mascot.tsx": 1191,
+    "apps/web/src/Mascot.tsx": 1200,
     "apps/web/src/mascotSpans.ts": 116,
     "apps/web/src/mp/ControllerView.tsx": 127,
     "apps/web/src/mp/mpApi.ts": 23,


### PR DESCRIPTION
Swap the plain CSS spinner in StudioStageCard for a busy-emotion Mascot,
matching the pattern already used for loading/empty states elsewhere
(ArcadeCatalog, AppLoadingScreen).