### PR TITLE
docs: verify AGENT_TASK_MODELS is still current, no list change

### DIFF
--- a/apps/api/src/agent-tasks.ts
+++ b/apps/api/src/agent-tasks.ts
@@ -28,6 +28,7 @@ export { AGENT_TASK_STATES, type AgentTaskState } from './agent-state.js';
  * the user's plan and organization policies", so an unknown value is a soft failure at
  * dispatch, not a reason to reject a job before we have tried.
  */
+// Confirmed unchanged against GitHub's public REST API spec, Aug 2026.
 export const AGENT_TASK_MODELS = [
   'claude-sonnet-4.6',
   'claude-opus-4.6',

--- a/apps/api/src/agent-tasks.ts
+++ b/apps/api/src/agent-tasks.ts
@@ -28,7 +28,7 @@ export { AGENT_TASK_STATES, type AgentTaskState } from './agent-state.js';
  * the user's plan and organization policies", so an unknown value is a soft failure at
  * dispatch, not a reason to reject a job before we have tried.
  */
-// Confirmed unchanged against GitHub's public REST API spec, Aug 2026.
+// Confirmed unchanged against GitHub's REST API spec on 2026-08-12.
 export const AGENT_TASK_MODELS = [
   'claude-sonnet-4.6',
   'claude-opus-4.6',


### PR DESCRIPTION
## Summary

`agent-tasks.ts`'s header claims the file was "verified against `gamedevpl` on 2026-07-29" — over two weeks stale as of this check. Elsewhere in the codebase, a different product's model defaults (`chat-agent.ts`, `code-lane.ts`, `editor-assist.ts`, `game-seed.ts`, `refine.ts`, `moderation.ts` — all using the Gemini API directly) have moved to newer generations, but that has no bearing on what GitHub's Agent Tasks API supports, so it isn't evidence this list is stale on its own. This is a verify-first check, not an assumed update.

**This environment has no `AGENT_TASKS_TOKEN`**, so I couldn't repeat the original live `gamedevpl`-scoped query. Instead I checked GitHub's public REST API description directly — not the prose docs page (which just links out to the API reference without listing values), but the machine-readable OpenAPI schema itself: `github/rest-api-description`'s `descriptions/api.github.com/api.github.com.json`, fetched fresh. The `model` parameter on the "Create an agent task" operation (`POST /agents/repos/{owner}/{repo}/tasks`) reads:

> The model to use for this task. The allowed models may change over time and depend on the user's GitHub Copilot plan and organization policies. Currently supported values: `claude-sonnet-4.6`, `claude-opus-4.6`, `gpt-5.2-codex`, `gpt-5.3-codex`, `gpt-5.4`, `claude-sonnet-4.5`, `claude-opus-4.5`

That is exactly `AGENT_TASK_MODELS` as it stands today, in the same order, and the same "may change over time..." language the existing code comment already paraphrases. **The list is unchanged.**

## What this PR does — and doesn't do

Per the task brief this is drawn from: "if it has not changed... say so in the PR and change nothing." A wrong update is worse than a stale-but-correct one.

- `AGENT_TASK_MODELS` — **unchanged**.
- `DEFAULT_MODEL` in `copilot-backend.ts` (`claude-sonnet-4.6`) — **unchanged**. Since the source of truth confirms nothing moved, there is no decision to make here.
- The probe script's Copilot default (`AGENT_TASKS_MODEL` env fallback) — **unchanged**, same reasoning.
- The only edit is a one-line comment recording what was checked and when, so the next person verifying this doesn't have to re-derive it from a PR description that may have scrolled out of view. The file's own "verified against `gamedevpl` on 2026-07-29" header line is left as-is — that line specifically documents a *live org-scoped* check of the three behavioral quirks (`create_pull_request` default, `head_ref` silent-ignore, `model` namespace echo), which I did not have a token to re-run, so I didn't want to imply otherwise by touching that date.

## Out of scope

Per the cleanup brief this PR is drawn from: this does not retire, delete, or feature-flag `copilot-backend.ts`, and does not change which backend any submission routes to.

## Test plan

- [x] `npm run lint` (including the comment-prose check — this comment is a compliant one-liner, 0 words counted against the file's budget) — green
- [x] `npm run type-check` (API workspace) — green
- [x] `npx vitest run apps/api/src/agent-tasks.test.ts apps/api/src/copilot-backend.test.ts` — green, 48 tests, unmodified
- [ ] `npm run build` — not run for this PR; the change is a single comment line with no code-path impact


---
_Generated by [Claude Code](https://claude.ai/code/session_01PAsj5Z8XRHPmrrBsQzzs84)_