### PR TITLE
Add a mascot snack-catch minigame on the closed-beta splash

### DIFF
--- a/apps/web/src/ClosedBetaSplash.test.ts
+++ b/apps/web/src/ClosedBetaSplash.test.ts
@@ -19,6 +19,7 @@ describe('ClosedBetaSplash', () => {
   afterEach(() => {
     document.body.innerHTML = '';
     vi.restoreAllMocks();
+    vi.useRealTimers();
     delete (globalThis as { google?: unknown }).google;
     setVisitSessionForTesting(null);
   });
@@ -75,6 +76,42 @@ describe('ClosedBetaSplash', () => {
     const mascot = container.querySelector<HTMLButtonElement>('button.mascot-interactive.beta-splash__mascot');
     expect(mascot).not.toBeNull();
     expect(mascot?.getAttribute('aria-label')).toMatch(/poke|szturchnij/i);
+    expect(container.querySelector('.splash-game__play')).not.toBeNull();
+
+    await act(async () => root.unmount());
+  });
+
+  it('keeps Join waitlist on screen after Feed him starts', async () => {
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    vi.useFakeTimers();
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async (input) => {
+      const url = String(input);
+      if (url.endsWith('/api/auth/me')) return new Response(JSON.stringify({}), { status: 401 });
+      if (url.endsWith('/api/health')) {
+        return new Response(JSON.stringify({ status: 'ok', provider: 'mock', privateBeta: true }));
+      }
+      throw new Error(`unexpected fetch: ${url}`);
+    });
+
+    await i18n.changeLanguage('en');
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(createElement(AuthProvider, null, createElement(ClosedBetaSplash)));
+      await flushEffects();
+    });
+
+    await act(async () => {
+      container.querySelector<HTMLButtonElement>('.splash-game__play')?.click();
+      await flushEffects();
+    });
+
+    expect(container.querySelector('.splash-game__stage')).not.toBeNull();
+    expect(container.querySelector('#btn-join-waitlist')).not.toBeNull();
+    expect(container.querySelector('.beta-splash__signin')).not.toBeNull();
+    expect(container.querySelector('.beta-splash__legal')).not.toBeNull();
 
     await act(async () => root.unmount());
   });
@@ -126,6 +163,7 @@ describe('ClosedBetaSplash', () => {
     });
 
     expect(container.querySelector('#btn-accept-beta-invite')).not.toBeNull();
+    expect(container.querySelector('.splash-game__play')).toBeNull();
     await act(async () => {
       capturedCallback!({ credential: 'invite-credential' });
       await flushEffects();

--- a/apps/web/src/ClosedBetaSplash.test.ts
+++ b/apps/web/src/ClosedBetaSplash.test.ts
@@ -76,12 +76,11 @@ describe('ClosedBetaSplash', () => {
     const mascot = container.querySelector<HTMLButtonElement>('button.mascot-interactive.beta-splash__mascot');
     expect(mascot).not.toBeNull();
     expect(mascot?.getAttribute('aria-label')).toMatch(/poke|szturchnij/i);
-    expect(container.querySelector('.splash-game__play')).not.toBeNull();
 
     await act(async () => root.unmount());
   });
 
-  it('keeps Join waitlist on screen after Feed him starts', async () => {
+  it('keeps Join waitlist on screen after the secret game starts', async () => {
     (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
     vi.useFakeTimers();
     vi.spyOn(globalThis, 'fetch').mockImplementation(async (input) => {
@@ -103,8 +102,10 @@ describe('ClosedBetaSplash', () => {
       await flushEffects();
     });
 
+    const mascot = container.querySelector<HTMLButtonElement>('button.mascot-interactive.beta-splash__mascot');
+    expect(mascot).not.toBeNull();
     await act(async () => {
-      container.querySelector<HTMLButtonElement>('.splash-game__play')?.click();
+      for (let i = 0; i < 5; i += 1) mascot!.click();
       await flushEffects();
     });
 
@@ -163,7 +164,6 @@ describe('ClosedBetaSplash', () => {
     });
 
     expect(container.querySelector('#btn-accept-beta-invite')).not.toBeNull();
-    expect(container.querySelector('.splash-game__play')).toBeNull();
     await act(async () => {
       capturedCallback!({ credential: 'invite-credential' });
       await flushEffects();

--- a/apps/web/src/ClosedBetaSplash.tsx
+++ b/apps/web/src/ClosedBetaSplash.tsx
@@ -4,6 +4,7 @@ import { AppleSignInButton } from './AppleSignInButton.js';
 import { useAuth } from './AuthContext.js';
 import { GoogleSignInButton } from './GoogleSignInButton.js';
 import { InteractiveMascot } from './Mascot.js';
+import { SplashMascotGame } from './SplashMascotGame.js';
 import { recordBetaInviteStep, recordWaitlistStep } from './visitTelemetry.js';
 
 type WaitlistState = 'idle' | 'joining' | 'joined' | 'error';
@@ -80,14 +81,18 @@ export function ClosedBetaSplash({ inviteCode }: { inviteCode?: string }) {
   return (
     <div className="beta-splash">
       <div className="beta-splash__card">
-        <InteractiveMascot
-          className="beta-splash__mascot"
-          idleEmotion="wave"
-          reactsToTilt
-          doesPullUps
-          size={96}
-          pokeLabel={t('mascot.poke')}
-        />
+        {isInvite ? (
+          <InteractiveMascot
+            className="beta-splash__mascot"
+            idleEmotion="wave"
+            reactsToTilt
+            doesPullUps
+            size={96}
+            pokeLabel={t('mascot.poke')}
+          />
+        ) : (
+          <SplashMascotGame pokeLabel={t('mascot.poke')} />
+        )}
         <div className="beta-splash__logo">
           <span className="beta-splash__logo-main">gamedev</span>
           <span className="beta-splash__logo-tld">.pl</span>

--- a/apps/web/src/Mascot.tsx
+++ b/apps/web/src/Mascot.tsx
@@ -560,6 +560,7 @@ type InteractiveMascotProps = {
    * a few pull-ups. Opt-in — only the closed-beta splash wants this gag.
    */
   doesPullUps?: boolean;
+  onPoke?: () => void;
 };
 
 /**
@@ -573,6 +574,7 @@ export function InteractiveMascot({
   pokeLabel,
   reactsToTilt = false,
   doesPullUps = false,
+  onPoke,
 }: InteractiveMascotProps) {
   const rootRef = useRef<HTMLButtonElement>(null);
   const pokeTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -804,6 +806,7 @@ export function InteractiveMascot({
       setEmotion(settleEmotion());
       pokeTimer.current = null;
     }, POKE_HOLD_MS);
+    onPoke?.();
   };
 
   /*

--- a/apps/web/src/SplashMascotGame.test.tsx
+++ b/apps/web/src/SplashMascotGame.test.tsx
@@ -1,0 +1,115 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from 'react';
+import { createRoot } from 'react-dom/client';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { SplashMascotGame } from './SplashMascotGame.js';
+import i18n from './i18n/index.js';
+
+async function flushEffects() {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+describe('SplashMascotGame', () => {
+  afterEach(() => {
+    document.body.innerHTML = '';
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+  });
+
+  it('keeps the poke mascot until Feed him is pressed', async () => {
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    await i18n.changeLanguage('en');
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(createElement(SplashMascotGame, { pokeLabel: 'Poke' }));
+      await flushEffects();
+    });
+
+    expect(container.querySelector('button.mascot-interactive.beta-splash__mascot')).not.toBeNull();
+    const play = container.querySelector<HTMLButtonElement>('.splash-game__play');
+    expect(play).not.toBeNull();
+    expect(play?.textContent).toMatch(/feed him/i);
+    expect(container.querySelector('.splash-game__stage')).toBeNull();
+
+    await act(async () => root.unmount());
+  });
+
+  it('opens a catch stage without dropping the waitlist-sized playfield', async () => {
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    vi.useFakeTimers();
+    await i18n.changeLanguage('en');
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(createElement(SplashMascotGame, { pokeLabel: 'Poke' }));
+      await flushEffects();
+    });
+
+    await act(async () => {
+      container.querySelector<HTMLButtonElement>('.splash-game__play')?.click();
+      await flushEffects();
+    });
+
+    const stage = container.querySelector<HTMLDivElement>('.splash-game__stage');
+    expect(stage).not.toBeNull();
+    expect(container.querySelector('.splash-game--playing')).not.toBeNull();
+    expect(container.querySelector('button.mascot-interactive')).toBeNull();
+    expect(container.querySelector('.splash-game__catcher')).not.toBeNull();
+    expect(container.querySelector('.splash-game__hint')?.textContent).toMatch(/slide to catch/i);
+
+    Object.defineProperty(stage!, 'getBoundingClientRect', {
+      value: () => ({
+        left: 0,
+        top: 0,
+        width: 200,
+        height: 160,
+        right: 200,
+        bottom: 160,
+        x: 0,
+        y: 0,
+        toJSON: () => ({}),
+      }),
+    });
+
+    await act(async () => {
+      stage!.dispatchEvent(new PointerEvent('pointermove', { bubbles: true, clientX: 40, clientY: 80 }));
+    });
+    expect(container.querySelector<HTMLElement>('.splash-game__catcher')?.style.left).toBe('20%');
+
+    await act(async () => root.unmount());
+  });
+
+  it('moves the mascot with arrow keys', async () => {
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    vi.useFakeTimers();
+    await i18n.changeLanguage('en');
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(createElement(SplashMascotGame, { pokeLabel: 'Poke' }));
+      await flushEffects();
+    });
+
+    await act(async () => {
+      container.querySelector<HTMLButtonElement>('.splash-game__play')?.click();
+      await flushEffects();
+    });
+
+    const stage = container.querySelector<HTMLDivElement>('.splash-game__stage')!;
+    await act(async () => {
+      stage.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }));
+    });
+    expect(container.querySelector<HTMLElement>('.splash-game__catcher')?.style.left).toBe('60%');
+
+    await act(async () => root.unmount());
+  });
+});

--- a/apps/web/src/SplashMascotGame.test.tsx
+++ b/apps/web/src/SplashMascotGame.test.tsx
@@ -11,6 +11,15 @@ async function flushEffects() {
   await Promise.resolve();
 }
 
+async function unlockWithMascot(container: HTMLElement) {
+  const mascot = container.querySelector<HTMLButtonElement>('button.mascot-interactive.beta-splash__mascot');
+  expect(mascot).not.toBeNull();
+  await act(async () => {
+    for (let i = 0; i < 5; i += 1) mascot!.click();
+    await flushEffects();
+  });
+}
+
 describe('SplashMascotGame', () => {
   afterEach(() => {
     document.body.innerHTML = '';
@@ -18,7 +27,7 @@ describe('SplashMascotGame', () => {
     vi.useRealTimers();
   });
 
-  it('keeps the poke mascot until Feed him is pressed', async () => {
+  it('keeps the game secret until the mascot is poked five times', async () => {
     (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
     await i18n.changeLanguage('en');
     const container = document.createElement('div');
@@ -31,10 +40,20 @@ describe('SplashMascotGame', () => {
     });
 
     expect(container.querySelector('button.mascot-interactive.beta-splash__mascot')).not.toBeNull();
-    const play = container.querySelector<HTMLButtonElement>('.splash-game__play');
-    expect(play).not.toBeNull();
-    expect(play?.textContent).toMatch(/feed him/i);
+    const mascot = container.querySelector<HTMLButtonElement>('button.mascot-interactive.beta-splash__mascot')!;
     expect(container.querySelector('.splash-game__stage')).toBeNull();
+
+    await act(async () => {
+      for (let i = 0; i < 4; i += 1) mascot.click();
+      await flushEffects();
+    });
+    expect(container.querySelector('.splash-game__stage')).toBeNull();
+
+    await act(async () => {
+      mascot.click();
+      await flushEffects();
+    });
+    expect(container.querySelector('.splash-game__stage')).not.toBeNull();
 
     await act(async () => root.unmount());
   });
@@ -52,10 +71,7 @@ describe('SplashMascotGame', () => {
       await flushEffects();
     });
 
-    await act(async () => {
-      container.querySelector<HTMLButtonElement>('.splash-game__play')?.click();
-      await flushEffects();
-    });
+    await unlockWithMascot(container);
 
     const stage = container.querySelector<HTMLDivElement>('.splash-game__stage');
     expect(stage).not.toBeNull();
@@ -99,10 +115,7 @@ describe('SplashMascotGame', () => {
       await flushEffects();
     });
 
-    await act(async () => {
-      container.querySelector<HTMLButtonElement>('.splash-game__play')?.click();
-      await flushEffects();
-    });
+    await unlockWithMascot(container);
 
     const stage = container.querySelector<HTMLDivElement>('.splash-game__stage')!;
     await act(async () => {
@@ -139,10 +152,7 @@ describe('SplashMascotGame', () => {
       await flushEffects();
     });
 
-    await act(async () => {
-      container.querySelector<HTMLButtonElement>('.splash-game__play')?.click();
-      await flushEffects();
-    });
+    await unlockWithMascot(container);
 
     await act(async () => {
       vi.advanceTimersByTime(20_000);

--- a/apps/web/src/SplashMascotGame.test.tsx
+++ b/apps/web/src/SplashMascotGame.test.tsx
@@ -112,4 +112,57 @@ describe('SplashMascotGame', () => {
 
     await act(async () => root.unmount());
   });
+
+  it('lets Again start a new round after three misses', async () => {
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    vi.useFakeTimers();
+    vi.spyOn(Math, 'random').mockReturnValue(0);
+    let now = 0;
+    vi.spyOn(performance, 'now').mockImplementation(() => now);
+    vi.stubGlobal('requestAnimationFrame', (cb: FrameRequestCallback) => {
+      return setTimeout(() => {
+        now += 16;
+        cb(now);
+      }, 16) as unknown as number;
+    });
+    vi.stubGlobal('cancelAnimationFrame', (id: number) => {
+      clearTimeout(id);
+    });
+
+    await i18n.changeLanguage('en');
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(createElement(SplashMascotGame, { pokeLabel: 'Poke' }));
+      await flushEffects();
+    });
+
+    await act(async () => {
+      container.querySelector<HTMLButtonElement>('.splash-game__play')?.click();
+      await flushEffects();
+    });
+
+    await act(async () => {
+      vi.advanceTimersByTime(20_000);
+      await flushEffects();
+    });
+
+    expect(container.querySelector('.splash-game--over')).not.toBeNull();
+    const again = container.querySelector<HTMLButtonElement>('.splash-game__again');
+    expect(again).not.toBeNull();
+
+    await act(async () => {
+      again!.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true }));
+      again!.click();
+      await flushEffects();
+    });
+
+    expect(container.querySelector('.splash-game--playing')).not.toBeNull();
+    expect(container.querySelector('.splash-game--over')).toBeNull();
+    expect(container.querySelector('.splash-game__score')?.textContent).toMatch(/score 0/i);
+
+    await act(async () => root.unmount());
+  });
 });

--- a/apps/web/src/SplashMascotGame.tsx
+++ b/apps/web/src/SplashMascotGame.tsx
@@ -1,7 +1,6 @@
 import { useEffect, useRef, useState, type KeyboardEvent, type PointerEvent as ReactPointerEvent } from 'react';
 import { useTranslation } from 'react-i18next';
 import { InteractiveMascot, Mascot, type MascotEmotion } from './Mascot.js';
-import { PixelIcon } from './PixelIcon.js';
 import {
   SNACK_ICONS,
   SPLASH_LIVES,
@@ -24,6 +23,8 @@ function motionSpeed(): number {
   return matchMedia('(prefers-reduced-motion: reduce)').matches ? 0.45 : 1;
 }
 
+const SECRET_POKES = 5;
+
 export function SplashMascotGame({ pokeLabel }: { pokeLabel: string }) {
   const { t } = useTranslation();
   const [phase, setPhase] = useState<'idle' | 'playing' | 'over'>('idle');
@@ -37,9 +38,11 @@ export function SplashMascotGame({ pokeLabel }: { pokeLabel: string }) {
   const speedRef = useRef(1);
   const flashTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const chompTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const pokeCountRef = useRef(0);
 
   const startGame = () => {
     const next = createSplashGame();
+    pokeCountRef.current = 0;
     stateRef.current = next;
     lastTsRef.current = 0;
     speedRef.current = motionSpeed();
@@ -49,6 +52,11 @@ export function SplashMascotGame({ pokeLabel }: { pokeLabel: string }) {
     setEmotion('curious');
     setView(next);
     setPhase('playing');
+  };
+
+  const handleSecretPoke = () => {
+    pokeCountRef.current += 1;
+    if (pokeCountRef.current >= SECRET_POKES) startGame();
   };
 
   useEffect(() => {
@@ -138,11 +146,8 @@ export function SplashMascotGame({ pokeLabel }: { pokeLabel: string }) {
           doesPullUps
           size={96}
           pokeLabel={pokeLabel}
+          onPoke={handleSecretPoke}
         />
-        <button type="button" className="splash-game__play" onClick={startGame}>
-          <PixelIcon name="gamepad" size={14} />
-          {t('betaSplash.game.play')}
-        </button>
       </div>
     );
   }

--- a/apps/web/src/SplashMascotGame.tsx
+++ b/apps/web/src/SplashMascotGame.tsx
@@ -1,0 +1,205 @@
+import { useEffect, useRef, useState, type KeyboardEvent, type PointerEvent as ReactPointerEvent } from 'react';
+import { useTranslation } from 'react-i18next';
+import { InteractiveMascot, Mascot, type MascotEmotion } from './Mascot.js';
+import { PixelIcon } from './PixelIcon.js';
+import {
+  SNACK_ICONS,
+  SPLASH_LIVES,
+  createSplashGame,
+  nudgeSplashMascot,
+  setSplashMascotX,
+  tickSplashGame,
+  type SplashGameState,
+} from './splashGame.js';
+
+function overEmotion(score: number): MascotEmotion {
+  if (score >= 15) return 'excited';
+  if (score >= 8) return 'proud';
+  if (score >= 1) return 'happy';
+  return 'confused';
+}
+
+function motionSpeed(): number {
+  if (typeof matchMedia !== 'function') return 1;
+  return matchMedia('(prefers-reduced-motion: reduce)').matches ? 0.45 : 1;
+}
+
+export function SplashMascotGame({ pokeLabel }: { pokeLabel: string }) {
+  const { t } = useTranslation();
+  const [phase, setPhase] = useState<'idle' | 'playing' | 'over'>('idle');
+  const [view, setView] = useState<SplashGameState | null>(null);
+  const [emotion, setEmotion] = useState<MascotEmotion>('curious');
+  const [chomp, setChomp] = useState(false);
+  const stageRef = useRef<HTMLDivElement>(null);
+  const stateRef = useRef<SplashGameState | null>(null);
+  const rafRef = useRef(0);
+  const lastTsRef = useRef(0);
+  const speedRef = useRef(1);
+  const flashTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const chompTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const startGame = () => {
+    const next = createSplashGame();
+    stateRef.current = next;
+    lastTsRef.current = 0;
+    speedRef.current = motionSpeed();
+    if (flashTimer.current) clearTimeout(flashTimer.current);
+    if (chompTimer.current) clearTimeout(chompTimer.current);
+    setChomp(false);
+    setEmotion('curious');
+    setView(next);
+    setPhase('playing');
+  };
+
+  useEffect(() => {
+    return () => {
+      if (flashTimer.current) clearTimeout(flashTimer.current);
+      if (chompTimer.current) clearTimeout(chompTimer.current);
+      cancelAnimationFrame(rafRef.current);
+    };
+  }, []);
+
+  useEffect(() => {
+    if (phase === 'playing') stageRef.current?.focus({ preventScroll: true });
+  }, [phase]);
+
+  useEffect(() => {
+    if (phase !== 'playing') return;
+
+    const flash = (next: MascotEmotion) => {
+      setEmotion(next);
+      if (flashTimer.current) clearTimeout(flashTimer.current);
+      flashTimer.current = setTimeout(() => {
+        flashTimer.current = null;
+        setEmotion('curious');
+      }, 420);
+    };
+
+    const loop = (ts: number) => {
+      const prev = stateRef.current;
+      if (!prev) return;
+      const last = lastTsRef.current || ts;
+      lastTsRef.current = ts;
+      const { state, caught, missed } = tickSplashGame(prev, (ts - last) / 1000, Math.random, speedRef.current);
+      stateRef.current = state;
+      setView(state);
+      if (caught > 0) {
+        flash('happy');
+        setChomp(true);
+        if (chompTimer.current) clearTimeout(chompTimer.current);
+        chompTimer.current = setTimeout(() => {
+          chompTimer.current = null;
+          setChomp(false);
+        }, 180);
+      } else if (missed > 0) {
+        flash('sad');
+      }
+      if (state.status === 'over') {
+        if (flashTimer.current) clearTimeout(flashTimer.current);
+        setEmotion(overEmotion(state.score));
+        setPhase('over');
+        return;
+      }
+      rafRef.current = requestAnimationFrame(loop);
+    };
+
+    rafRef.current = requestAnimationFrame(loop);
+    return () => cancelAnimationFrame(rafRef.current);
+  }, [phase]);
+
+  const aim = (event: ReactPointerEvent<HTMLDivElement>) => {
+    const node = stageRef.current;
+    const prev = stateRef.current;
+    if (!node || !prev || prev.status !== 'playing') return;
+    const rect = node.getBoundingClientRect();
+    if (rect.width === 0) return;
+    const next = setSplashMascotX(prev, (event.clientX - rect.left) / rect.width);
+    stateRef.current = next;
+    setView(next);
+  };
+
+  const onKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+    const prev = stateRef.current;
+    if (!prev || prev.status !== 'playing') return;
+    if (event.key !== 'ArrowLeft' && event.key !== 'ArrowRight') return;
+    event.preventDefault();
+    const next = nudgeSplashMascot(prev, event.key === 'ArrowLeft' ? -1 : 1);
+    stateRef.current = next;
+    setView(next);
+  };
+
+  if (phase === 'idle' || view == null) {
+    return (
+      <div className="splash-game">
+        <InteractiveMascot
+          className="beta-splash__mascot"
+          idleEmotion="wave"
+          reactsToTilt
+          doesPullUps
+          size={96}
+          pokeLabel={pokeLabel}
+        />
+        <button type="button" className="splash-game__play" onClick={startGame}>
+          <PixelIcon name="gamepad" size={14} />
+          {t('betaSplash.game.play')}
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div className={phase === 'over' ? 'splash-game splash-game--over' : 'splash-game splash-game--playing'}>
+      <div className="splash-game__hud">
+        <span className="splash-game__score" aria-live="polite">
+          {t('betaSplash.game.score', { count: view.score })}
+        </span>
+        <span className="splash-game__lives" aria-label={t('betaSplash.game.lives', { count: view.lives })}>
+          {Array.from({ length: SPLASH_LIVES }, (_, index) => (
+            <span
+              key={index}
+              className={index < view.lives ? 'splash-game__life' : 'splash-game__life splash-game__life--gone'}
+            />
+          ))}
+        </span>
+      </div>
+      <div
+        ref={stageRef}
+        className="splash-game__stage"
+        tabIndex={0}
+        role="group"
+        aria-label={t('betaSplash.game.region')}
+        onPointerDown={(event) => {
+          event.currentTarget.setPointerCapture(event.pointerId);
+          aim(event);
+        }}
+        onPointerMove={aim}
+        onKeyDown={onKeyDown}
+      >
+        {view.snacks.map((snack) => (
+          <span
+            key={snack.id}
+            className={`splash-game__snack splash-game__snack--${snack.kind}`}
+            style={{ left: `${snack.x * 100}%`, top: `${snack.y * 100}%` }}
+          >
+            <PixelIcon name={SNACK_ICONS[snack.kind]} size={22} />
+          </span>
+        ))}
+        <div
+          className={chomp ? 'splash-game__catcher splash-game__catcher--chomp' : 'splash-game__catcher'}
+          style={{ left: `${view.mascotX * 100}%` }}
+        >
+          <Mascot emotion={emotion} size={72} />
+        </div>
+        {phase === 'over' ? (
+          <div className="splash-game__over">
+            <p className="splash-game__over-copy">{t('betaSplash.game.over', { count: view.score })}</p>
+            <button type="button" className="splash-game__again" onClick={startGame}>
+              {t('betaSplash.game.again')}
+            </button>
+          </div>
+        ) : null}
+      </div>
+      {phase === 'playing' ? <p className="splash-game__hint">{t('betaSplash.game.hint')}</p> : null}
+    </div>
+  );
+}

--- a/apps/web/src/SplashMascotGame.tsx
+++ b/apps/web/src/SplashMascotGame.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState, type KeyboardEvent, type PointerEvent as ReactPointerEvent } from 'react';
 import { useTranslation } from 'react-i18next';
 import { InteractiveMascot, Mascot, type MascotEmotion } from './Mascot.js';
+import { PixelIcon } from './PixelIcon.js';
 import {
   SNACK_ICONS,
   SPLASH_LIVES,

--- a/apps/web/src/SplashMascotGame.tsx
+++ b/apps/web/src/SplashMascotGame.tsx
@@ -169,6 +169,7 @@ export function SplashMascotGame({ pokeLabel }: { pokeLabel: string }) {
         role="group"
         aria-label={t('betaSplash.game.region')}
         onPointerDown={(event) => {
+          if (phase !== 'playing') return;
           event.currentTarget.setPointerCapture(event.pointerId);
           aim(event);
         }}
@@ -193,7 +194,12 @@ export function SplashMascotGame({ pokeLabel }: { pokeLabel: string }) {
         {phase === 'over' ? (
           <div className="splash-game__over">
             <p className="splash-game__over-copy">{t('betaSplash.game.over', { count: view.score })}</p>
-            <button type="button" className="splash-game__again" onClick={startGame}>
+            <button
+              type="button"
+              className="splash-game__again"
+              onPointerDown={(event) => event.stopPropagation()}
+              onClick={startGame}
+            >
               {t('betaSplash.game.again')}
             </button>
           </div>

--- a/apps/web/src/betaSplashFit.test.ts
+++ b/apps/web/src/betaSplashFit.test.ts
@@ -21,9 +21,22 @@ describe('the beta splash fits a small phone', () => {
     const query = css.slice(css.indexOf('@media (max-height: 720px)'));
     expect(query.slice(0, 40)).toContain('@media (max-height: 720px)');
     // Keyed on height, not width — a phone in landscape is short too.
-    for (const selector of ['.beta-splash__card', '.beta-splash__mascot .mascot', '.beta-splash__headline']) {
+    for (const selector of [
+      '.beta-splash__card',
+      '.beta-splash__mascot .mascot',
+      '.beta-splash__headline',
+      '.splash-game__stage',
+    ]) {
       expect(query).toContain(selector);
     }
+  });
+
+  it('hides pitch, not legal links, while a snack-catch round is on', () => {
+    const query = css.slice(css.indexOf('@media (max-height: 720px)'));
+    expect(query).toMatch(/\.beta-splash__card:has\(\.splash-game--playing\) \.beta-splash__headline/);
+    expect(query).toMatch(/\.beta-splash__card:has\(\.splash-game--playing\) \.beta-splash__footer/);
+    const legalBlock = query.slice(query.indexOf('.beta-splash__legal'), query.indexOf('.beta-splash__legal') + 120);
+    expect(legalBlock).not.toMatch(/display:\s*none/);
   });
 
   it('centres the card without making an overflowing one unreachable', () => {

--- a/apps/web/src/betaSplashFit.test.ts
+++ b/apps/web/src/betaSplashFit.test.ts
@@ -29,6 +29,8 @@ describe('the beta splash fits a small phone', () => {
     ]) {
       expect(query).toContain(selector);
     }
+    expect(query).toMatch(/\.beta-splash \.splash-game__stage \{[\s\S]*height: 140px;/);
+    expect(query).toMatch(/\.beta-splash \.splash-game__hint \{[\s\S]*font-size: 0\.72rem;/);
   });
 
   it('hides pitch, not legal links, while a snack-catch round is on', () => {

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -931,7 +931,6 @@
     "waitlistError": "Couldn't join the waitlist right now. Please try again.",
     "footer": "Access is invite-only during the closed beta.",
     "game": {
-      "play": "Feed him",
       "hint": "Slide to catch the snacks",
       "region": "Snack catch with the mascot",
       "score": "Score {{count}}",

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -929,7 +929,18 @@
     "waitlistApproved": "🎉 You've been approved! Please sign in again to access the beta.",
     "waitlistRejected": "Your application wasn't accepted this time. Thanks for your interest.",
     "waitlistError": "Couldn't join the waitlist right now. Please try again.",
-    "footer": "Access is invite-only during the closed beta."
+    "footer": "Access is invite-only during the closed beta.",
+    "game": {
+      "play": "Feed him",
+      "hint": "Slide to catch the snacks",
+      "region": "Snack catch with the mascot",
+      "score": "Score {{count}}",
+      "lives_one": "{{count}} chance left",
+      "lives_other": "{{count}} chances left",
+      "over_one": "He ate {{count}} snack",
+      "over_other": "He ate {{count}} snacks",
+      "again": "Again"
+    }
   },
   "betaInvite": {
     "headline": "You've been invited to the closed beta.",

--- a/apps/web/src/i18n/locales/pl.json
+++ b/apps/web/src/i18n/locales/pl.json
@@ -937,7 +937,6 @@
     "waitlistError": "Nie udało się dołączyć do listy. Spróbuj ponownie.",
     "footer": "W trakcie zamkniętej bety dostęp jest tylko na zaproszenie.",
     "game": {
-      "play": "Nakarm go",
       "hint": "Przesuwaj, żeby łapać przekąski",
       "region": "Łapanie przekąsek z maskotką",
       "score": "Wynik {{count}}",

--- a/apps/web/src/i18n/locales/pl.json
+++ b/apps/web/src/i18n/locales/pl.json
@@ -935,7 +935,22 @@
     "waitlistApproved": "🎉 Twoja aplikacja została zaakceptowana! Zaloguj się ponownie, aby uzyskać dostęp.",
     "waitlistRejected": "Twoja aplikacja nie została zaakceptowana tym razem. Dziękujemy za zainteresowanie.",
     "waitlistError": "Nie udało się dołączyć do listy. Spróbuj ponownie.",
-    "footer": "W trakcie zamkniętej bety dostęp jest tylko na zaproszenie."
+    "footer": "W trakcie zamkniętej bety dostęp jest tylko na zaproszenie.",
+    "game": {
+      "play": "Nakarm go",
+      "hint": "Przesuwaj, żeby łapać przekąski",
+      "region": "Łapanie przekąsek z maskotką",
+      "score": "Wynik {{count}}",
+      "lives_one": "Została {{count}} szansa",
+      "lives_few": "Zostały {{count}} szanse",
+      "lives_many": "Zostało {{count}} szans",
+      "lives_other": "Zostało {{count}} szans",
+      "over_one": "Zjadł {{count}} przekąskę",
+      "over_few": "Zjadł {{count}} przekąski",
+      "over_many": "Zjadł {{count}} przekąsek",
+      "over_other": "Zjadł {{count}} przekąsek",
+      "again": "Jeszcze raz"
+    }
   },
   "betaInvite": {
     "headline": "Otrzymujesz zaproszenie do zamkniętej bety.",

--- a/apps/web/src/splashGame.test.ts
+++ b/apps/web/src/splashGame.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from 'vitest';
+import {
+  CATCH_Y0,
+  CATCH_Y1,
+  MASCOT_HALF,
+  SPLASH_LIVES,
+  createSplashGame,
+  fallSpeed,
+  nudgeSplashMascot,
+  setSplashMascotX,
+  spawnInterval,
+  tickSplashGame,
+  type SplashGameState,
+  type SplashSnack,
+} from './splashGame.js';
+
+const mid = () => 0.5;
+
+function snack(partial: Partial<SplashSnack> = {}): SplashSnack {
+  return { id: 1, x: 0.5, y: 0, vy: 0.4, kind: 0, ...partial };
+}
+
+function playing(partial: Partial<SplashGameState> = {}): SplashGameState {
+  return { ...createSplashGame(), spawnIn: 99, ...partial };
+}
+
+describe('splash snack-catch', () => {
+  it('starts centred with three lives and no snacks', () => {
+    const state = createSplashGame();
+    expect(state.mascotX).toBe(0.5);
+    expect(state.lives).toBe(SPLASH_LIVES);
+    expect(state.snacks).toEqual([]);
+    expect(state.status).toBe('playing');
+  });
+
+  it('clamps the mascot so he stays on the stage', () => {
+    const state = createSplashGame();
+    expect(setSplashMascotX(state, -1).mascotX).toBe(MASCOT_HALF);
+    expect(setSplashMascotX(state, 2).mascotX).toBe(1 - MASCOT_HALF);
+    expect(nudgeSplashMascot(state, -1).mascotX).toBe(0.4);
+    expect(nudgeSplashMascot(state, 1).mascotX).toBe(0.6);
+  });
+
+  it('does not move him after the round is over', () => {
+    const over = playing({ status: 'over', mascotX: 0.5 });
+    expect(setSplashMascotX(over, 0.8).mascotX).toBe(0.5);
+  });
+
+  it('catches a snack that falls onto him', () => {
+    const state = playing({
+      snacks: [snack({ y: CATCH_Y0 - 0.01, vy: 1 })],
+    });
+    const { state: next, caught, missed } = tickSplashGame(state, 0.03, mid);
+    expect(caught).toBe(1);
+    expect(missed).toBe(0);
+    expect(next.score).toBe(1);
+    expect(next.lives).toBe(SPLASH_LIVES);
+    expect(next.snacks).toEqual([]);
+  });
+
+  it('misses a snack that falls past him', () => {
+    const state = playing({
+      mascotX: MASCOT_HALF,
+      snacks: [snack({ x: 1 - MASCOT_HALF, y: CATCH_Y1 - 0.01, vy: 1 })],
+    });
+    const { state: next, caught, missed } = tickSplashGame(state, 0.03, mid);
+    expect(caught).toBe(0);
+    expect(missed).toBe(1);
+    expect(next.score).toBe(0);
+    expect(next.lives).toBe(SPLASH_LIVES - 1);
+  });
+
+  it('ends the round on the third miss', () => {
+    const state = playing({
+      lives: 1,
+      mascotX: MASCOT_HALF,
+      snacks: [snack({ x: 1 - MASCOT_HALF, y: CATCH_Y1 - 0.01, vy: 1 })],
+    });
+    const { state: next } = tickSplashGame(state, 0.03, mid);
+    expect(next.status).toBe('over');
+    expect(next.lives).toBe(0);
+    expect(next.snacks).toEqual([]);
+  });
+
+  it('spawns a snack when the timer elapses', () => {
+    const state = playing({ spawnIn: 0, snacks: [] });
+    const { state: next } = tickSplashGame(state, 0.016, () => 0.25);
+    expect(next.snacks).toHaveLength(1);
+    expect(next.snacks[0]?.y).toBeLessThan(0);
+    expect(next.nextId).toBe(2);
+  });
+
+  it('does not tick a finished round', () => {
+    const over = playing({ status: 'over', score: 4, snacks: [snack()] });
+    const { state: next, caught } = tickSplashGame(over, 1, mid);
+    expect(next).toBe(over);
+    expect(caught).toBe(0);
+  });
+
+  it('ramps speed with score but keeps a floor and a cap', () => {
+    expect(spawnInterval(0)).toBeGreaterThan(spawnInterval(20));
+    expect(spawnInterval(100)).toBe(0.55);
+    expect(fallSpeed(0)).toBeLessThan(fallSpeed(20));
+    expect(fallSpeed(100)).toBe(0.72);
+  });
+});

--- a/apps/web/src/splashGame.ts
+++ b/apps/web/src/splashGame.ts
@@ -1,0 +1,127 @@
+export const SPLASH_LIVES = 3;
+export const MASCOT_HALF = 0.2;
+export const CATCH_Y0 = 0.68;
+export const CATCH_Y1 = 0.88;
+export const KEY_NUDGE = 0.1;
+export const MAX_SNACKS = 4;
+
+export const SNACK_ICONS = ['sparkle', 'star', 'gamepad'] as const;
+export type SplashSnackKind = 0 | 1 | 2;
+
+export type SplashSnack = {
+  id: number;
+  x: number;
+  y: number;
+  vy: number;
+  kind: SplashSnackKind;
+};
+
+export type SplashGameState = {
+  mascotX: number;
+  snacks: SplashSnack[];
+  score: number;
+  lives: number;
+  spawnIn: number;
+  nextId: number;
+  status: 'playing' | 'over';
+};
+
+export type SplashTick = {
+  state: SplashGameState;
+  caught: number;
+  missed: number;
+};
+
+const clamp = (n: number, min: number, max: number) => Math.min(max, Math.max(min, n));
+
+export function createSplashGame(): SplashGameState {
+  return {
+    mascotX: 0.5,
+    snacks: [],
+    score: 0,
+    lives: SPLASH_LIVES,
+    spawnIn: 0.2,
+    nextId: 1,
+    status: 'playing',
+  };
+}
+
+export function setSplashMascotX(state: SplashGameState, x: number): SplashGameState {
+  if (state.status !== 'playing') return state;
+  return { ...state, mascotX: clamp(x, MASCOT_HALF, 1 - MASCOT_HALF) };
+}
+
+export function nudgeSplashMascot(state: SplashGameState, dir: -1 | 1): SplashGameState {
+  return setSplashMascotX(state, state.mascotX + dir * KEY_NUDGE);
+}
+
+export function spawnInterval(score: number): number {
+  return Math.max(0.55, 1.2 - score * 0.022);
+}
+
+export function fallSpeed(score: number): number {
+  return Math.min(0.72, 0.3 + score * 0.014);
+}
+
+function spawnSnack(score: number, nextId: number, rng: () => number): SplashSnack {
+  return {
+    id: nextId,
+    x: MASCOT_HALF + rng() * (1 - 2 * MASCOT_HALF),
+    y: -0.06,
+    vy: fallSpeed(score),
+    kind: Math.floor(rng() * 3) as SplashSnackKind,
+  };
+}
+
+function inCatchZone(snack: SplashSnack, mascotX: number): boolean {
+  return snack.y >= CATCH_Y0 && snack.y <= CATCH_Y1 && Math.abs(snack.x - mascotX) <= MASCOT_HALF;
+}
+
+export function tickSplashGame(state: SplashGameState, dt: number, rng: () => number, speed = 1): SplashTick {
+  if (state.status !== 'playing') return { state, caught: 0, missed: 0 };
+  const step = Math.min(Math.max(dt, 0), 0.05) * Math.max(speed, 0.2);
+  let spawnIn = state.spawnIn - step;
+  let nextId = state.nextId;
+  let score = state.score;
+  let lives = state.lives;
+  let caught = 0;
+  let missed = 0;
+  const snacks: SplashSnack[] = [];
+
+  for (const snack of state.snacks) {
+    const next = { ...snack, y: snack.y + snack.vy * step };
+    if (inCatchZone(next, state.mascotX)) {
+      caught += 1;
+      score += 1;
+      continue;
+    }
+    if (next.y > CATCH_Y1) {
+      missed += 1;
+      lives -= 1;
+      continue;
+    }
+    snacks.push(next);
+  }
+
+  while (spawnIn <= 0 && snacks.length < MAX_SNACKS && lives > 0) {
+    snacks.push(spawnSnack(score, nextId, rng));
+    nextId += 1;
+    spawnIn += spawnInterval(score);
+  }
+  if (spawnIn < 0) spawnIn = 0;
+
+  const status = lives <= 0 ? 'over' : 'playing';
+  return {
+    state: {
+      mascotX: state.mascotX,
+      snacks: status === 'over' ? [] : snacks,
+      score,
+      lives: Math.max(0, lives),
+      spawnIn,
+      nextId,
+      status,
+    },
+    caught,
+    missed,
+  };
+}

--- a/apps/web/src/splashMascotPullups.test.ts
+++ b/apps/web/src/splashMascotPullups.test.ts
@@ -11,8 +11,8 @@ const read = (name: string) => readFileSync(fileURLToPath(new URL(`./${name}`, i
 
 describe('the splash mascot does idle pull-ups', () => {
   it('opts the splash InteractiveMascot into pull-ups', () => {
-    const splash = read('ClosedBetaSplash.tsx');
-    const mascot = splash.match(/<InteractiveMascot[\s\S]*?\/>/);
+    const game = read('SplashMascotGame.tsx');
+    const mascot = game.match(/<InteractiveMascot[\s\S]*?\/>/);
     expect(mascot).not.toBeNull();
     expect(mascot![0]).toMatch(/doesPullUps/);
   });

--- a/apps/web/src/splashMascotPullups.test.ts
+++ b/apps/web/src/splashMascotPullups.test.ts
@@ -55,4 +55,10 @@ describe('the splash mascot does idle pull-ups', () => {
     const reduced = css.slice(css.indexOf('@media (prefers-reduced-motion: reduce)'));
     expect(reduced).toMatch(/\.mascot-interactive--pullups/);
   });
+
+  it('does not let the stage steal the Again click', () => {
+    const src = read('SplashMascotGame.tsx');
+    expect(src).toMatch(/if \(phase !== 'playing'\) return;/);
+    expect(src).toMatch(/onPointerDown=\{\(event\) => event\.stopPropagation\(\)\}/);
+  });
 });

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -4789,13 +4789,37 @@ a.user-name--profile:focus-visible {
 
   /* CSS wins over the SVG's width/height attributes, so the mascot shrinks without
      the component needing to know anything about the viewport. */
-  .beta-splash__mascot .mascot {
+  .beta-splash__mascot .mascot,
+  .splash-game__catcher .mascot {
     width: 68px;
     height: 58px;
   }
 
   .beta-splash__mascot {
     margin-bottom: 10px;
+  }
+
+  .splash-game__play {
+    margin-bottom: 10px;
+    font-size: 0.72rem;
+  }
+
+  .splash-game__stage {
+    height: 140px;
+  }
+
+  .splash-game__hint {
+    margin: 6px 0 8px;
+    font-size: 0.72rem;
+  }
+
+  .beta-splash__card:has(.splash-game--playing) .beta-splash__headline,
+  .beta-splash__card:has(.splash-game--over) .beta-splash__headline,
+  .beta-splash__card:has(.splash-game--playing) .beta-splash__badge,
+  .beta-splash__card:has(.splash-game--over) .beta-splash__badge,
+  .beta-splash__card:has(.splash-game--playing) .beta-splash__footer,
+  .beta-splash__card:has(.splash-game--over) .beta-splash__footer {
+    display: none;
   }
 
   .beta-splash__logo {
@@ -10365,6 +10389,187 @@ button.builder-mode-selector:disabled {
   margin: 0 auto 20px;
 }
 
+.splash-game {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  width: 100%;
+  margin: 0 0 8px;
+}
+
+.splash-game .beta-splash__mascot {
+  margin-bottom: 8px;
+}
+
+.splash-game__play {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  margin: 0 0 16px;
+  padding: 4px 12px;
+  color: var(--turquoise);
+  font: inherit;
+  font-size: 0.78rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  background: transparent;
+  border: 1px dashed rgba(0, 228, 172, 0.45);
+  border-radius: 999px;
+  cursor: pointer;
+  -webkit-tap-highlight-color: transparent;
+}
+
+.splash-game__play:hover,
+.splash-game__play:focus-visible {
+  color: #08241d;
+  background: var(--turquoise);
+  border-style: solid;
+  outline: none;
+}
+
+.splash-game__hud {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  margin-bottom: 6px;
+  color: var(--turquoise);
+  font-size: 0.78rem;
+  font-weight: 700;
+}
+
+.splash-game__lives {
+  display: flex;
+  gap: 5px;
+}
+
+.splash-game__life {
+  width: 8px;
+  height: 8px;
+  background: var(--turquoise);
+  border-radius: 50%;
+  box-shadow: 0 0 8px var(--turquoise-glow);
+}
+
+.splash-game__life--gone {
+  background: var(--panel-border);
+  box-shadow: none;
+}
+
+.splash-game__stage {
+  position: relative;
+  width: 100%;
+  height: 168px;
+  overflow: hidden;
+  border-radius: 12px;
+  background: radial-gradient(ellipse at 50% 120%, rgba(0, 228, 172, 0.1), transparent 58%);
+  touch-action: none;
+  cursor: grab;
+  user-select: none;
+  -webkit-user-select: none;
+}
+
+.splash-game__stage:focus-visible {
+  outline: 2px solid var(--turquoise);
+  outline-offset: 3px;
+}
+
+.splash-game__snack {
+  position: absolute;
+  display: grid;
+  place-items: center;
+  width: 28px;
+  height: 28px;
+  margin: -14px 0 0 -14px;
+  pointer-events: none;
+  filter: drop-shadow(0 0 6px currentColor);
+  animation: splash-snack-wobble 0.9s ease-in-out infinite;
+}
+
+.splash-game__snack--0 {
+  color: var(--turquoise);
+}
+
+.splash-game__snack--1 {
+  color: var(--accent-blue);
+}
+
+.splash-game__snack--2 {
+  color: #ffd36a;
+}
+
+.splash-game__catcher {
+  position: absolute;
+  bottom: 2px;
+  transform: translateX(-50%);
+  color: var(--turquoise);
+  filter: drop-shadow(0 0 12px var(--turquoise-glow));
+  pointer-events: none;
+  transition: transform 0.12s ease-out;
+}
+
+.splash-game__catcher--chomp {
+  transform: translateX(-50%) scale(1.08, 0.9);
+  transition: transform 0.08s ease-out;
+}
+
+.splash-game__over {
+  position: absolute;
+  inset: 0;
+  z-index: 2;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: flex-start;
+  gap: 10px;
+  padding-top: 18px;
+  background: linear-gradient(180deg, rgba(22, 28, 34, 0.82) 0%, rgba(22, 28, 34, 0.15) 70%, transparent 100%);
+  pointer-events: none;
+}
+
+.splash-game__over-copy {
+  margin: 0;
+  color: var(--text);
+  font-size: 0.95rem;
+  font-weight: 700;
+}
+
+.splash-game__again {
+  pointer-events: auto;
+  padding: 6px 14px;
+  color: var(--turquoise);
+  font: inherit;
+  font-size: 0.85rem;
+  font-weight: 600;
+  background: transparent;
+  border: 1px solid var(--turquoise);
+  border-radius: 999px;
+  cursor: pointer;
+}
+
+.splash-game__again:hover,
+.splash-game__again:focus-visible {
+  color: #08241d;
+  background: var(--turquoise);
+  outline: none;
+}
+
+.splash-game__hint {
+  margin: 8px 0 12px;
+  color: var(--muted);
+  font-size: 0.78rem;
+}
+
+@keyframes splash-snack-wobble {
+  0%,
+  100% {
+    transform: rotate(-12deg);
+  }
+  50% {
+    transform: rotate(12deg);
+  }
+}
+
 /* Interactive poke target — used on the closed-beta splash. */
 .mascot-interactive {
   display: inline-flex;
@@ -10554,6 +10759,13 @@ button.builder-mode-selector:disabled {
   .mascot-interactive--pullups {
     transition: none;
     animation: none;
+  }
+
+  .splash-game__snack,
+  .splash-game__catcher,
+  .splash-game__catcher--chomp {
+    animation: none;
+    transition: none;
   }
 
   /* The gesture reactions are motion by definition, so they go entirely — the

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -4799,11 +4799,6 @@ a.user-name--profile:focus-visible {
     margin-bottom: 10px;
   }
 
-  .splash-game__play {
-    margin-bottom: 10px;
-    font-size: 0.72rem;
-  }
-
   .splash-game__stage {
     height: 140px;
   }
@@ -10399,32 +10394,6 @@ button.builder-mode-selector:disabled {
 
 .splash-game .beta-splash__mascot {
   margin-bottom: 8px;
-}
-
-.splash-game__play {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  margin: 0 0 16px;
-  padding: 4px 12px;
-  color: var(--turquoise);
-  font: inherit;
-  font-size: 0.78rem;
-  font-weight: 600;
-  letter-spacing: 0.02em;
-  background: transparent;
-  border: 1px dashed rgba(0, 228, 172, 0.45);
-  border-radius: 999px;
-  cursor: pointer;
-  -webkit-tap-highlight-color: transparent;
-}
-
-.splash-game__play:hover,
-.splash-game__play:focus-visible {
-  color: #08241d;
-  background: var(--turquoise);
-  border-style: solid;
-  outline: none;
 }
 
 .splash-game__hud {

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -4799,11 +4799,11 @@ a.user-name--profile:focus-visible {
     margin-bottom: 10px;
   }
 
-  .splash-game__stage {
+  .beta-splash .splash-game__stage {
     height: 140px;
   }
 
-  .splash-game__hint {
+  .beta-splash .splash-game__hint {
     margin: 6px 0 8px;
     font-size: 0.72rem;
   }

--- a/docs/closed-beta-splash-plan.md
+++ b/docs/closed-beta-splash-plan.md
@@ -22,6 +22,20 @@ render a branded closed-beta landing instead of the app UI:
 - No data fetches beyond `/api/auth/me` — the catalog is walled anyway;
   don't fire requests that will 401 and log noise.
 
+## Splash minigame
+
+The signed-out splash (not the invite page) includes a lightweight snack-catch
+around the mascot: **Feed him**. Pointer/touch slides him; snacks fall; three
+misses end the round. It is CSS/React in the shell — not GameKit, not an iframe.
+
+- Waitlist and sign-in stay the primary actions. The play chip is a dashed
+  secondary control; the catch stage never covers those buttons.
+- Short screens (`max-height: 720px`) hide the headline, badge, and footer
+  while a round is in progress so the legal links and Join CTA still fit.
+- `prefers-reduced-motion` keeps the game, slows the fall, and drops snack
+  wobble / catch squash.
+- No extra `/api` calls. Score lives in component state for the tab only.
+
 ## Waitlist — sign-in based, consent-explicit
 
 Mechanic: the splash always shows **Join the waitlist** above the sign-in buttons.

--- a/docs/closed-beta-splash-plan.md
+++ b/docs/closed-beta-splash-plan.md
@@ -25,11 +25,12 @@ render a branded closed-beta landing instead of the app UI:
 ## Splash minigame
 
 The signed-out splash (not the invite page) includes a lightweight snack-catch
-around the mascot: **Feed him**. Pointer/touch slides him; snacks fall; three
-misses end the round. It is CSS/React in the shell — not GameKit, not an iframe.
+secret: poke the mascot five times to unlock it. Pointer/touch slides him; snacks
+fall; three misses end the round. It is CSS/React in the shell — not GameKit, not
+an iframe.
 
-- Waitlist and sign-in stay the primary actions. The play chip is a dashed
-  secondary control; the catch stage never covers those buttons.
+- Waitlist and sign-in stay the only visible actions. The mascot's existing poke
+  reactions are the discoverability cue; no second CTA competes with the waitlist.
 - Short screens (`max-height: 720px`) hide the headline, badge, and footer
   while a round is in progress so the legal links and Join CTA still fit.
 - `prefers-reduced-motion` keeps the game, slows the fall, and drops snack


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
The closed-beta landing includes a lightweight mascot snack-catch easter egg.

## What you play

Poke the mascot five times to unlock the snack-catch game. The existing mascot reactions are the only cue; there is no persistent game CTA competing with **Join the waitlist**. Once unlocked, falling pixel snacks (sparkle / star / gamepad) drop toward the mascot. Slide a finger or mouse — or use the arrow keys — to catch them. Three misses end the round; **Again** restarts.

It is CSS + React in the shell, not GameKit and not a sandboxed iframe. Physics live in `splashGame.ts` so the catch/miss rules are unit-tested without `requestAnimationFrame`.

## Why this shape

- The mascot stays the visual discovery surface; the waitlist and Google/Apple sign-in remain the only visible actions.
- Five explicit pokes make the game opt-in and non-invasive while the mascot's changing reactions give feedback.
- One-thumb on a phone, pointer on a desktop — no keyboard required.
- The invite-claim page does not get the game (that screen is for accepting access).
- Idle poke / tilt / pull-ups are unchanged until the fifth poke.
- Short screens (`max-height: 720px`) hide headline, badge, and footer while a round is on so Join and the legal links still fit. Legal links are never hidden.
- `prefers-reduced-motion` keeps the game, slows the fall, and drops snack wobble.

## Instrumentation

None of the seven product questions change: this is a tab-local diversion on the signed-out splash, not play telemetry and not the waitlist funnel (`cta_clicked` → `joined`). Named gap: the anonymous visit stream does not currently tell us how many visitors discover the five-poke interaction. Adding a new funnel event would be a separate measurement decision. Score is local React state — no extra `/api` calls.

## Tests

Logic (catch, miss, third-miss game-over, spawn, clamp), secret unlock (four pokes stay idle, fifth starts), UI (pointer and arrows, Again after three misses), splash still shows Join after unlock, invite page remains separate, i18n en/pl including Polish plurals, and the short-screen CSS contract.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-759b13f3-c156-4a3e-8761-1c46df3b2259?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-759b13f3-c156-4a3e-8761-1c46df3b2259&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

