### PR TITLE
Fix wasted Code header space

### DIFF
--- a/apps/web/src/CodeSurface.test.tsx
+++ b/apps/web/src/CodeSurface.test.tsx
@@ -137,7 +137,7 @@ describe('CodeSurface', () => {
     expect(textarea.value).toContain('export const boot');
   });
 
-  it('uses a native file picker instead of a scrolling mobile rail', async () => {
+  it('uses an on-demand file sheet instead of a scrolling mobile rail', async () => {
     mocked.fetchCodeSurfaceSources.mockResolvedValue(
       sourcesFor({
         files: [
@@ -149,17 +149,28 @@ describe('CodeSurface', () => {
 
     await render();
 
-    const picker = container.querySelector<HTMLSelectElement>('.code-surface-file-select');
+    const picker = container.querySelector<HTMLButtonElement>('.code-surface-file-trigger');
     expect(picker).not.toBeNull();
-    expect([...picker!.options].map((option) => option.value)).toEqual(['GAME.json', 'src/main.ts']);
+    expect(picker!.textContent).toContain('GAME.json');
 
     await act(async () => {
-      picker!.value = 'src/main.ts';
-      picker!.dispatchEvent(new Event('change', { bubbles: true }));
+      picker!.click();
+    });
+
+    const sheet = container.querySelector('[role="dialog"]');
+    expect(sheet).not.toBeNull();
+    expect(sheet?.textContent).toContain('GAME.json');
+    expect(sheet?.textContent).toContain('src/main.ts');
+
+    await act(async () => {
+      [...container.querySelectorAll<HTMLButtonElement>('.code-surface-file-option')]
+        .find((option) => option.textContent?.includes('src/main.ts'))
+        ?.click();
     });
 
     expect(container.querySelector('textarea')!.value).toContain('export const boot');
     expect(container.querySelector('.code-surface-rail-item.is-active')?.textContent).toContain('src/main.ts');
+    expect(container.querySelector('[role="dialog"]')).toBeNull();
   });
 
   it('autosaves an edit into the working copy, marks the rail dirty, and schedules a preview rebuild', async () => {

--- a/apps/web/src/CodeSurface.test.tsx
+++ b/apps/web/src/CodeSurface.test.tsx
@@ -117,6 +117,8 @@ describe('CodeSurface', () => {
     // Read-only during a live agent round (CE-08): no editable textarea, and the banner shows.
     expect(container.querySelector('textarea')).toBeNull();
     expect(container.querySelector('.code-surface-readonly-banner')).not.toBeNull();
+    expect(container.querySelector('.code-surface-readonly-banner-full')).not.toBeNull();
+    expect(container.querySelector('.code-surface-readonly-banner-compact')).not.toBeNull();
     expect(container.textContent).toContain('export const boot');
   });
 

--- a/apps/web/src/CodeSurface.test.tsx
+++ b/apps/web/src/CodeSurface.test.tsx
@@ -137,6 +137,31 @@ describe('CodeSurface', () => {
     expect(textarea.value).toContain('export const boot');
   });
 
+  it('uses a native file picker instead of a scrolling mobile rail', async () => {
+    mocked.fetchCodeSurfaceSources.mockResolvedValue(
+      sourcesFor({
+        files: [
+          { path: 'GAME.json', content: '{"engine":{"modules":[]}}' },
+          { path: 'src/main.ts', content: 'export const boot = () => {};' },
+        ],
+      }),
+    );
+
+    await render();
+
+    const picker = container.querySelector<HTMLSelectElement>('.code-surface-file-select');
+    expect(picker).not.toBeNull();
+    expect([...picker!.options].map((option) => option.value)).toEqual(['GAME.json', 'src/main.ts']);
+
+    await act(async () => {
+      picker!.value = 'src/main.ts';
+      picker!.dispatchEvent(new Event('change', { bubbles: true }));
+    });
+
+    expect(container.querySelector('textarea')!.value).toContain('export const boot');
+    expect(container.querySelector('.code-surface-rail-item.is-active')?.textContent).toContain('src/main.ts');
+  });
+
   it('autosaves an edit into the working copy, marks the rail dirty, and schedules a preview rebuild', async () => {
     mocked.fetchCodeSurfaceSources.mockResolvedValue(sourcesFor());
     mocked.stageCodeSurfaceFile.mockResolvedValue({

--- a/apps/web/src/CodeSurface.tsx
+++ b/apps/web/src/CodeSurface.tsx
@@ -151,11 +151,13 @@ export function CodeSurface({ slug, onBack, editorPushRef }: CodeSurfaceProps) {
   const [discardState, setDiscardState] = useState<DiscardState>('idle');
   const [deliverState, setDeliverState] = useState<'idle' | 'delivering' | 'delivered'>('idle');
   const [deliverMessage, setDeliverMessage] = useState<string | null>(null);
+  const [filePickerOpen, setFilePickerOpen] = useState(false);
   /** Briefly true after a live param push (§E tier 1) — separate from `saveState`. */
   const [livePush, setLivePush] = useState(false);
 
   const openedRecordedRef = useRef(false);
   const fileOpenedRecordedRef = useRef(new Set<string>());
+  const filePickerTriggerRef = useRef<HTMLButtonElement | null>(null);
   const railRef = useRef<HTMLElement | null>(null);
   /** One autosave timer per dirty path, not one shared timer — editing a second file
    * inside the debounce window must not cancel the first file's pending save. */
@@ -233,6 +235,17 @@ export function CodeSurface({ slug, onBack, editorPushRef }: CodeSurfaceProps) {
   useEffect(() => {
     setCodeSurfaceSessionState(slug, { selected, drafts });
   }, [slug, selected, drafts]);
+
+  useEffect(() => {
+    if (!filePickerOpen) return undefined;
+    function onKeyDown(event: KeyboardEvent) {
+      if (event.key !== 'Escape') return;
+      setFilePickerOpen(false);
+      filePickerTriggerRef.current?.focus();
+    }
+    document.addEventListener('keydown', onKeyDown);
+    return () => document.removeEventListener('keydown', onKeyDown);
+  }, [filePickerOpen]);
 
   useEffect(
     () => () => {
@@ -643,21 +656,24 @@ export function CodeSurface({ slug, onBack, editorPushRef }: CodeSurfaceProps) {
         ) : null}
       </header>
 
-      <label className="code-surface-file-picker">
-        <span>{t('studioPanel.code.filePicker')}</span>
-        <select
-          className="code-surface-file-select"
-          value={selected ?? ''}
+      <div className="code-surface-file-picker">
+        <button
+          ref={filePickerTriggerRef}
+          type="button"
+          className="code-surface-file-trigger"
           disabled={sources.files.length === 0}
-          onChange={(event) => selectFile(event.currentTarget.value)}
+          aria-label={t('studioPanel.code.filePicker')}
+          aria-haspopup="dialog"
+          aria-expanded={filePickerOpen}
+          onClick={() => setFilePickerOpen(true)}
         >
-          {sources.files.map((entry) => (
-            <option key={entry.path} value={entry.path}>
-              {entry.path}
-            </option>
-          ))}
-        </select>
-      </label>
+          <PixelIcon name="code" size={13} />
+          <span className="code-surface-file-trigger-path">
+            {file?.path ?? t('studioPanel.code.noFiles')}
+          </span>
+          <PixelIcon name="chevronDown" size={11} />
+        </button>
+      </div>
 
       <div className="code-surface-body">
         <nav className="code-surface-rail" aria-label={t('studioPanel.tabs.code')} ref={railRef}>
@@ -791,6 +807,76 @@ export function CodeSurface({ slug, onBack, editorPushRef }: CodeSurfaceProps) {
             </span>
           ) : null}
         </footer>
+      ) : null}
+
+      {filePickerOpen ? (
+        <div
+          className="code-surface-file-backdrop"
+          role="presentation"
+          onClick={() => {
+            setFilePickerOpen(false);
+            filePickerTriggerRef.current?.focus();
+          }}
+        >
+          <section
+            className="code-surface-file-sheet"
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="code-surface-file-picker-title"
+            onClick={(event) => event.stopPropagation()}
+          >
+            <header className="code-surface-file-sheet-head">
+              <h3 id="code-surface-file-picker-title">{t('studioPanel.code.filePicker')}</h3>
+              <button
+                type="button"
+                className="modal-close-btn"
+                onClick={() => {
+                  setFilePickerOpen(false);
+                  filePickerTriggerRef.current?.focus();
+                }}
+                aria-label={t('studioPanel.code.filePickerClose')}
+              >
+                <PixelIcon name="close" size={13} />
+              </button>
+            </header>
+            <div className="code-surface-file-options" role="listbox" aria-label={t('studioPanel.code.filePicker')}>
+              {sources.files.map((entry) => (
+                <button
+                  key={entry.path}
+                  type="button"
+                  className={`code-surface-file-option${entry.path === selected ? ' is-active' : ''}`}
+                  role="option"
+                  aria-selected={entry.path === selected}
+                  onClick={() => {
+                    selectFile(entry.path);
+                    setFilePickerOpen(false);
+                    filePickerTriggerRef.current?.focus();
+                  }}
+                >
+                  <span className="code-surface-file-option-path">{entry.path}</span>
+                  {entry.stagedBy ? (
+                    <span className="code-surface-file-option-status">
+                      {t('studioPanel.code.stagedBy', { who: entry.stagedBy })}
+                    </span>
+                  ) : null}
+                  {entry.path === selected ? <PixelIcon name="check" size={13} /> : null}
+                </button>
+              ))}
+              {LOCKED_DIRS.map((dir) => (
+                <div
+                  key={dir}
+                  className="code-surface-file-option is-locked"
+                  role="option"
+                  aria-selected="false"
+                  aria-disabled="true"
+                >
+                  <PixelIcon name="lock" size={11} />
+                  <span className="code-surface-file-option-path">{dir}</span>
+                </div>
+              ))}
+            </div>
+          </section>
+        </div>
       ) : null}
     </div>
   );

--- a/apps/web/src/CodeSurface.tsx
+++ b/apps/web/src/CodeSurface.tsx
@@ -643,6 +643,22 @@ export function CodeSurface({ slug, onBack, editorPushRef }: CodeSurfaceProps) {
         ) : null}
       </header>
 
+      <label className="code-surface-file-picker">
+        <span>{t('studioPanel.code.filePicker')}</span>
+        <select
+          className="code-surface-file-select"
+          value={selected ?? ''}
+          disabled={sources.files.length === 0}
+          onChange={(event) => selectFile(event.currentTarget.value)}
+        >
+          {sources.files.map((entry) => (
+            <option key={entry.path} value={entry.path}>
+              {entry.path}
+            </option>
+          ))}
+        </select>
+      </label>
+
       <div className="code-surface-body">
         <nav className="code-surface-rail" aria-label={t('studioPanel.tabs.code')} ref={railRef}>
           {sources.files.map((entry) => (

--- a/apps/web/src/CodeSurface.tsx
+++ b/apps/web/src/CodeSurface.tsx
@@ -650,8 +650,16 @@ export function CodeSurface({ slug, onBack, editorPushRef }: CodeSurfaceProps) {
         </button>
         <h2>{t('studioPanel.tabs.code')}</h2>
         {sources.readOnly ? (
-          <span className="code-surface-readonly-banner" role="status">
-            {t('studioPanel.code.agentRound')}
+          <span
+            className="code-surface-readonly-banner"
+            role="status"
+            aria-label={t('studioPanel.code.agentRound')}
+            title={t('studioPanel.code.agentRound')}
+          >
+            <span className="code-surface-readonly-banner-full">{t('studioPanel.code.agentRound')}</span>
+            <span className="code-surface-readonly-banner-compact">
+              {t('studioPanel.code.agentRoundCompact')}
+            </span>
           </span>
         ) : null}
       </header>

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -313,6 +313,7 @@
     },
     "code": {
       "back": "Thread",
+      "filePicker": "File",
       "loading": "Loading your game's sources…",
       "loadError": "Sources could not be loaded right now.",
       "agentRound": "An agent is actively building — read only until it finishes",

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -318,6 +318,7 @@
       "loading": "Loading your game's sources…",
       "loadError": "Sources could not be loaded right now.",
       "agentRound": "An agent is actively building — read only until it finishes",
+      "agentRoundCompact": "Read only",
       "stagedBy": "changed · {{who}}",
       "lockedHint": "Read-only — GameKit and the tooling are shared, never edited here",
       "noFiles": "Nothing to show yet",

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -313,7 +313,8 @@
     },
     "code": {
       "back": "Thread",
-      "filePicker": "File",
+      "filePicker": "Choose file",
+      "filePickerClose": "Close file list",
       "loading": "Loading your game's sources…",
       "loadError": "Sources could not be loaded right now.",
       "agentRound": "An agent is actively building — read only until it finishes",

--- a/apps/web/src/i18n/locales/pl.json
+++ b/apps/web/src/i18n/locales/pl.json
@@ -315,7 +315,8 @@
     },
     "code": {
       "back": "Wątek",
-      "filePicker": "Plik",
+      "filePicker": "Wybierz plik",
+      "filePickerClose": "Zamknij listę plików",
       "loading": "Wczytywanie plików źródłowych…",
       "loadError": "Nie udało się teraz wczytać plików źródłowych.",
       "agentRound": "Agent aktywnie pracuje — tylko do odczytu, dopóki nie skończy",

--- a/apps/web/src/i18n/locales/pl.json
+++ b/apps/web/src/i18n/locales/pl.json
@@ -320,6 +320,7 @@
       "loading": "Wczytywanie plików źródłowych…",
       "loadError": "Nie udało się teraz wczytać plików źródłowych.",
       "agentRound": "Agent aktywnie pracuje — tylko do odczytu, dopóki nie skończy",
+      "agentRoundCompact": "Tylko odczyt",
       "stagedBy": "zmienione · {{who}}",
       "lockedHint": "Tylko do odczytu — GameKit i narzędzia są wspólne, nie edytuje się ich tutaj",
       "noFiles": "Nie ma jeszcze nic do pokazania",

--- a/apps/web/src/i18n/locales/pl.json
+++ b/apps/web/src/i18n/locales/pl.json
@@ -315,6 +315,7 @@
     },
     "code": {
       "back": "Wątek",
+      "filePicker": "Plik",
       "loading": "Wczytywanie plików źródłowych…",
       "loadError": "Nie udało się teraz wczytać plików źródłowych.",
       "agentRound": "Agent aktywnie pracuje — tylko do odczytu, dopóki nie skończy",

--- a/apps/web/src/styles.codeSurfaceButtons.test.ts
+++ b/apps/web/src/styles.codeSurfaceButtons.test.ts
@@ -39,9 +39,13 @@ describe('the Code surface Publish button', () => {
     expect(ruleFor('.studio-stage-layout:has(.studio-code-overlay) .studio-fullbleed')).toMatch(/top:\s*10px/);
   });
 
-  it('gives the global escape its own row on narrow phones', () => {
+  it('gives the global escape its own row below desktop widths', () => {
     expect(css).toMatch(
-      /@media \(max-width: 600px\)[\s\S]*?\.studio-stage-layout:has\(\.studio-code-overlay\) \.code-surface-head \{\s*padding: 52px 14px 10px;/,
+      /@media \(max-width: 1099px\)[\s\S]*?\.studio-stage-layout:has\(\.studio-code-overlay\) \.code-surface-head \{\s*padding: 52px 14px 10px;/,
+    );
+    expect(css).toMatch(/\.code-surface-readonly-banner-compact \{\s*display: none;/);
+    expect(css).toMatch(
+      /@media \(max-width: 1099px\)[\s\S]*?\.code-surface-readonly-banner-full \{\s*display: none;[\s\S]*?\.code-surface-readonly-banner-compact \{\s*display: inline;/,
     );
   });
 

--- a/apps/web/src/styles.codeSurfaceButtons.test.ts
+++ b/apps/web/src/styles.codeSurfaceButtons.test.ts
@@ -38,4 +38,10 @@ describe('the Code surface Publish button', () => {
     );
     expect(ruleFor('.studio-stage-layout:has(.studio-code-overlay) .studio-fullbleed')).toMatch(/top:\s*10px/);
   });
+
+  it('gives the global escape its own row on narrow phones', () => {
+    expect(css).toMatch(
+      /@media \(max-width: 600px\)[\s\S]*?\.studio-stage-layout:has\(\.studio-code-overlay\) \.code-surface-head \{\s*padding: 52px 14px 10px;/,
+    );
+  });
 });

--- a/apps/web/src/styles.codeSurfaceButtons.test.ts
+++ b/apps/web/src/styles.codeSurfaceButtons.test.ts
@@ -30,4 +30,12 @@ describe('the Code surface Publish button', () => {
   it('no longer ships a separate Stage-it primary CTA — preview rebuilds on autosave', () => {
     expect(css).not.toMatch(/\.code-surface-stage-it/);
   });
+
+  it('keeps Code navigation beside the global escape', () => {
+    expect(ruleFor('.code-surface-head')).toMatch(/padding:\s*10px 14px/);
+    expect(ruleFor('.studio-stage-layout:has(.studio-code-overlay) .code-surface-head')).toMatch(
+      /padding-left:\s*180px/,
+    );
+    expect(ruleFor('.studio-stage-layout:has(.studio-code-overlay) .studio-fullbleed')).toMatch(/top:\s*10px/);
+  });
 });

--- a/apps/web/src/styles.codeSurfaceButtons.test.ts
+++ b/apps/web/src/styles.codeSurfaceButtons.test.ts
@@ -44,4 +44,13 @@ describe('the Code surface Publish button', () => {
       /@media \(max-width: 600px\)[\s\S]*?\.studio-stage-layout:has\(\.studio-code-overlay\) \.code-surface-head \{\s*padding: 52px 14px 10px;/,
     );
   });
+
+  it('keeps mobile file navigation on demand instead of rendering a tab rail', () => {
+    expect(css).not.toMatch(/\.code-surface-file-select/);
+    expect(css).toMatch(/\.code-surface-file-trigger-path[\s\S]*?text-overflow:\s*ellipsis/);
+    expect(css).toMatch(
+      /@media \(max-width: 1099px\)[\s\S]*?\.code-surface-file-backdrop \{\s*position: absolute;[\s\S]*?\.code-surface-file-sheet \{\s*position: relative;/,
+    );
+    expect(css).toMatch(/\.code-surface-file-option \{[\s\S]*?min-height: 44px/);
+  });
 });

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -11577,11 +11577,16 @@ button.builder-mode-selector:disabled {
 
 .code-surface-readonly-banner {
   margin-left: auto;
+  min-width: 0;
   font-size: 0.78rem;
   color: var(--muted);
   padding: 4px 10px;
   border-radius: 999px;
   background: rgba(148, 163, 184, 0.12);
+}
+
+.code-surface-readonly-banner-compact {
+  display: none;
 }
 
 .code-surface-loading,
@@ -12051,12 +12056,20 @@ button.builder-mode-selector:disabled {
   }
 }
 
-/* On phones the global escape is a separate top row. Keeping it in the same row as
-   Wątek, Kod, and the readonly badge makes the header look like one crowded toolbar and
-   clips the right-hand status on narrow screens. */
-@media (max-width: 600px) {
+/* Below desktop widths the global escape gets its own top row. The desktop 180px
+   reservation leaves too little room for the Code controls and the live read-only
+   status on phones and narrow tablets. */
+@media (max-width: 1099px) {
   .studio-stage-layout:has(.studio-code-overlay) .code-surface-head {
     padding: 52px 14px 10px;
+  }
+
+  .code-surface-readonly-banner-full {
+    display: none;
+  }
+
+  .code-surface-readonly-banner-compact {
+    display: inline;
   }
 }
 

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -11909,6 +11909,15 @@ button.builder-mode-selector:disabled {
   }
 }
 
+/* On phones the global escape is a separate top row. Keeping it in the same row as
+   Wątek, Kod, and the readonly badge makes the header look like one crowded toolbar and
+   clips the right-hand status on narrow screens. */
+@media (max-width: 600px) {
+  .studio-stage-layout:has(.studio-code-overlay) .code-surface-head {
+    padding: 52px 14px 10px;
+  }
+}
+
 /* ── THE CHAT RAIL ────────────────────────────────────────────────────────────── */
 
 .studio-chat-unread-badge {

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -11504,6 +11504,7 @@ button.builder-mode-selector:disabled {
 /* ── THE CODE SURFACE (creator-code-editing-execution-plan.md) ─────────────────── */
 
 .code-surface {
+  position: relative;
   display: flex;
   flex-direction: column;
   min-height: 0;
@@ -11535,6 +11536,42 @@ button.builder-mode-selector:disabled {
 }
 
 .code-surface-file-picker {
+  display: none;
+}
+
+.code-surface-file-trigger {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+  border: 0;
+  background: transparent;
+  color: var(--text);
+  font: inherit;
+  cursor: pointer;
+}
+
+.code-surface-file-trigger-path {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: var(--mono-font, monospace);
+  font-size: 0.78rem;
+}
+
+.code-surface-file-trigger:hover:not(:disabled),
+.code-surface-file-trigger:focus-visible {
+  color: var(--turquoise);
+}
+
+.code-surface-file-trigger:disabled {
+  color: var(--muted);
+  cursor: default;
+}
+
+.code-surface-file-backdrop,
+.code-surface-file-sheet {
   display: none;
 }
 
@@ -11863,24 +11900,119 @@ button.builder-mode-selector:disabled {
   .code-surface-file-picker {
     display: flex;
     align-items: center;
-    gap: 10px;
     flex: none;
-    padding: 8px 12px;
+    min-width: 0;
+    padding: 5px 12px;
     border-bottom: 1px solid var(--panel-border);
-    color: var(--muted);
-    font-size: 0.76rem;
-    font-weight: 600;
   }
 
-  .code-surface-file-select {
+  .code-surface-file-trigger {
+    width: 100%;
+    min-height: 34px;
+    padding: 5px 7px;
+    border: 1px solid transparent;
+    border-radius: 8px;
+    text-align: left;
+  }
+
+  .code-surface-file-trigger:hover:not(:disabled),
+  .code-surface-file-trigger:focus-visible {
+    border-color: rgba(0, 228, 172, 0.35);
+    background: rgba(0, 228, 172, 0.08);
+  }
+
+  .code-surface-file-backdrop {
+    position: absolute;
+    z-index: 20;
+    inset: 0;
+    display: flex;
+    align-items: flex-end;
+    justify-content: center;
+    background: rgba(3, 8, 13, 0.66);
+  }
+
+  .code-surface-file-sheet {
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    min-width: 0;
+    width: min(100%, 480px);
+    max-height: min(76%, 34rem);
+    border: 1px solid var(--panel-border);
+    border-bottom: 0;
+    border-radius: 16px 16px 0 0;
+    background: var(--panel);
+    box-shadow: 0 -12px 36px rgba(0, 0, 0, 0.42);
+    overflow: hidden;
+  }
+
+  .code-surface-file-sheet-head {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    flex: none;
+    padding: 12px 12px 10px 16px;
+    border-bottom: 1px solid var(--panel-border);
+  }
+
+  .code-surface-file-sheet-head h3 {
+    flex: 1;
+    min-width: 0;
+    margin: 0;
+    font-size: 0.86rem;
+  }
+
+  .code-surface-file-options {
+    min-height: 0;
+    overflow-y: auto;
+    overscroll-behavior: contain;
+    padding: 5px 8px max(8px, env(safe-area-inset-bottom));
+  }
+
+  .code-surface-file-option {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    width: 100%;
+    min-height: 44px;
+    padding: 8px 9px;
+    border: 1px solid transparent;
+    border-radius: 8px;
+    background: transparent;
+    color: var(--text);
+    text-align: left;
+    font: inherit;
+    cursor: pointer;
+  }
+
+  .code-surface-file-option:hover,
+  .code-surface-file-option:focus-visible {
+    border-color: rgba(0, 228, 172, 0.3);
+    background: rgba(0, 228, 172, 0.07);
+  }
+
+  .code-surface-file-option.is-active {
+    color: var(--turquoise);
+    background: rgba(0, 228, 172, 0.12);
+  }
+
+  .code-surface-file-option.is-locked {
+    color: var(--muted);
+    cursor: default;
+  }
+
+  .code-surface-file-option-path {
     min-width: 0;
     flex: 1;
-    border: 1px solid var(--panel-border);
-    border-radius: 7px;
-    background: var(--panel-card);
-    color: var(--text);
-    padding: 7px 9px;
-    font: inherit;
+    overflow-wrap: anywhere;
+    font-family: var(--mono-font, monospace);
+    font-size: 0.78rem;
+  }
+
+  .code-surface-file-option-status {
+    flex: none;
+    color: var(--muted);
+    font-size: 0.68rem;
   }
 
   .code-surface-rail {

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -11534,6 +11534,10 @@ button.builder-mode-selector:disabled {
   font-weight: 700;
 }
 
+.code-surface-file-picker {
+  display: none;
+}
+
 .code-surface-readonly-banner {
   margin-left: auto;
   font-size: 0.78rem;
@@ -11853,28 +11857,34 @@ button.builder-mode-selector:disabled {
 @media (max-width: 1099px) {
   .code-surface-body {
     grid-template-columns: minmax(0, 1fr);
-    grid-template-rows: auto minmax(0, 1fr);
+    grid-template-rows: minmax(0, 1fr);
+  }
+
+  .code-surface-file-picker {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    flex: none;
+    padding: 8px 12px;
+    border-bottom: 1px solid var(--panel-border);
+    color: var(--muted);
+    font-size: 0.76rem;
+    font-weight: 600;
+  }
+
+  .code-surface-file-select {
+    min-width: 0;
+    flex: 1;
+    border: 1px solid var(--panel-border);
+    border-radius: 7px;
+    background: var(--panel-card);
+    color: var(--text);
+    padding: 7px 9px;
+    font: inherit;
   }
 
   .code-surface-rail {
-    flex-direction: row;
-    overflow-x: auto;
-    border-right: 0;
-    border-bottom: 1px solid var(--panel-border);
-    scroll-snap-type: x proximity;
-  }
-
-  /* Row mode has no bounded width like the desktop rail's own column, so without a
-     cap the ellipsis rule on .code-surface-rail-path never triggers — a handful of
-     `game/`-prefixed files spell out the whole row and the active one scrolls off. */
-  .code-surface-rail-item {
-    flex: 0 0 auto;
-    max-width: 40vw;
-    scroll-snap-align: start;
-  }
-
-  .code-surface-rail-locked {
-    flex: none;
+    display: none;
   }
 }
 

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -11515,12 +11515,17 @@ button.builder-mode-selector:disabled {
   align-items: center;
   gap: 10px;
   flex: none;
-  /* Extra top clearance: `.studio-fullbleed` floats over this same top-left corner
-     (position:absolute, top:14px, left:14px, z-index:1150) whenever this panel is
-     open, since opening it is what makes `covered` true. Reserve room below it
-     rather than let the two overlap. */
-  padding: 44px 14px 10px;
+  padding: 10px 14px;
   border-bottom: 1px solid var(--panel-border);
+}
+
+/* Keep the global escape and Code's thread action on one row. */
+.studio-stage-layout:has(.studio-code-overlay) .code-surface-head {
+  padding-left: 180px;
+}
+
+.studio-stage-layout:has(.studio-code-overlay) .studio-fullbleed {
+  top: 10px;
 }
 
 .code-surface-head h2 {


### PR DESCRIPTION
## Summary

- compact the desktop Code header while preserving the global escape action
- keep the global escape on its own row on narrow phones
- replace the mobile scrolling filename rail and native select with a compact current-file disclosure
- open mobile file navigation as a focused bottom sheet with touch-sized rows, selected-file state, locked directories, backdrop dismissal, and Escape support
- preserve the desktop file rail and existing file-open telemetry

## Measurement / telemetry

- no new event or PII
- existing `code_step: file_opened` remains the signal for both desktop rail selection and mobile sheet selection
- the admin coding funnel remains comparable before and after the UI change

## Validation

- focused Code surface + CSS tests: 22 passed
- web type-check, lint, and production build passed
- visual checks at 320px and 390px
- all web tests passed (151 files, 1,292 tests); package and rules tests passed
- 22 unrelated API/world websocket tests fail under the sandbox with `listen EPERM`
