### PR TITLE
refactor: extract shared seed-branch staging for both Copilot implementations

### DIFF
--- a/apps/api/src/agent-tasks.test.ts
+++ b/apps/api/src/agent-tasks.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import {
   createAgentTasksClient,
   creditsFromUsageAmount,
@@ -6,6 +6,8 @@ import {
   normalizeModel,
   parseAgentTask,
   resolveTaskBranch,
+  seedBranchName,
+  stageAndCleanupSeedBranch,
 } from './agent-tasks.js';
 
 /** A settled task, shaped exactly as the live API answered on 2026-07-29. */
@@ -268,5 +270,95 @@ describe('listTasks', () => {
     const { impl } = stubFetch(() => ({}));
     const client = createAgentTasksClient({ token: 't', repo: 'o/r', fetchImpl: impl });
     expect(await client.listTasks()).toEqual([]);
+  });
+});
+
+function stubBranchGithub(
+  overrides: Partial<{ deleteBranch: ReturnType<typeof vi.fn>; createBranchWithFiles: ReturnType<typeof vi.fn> }> = {},
+) {
+  return {
+    deleteBranch: overrides.deleteBranch ?? vi.fn(async () => undefined),
+    createBranchWithFiles: overrides.createBranchWithFiles ?? vi.fn(async () => ({ branch: 'x', sha: 'sha' })),
+  };
+}
+
+describe('stageAndCleanupSeedBranch', () => {
+  it('names the branch from the issue and commits the given files', async () => {
+    const github = stubBranchGithub();
+    const files = [{ path: 'games/comet-courier/game.ts', content: 'export {};\n' }];
+
+    const branch = await stageAndCleanupSeedBranch({
+      github,
+      issueNumber: 42,
+      baseRef: 'main',
+      slug: 'comet-courier',
+      files,
+    });
+
+    expect(branch).toBe('seed/job-42');
+    expect(branch).toBe(seedBranchName(42));
+    expect(github.createBranchWithFiles).toHaveBeenCalledWith({
+      branch: 'seed/job-42',
+      baseRef: 'main',
+      message: 'Seed round 0 for comet-courier (job 42)',
+      files,
+    });
+  });
+
+  it('deletes any stale branch before committing the new one', async () => {
+    const github = stubBranchGithub();
+
+    await stageAndCleanupSeedBranch({ github, issueNumber: 42, baseRef: 'main', slug: 'x', files: [] });
+
+    expect(github.deleteBranch).toHaveBeenCalledWith('seed/job-42');
+    expect(github.deleteBranch.mock.invocationCallOrder[0]).toBeLessThan(
+      github.createBranchWithFiles.mock.invocationCallOrder[0],
+    );
+  });
+
+  it('does not let a stale-branch delete failure block staging the new one', async () => {
+    // A first dispatch has no stale branch to delete.
+    const github = stubBranchGithub({
+      deleteBranch: vi.fn(async () => {
+        throw new Error('not found');
+      }),
+    });
+
+    const branch = await stageAndCleanupSeedBranch({ github, issueNumber: 1, baseRef: 'main', slug: 'x', files: [] });
+
+    expect(branch).toBe('seed/job-1');
+  });
+
+  it('fails open to null and reports the error when staging fails', async () => {
+    const onStageError = vi.fn();
+    const github = stubBranchGithub({
+      createBranchWithFiles: vi.fn(async () => {
+        throw new Error('ref already exists');
+      }),
+    });
+
+    const branch = await stageAndCleanupSeedBranch({
+      github,
+      issueNumber: 1,
+      baseRef: 'main',
+      slug: 'x',
+      files: [],
+      onStageError,
+    });
+
+    expect(branch).toBeNull();
+    expect(onStageError).toHaveBeenCalledWith(expect.any(Error));
+  });
+
+  it('fails open to null without a callback when none is given', async () => {
+    const github = stubBranchGithub({
+      createBranchWithFiles: vi.fn(async () => {
+        throw new Error('boom');
+      }),
+    });
+
+    await expect(
+      stageAndCleanupSeedBranch({ github, issueNumber: 1, baseRef: 'main', slug: 'x', files: [] }),
+    ).resolves.toBeNull();
   });
 });

--- a/apps/api/src/agent-tasks.ts
+++ b/apps/api/src/agent-tasks.ts
@@ -17,6 +17,7 @@
 
 import { isAgentTaskState, type AgentTaskState } from './agent-state.js';
 import { isRateLimitResponse } from './github-rate-limit.js';
+import type { GitHubClient } from './github-client.js';
 
 const AGENT_TASKS_API_VERSION = '2026-03-10';
 
@@ -272,6 +273,40 @@ export function parseAgentTask(raw: Record<string, unknown>): AgentTask {
  */
 export function resolveTaskBranch(task: AgentTask): string | null {
   return task.branch?.headRef ?? task.sessions[task.sessions.length - 1]?.headRef ?? null;
+}
+
+// Derived from the job id — findable without a stored record.
+export function seedBranchName(issueNumber: number | string): string {
+  return `seed/job-${issueNumber}`;
+}
+
+export interface StageSeedBranchOptions {
+  github: Pick<GitHubClient, 'deleteBranch' | 'createBranchWithFiles'>;
+  issueNumber: number | string;
+  baseRef: string;
+  slug: string;
+  // Full repository paths — callers own the `games/<slug>/` prefixing.
+  files: Array<{ path: string; content: string }>;
+  // Called with the staging error before this returns null.
+  onStageError?: (error: unknown) => void;
+}
+
+// Shared staging+cleanup for both Copilot callers; fails open to null.
+export async function stageAndCleanupSeedBranch(options: StageSeedBranchOptions): Promise<string | null> {
+  const branch = seedBranchName(options.issueNumber);
+  try {
+    await options.github.deleteBranch(branch).catch(() => undefined);
+    await options.github.createBranchWithFiles({
+      branch,
+      baseRef: options.baseRef,
+      message: `Seed round 0 for ${options.slug} (job ${options.issueNumber})`,
+      files: options.files,
+    });
+    return branch;
+  } catch (error) {
+    options.onStageError?.(error);
+    return null;
+  }
 }
 
 function resolveTimeoutMs(explicit: number | undefined): number {

--- a/apps/api/src/copilot-backend.ts
+++ b/apps/api/src/copilot-backend.ts
@@ -15,11 +15,14 @@ import { buildPrompt } from './build-prompt.js';
 import {
   creditsFromUsageAmount,
   resolveTaskBranch,
+  stageAndCleanupSeedBranch,
   type AgentTaskModel,
   type AgentTasksClient,
 } from './agent-tasks.js';
 import type { GitHubClient } from './github-client.js';
 import type { AgentObservation } from './job-state.js';
+
+export { seedBranchName } from './agent-tasks.js';
 
 export interface CopilotBackendOptions {
   tasks: AgentTasksClient;
@@ -47,49 +50,25 @@ export interface CopilotBackendOptions {
 
 const DEFAULT_MODEL: AgentTaskModel = 'claude-sonnet-4.6';
 
-/**
- * Where a job's generated round 0 is staged.
- *
- * Derived from the job id rather than stored, so the name is knowable from the job alone
- * — a sweep can find a leaked seed branch without reading a record, and a redispatch
- * reuses the same name instead of leaving one branch per attempt behind.
- */
-export function seedBranchName(issueNumber: number): string {
-  return `seed/job-${issueNumber}`;
-}
-
 export function createCopilotBackend(options: CopilotBackendOptions): AgentBackend {
   const baseRef = options.baseRef ?? 'main';
   const model = options.model ?? DEFAULT_MODEL;
   const createPullRequest = options.createPullRequest ?? false;
 
-  /**
-   * Puts the draft on a branch, or returns null and lets the build start unseeded.
-   *
-   * The stale-branch delete is what makes a redispatch of the same job work: the name is
-   * derived from the job id, so a second attempt would otherwise collide with the first
-   * attempt's branch and fail on a ref that already exists. Deleting is safe because a
-   * seed branch is never anything but a starting point — no delivery, no review, and no
-   * history anyone reads.
-   */
+  // Stages the draft on a branch, or returns null to build unseeded.
   async function stageSeed(issueNumber: number, seed: SeedFiles): Promise<string | null> {
-    const branch = seedBranchName(issueNumber);
-    try {
-      await options.github.deleteBranch(branch).catch(() => undefined);
-      await options.github.createBranchWithFiles({
-        branch,
-        baseRef,
-        message: `Seed round 0 for ${seed.slug} (job ${issueNumber})`,
-        files: seed.files.map((file) => ({ path: `games/${seed.slug}/${file.path}`, content: file.content })),
-      });
-      return branch;
-    } catch (error) {
-      options.log?.warn(
-        { err: error, issueNumber, slug: seed.slug },
-        'could not stage the generated seed, dispatching unseeded',
-      );
-      return null;
-    }
+    return stageAndCleanupSeedBranch({
+      github: options.github,
+      issueNumber,
+      baseRef,
+      slug: seed.slug,
+      files: seed.files.map((file) => ({ path: `games/${seed.slug}/${file.path}`, content: file.content })),
+      onStageError: (error) =>
+        options.log?.warn(
+          { err: error, issueNumber, slug: seed.slug },
+          'could not stage the generated seed, dispatching unseeded',
+        ),
+    });
   }
 
   return {

--- a/apps/api/src/managed-provider-copilot.ts
+++ b/apps/api/src/managed-provider-copilot.ts
@@ -2,6 +2,7 @@ import {
   createAgentTasksClient,
   creditsFromUsageAmount,
   resolveTaskBranch,
+  stageAndCleanupSeedBranch,
   type AgentTask,
   type AgentTasksClient,
   type AgentTaskModel,
@@ -45,10 +46,6 @@ function withoutSeedPrompt(prompt: string): string {
   );
 }
 
-function seedBranchName(correlationId: string): string {
-  return `seed/job-${correlationId}`;
-}
-
 async function stageSeed(
   request: ManagedSessionRequest,
   baseRef: string,
@@ -57,19 +54,7 @@ async function stageSeed(
   const files = request.workspaceFiles;
   const slug = seedSlug(files);
   if (!files?.length || !slug) return null;
-  const branch = seedBranchName(request.correlationId);
-  try {
-    await github.deleteBranch(branch).catch(() => undefined);
-    await github.createBranchWithFiles({
-      branch,
-      baseRef,
-      message: `Seed round 0 for ${slug} (job ${request.correlationId})`,
-      files,
-    });
-    return branch;
-  } catch {
-    return null;
-  }
+  return stageAndCleanupSeedBranch({ github, issueNumber: request.correlationId, baseRef, slug, files });
 }
 
 function taskSession(task: AgentTask, model: string): ManagedSession {


### PR DESCRIPTION
## Summary

`copilot-backend.ts`'s `stageSeed` and `managed-provider-copilot.ts`'s `stageSeed` independently implemented the same "delete any stale seed branch, then commit the draft to a fresh disposable branch" logic — same seed-branch naming (`seed/job-<issueNumber>`), same fail-open-to-null behavior on any staging error. Two implementations of that logic means a GitHub-behavior surprise (`agent-tasks.ts` already documents several places where GitHub's API contradicts its own docs) gets found and fixed once, or silently only once, instead of both places getting the fix.

- Extracts `stageAndCleanupSeedBranch` and `seedBranchName` into `agent-tasks.ts`, since both callers already depend on it and it's where the equivalent GitHub-quirk documentation for this dispatch surface already lives (checked for a better home first — no other shared module fit as well).
- Both callers now delegate to it, still injecting their own `github` client. `copilot-backend.ts` also passes its own failure-logging callback via a new `onStageError` hook, preserving the one real behavioral difference between the two callers: the direct backend logs a staging failure, the managed provider does not.
- `copilot-backend.ts` re-exports `seedBranchName` from `agent-tasks.ts` to keep its existing public export working.

## What did not change

**No dispatch-visible behavior changed:** same seed-branch naming, same fail-open semantics, same stale-branch-delete-before-create ordering. `copilot-backend.test.ts` and `managed-provider-copilot.test.ts` both pass **unmodified** — they mock the `github` client directly rather than the extracted helper, so they exercise the new code path with zero test changes needed. That's the evidence this refactor didn't touch behavior: the assertions are unchanged, only the implementation underneath moved.

**The trivial post-round branch deletion was left alone.** The brief that prompted this cleanup also flagged `copilot-backend.ts`'s `cleanup` and `managed-provider-copilot.ts`'s `deleteWorkspace` as duplicated. After reading both, they're each a single delegated call to the shared `GitHubClient.deleteBranch` (one has an `if (!workspace) return` guard the other doesn't need) — there's no logic there to duplicate a bug in. Wrapping that one-line delegation in a "shared helper" would add an abstraction with nothing to test, which the repo's own conventions argue against, so I left it as-is rather than force an extraction for its own sake. Flagging this explicitly per the task brief's request to state reasoning rather than silently deciding.

## Out of scope

Per the cleanup brief this PR is drawn from: this does not retire, delete, or feature-flag `copilot-backend.ts` (the games-repo dedup work is a separate, gated decision — internal task "MP-04"), and does not change which backend any submission routes to. `managed-backend.ts` and `managed-agent.ts` are untouched.

## Test plan

- [x] `npm run lint` (including the comment-prose check) — green
- [x] `npm run type-check` — green
- [x] `npm run test` — green: `copilot-backend.test.ts` (29 tests) and `managed-provider-copilot.test.ts` (8 tests) both pass unmodified, plus the full monorepo suite (3122 API-workspace tests, 1288 web tests, 20 world tests, 36 eslint-rule tests — all green)
- [x] `npm run build` — green


---
_Generated by [Claude Code](https://claude.ai/code/session_01PAsj5Z8XRHPmrrBsQzzs84)_