### PR TITLE
fix: restart ended platform feedback rounds

### DIFF
--- a/.claude/skills/byoca-mcp/SKILL.md
+++ b/.claude/skills/byoca-mcp/SKILL.md
@@ -425,6 +425,14 @@ creator **self→platform** handoff immediately). Still call **`end`**:
 - Without `end`, your session may look finished while still connected; quiet
   (~15 minutes) remains a fallback only
 
+### Submit handoff is not an explicit end
+
+`submit_sources` also marks `agentEndedAt` optimistically so creator handoff unlocks
+immediately. That marker does **not** prove the platform session stopped: an agent may
+still be iterating locally and clear it with its next channel write. Feedback routing must
+distinguish the submit marker from an explicit `end` (or a confirmed terminal vendor state)
+before superseding a platform session. The API records this as `agentEndedBy: submit | end`.
+
 ### `end({ summary })` is the only channel for a closing answer
 
 The platform reads tool calls, never the agent's transcript. An agent that answers

--- a/apps/api/src/builder.test.ts
+++ b/apps/api/src/builder.test.ts
@@ -99,6 +99,20 @@ describe('builder helpers', () => {
     ).toBe(true);
     // Builder handoff must resume, not mail the agent we are about to invalidate.
     expect(shouldSteerFeedbackViaInbox({ state: 'building', ...withRef }, { builderChanging: true })).toBe(false);
+    expect(
+      shouldSteerFeedbackViaInbox(
+        { state: 'building', agentEndedAt: '2026-08-11T16:00:00Z', ...withRef },
+        { stall: 'ended' },
+      ),
+    ).toBe(false);
+    expect(shouldSteerFeedbackViaInbox({ state: 'building', ...withRef }, { stall: 'quiet' })).toBe(false);
+    expect(shouldSteerFeedbackViaInbox({ state: 'dispatched', ...withRef }, { stall: 'not_dispatched' })).toBe(false);
+    expect(
+      shouldSteerFeedbackViaInbox(
+        { state: 'building', builder: 'self', agentEndedAt: '2026-08-11T16:00:00Z', ...withRef },
+        { stall: 'ended' },
+      ),
+    ).toBe(true);
     // Dispatch never landed — feedback must retry starting a session.
     expect(shouldSteerFeedbackViaInbox({ state: 'queued' })).toBe(false);
     expect(shouldSteerFeedbackViaInbox({ state: 'queued', dispatch: { refs: [] } })).toBe(false);

--- a/apps/api/src/builder.test.ts
+++ b/apps/api/src/builder.test.ts
@@ -105,6 +105,24 @@ describe('builder helpers', () => {
         { stall: 'ended' },
       ),
     ).toBe(false);
+    expect(
+      shouldSteerFeedbackViaInbox(
+        { state: 'submitted', agentEndedAt: '2026-08-11T16:00:00Z', agentEndedBy: 'submit', ...withRef },
+        { stall: 'ended' },
+      ),
+    ).toBe(true);
+    expect(
+      shouldSteerFeedbackViaInbox(
+        {
+          state: 'submitted',
+          agentEndedAt: '2026-08-11T16:00:00Z',
+          agentEndedBy: 'submit',
+          agentState: 'completed',
+          ...withRef,
+        },
+        { stall: 'ended' },
+      ),
+    ).toBe(false);
     expect(shouldSteerFeedbackViaInbox({ state: 'building', ...withRef }, { stall: 'quiet' })).toBe(false);
     expect(shouldSteerFeedbackViaInbox({ state: 'dispatched', ...withRef }, { stall: 'not_dispatched' })).toBe(false);
     expect(

--- a/apps/api/src/builder.ts
+++ b/apps/api/src/builder.ts
@@ -102,17 +102,21 @@ export function shouldSteerFeedbackViaInbox(
     dispatch?: { refs?: readonly string[] } | null;
     builder?: BuilderKind;
     agentEndedAt?: string | null;
+    agentEndedBy?: 'submit' | 'end';
+    agentState?: string;
   },
   opts?: { builderChanging?: boolean; stall?: JobStall | null },
 ): boolean {
   if (opts?.builderChanging) return false;
   if (record.state === 'publishing') return false;
   if (!isActiveBuildRound(record)) return false;
-  // A platform session that ended or stalled cannot collect another inbox note.
-  if (
-    (record.builder ?? 'platform') === 'platform' &&
-    (record.agentEndedAt || opts?.stall === 'not_dispatched' || opts?.stall === 'quiet' || opts?.stall === 'ended')
-  ) {
+  // A terminal platform session cannot collect another inbox note.
+  const terminalAgent = ['completed', 'failed', 'timed_out', 'cancelled'].includes(record.agentState ?? '');
+  const submitMarkerActive = record.agentEndedAt && record.agentEndedBy === 'submit' && !terminalAgent;
+  const platformSessionEnded = Boolean(record.agentEndedAt) && !submitMarkerActive;
+  const platformStalled =
+    opts?.stall === 'not_dispatched' || opts?.stall === 'quiet' || (opts?.stall === 'ended' && !submitMarkerActive);
+  if ((record.builder ?? 'platform') === 'platform' && (platformSessionEnded || platformStalled)) {
     return false;
   }
   return (record.dispatch?.refs?.length ?? 0) > 0;

--- a/apps/api/src/builder.ts
+++ b/apps/api/src/builder.ts
@@ -87,6 +87,8 @@ export function allowsCreatorBuilderHandoff(input: {
  * repair, where the same session is often still alive. Starting another Copilot task on
  * top of that is what produced concurrent builds of one game.
  *
+ * Ended or stalled platform rounds restart instead.
+ *
  * Excludes `publishing`: reaching it already closed the round (token generation bumped),
  * so no session can collect inbox mail — the feedback route rejects that state instead.
  *
@@ -101,11 +103,20 @@ export function shouldSteerFeedbackViaInbox(
     state?: JobState;
     transitions?: JobTransition[];
     dispatch?: { refs?: readonly string[] } | null;
+    builder?: BuilderKind;
+    agentEndedAt?: string | null;
   },
-  opts?: { builderChanging?: boolean },
+  opts?: { builderChanging?: boolean; stall?: JobStall | null },
 ): boolean {
   if (opts?.builderChanging) return false;
   if (record.state === 'publishing') return false;
   if (!isActiveBuildRound(record)) return false;
+  // A platform session that ended or stalled cannot collect another inbox note.
+  if (
+    (record.builder ?? 'platform') === 'platform' &&
+    (record.agentEndedAt || opts?.stall === 'not_dispatched' || opts?.stall === 'quiet' || opts?.stall === 'ended')
+  ) {
+    return false;
+  }
   return (record.dispatch?.refs?.length ?? 0) > 0;
 }

--- a/apps/api/src/builder.ts
+++ b/apps/api/src/builder.ts
@@ -82,12 +82,9 @@ export function allowsCreatorBuilderHandoff(input: {
 /**
  * Whether creator feedback should only go to the build-channel inbox (no new dispatch).
  *
- * An in-flight round that already has a dispatch ref has an agent that will poll the
- * inbox — including after delivery while the gate runs, and on gate-red / kit_outdated
- * repair, where the same session is often still alive. Starting another Copilot task on
- * top of that is what produced concurrent builds of one game.
- *
- * Ended or stalled platform rounds restart instead.
+ * Live rounds with dispatch refs steer feedback through the inbox, including gate waits
+ * and gate-red repair while the same session remains alive. Starting another Copilot task
+ * caused concurrent builds of one game.
  *
  * Excludes `publishing`: reaching it already closed the round (token generation bumped),
  * so no session can collect inbox mail — the feedback route rejects that state instead.

--- a/apps/api/src/mcp-server.test.ts
+++ b/apps/api/src/mcp-server.test.ts
@@ -1478,11 +1478,13 @@ describe('POST /api/mcp (BY-05)', () => {
     expect(submitWarnings.some((w) => w.code === 'gate_not_started')).toBe(true);
     // Successful MCP submit unlocks handoff even before explicit end.
     expect((await store.getSubmission(ISSUE))?.agentEndedAt).toBeTruthy();
+    expect((await store.getSubmission(ISSUE))?.agentEndedBy).toBe('submit');
 
     const ended = await callTool(app, 'end', { sessionKey }, { 'mcp-session-id': sessionId });
     expect(ended.isError).toBe(false);
     expect(ended.structured).toMatchObject({ ok: true, ended: true, stop: true, reason: 'agent_ended' });
     expect((await store.getSubmission(ISSUE))?.agentEndedAt).toBeTruthy();
+    expect((await store.getSubmission(ISSUE))?.agentEndedBy).toBe('end');
 
     // Gate red keeps the round open — verdict readable on the active key.
     await store.setSubmissionDeliveredVersion(ISSUE, 'v1');

--- a/apps/api/src/mcp-server.ts
+++ b/apps/api/src/mcp-server.ts
@@ -4313,7 +4313,7 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
         // call_end was ignored; mark ended here so Studio unlocks self→platform
         // handoff immediately. Further channel writes clear agentEndedAt again.
         if (accepted && store) {
-          await store.markAgentEnded(auth.issueNumber).catch(() => {});
+          await store.markAgentEnded(auth.issueNumber, undefined, 'submit').catch(() => {});
         }
         const warnings: Array<{ code: string; message: string }> = [];
         if (accepted) {

--- a/apps/api/src/store.test.ts
+++ b/apps/api/src/store.test.ts
@@ -165,10 +165,12 @@ describe('InMemoryStore', () => {
       { preserveEnded: true },
     );
     expect((await store.getSubmission(62))?.agentEndedAt).toBe('2026-08-04T01:00:00.000Z');
+    expect((await store.getSubmission(62))?.agentEndedBy).toBe('end');
     expect((await store.getSubmission(62))?.lastAgentSignalAt).toBe('2026-08-04T01:01:00.000Z');
 
     await store.touchLastAgentSignalAt(62, '2026-08-04T01:02:00.000Z', { key: 'browsing_kit' });
     expect((await store.getSubmission(62))?.agentEndedAt).toBeUndefined();
+    expect((await store.getSubmission(62))?.agentEndedBy).toBeUndefined();
   });
 
   it('ensureRoundGeneration initializes a legacy job without bumping an existing one', async () => {

--- a/apps/api/src/store.ts
+++ b/apps/api/src/store.ts
@@ -145,6 +145,8 @@ export interface BuilderHandoff {
   acknowledgedAt?: string;
 }
 
+export type AgentEndedBy = 'submit' | 'end';
+
 export interface SubmissionRecord {
   issueNumber: number;
   ownerUid: string;
@@ -284,6 +286,7 @@ export interface SubmissionRecord {
    * writes again or the round generation advances.
    */
   agentEndedAt?: string;
+  agentEndedBy?: AgentEndedBy;
   /**
    * Latest MCP presence thought (closed vocabulary key + timestamp).
    *
@@ -2009,7 +2012,7 @@ export interface Store {
    * Marks that the agent finished iterating this round (MCP `end`). Idempotent.
    * Does not bump generation or stop the channel — creator handoff does that.
    */
-  markAgentEnded(issueNumber: number, at?: string): Promise<void>;
+  markAgentEnded(issueNumber: number, at?: string, by?: AgentEndedBy): Promise<void>;
   /** Agent progress events for a build, newest first. */
   listBuildEvents(issueNumber: number, opts?: { limit?: number }): Promise<BuildEvent[]>;
   /** How many events a build has recorded — the cap that bounds a runaway agent. */
@@ -3084,6 +3087,7 @@ export class InMemoryStore implements Store {
       delete next.lastAgentSignalAt;
       delete next.lastAgentPresence;
       delete next.agentEndedAt;
+      delete next.agentEndedBy;
       delete next.roundKitEngineRef;
       delete next.roundTypecheckPreflightBypassErrors;
       delete next.roundLastGateMetricKey;
@@ -3111,6 +3115,7 @@ export class InMemoryStore implements Store {
     delete next.lastAgentSignalAt;
     delete next.lastAgentPresence;
     delete next.agentEndedAt;
+    delete next.agentEndedBy;
     delete next.roundKitEngineRef;
     delete next.roundTypecheckPreflightBypassErrors;
     delete next.roundLastGateMetricKey;
@@ -3171,6 +3176,7 @@ export class InMemoryStore implements Store {
     delete next.lastAgentSignalAt;
     delete next.lastAgentPresence;
     delete next.agentEndedAt;
+    delete next.agentEndedBy;
     this.submissions.set(issueNumber, next);
   }
 
@@ -3494,6 +3500,7 @@ export class InMemoryStore implements Store {
       delete next.lastAgentPresence;
       // Resumed work after MCP `end` — clear so stall is no longer `ended`.
       delete next.agentEndedAt;
+      delete next.agentEndedBy;
       this.submissions.set(issueNumber, next);
     }
     return { ...record };
@@ -3515,16 +3522,18 @@ export class InMemoryStore implements Store {
     };
     if (!options?.preserveEnded) {
       delete next.agentEndedAt;
+      delete next.agentEndedBy;
     }
     this.submissions.set(issueNumber, next);
   }
 
-  async markAgentEnded(issueNumber: number, at?: string): Promise<void> {
+  async markAgentEnded(issueNumber: number, at?: string, by: AgentEndedBy = 'end'): Promise<void> {
     const submission = this.submissions.get(issueNumber);
     if (!submission) return;
     this.submissions.set(issueNumber, {
       ...submission,
       agentEndedAt: at ?? new Date().toISOString(),
+      agentEndedBy: by,
     });
   }
 
@@ -5421,6 +5430,7 @@ export class FirestoreStore implements Store {
         delete next.lastAgentSignalAt;
         delete next.lastAgentPresence;
         delete next.agentEndedAt;
+        delete next.agentEndedBy;
         delete next.roundKitEngineRef;
         delete next.roundTypecheckPreflightBypassErrors;
         delete next.roundLastGateMetricKey;
@@ -5462,6 +5472,7 @@ export class FirestoreStore implements Store {
       delete next.lastAgentSignalAt;
       delete next.lastAgentPresence;
       delete next.agentEndedAt;
+      delete next.agentEndedBy;
       delete next.roundKitEngineRef;
       delete next.roundTypecheckPreflightBypassErrors;
       delete next.roundLastGateMetricKey;
@@ -5549,6 +5560,7 @@ export class FirestoreStore implements Store {
       delete next.lastAgentSignalAt;
       delete next.lastAgentPresence;
       delete next.agentEndedAt;
+      delete next.agentEndedBy;
       tx.set(ref, next);
     });
   }
@@ -5984,6 +5996,7 @@ export class FirestoreStore implements Store {
         lastAgentPresence: FieldValue.delete(),
         // Resumed work after MCP `end`.
         agentEndedAt: FieldValue.delete(),
+        agentEndedBy: FieldValue.delete(),
       },
       { merge: true },
     );
@@ -6003,18 +6016,18 @@ export class FirestoreStore implements Store {
       .set(
         {
           lastAgentSignalAt: stamped,
-          ...(options?.preserveEnded ? {} : { agentEndedAt: FieldValue.delete() }),
+          ...(options?.preserveEnded ? {} : { agentEndedAt: FieldValue.delete(), agentEndedBy: FieldValue.delete() }),
           ...(presence ? { lastAgentPresence: { key: presence.key, at: stamped } } : {}),
         },
         { merge: true },
       );
   }
 
-  async markAgentEnded(issueNumber: number, at?: string): Promise<void> {
+  async markAgentEnded(issueNumber: number, at?: string, by: AgentEndedBy = 'end'): Promise<void> {
     await this.db
       .collection('submissions')
       .doc(String(issueNumber))
-      .set({ agentEndedAt: at ?? new Date().toISOString() }, { merge: true });
+      .set({ agentEndedAt: at ?? new Date().toISOString(), agentEndedBy: by }, { merge: true });
   }
 
   async listBuildEvents(issueNumber: number, opts?: { limit?: number }): Promise<BuildEvent[]> {

--- a/apps/api/src/submissions.test.ts
+++ b/apps/api/src/submissions.test.ts
@@ -864,6 +864,40 @@ describe('submission routes', () => {
     await app.close();
   });
 
+  it('keeps feedback in the inbox after an optimistic submit marker', async () => {
+    const { githubClient } = createGithubClientStub({ issueNumber: 77 });
+    const { backend, briefs } = createBackendStub();
+    const { app, authHeaders, store } = await createApp({
+      githubClient,
+      agentBackend: backend,
+      submissionTokenSecret: secret,
+      chatAgent: { decide: async () => ({ kind: 'build' as const, text: 'On it!' }) },
+    });
+
+    await app.inject({
+      method: 'POST',
+      url: '/api/submissions',
+      headers: authHeaders,
+      payload: { title: 'A game', concept: 'A sufficiently long concept about delivering parcels in space.' },
+    });
+    const [job] = await store.listSubmissionsByOwner('g:test-user');
+    const briefsBefore = briefs.length;
+    await store.markAgentEnded(job.issueNumber, new Date().toISOString(), 'submit');
+
+    const response = await app.inject({
+      method: 'POST',
+      url: `/api/submissions/${mintToken(job.issueNumber, secret)}/feedback`,
+      headers: authHeaders,
+      payload: { feedback: 'Please make the parcels bigger and the asteroids slower.' },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(briefs).toHaveLength(briefsBefore);
+    expect((await store.getSubmission(job.issueNumber))?.agentEndedBy).toBe('submit');
+
+    await app.close();
+  });
+
   it('keeps gate-wait and gate-red rounds on inbox steering rather than a new session', async () => {
     // After submit the job is `submitted` while the same session waits on the gate; a
     // red verdict moves it to `needs_changes` with mustFixGate. Both must stay inbox-only.

--- a/apps/api/src/submissions.test.ts
+++ b/apps/api/src/submissions.test.ts
@@ -828,6 +828,42 @@ describe('submission routes', () => {
     await app.close();
   });
 
+  it('restarts a platform round after its agent has ended', async () => {
+    const { githubClient } = createGithubClientStub({ issueNumber: 77 });
+    const { backend, briefs } = createBackendStub();
+    const { app, authHeaders, store } = await createApp({
+      githubClient,
+      agentBackend: backend,
+      submissionTokenSecret: secret,
+      chatAgent: { decide: async () => ({ kind: 'build' as const, text: 'On it!' }) },
+    });
+
+    await app.inject({
+      method: 'POST',
+      url: '/api/submissions',
+      headers: authHeaders,
+      payload: { title: 'A game', concept: 'A sufficiently long concept about delivering parcels in space.' },
+    });
+    const [job] = await store.listSubmissionsByOwner('g:test-user');
+    const briefsBefore = briefs.length;
+    await store.markAgentEnded(job.issueNumber, new Date().toISOString());
+
+    const response = await app.inject({
+      method: 'POST',
+      url: `/api/submissions/${mintToken(job.issueNumber, secret)}/feedback`,
+      headers: authHeaders,
+      payload: { feedback: 'Please make the parcels bigger and the asteroids slower.' },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(briefs).toHaveLength(briefsBefore + 1);
+    expect((await store.getSubmission(job.issueNumber))?.state).toBe('dispatched');
+    const messages = await store.listCreatorMessages(job.issueNumber);
+    expect(messages.some((message) => message.origin === 'studio_ack')).toBe(true);
+
+    await app.close();
+  });
+
   it('keeps gate-wait and gate-red rounds on inbox steering rather than a new session', async () => {
     // After submit the job is `submitted` while the same session waits on the gate; a
     // red verdict moves it to `needs_changes` with mustFixGate. Both must stay inbox-only.
@@ -2257,6 +2293,7 @@ describe('submission routes', () => {
       githubClient,
       agentBackend: backend,
       submissionTokenSecret: secret,
+      chatAgent: { decide: async () => ({ kind: 'build' as const, text: 'On it!' }) },
     });
 
     await app.inject({
@@ -2285,7 +2322,10 @@ describe('submission routes', () => {
     // of nothing: out of capacity is a billing problem, not a broken game.
     expect(response.statusCode).toBe(200);
     expect(response.json()).toMatchObject({ ok: true, roundStarted: false, reason: 'no_capacity' });
-    expect(await store.listCreatorMessages(job.issueNumber)).not.toHaveLength(0);
+    const messages = await store.listCreatorMessages(job.issueNumber);
+    expect(messages).not.toHaveLength(0);
+    // A failed dispatch must not leave a transcript claiming it started.
+    expect(messages.some((message) => message.origin === 'studio_ack')).toBe(false);
     // And the job must not claim to be building when no session exists.
     expect((await store.getSubmission(job.issueNumber))?.state).not.toBe('building');
 

--- a/apps/api/src/submissions.ts
+++ b/apps/api/src/submissions.ts
@@ -3921,25 +3921,27 @@ export async function registerSubmissionRoutes(
       const builderChanging = Boolean(
         record && requestedBuilder && isBuilderKind(requestedBuilder) && requestedBuilder !== builderOf(record),
       );
-      if (record && requestedBuilder && isActiveBuildRound(record)) {
-        const current = builderOf(record);
-        if (requestedBuilder !== current) {
-          const stall = detectStall({
+      const currentStall = record
+        ? detectStall({
             state: record.state ?? 'queued',
             stateSince: record.stateSince ?? record.createdAt,
             lastAgentSignalAt: record.lastAgentSignalAt,
             agentState: record.agentState,
             agentEndedAt: record.agentEndedAt,
             now: now(),
-            builder: current,
-          });
+            builder: builderOf(record),
+          })
+        : null;
+      if (record && requestedBuilder && isActiveBuildRound(record)) {
+        const current = builderOf(record);
+        if (requestedBuilder !== current) {
           // Ended (MCP `end`) or quiet self → platform is the handoff escape hatch.
           // Anything else mid-round stays locked (two agents must not write the same round).
           if (
             !allowsSelfToPlatformHandoff({
               currentBuilder: current,
               requestedBuilder,
-              stall,
+              stall: currentStall,
               agentEndedAt: record.agentEndedAt,
             })
           ) {
@@ -4011,12 +4013,12 @@ export async function registerSubmissionRoutes(
           request.log.error({ err: queueError }, 'failed to queue feedback for the agent');
         }
       }
-      if (store && queued && studioAckText) {
-        // Optional ack, after the creator's own message so order stays honest.
+      const appendStudioAck = async () => {
+        if (!store || !queued || !studioAckText) return;
         await store
           .appendCreatorMessage(issueNumber, studioAckText, { origin: 'studio_ack', delivered: true })
           .catch(() => {});
-      }
+      };
 
       // An in-flight round that already has a dispatch ref steers via the inbox (every
       // progress reply carries pending messages) — including gate-wait and gate-red
@@ -4030,10 +4032,12 @@ export async function registerSubmissionRoutes(
       //
       // Self→platform handoff must resume (generation bump + platform dispatch),
       // not drop mail for the agent we are about to invalidate.
-      if (record && shouldSteerFeedbackViaInbox(record, { builderChanging })) {
+      if (record && shouldSteerFeedbackViaInbox(record, { builderChanging, stall: currentStall })) {
         if (!queued) {
           return reply.status(503).send({ error: 'failed to queue feedback for the agent' });
         }
+        // The current agent accepted the note, so its acknowledgement is truthful.
+        await appendStudioAck();
         // Inbox-only: still drop the status cache so the creator's note appears on the
         // next poll instead of riding a stale 60s snapshot.
         invalidateStatusCache(issueNumber);
@@ -4043,18 +4047,7 @@ export async function registerSubmissionRoutes(
         });
       }
 
-      const handoffStall =
-        builderChanging && record
-          ? detectStall({
-              state: record.state ?? 'queued',
-              stateSince: record.stateSince ?? record.createdAt,
-              lastAgentSignalAt: record.lastAgentSignalAt,
-              agentState: record.agentState,
-              agentEndedAt: record.agentEndedAt,
-              now: now(),
-              builder: builderOf(record),
-            })
-          : null;
+      const handoffStall = builderChanging && record ? currentStall : null;
       const handoffReason =
         record?.agentEndedAt || handoffStall === 'ended'
           ? 'agent_ended_handoff'
@@ -4080,6 +4073,8 @@ export async function registerSubmissionRoutes(
         },
       });
 
+      // Store the acknowledgement only after a new session is accepted.
+      if (outcome.started) await appendStudioAck();
       // Drop the cached status: without this, Studio kept serving the previous self
       // round (`no_agent_yet` / ended) for up to a minute while Copilot was already
       // queued on GitHub — exactly the "agent not connected" false warning.

--- a/apps/web/src/ReviewDesk.tsx
+++ b/apps/web/src/ReviewDesk.tsx
@@ -93,6 +93,7 @@ export function ReviewDesk() {
   const dragXRef = useRef(0);
   const dragYRef = useRef(0);
   const videoRef = useRef<HTMLVideoElement | null>(null);
+  const flashTimerRef = useRef<number | null>(null);
 
   const current = items[0] ?? null;
   const screenshots = current?.media?.screenshots ?? [];
@@ -102,7 +103,12 @@ export function ReviewDesk() {
   const videoUrl = current && videoFile ? catalogMediaUrl(current.slug, videoFile) : null;
 
   useEffect(() => {
-    return () => recognitionRef.current?.stop();
+    return () => {
+      recognitionRef.current?.stop();
+      if (flashTimerRef.current !== null) {
+        window.clearTimeout(flashTimerRef.current);
+      }
+    };
   }, []);
 
   useEffect(() => {
@@ -240,7 +246,13 @@ export function ReviewDesk() {
       setError(err instanceof Error ? err.message : t('review.error'));
     } finally {
       setBusy(false);
-      window.setTimeout(() => setFlash(null), 280);
+      if (flashTimerRef.current !== null) {
+        window.clearTimeout(flashTimerRef.current);
+      }
+      flashTimerRef.current = window.setTimeout(() => {
+        flashTimerRef.current = null;
+        setFlash(null);
+      }, 280);
     }
   };
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- restart platform feedback when the previous session has explicitly ended or stalled instead of leaving the note in an unread inbox
- keep feedback inbox-steered after the optimistic `submit_sources` handoff marker while the agent may still be connected
- persist Studio acknowledgements only after the note is accepted by an active agent or a new round
- clear the Review Desk flash timer on unmount so CI cannot update torn-down jsdom windows
- cover ended, stalled, submit-marker, self-build, and failed-dispatch routing with regression tests

## Validation
- CI failure reproduced from logs: `ReviewDesk` left a 280ms `window.setTimeout` callback after jsdom teardown.
- Targeted Review Desk tests: 3 passed.
- Full gate passed locally: `npm run type-check && npm run lint && npm run test && npm run build`.

## Measurement
- No new telemetry is needed; existing build-channel messages and job state remain the source of truth for this flow.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-66db5c7b-0844-4d11-9306-0fd2b4a1cc72?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-66db5c7b-0844-4d11-9306-0fd2b4a1cc72&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

