### PR TITLE
Clear stale agent-ended signals on undelivered round resume

### DIFF
--- a/apps/api/src/store.ts
+++ b/apps/api/src/store.ts
@@ -1798,15 +1798,7 @@ export interface Store {
    * validation rejects the brand-new key (`active === undefined`).
    */
   ensureRoundGeneration(issueNumber: number): Promise<number | null>;
-  /**
-   * Clears the ended/stall signals a previous turn left behind — `agentEndedAt`,
-   * `lastAgentSignalAt`, `lastAgentPresence` — without touching round counters or
-   * generation. `bumpRoundGeneration` already does this as part of closing a round;
-   * this exists for resumes that keep the round open (`ensureRoundGeneration`, the
-   * undelivered path) but still hand the job to a fresh agent invocation, so a stale
-   * `agentEndedAt` from the prior turn must not make Studio show the build as idle
-   * while the new turn is actively running.
-   */
+  // Clears stale agentEndedAt/lastAgentSignalAt/lastAgentPresence without touching round counters.
   clearAgentEnded(issueNumber: number): Promise<void>;
   // Fixes the round's kit engine and returns it; first caller wins.
   // `replace` overrides the pin: kit_outdated recovery, or a kit gone.

--- a/apps/api/src/store.ts
+++ b/apps/api/src/store.ts
@@ -1798,6 +1798,16 @@ export interface Store {
    * validation rejects the brand-new key (`active === undefined`).
    */
   ensureRoundGeneration(issueNumber: number): Promise<number | null>;
+  /**
+   * Clears the ended/stall signals a previous turn left behind — `agentEndedAt`,
+   * `lastAgentSignalAt`, `lastAgentPresence` — without touching round counters or
+   * generation. `bumpRoundGeneration` already does this as part of closing a round;
+   * this exists for resumes that keep the round open (`ensureRoundGeneration`, the
+   * undelivered path) but still hand the job to a fresh agent invocation, so a stale
+   * `agentEndedAt` from the prior turn must not make Studio show the build as idle
+   * while the new turn is actively running.
+   */
+  clearAgentEnded(issueNumber: number): Promise<void>;
   // Fixes the round's kit engine and returns it; first caller wins.
   // `replace` overrides the pin: kit_outdated recovery, or a kit gone.
   pinRoundKitEngineRef(issueNumber: number, engineRef: string, replace?: boolean): Promise<string | null>;
@@ -3132,6 +3142,16 @@ export class InMemoryStore implements Store {
     if (sub.roundGeneration !== undefined) return sub.roundGeneration;
     this.submissions.set(issueNumber, { ...sub, roundGeneration: 1 });
     return 1;
+  }
+
+  async clearAgentEnded(issueNumber: number): Promise<void> {
+    const sub = this.submissions.get(issueNumber);
+    if (!sub) return;
+    const next = { ...sub };
+    delete next.lastAgentSignalAt;
+    delete next.lastAgentPresence;
+    delete next.agentEndedAt;
+    this.submissions.set(issueNumber, next);
   }
 
   async setSubmissionAgentState(issueNumber: number, agentState: AgentTaskState): Promise<void> {
@@ -5496,6 +5516,20 @@ export class FirestoreStore implements Store {
       if (current.roundGeneration !== undefined) return current.roundGeneration;
       tx.set(ref, { roundGeneration: 1 }, { merge: true });
       return 1;
+    });
+  }
+
+  async clearAgentEnded(issueNumber: number): Promise<void> {
+    const ref = this.db.collection('submissions').doc(String(issueNumber));
+    await this.db.runTransaction(async (tx) => {
+      const snap = await tx.get(ref);
+      if (!snap.exists) return;
+      const current = snap.data() as SubmissionRecord;
+      const next = { ...current };
+      delete next.lastAgentSignalAt;
+      delete next.lastAgentPresence;
+      delete next.agentEndedAt;
+      tx.set(ref, next);
     });
   }
 

--- a/apps/api/src/submissions.test.ts
+++ b/apps/api/src/submissions.test.ts
@@ -1145,6 +1145,72 @@ describe('submission routes', () => {
     await app.close();
   });
 
+  it('drops cached stall=ended when an undelivered round is resumed via retry', async () => {
+    // Same hazard as the delivered case above, but for a game with no candidate yet.
+    // `resumeBuild`'s `undelivered: true` branch (used whenever `deliveredVersion` is
+    // unset — creator feedback, the reconciler's "finished without delivering" nudge,
+    // and operator retry all take it) called `ensureRoundGeneration`, which — unlike
+    // `bumpRoundGeneration` on the delivered path — did not clear a stale
+    // `agentEndedAt` left over from a prior MCP `end`. Studio's foot bar treated that
+    // leftover as "agent not working" and collapsed the build-progress UI even while a
+    // fresh session was actively running underneath.
+    const { githubClient } = createGithubClientStub({ issueNumber: 79 });
+    const { backend } = createBackendStub();
+    const { app, authHeaders, store } = await createApp({
+      githubClient,
+      agentBackend: backend,
+      submissionTokenSecret: secret,
+      adminUids: 'g:boss',
+    });
+    await store.upsertUser({ uid: 'g:boss' });
+
+    await app.inject({
+      method: 'POST',
+      url: '/api/submissions',
+      headers: authHeaders,
+      payload: { title: 'A game', concept: 'A sufficiently long concept about delivering parcels in space.' },
+    });
+    const [job] = await store.listSubmissionsByOwner('g:test-user');
+    const token = mintToken(job.issueNumber, secret);
+    await store.setRoundBuilder(job.issueNumber, 'self');
+    await store.ensureRoundGeneration(job.issueNumber);
+    await store.recordJobTransition(job.issueNumber, {
+      to: 'building',
+      at: new Date().toISOString(),
+      by: 'agent',
+      reason: 'self_signal',
+    });
+    await store.touchLastAgentSignalAt(job.issueNumber, new Date().toISOString());
+    await store.markAgentEnded(job.issueNumber, new Date().toISOString());
+
+    // No deliveredVersion — the job never uploaded a candidate, so this is the
+    // `undelivered: true` path.
+    const before = await store.getSubmission(job.issueNumber);
+    expect(before?.deliveredVersion).toBeFalsy();
+
+    const ended = await app.inject({ method: 'GET', url: `/api/submissions/${token}`, headers: authHeaders });
+    expect(ended.statusCode).toBe(200);
+    expect(ended.json()).toMatchObject({ builder: 'self', stall: 'ended' });
+    expect(ended.json().agentEndedAt).toBeTruthy();
+
+    const response = await app.inject({
+      method: 'POST',
+      url: `/api/admin/jobs/${job.issueNumber}/retry`,
+      headers: getAuthHeaders('g:boss'),
+    });
+    expect(response.statusCode).toBe(200);
+
+    const after = await store.getSubmission(job.issueNumber);
+    expect(after?.agentEndedAt).toBeUndefined();
+
+    const resumed = await app.inject({ method: 'GET', url: `/api/submissions/${token}`, headers: authHeaders });
+    expect(resumed.statusCode).toBe(200);
+    expect(resumed.json().stall).not.toBe('ended');
+    expect(resumed.json().agentEndedAt).toBeUndefined();
+
+    await app.close();
+  });
+
   it('self→platform handoff lands on dispatched and busts the status cache', async () => {
     // Without the cache bust, Studio kept serving the previous self stall
     // (`no_agent_yet` / ended) for up to a minute while Copilot was already queued.

--- a/apps/api/src/submissions.test.ts
+++ b/apps/api/src/submissions.test.ts
@@ -1201,6 +1201,60 @@ describe('submission routes', () => {
     await app.close();
   });
 
+  it('keeps stall=ended when an undelivered retry fails to start', async () => {
+    const { githubClient } = createGithubClientStub({ issueNumber: 80 });
+    let failNext = false;
+    const backend: AgentBackend = {
+      name: 'stub',
+      dispatch: async () => {
+        if (failNext) throw new Error('backend unavailable');
+        return { ref: 'task-1', workspace: 'copilot/x' };
+      },
+      resume: async () => {
+        if (failNext) throw new Error('backend unavailable');
+        return { ref: 'task-2', workspace: 'copilot/y' };
+      },
+      observe: async () => null,
+      cancel: async () => ({ enforced: false }),
+    };
+    const { app, authHeaders, store } = await createApp({
+      githubClient,
+      agentBackend: backend,
+      submissionTokenSecret: secret,
+      adminUids: 'g:boss',
+    });
+    await store.upsertUser({ uid: 'g:boss' });
+
+    await app.inject({
+      method: 'POST',
+      url: '/api/submissions',
+      headers: authHeaders,
+      payload: { title: 'A game', concept: 'A sufficiently long concept about delivering parcels in space.' },
+    });
+    const [job] = await store.listSubmissionsByOwner('g:test-user');
+    const token = mintToken(job.issueNumber, secret);
+    await store.ensureRoundGeneration(job.issueNumber);
+    await store.touchLastAgentSignalAt(job.issueNumber, new Date().toISOString());
+    await store.markAgentEnded(job.issueNumber, new Date().toISOString());
+
+    failNext = true;
+    const response = await app.inject({
+      method: 'POST',
+      url: `/api/admin/jobs/${job.issueNumber}/retry`,
+      headers: getAuthHeaders('g:boss'),
+    });
+    expect(response.statusCode).toBe(502);
+
+    const after = await store.getSubmission(job.issueNumber);
+    expect(after?.agentEndedAt).toBeTruthy();
+
+    const resumed = await app.inject({ method: 'GET', url: `/api/submissions/${token}`, headers: authHeaders });
+    expect(resumed.statusCode).toBe(200);
+    expect(resumed.json().stall).toBe('ended');
+
+    await app.close();
+  });
+
   it('self→platform handoff lands on dispatched and busts the status cache', async () => {
     // Without the cache bust, Studio kept serving the previous self stall
     // (`no_agent_yet` / ended) for up to a minute while Copilot was already queued.

--- a/apps/api/src/submissions.test.ts
+++ b/apps/api/src/submissions.test.ts
@@ -1146,14 +1146,6 @@ describe('submission routes', () => {
   });
 
   it('drops cached stall=ended when an undelivered round is resumed via retry', async () => {
-    // Same hazard as the delivered case above, but for a game with no candidate yet.
-    // `resumeBuild`'s `undelivered: true` branch (used whenever `deliveredVersion` is
-    // unset — creator feedback, the reconciler's "finished without delivering" nudge,
-    // and operator retry all take it) called `ensureRoundGeneration`, which — unlike
-    // `bumpRoundGeneration` on the delivered path — did not clear a stale
-    // `agentEndedAt` left over from a prior MCP `end`. Studio's foot bar treated that
-    // leftover as "agent not working" and collapsed the build-progress UI even while a
-    // fresh session was actively running underneath.
     const { githubClient } = createGithubClientStub({ issueNumber: 79 });
     const { backend } = createBackendStub();
     const { app, authHeaders, store } = await createApp({
@@ -1183,8 +1175,6 @@ describe('submission routes', () => {
     await store.touchLastAgentSignalAt(job.issueNumber, new Date().toISOString());
     await store.markAgentEnded(job.issueNumber, new Date().toISOString());
 
-    // No deliveredVersion — the job never uploaded a candidate, so this is the
-    // `undelivered: true` path.
     const before = await store.getSubmission(job.issueNumber);
     expect(before?.deliveredVersion).toBeFalsy();
 

--- a/apps/api/src/submissions.ts
+++ b/apps/api/src/submissions.ts
@@ -1281,11 +1281,7 @@ export async function registerSubmissionRoutes(
       const roundGeneration = input.undelivered
         ? ((await store.ensureRoundGeneration(input.issueNumber)) ?? 1)
         : ((await store.bumpRoundGeneration(input.issueNumber)) ?? (record?.roundGeneration ?? 0) + 1);
-      // `bumpRoundGeneration` already clears these as part of closing the previous
-      // round. `ensureRoundGeneration` does not — an undelivered nudge keeps the same
-      // round, but a fresh agent invocation is still about to run, so a stale
-      // `agentEndedAt` from the prior turn must not survive to make Studio read the
-      // new turn as idle. Calling this unconditionally is a no-op on the bumped path.
+      // ensureRoundGeneration doesn't clear agentEndedAt like bumpRoundGeneration does.
       if (input.undelivered) {
         await store.clearAgentEnded(input.issueNumber);
       }

--- a/apps/api/src/submissions.ts
+++ b/apps/api/src/submissions.ts
@@ -1281,6 +1281,14 @@ export async function registerSubmissionRoutes(
       const roundGeneration = input.undelivered
         ? ((await store.ensureRoundGeneration(input.issueNumber)) ?? 1)
         : ((await store.bumpRoundGeneration(input.issueNumber)) ?? (record?.roundGeneration ?? 0) + 1);
+      // `bumpRoundGeneration` already clears these as part of closing the previous
+      // round. `ensureRoundGeneration` does not — an undelivered nudge keeps the same
+      // round, but a fresh agent invocation is still about to run, so a stale
+      // `agentEndedAt` from the prior turn must not survive to make Studio read the
+      // new turn as idle. Calling this unconditionally is a no-op on the bumped path.
+      if (input.undelivered) {
+        await store.clearAgentEnded(input.issueNumber);
+      }
       if (!input.undelivered) {
         await store.setRoundBuilder(input.issueNumber, builder, {
           resetRoundBudget: !input.preserveRoundBudget,

--- a/apps/api/src/submissions.ts
+++ b/apps/api/src/submissions.ts
@@ -1281,10 +1281,6 @@ export async function registerSubmissionRoutes(
       const roundGeneration = input.undelivered
         ? ((await store.ensureRoundGeneration(input.issueNumber)) ?? 1)
         : ((await store.bumpRoundGeneration(input.issueNumber)) ?? (record?.roundGeneration ?? 0) + 1);
-      // ensureRoundGeneration doesn't clear agentEndedAt like bumpRoundGeneration does.
-      if (input.undelivered) {
-        await store.clearAgentEnded(input.issueNumber);
-      }
       if (!input.undelivered) {
         await store.setRoundBuilder(input.issueNumber, builder, {
           resetRoundBudget: !input.preserveRoundBudget,
@@ -1341,6 +1337,9 @@ export async function registerSubmissionRoutes(
             workspace: previous!.workspace,
           })
         : await selected.dispatch(brief);
+      if (input.undelivered) {
+        await store.clearAgentEnded(input.issueNumber);
+      }
       await store.recordDispatch(input.issueNumber, {
         backend: selected.name,
         ref: result.ref,


### PR DESCRIPTION
## Summary
Fixes a bug where resuming an undelivered round (via operator retry or reconciler nudge) would leave stale `agentEndedAt` signals from the previous agent invocation, causing Studio to incorrectly display the build as idle while a fresh agent session was actively running.

## Changes
- **New `clearAgentEnded()` store method**: Clears `agentEndedAt`, `lastAgentSignalAt`, and `lastAgentPresence` without modifying round counters or generation. This is needed for undelivered resumes that keep the same round open but hand the job to a fresh agent invocation.
  - Implemented in both `InMemoryStore` and `FirestoreStore`

- **Updated `resumeBuild()` in submissions route**: Calls `clearAgentEnded()` when resuming via the undelivered path (`ensureRoundGeneration`). The delivered path already clears these signals as part of `bumpRoundGeneration`, so this call is a no-op on that path.

- **Added test case**: Verifies that after retrying an undelivered round, the stale `agentEndedAt` is cleared and the submission no longer reports `stall: 'ended'`.

## Implementation Details
- `bumpRoundGeneration` (used for delivered resumes) already clears agent-ended signals as part of closing the previous round
- `ensureRoundGeneration` (used for undelivered resumes) does not clear these signals since it keeps the same round open
- The fix ensures that even though the round stays open, a fresh agent invocation won't be shadowed by stale ended signals from the prior turn

https://claude.ai/code/session_01Wba6ATpiLhYmL1i6tpb2N6