### PR TITLE
docs: document the MCP fast lane in build-brief.md's delivery table

### DIFF
--- a/docs/build-brief.md
+++ b/docs/build-brief.md
@@ -19,14 +19,21 @@ both pin this; it is not a mode, and no delivery contract turns it off.
 `buildPrompt` takes a `DeliveryContract` because a prompt that disagrees with its backend
 is worse than a vague one:
 
-| Contract              | The agent is told                                | Used by                              |
-| --------------------- | ------------------------------------------------ | ------------------------------------ |
-| `{ kind: 'channel' }` | Upload over the build channel, report progress   | Copilot; managed sessions given MCP  |
-| `{ kind: 'outputs' }` | Write the game into the session output directory | Managed sessions delivered by a pull |
+| Contract                          | The agent is told                                                                                    | Used by                                             |
+| --------------------------------- | ---------------------------------------------------------------------------------------------------- | --------------------------------------------------- |
+| `{ kind: 'channel' }`             | Upload over the build channel, report progress; full repository checkout                             | Copilot on the harness lane                         |
+| `{ kind: 'channel', fast: true }` | Same build-channel upload, but on a clock (~two minutes), MCP-tool-only — no shell, no repo checkout | Anthropic, Gemini, and Copilot's MCP connector lane |
+| `{ kind: 'outputs' }`             | Write the game into the session output directory                                                     | Managed sessions delivered by a pull                |
 
 An agent told to run `npm run submit` inside a sandbox with no route to the API spends the
 round discovering that. An agent told to write files into a directory nobody reads delivers
 nothing at all. The backend knows which is true, so the backend says which.
+
+The `fast` flag follows a managed backend's `promptLane` (`managed-backend.ts`): the
+`harness` lane — Copilot's default — gets the plain `channel` contract, and the `mcp` lane
+gets `channel` with `fast: true`. `build-prompt.ts`'s `channelDelivery` function is where
+the two branches diverge — the fast branch is written for a session with no shell and no
+checkout, so it skips every instruction that assumes either.
 
 **A pull request is not a delivery**, in either mode. Nothing downstream reads pull
 requests: the gate, review and publication all read the store. This has to be said out loud

--- a/docs/build-brief.md
+++ b/docs/build-brief.md
@@ -35,6 +35,14 @@ gets `channel` with `fast: true`. `build-prompt.ts`'s `channelDelivery` function
 the two branches diverge — the fast branch is written for a session with no shell and no
 checkout, so it skips every instruction that assumes either.
 
+**That "no shell" framing only covers `channelDelivery` itself.** The revision block
+(`brief.feedback`) and the undelivered-round block (`brief.previousWorkspace`) run earlier
+in `buildPrompt` and are not gated on `fast` — a fast-lane revision is still told to run
+`npm run restore`, and a fast-lane undelivered round is still told to `git fetch` /
+`git checkout`. A session with no shell has no way to follow either. This is an existing
+prompt/backend mismatch, not something this doc update fixes; noted here so the table
+above isn't read as a guarantee those two round shapes hold on the fast lane today.
+
 **A pull request is not a delivery**, in either mode. Nothing downstream reads pull
 requests: the gate, review and publication all read the store. This has to be said out loud
 because opening a PR is what a coding agent does by default, and an agent that opens one


### PR DESCRIPTION
## Summary

`buildPrompt`'s `DeliveryContract` type carries a `fast` flag on the `channel` kind (`build-prompt.ts`), and `channelDelivery` branches materially on it — a clocked, MCP-tool-only, no-shell, no-checkout prompt vs. the full harness prompt. `docs/build-brief.md`'s delivery-contract table only had one `channel` row, so a reader couldn't tell which prompt shape a given driver actually receives without reading `managed-backend.ts` themselves.

The table's existing "Used by" column was also wrong, not just incomplete: it listed Copilot in the same row as "managed sessions given MCP," but `managed-provider-copilot.ts` declares `promptLane: 'harness'` by default (plain `channel`, no `fast`), while `managed-provider-anthropic.ts` and `managed-provider-gemini.ts` both declare `promptLane: 'mcp'` (`channel` with `fast: true`). I verified this against `managed-backend.ts`'s `promptLane` handling before writing the table, per the task brief — the harness lane maps to the plain contract, the mcp lane maps to `fast: true`.

- Splits the row into `{ kind: 'channel' }` (harness lane — full repo checkout, no clock) and `{ kind: 'channel', fast: true }` (MCP lane — MCP-tool-only, no shell, no checkout, ~two-minute clock).
- Updates "Used by": Copilot on the harness lane for the plain contract; Anthropic, Gemini, and Copilot's MCP connector lane (per `managed-agent-backend.md`'s "Copilot MCP lane" section) for the fast contract.
- Adds one paragraph tying the `fast` flag to `managed-backend.ts`'s `promptLane` and to where `build-prompt.ts`'s `channelDelivery` actually branches, so the table doesn't stand alone as an unsourced claim.

No other part of `build-brief.md` is touched — the doc was otherwise accurate.

## Out of scope

Per the cleanup brief this PR is drawn from: this does not retire, delete, or feature-flag `copilot-backend.ts`, and does not change which backend any submission routes to.

## Test plan

- [x] `npm run lint` (includes the comment-prose check) — green
- [ ] `npm run type-check` / `npm run test` / `npm run build` — not applicable, docs-only change, no TypeScript touched


---
_Generated by [Claude Code](https://claude.ai/code/session_01PAsj5Z8XRHPmrrBsQzzs84)_