### PR TITLE
Fix closing summaries after source submission

### DIFF
--- a/apps/api/src/agent-channel.test.ts
+++ b/apps/api/src/agent-channel.test.ts
@@ -495,6 +495,48 @@ describe('agent build channel', () => {
     expect(events.filter((event) => event.kind === 'done')).toHaveLength(1);
   });
 
+  it('still records the summary when submit already marked the round ended', async () => {
+    const store = new InMemoryStore();
+    await seedSubmission(store);
+    await store.markAgentEnded(ISSUE, '2026-08-12T12:00:00.000Z', 'submit');
+    app = await createApp(store);
+
+    const end = await app.inject({
+      method: 'POST',
+      url: '/api/agent/build/end',
+      headers: agentHeaders(),
+      payload: { summary: 'Preview fixed and resubmitted with the save module enabled.' },
+    });
+
+    expect(end.json()).toMatchObject({ accepted: true, ended: true, summaryShown: true });
+    expect((await store.listBuildEvents(ISSUE))[0]).toMatchObject({
+      kind: 'done',
+      text: 'Preview fixed and resubmitted with the save module enabled.',
+    });
+  });
+
+  it('does not duplicate the summary on a legacy ended record without agentEndedBy', async () => {
+    const store = new InMemoryStore();
+    await seedSubmission(store);
+    await store.markAgentEnded(ISSUE, '2026-08-11T12:00:00.000Z');
+    const stored = (
+      store as unknown as { submissions: Map<number, import('./store.js').SubmissionRecord> }
+    ).submissions.get(ISSUE);
+    delete stored!.agentEndedBy;
+    app = await createApp(store);
+
+    const retry = await app.inject({
+      method: 'POST',
+      url: '/api/agent/build/end',
+      headers: agentHeaders(),
+      payload: { summary: 'Should not appear on a legacy retry.' },
+    });
+
+    expect(retry.json()).toMatchObject({ accepted: true, ended: true });
+    expect(retry.json().summaryShown).toBeUndefined();
+    expect(await store.listBuildEvents(ISSUE)).toHaveLength(0);
+  });
+
   it('records a fresh summary once the agent has resumed and ended again', async () => {
     const store = new InMemoryStore();
     await seedSubmission(store);

--- a/apps/api/src/agent-channel.ts
+++ b/apps/api/src/agent-channel.ts
@@ -2004,7 +2004,7 @@ export async function registerAgentChannelRoutes(
         return reply.send({ accepted: false, rejected: 'stopped', ...(await channelState(issueNumber, record)) });
       }
 
-      // Submit marks the round ended optimistically; only a prior `end` is a retry.
+      // Submit can mark a round ended; `end` still carries the summary.
       const summarized = record.agentEndedBy === 'end' ? false : await recordSummary();
       await store!.markAgentEnded(issueNumber);
       options.onEvent?.(issueNumber);

--- a/apps/api/src/agent-channel.ts
+++ b/apps/api/src/agent-channel.ts
@@ -2004,8 +2004,8 @@ export async function registerAgentChannelRoutes(
         return reply.send({ accepted: false, rejected: 'stopped', ...(await channelState(issueNumber, record)) });
       }
 
-      // Submit can mark a round ended; `end` still carries the summary.
-      const summarized = record.agentEndedBy === 'end' ? false : await recordSummary();
+      // Submit-ended still records; a prior or legacy end does not.
+      const summarized = record.agentEndedAt && record.agentEndedBy !== 'submit' ? false : await recordSummary();
       await store!.markAgentEnded(issueNumber);
       options.onEvent?.(issueNumber);
       const fresh = (await store!.getSubmission(issueNumber)) ?? record;

--- a/apps/api/src/agent-channel.ts
+++ b/apps/api/src/agent-channel.ts
@@ -2004,8 +2004,8 @@ export async function registerAgentChannelRoutes(
         return reply.send({ accepted: false, rejected: 'stopped', ...(await channelState(issueNumber, record)) });
       }
 
-      // Already ended: skip the summary so a retried `end` cannot duplicate it.
-      const summarized = record.agentEndedAt ? false : await recordSummary();
+      // Submit marks the round ended optimistically; only a prior `end` is a retry.
+      const summarized = record.agentEndedBy === 'end' ? false : await recordSummary();
       await store!.markAgentEnded(issueNumber);
       options.onEvent?.(issueNumber);
       const fresh = (await store!.getSubmission(issueNumber)) ?? record;

--- a/apps/api/src/mcp-server.test.ts
+++ b/apps/api/src/mcp-server.test.ts
@@ -1486,9 +1486,24 @@ describe('POST /api/mcp (BY-05)', () => {
     expect((await store.getSubmission(ISSUE))?.agentEndedAt).toBeTruthy();
     expect((await store.getSubmission(ISSUE))?.agentEndedBy).toBe('submit');
 
-    const ended = await callTool(app, 'end', { sessionKey }, { 'mcp-session-id': sessionId });
+    const ended = await callTool(
+      app,
+      'end',
+      { sessionKey, summary: 'Preview fixed and resubmitted with the save module enabled.' },
+      { 'mcp-session-id': sessionId },
+    );
     expect(ended.isError).toBe(false);
-    expect(ended.structured).toMatchObject({ ok: true, ended: true, stop: true, reason: 'agent_ended' });
+    expect(ended.structured).toMatchObject({
+      ok: true,
+      ended: true,
+      summaryShown: true,
+      stop: true,
+      reason: 'agent_ended',
+    });
+    expect((await store.listBuildEvents(ISSUE))[0]).toMatchObject({
+      kind: 'done',
+      text: 'Preview fixed and resubmitted with the save module enabled.',
+    });
     expect((await store.getSubmission(ISSUE))?.agentEndedAt).toBeTruthy();
     expect((await store.getSubmission(ISSUE))?.agentEndedBy).toBe('end');
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- preserve `end({ summary })` after `submit_sources` marks the round ended optimistically
- keep retries after an actual `end` idempotent, including legacy records that have `agentEndedAt` but no `agentEndedBy`
- add regression tests covering submit → end with a creator-visible summary, and a legacy retry that must not duplicate it

## Verification
- `npm run type-check` ✅
- `npm run lint` ✅
- `npm run test` ✅
- `npm run build` ✅
- Copilot review comment addressed: skip summary when `agentEndedAt` is set unless `agentEndedBy === 'submit'`
- No new telemetry is needed; this restores an existing creator-facing build event and does not change the measurement contract.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c6e8f143-792f-457c-96fd-8730350389b8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c6e8f143-792f-457c-96fd-8730350389b8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

