### PR TITLE
Record puzzle-skip verification miss from echo-loop review

### DIFF
--- a/.claude/skills/verify-agent-work/SKILL.md
+++ b/.claude/skills/verify-agent-work/SKILL.md
@@ -189,6 +189,14 @@ Two concrete instances of that (observed 2026-07-23):
   deserves the same scrutiny as the source change. For agent-facing surfaces
   specifically, check that any replacement error still tells the agent what to do next;
   a status code is not an instruction.
+- **A green games-repo `check:game` does not prove a puzzle's obstacles obstruct.** Observed
+  (echo-loop / www.gamedev.pl-games#699, 2026-08-12): TRACE, ACCEPTANCE, agency `--strict`,
+  and a scripted capture were green while hold-right + one jump cleared plate/door rooms
+  with `ghostCount: 0`. Capture drives the intended path; agency only fails idle / one
+  held key; ACCEPTANCE that restates the capture floor (`roomsCleared >= 2`) cannot see a
+  skip. For puzzle games, import the pure model in a throwaway clone and prove a
+  no-mechanic control *fails* (walk-only into the door, jump-over) in the same session as
+  the intended solve.
 
 ## Read the diff against the spec
 
@@ -249,6 +257,12 @@ usually closured and unreadable). Prove the three things the spec promises: spaw
 transition (the game-over overlay floods the canvas dark). The definitive proof is still
 playing the _published_ game on the live site, where a foregrounded real-user tab runs rAF
 normally.
+
+For **puzzle** games, also probe the skip, not only the scripted solve. `npm run check:game`
+replays `CAPTURE.json`; it will not notice a two-tile door you can jump, a shard door you
+can clear without the shard, or an ACCEPTANCE bar that is just the capture floor. Drive
+`updateRound` / the pure model with a no-echo / no-key / jump-over control and require that
+control to fail.
 
 ## Verifying behind sign-in (you don't need the owner's Gmail)
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The echo-loop review (gamedevpl/www.gamedev.pl-games#699) found a verification miss this playbook did not name: `check:game`, TRACE, ACCEPTANCE, and agency `--strict` can all be green while a puzzle's obstacles do not obstruct, because capture scripts the intended path and agency only fails idle / one held key.

This records that failure mode and the control to run next time (pure-model no-mechanic probe in a throwaway clone).

## Test plan

- Markdown-only skill update; no runtime change.
- Confirm the new bullet is the echo-loop skip (jump-over doors) and does not quote private ops docs.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f8f8c5c7-4d1b-486a-a98f-58071c516e15?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f8f8c5c7-4d1b-486a-a98f-58071c516e15&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

