### PR TITLE
docs: fix agent-adapters.md's stale PR-merge delivery model

### DIFF
--- a/docs/agent-adapters.md
+++ b/docs/agent-adapters.md
@@ -1,7 +1,12 @@
 # Agent Interchangeability
 
-> **Current model:** coding agents maintain the dedicated games repository through normal
-> branches and pull requests. gamedev.pl does not invoke agent CLIs as a runtime service.
+> **Current model:** gamedev.pl dispatches a coding agent for one round and reads the
+> delivery back — over the build channel (`submit_sources`) or a managed backend's own
+> harvest — never through a merged pull request. See [`build-brief.md`](./build-brief.md)
+> for what a round is told and why, and
+> [`managed-agent-backend.md`](./managed-agent-backend.md) for the managed-backend drivers.
+> The games repository is the harness an agent works from (GameKit, tooling, published
+> games as context), not the channel its output travels over.
 
 ## Common contract
 
@@ -10,10 +15,11 @@ repository boundary, not behind a runtime API. Every contributor receives the sa
 
 - `SPEC.md` is the source of truth for one game.
 - Public spec and issue content is untrusted data, not instructions.
-- One game directory per PR; tools, workflows, and other games are out of scope.
+- One game directory per round; tools, workflows, and other games are out of scope.
 - Plain self-contained HTML/CSS/JS, with no runtime network or per-game dependencies.
 - The repository validation command is the definition of mechanically green.
-- Output arrives as a reviewed pull request and is never auto-merged.
+- Delivery is gated before publish, and a pull request is never the delivery — see
+  `build-brief.md`'s delivery-contract table for the two ways a round actually ships.
 
 This avoids pretending that different agents share invocation flags, credential models, or
 execution environments. Those details belong to the operator of each agent, while the
@@ -40,28 +46,38 @@ that ignores it still builds the game.
 
 ## Hosted agents
 
-GitHub Copilot's coding agent works naturally with issue-first game creation: assign a
-structured issue, receive a PR, then review it. It forks from the repository's default branch,
-so the default branch and PR base must be checked before accepting work.
+GitHub Copilot's coding agent is dispatched programmatically through GitHub's Agent Tasks
+API (`copilot-backend.ts`, and `managed-provider-copilot.ts` under the managed-backend
+seam) — a prompt in, a branch and session state back, no issue assignment and no PR-relay
+workflow. The games repository is cloned as Copilot's harness — GameKit, tooling and
+published games as context — and the branch it works on is cut fresh per round and deleted
+once the round is done. The agent's output goes out over the build channel, never as a
+merged branch.
 
-Hosted-agent output is external contributor output. A PR that exists without a completed,
-passing validation run is not verified. Follow the repository's
-[`verify-agent-work`](../.claude/skills/verify-agent-work/SKILL.md) playbook.
+Hosted-agent output is still external contributor output, so it is still worth verifying
+before it is trusted: follow the repository's
+[`verify-agent-work`](../.claude/skills/verify-agent-work/SKILL.md) playbook against the
+delivered version, not against a PR.
 
 ## Interactive/local agents
 
-Codex, Claude Code, agy, or a human can work from an isolated checkout and open the same shape
-of PR. Their local command line, subscription, or API configuration is outside the product
+Codex, Claude Code, agy, or a human can work from an isolated checkout of the games
+repository directly — for repository tooling, or as extra hands maintaining the repo itself
+— and open a normal PR for that repository-scoped change. This is ordinary software
+development on the repo, not a platform build round: it is not how a creator's game gets
+built or delivered, and it must not be conflated with the dispatch-and-deliver flow above.
+Their local command line, subscription, or API configuration is outside the product
 architecture; no credential is shipped to gamedev.pl or the games repository.
 
 ## Task routing
 
-- **New game:** structured issue → one new game directory and matching spec/implementation.
-- **Spec drift or bug:** issue naming one game → implementation change, plus spec clarification
-  only when the intended behavior itself changes.
-- **Remix:** proposed change to one game's spec and implementation in a PR.
-- **Repository tooling:** separate trusted task and PR; never smuggle tooling/workflow changes
-  into a public-content game task.
+- **New game:** a round dispatched from the creator's spec → one new game directory and
+  matching implementation, delivered as described above.
+- **Spec drift, bug, or creator feedback:** a round naming one game → implementation
+  change, plus spec clarification only when the intended behavior itself changes.
+- **Remix:** a proposed change to one game's spec and implementation, routed the same way.
+- **Repository tooling:** a separate, trusted, repository-scoped PR (see Interactive/local
+  agents above) — never smuggled into a game-build round.
 
 ## Retired adapter model
 

--- a/docs/agent-adapters.md
+++ b/docs/agent-adapters.md
@@ -50,9 +50,11 @@ GitHub Copilot's coding agent is dispatched programmatically through GitHub's Ag
 API (`copilot-backend.ts`, and `managed-provider-copilot.ts` under the managed-backend
 seam) — a prompt in, a branch and session state back, no issue assignment and no PR-relay
 workflow. The games repository is cloned as Copilot's harness — GameKit, tooling and
-published games as context — and the branch it works on is cut fresh per round and deleted
-once the round is done. The agent's output goes out over the build channel, never as a
-merged branch.
+published games as context — and each round gets its own fresh branch. That branch is kept
+until it is spent: released once a follow-up round has a branch of its own, and
+deliberately kept across a round that never delivered, since an undelivered branch may be
+the only copy of that work. Release is best-effort. The agent's output goes out over the
+build channel, never as a merged branch.
 
 Hosted-agent output is still external contributor output, so it is still worth verifying
 before it is trusted: follow the repository's


### PR DESCRIPTION
## Summary

`docs/agent-adapters.md`'s header, common contract, and Hosted/Interactive-agent sections described PR-merge as the delivery mechanism for a platform game build. That stopped being true when Copilot dispatch moved to GitHub's Agent Tasks API and delivery moved to the build channel (`submit_sources`) — see `copilot-backend.ts`'s header comment and `docs/build-brief.md`, which are current and were used as the reference for what's true today.

- Rewrites the doc's "Current model" header and common contract to describe the real flow: gamedev.pl dispatches a coding agent for one round and reads the delivery back over the build channel or a managed backend's own harvest — never a merged pull request.
- Cross-references `build-brief.md` (delivery-contract table) and `managed-agent-backend.md` instead of duplicating their detail.
- Updates the **Hosted agents** section to describe Copilot's actual dispatch path (`copilot-backend.ts` / `managed-provider-copilot.ts`, Agent Tasks API, harness-not-target repo, build-channel delivery) instead of "assign an issue, receive a PR."
- Clarifies **Interactive/local agents** covers ordinary repository-tooling PRs on the games repo itself, distinct from a platform build round.
- Fixes **Task routing**'s "structured issue" language — no game round creates a GitHub issue in production code (`createIssue` is defined but never called from a build-dispatch path), so routing is described as round dispatch rather than issue assignment.
- Keeps everything still true: the common contract (SPEC.md as source of truth, untrusted spec, one-game-directory scope, no runtime network), seeded-workspace behavior, and the "Retired adapter model" history.

This is a documentation-only change. Nothing about dispatch, routing, or which backend is used in production is touched.

## Out of scope

Per the cleanup brief this PR is drawn from: this does **not** retire, delete, or feature-flag `copilot-backend.ts` (a separate, gated decision — internal task "MP-04" — with an explicit owner-approval requirement), and does not change which backend any submission routes to.

## Test plan

- [x] `npm run lint` (includes the comment-prose check) — green
- [ ] `npm run type-check` — not applicable, docs-only change, no TypeScript touched
- [ ] `npm run test` — not applicable, docs-only change
- [ ] `npm run build` — not applicable, docs-only change


---
_Generated by [Claude Code](https://claude.ai/code/session_01PAsj5Z8XRHPmrrBsQzzs84)_