### PR TITLE
fix(web): increase mobile studio sheet height

### DIFF
--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -12091,7 +12091,7 @@ button.builder-mode-selector:disabled {
   }
 
   .studio-chat-rail.is-half {
-    height: 46vh;
+    height: 48vh;
   }
 
   .studio-chat-rail.is-full {


### PR DESCRIPTION
## Summary

- Increase the mobile studio half-sheet height from 46vh to 48vh.
- Restore enough transcript space for the phone browser gate when the status notice and composer are both visible.

## Root cause

At 390x844, the 46vh sheet left the transcript too short and caused the studio-shell layout assertion to fall below its minimum ratio. Tablet and desktop layouts were unaffected.

## Validation

- `npm run type-check`
- `npm run lint`
- `npm run test`
- `npm run build`
- Local studio-shell layout assertions across phone, tablet, and desktop viewports