### PR TITLE
fix(review): clarify play button

### DIFF
--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -17263,9 +17263,17 @@ body.remix-entry-open {
   top: 0.55rem;
   bottom: auto;
   z-index: 3;
-  background: color-mix(in srgb, var(--panel-card, #1b2229) 88%, transparent);
-  backdrop-filter: blur(8px);
-  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.35);
+  border-color: var(--turquoise);
+  background: var(--turquoise);
+  color: #08241d;
+  font-weight: 700;
+  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.45), 0 0 14px var(--turquoise-glow);
+}
+
+.review-play-btn.is-overlay:hover,
+.review-play-btn.is-overlay:focus-visible {
+  filter: brightness(1.08);
+  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.45), 0 0 20px var(--turquoise-glow);
 }
 
 .review-play-btn.is-active {

--- a/apps/web/src/styles.reviewDesk.test.ts
+++ b/apps/web/src/styles.reviewDesk.test.ts
@@ -49,6 +49,9 @@ describe('review desk shell', () => {
     const play = ruleBody('.review-play-btn.is-overlay');
     expect(play).toMatch(/top:\s*0\.55rem/);
     expect(play).not.toMatch(/bottom:\s*0\.55rem/);
+    expect(play).toMatch(/background:\s*var\(--turquoise\)/);
+    expect(play).toMatch(/color:\s*#08241d/);
+    expect(play).toMatch(/border-color:\s*var\(--turquoise\)/);
 
     const keep = ruleBody('.review-stamp.is-keep');
     expect(keep).toMatch(/left:\s*50%/);


### PR DESCRIPTION
## Summary

- Make the reviewer desk’s `Zagraj` CTA visibly distinct with a turquoise background, high-contrast text, border, and focus/hover treatment.
- Add CSS contract assertions to prevent the button from regressing to a low-contrast overlay.

## Root cause

The overlay button used the same dark translucent treatment as surrounding review chrome, so it disappeared against dark gameplay previews.

## Validation

- `npm run type-check`
- `npm run lint`
- `npm run test`
- `npm run build`

All checks pass.