### PR TITLE
fix(studio): phone chat sheet fullscreen, drag, and agent picker stacking

### DIFF
--- a/apps/web/src/CreatorStudioView.tsx
+++ b/apps/web/src/CreatorStudioView.tsx
@@ -975,7 +975,6 @@ export function CreatorStudioView({
                             }
                           }}
                           unreadCount={checklistUnread}
-                          standaloneHref={`/status/${encodeURIComponent(threadToken ?? activeGame.token)}`}
                           latestEntryLabel={latestActivityRef.current}
                           onVisiblyOpenChange={setRailVisiblyOpen}
                         >

--- a/apps/web/src/StudioChatRail.test.tsx
+++ b/apps/web/src/StudioChatRail.test.tsx
@@ -6,13 +6,23 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import i18n from './i18n/index.js';
 import { StudioChatRail } from './StudioChatRail.js';
 
+function mockSheetMedia(matches: boolean) {
+  window.matchMedia = vi.fn().mockReturnValue({
+    matches,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+  });
+}
+
 describe('StudioChatRail', () => {
   afterEach(() => {
     document.body.innerHTML = '';
+    vi.restoreAllMocks();
   });
 
-  it('separates and names both icon actions', async () => {
+  it('names the close action on desktop without a no-op pop-out link', async () => {
     (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    mockSheetMedia(false);
     await i18n.changeLanguage('en');
     const onOpenChange = vi.fn();
     const host = document.createElement('div');
@@ -21,24 +31,16 @@ describe('StudioChatRail', () => {
 
     await act(async () => {
       root.render(
-        <StudioChatRail
-          title="Sky Dodge"
-          open
-          onOpenChange={onOpenChange}
-          unreadCount={0}
-          standaloneHref="/status/sky-dodge"
-        >
+        <StudioChatRail title="Sky Dodge" open onOpenChange={onOpenChange} unreadCount={0}>
           <p>Thread</p>
         </StudioChatRail>,
       );
     });
 
-    const popout = host.querySelector<HTMLAnchorElement>('.studio-chat-rail-popout');
     const close = host.querySelector<HTMLButtonElement>('.studio-chat-rail-close');
-    expect(host.querySelectorAll('.studio-chat-rail-head-action')).toHaveLength(2);
-    expect(popout?.getAttribute('aria-label')).toBe('Open as page');
-    expect(popout?.dataset.tooltip).toBe('Open as page');
-    expect(popout?.querySelector('svg')?.getAttribute('width')).toBe('14');
+    expect(host.querySelector('.studio-chat-rail-popout')).toBeNull();
+    expect(host.querySelector('.studio-chat-rail-expand')).toBeNull();
+    expect(host.querySelectorAll('.studio-chat-rail-head-action')).toHaveLength(1);
     expect(close?.getAttribute('aria-label')).toBe('Close chat');
     expect(close?.dataset.tooltip).toBe('Close chat');
     expect(close?.querySelector('svg')?.getAttribute('width')).toBe('14');
@@ -53,11 +55,7 @@ describe('StudioChatRail', () => {
 
   it('keeps a phone peek detent while another pane temporarily covers chat', async () => {
     (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
-    window.matchMedia = vi.fn().mockReturnValue({
-      matches: true,
-      addEventListener: vi.fn(),
-      removeEventListener: vi.fn(),
-    });
+    mockSheetMedia(true);
     const host = document.createElement('div');
     document.body.appendChild(host);
     const root = createRoot(host);
@@ -81,6 +79,91 @@ describe('StudioChatRail', () => {
     expect(host.querySelector('.studio-chat-rail')?.classList.contains('is-collapsed')).toBe(true);
     await act(async () => render(false));
     expect(host.querySelector('.studio-chat-rail')?.classList.contains('is-peek')).toBe(true);
+
+    await act(async () => root.unmount());
+  });
+
+  it('expands the phone sheet to full screen from the header control', async () => {
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    mockSheetMedia(true);
+    await i18n.changeLanguage('en');
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    const root = createRoot(host);
+
+    await act(async () => {
+      root.render(
+        <StudioChatRail title="Sky Dodge" open onOpenChange={vi.fn()} unreadCount={0}>
+          <p>Thread</p>
+        </StudioChatRail>,
+      );
+    });
+
+    const rail = host.querySelector('.studio-chat-rail');
+    const expand = host.querySelector<HTMLButtonElement>('.studio-chat-rail-expand');
+    expect(rail?.classList.contains('is-half')).toBe(true);
+    expect(expand?.getAttribute('aria-label')).toBe('Full screen');
+    expect(host.querySelector('.studio-chat-rail-popout')).toBeNull();
+
+    await act(async () => {
+      expand?.click();
+    });
+    expect(rail?.classList.contains('is-full')).toBe(true);
+    expect(expand?.getAttribute('aria-label')).toBe('Exit full screen');
+
+    await act(async () => {
+      expand?.click();
+    });
+    expect(rail?.classList.contains('is-half')).toBe(true);
+
+    await act(async () => root.unmount());
+  });
+
+  it('snaps a dragged grab handle to the nearest detent', async () => {
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    mockSheetMedia(true);
+    Object.defineProperty(window, 'innerHeight', { configurable: true, value: 800 });
+    HTMLElement.prototype.setPointerCapture = vi.fn();
+    HTMLElement.prototype.releasePointerCapture = vi.fn();
+    HTMLElement.prototype.hasPointerCapture = vi.fn().mockReturnValue(true);
+
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    const root = createRoot(host);
+
+    await act(async () => {
+      root.render(
+        <StudioChatRail title="Sky Dodge" open onOpenChange={vi.fn()} unreadCount={0}>
+          <p>Thread</p>
+        </StudioChatRail>,
+      );
+    });
+
+    const rail = host.querySelector('.studio-chat-rail') as HTMLElement;
+    const grab = host.querySelector<HTMLButtonElement>('.studio-chat-rail-grab');
+    vi.spyOn(rail, 'getBoundingClientRect').mockReturnValue({
+      height: 384,
+      width: 390,
+      top: 416,
+      left: 0,
+      bottom: 800,
+      right: 390,
+      x: 0,
+      y: 416,
+      toJSON: () => ({}),
+    });
+
+    await act(async () => {
+      grab?.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true, pointerId: 1, clientY: 500, button: 0 }));
+      grab?.dispatchEvent(new PointerEvent('pointermove', { bubbles: true, pointerId: 1, clientY: 180 }));
+    });
+    expect(rail.classList.contains('is-dragging')).toBe(true);
+
+    await act(async () => {
+      grab?.dispatchEvent(new PointerEvent('pointerup', { bubbles: true, pointerId: 1, clientY: 180 }));
+    });
+    expect(rail.classList.contains('is-dragging')).toBe(false);
+    expect(rail.classList.contains('is-full')).toBe(true);
 
     await act(async () => root.unmount());
   });

--- a/apps/web/src/StudioChatRail.test.tsx
+++ b/apps/web/src/StudioChatRail.test.tsx
@@ -156,14 +156,11 @@ describe('StudioChatRail', () => {
     await act(async () => {
       grab?.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true, pointerId: 1, clientY: 500, button: 0 }));
       grab?.dispatchEvent(new PointerEvent('pointermove', { bubbles: true, pointerId: 1, clientY: 180 }));
-    });
-    expect(rail.classList.contains('is-dragging')).toBe(true);
-
-    await act(async () => {
       grab?.dispatchEvent(new PointerEvent('pointerup', { bubbles: true, pointerId: 1, clientY: 180 }));
     });
     expect(rail.classList.contains('is-dragging')).toBe(false);
     expect(rail.classList.contains('is-full')).toBe(true);
+    expect(rail.style.getPropertyValue('--studio-chat-rail-peek-height')).toBe('124px');
 
     await act(async () => root.unmount());
   });

--- a/apps/web/src/StudioChatRail.tsx
+++ b/apps/web/src/StudioChatRail.tsx
@@ -7,6 +7,7 @@ import {
   snapSheetDetent,
   type SheetDetent,
   SHEET_DRAG_CLICK_SLOP_PX,
+  SHEET_PEEK_PX,
 } from './studioChatSheet.js';
 
 /**
@@ -156,7 +157,7 @@ export function StudioChatRail({
     }
     if (!drag.moved) return;
     ignoreGrabClickRef.current = true;
-    const height = dragHeight ?? asideRef.current?.getBoundingClientRect().height ?? drag.startH;
+    const height = clampSheetDragHeight(drag.startH + drag.startY - event.clientY, window.innerHeight);
     setDetent(snapSheetDetent(height, window.innerHeight));
     setDragHeight(null);
   };
@@ -171,8 +172,11 @@ export function StudioChatRail({
 
   const dragging = dragHeight != null;
   const detentClass = isSheet ? ` is-sheet is-${detent}${dragging ? ' is-dragging' : ''}` : '';
-  const sheetStyle = dragging
-    ? ({ '--studio-chat-rail-drag-height': `${dragHeight}px` } as CSSProperties)
+  const sheetStyle = isSheet
+    ? ({
+        '--studio-chat-rail-peek-height': `${SHEET_PEEK_PX}px`,
+        ...(dragging ? { '--studio-chat-rail-drag-height': `${dragHeight}px` } : {}),
+      } as CSSProperties)
     : undefined;
 
   // The thread stays mounted whether collapsed, peeking, or fully open — a collapse

--- a/apps/web/src/StudioChatRail.tsx
+++ b/apps/web/src/StudioChatRail.tsx
@@ -1,6 +1,13 @@
-import { useEffect, useRef, useState, type ReactNode } from 'react';
+import { useEffect, useRef, useState, type CSSProperties, type PointerEvent, type ReactNode } from 'react';
 import { useTranslation } from 'react-i18next';
 import { PixelIcon } from './PixelIcon.js';
+import {
+  clampSheetDragHeight,
+  nextSheetDetent,
+  snapSheetDetent,
+  type SheetDetent,
+  SHEET_DRAG_CLICK_SLOP_PX,
+} from './studioChatSheet.js';
 
 /**
  * B3/B4: a glass shell around the embedded `SubmissionStatusView` thread — the chat
@@ -9,7 +16,7 @@ import { PixelIcon } from './PixelIcon.js';
  */
 
 const SHEET_MAX_WIDTH = 800;
-export type SheetDetent = 'peek' | 'half' | 'full';
+export type { SheetDetent };
 
 export type StudioChatRailProps = {
   title: string;
@@ -17,7 +24,6 @@ export type StudioChatRailProps = {
   covered?: boolean;
   onOpenChange: (open: boolean) => void;
   unreadCount: number;
-  standaloneHref?: string;
   latestEntryLabel?: string | null;
   /** Whether the transcript body is actually visible right now — `open` alone is true
    * even at the phone sheet's `peek` detent, where the body is hidden behind a one-line
@@ -33,7 +39,6 @@ export function StudioChatRail({
   covered = false,
   onOpenChange,
   unreadCount,
-  standaloneHref,
   latestEntryLabel,
   onVisiblyOpenChange,
   children,
@@ -41,8 +46,12 @@ export function StudioChatRail({
   const { t } = useTranslation();
   const [isSheet, setIsSheet] = useState(false);
   const [detent, setDetent] = useState<SheetDetent>('half');
+  const [dragHeight, setDragHeight] = useState<number | null>(null);
   const asideRef = useRef<HTMLElement | null>(null);
+  const dragRef = useRef<{ pointerId: number; startY: number; startH: number; moved: boolean } | null>(null);
+  const ignoreGrabClickRef = useRef(false);
   const visible = open && !covered;
+  const peeking = isSheet && detent === 'peek' && dragHeight == null;
 
   // A collapsed rail stays mounted but is clipped to 1px via CSS, not
   // display:none — `aria-hidden` alone does not remove its buttons/textarea from the
@@ -71,9 +80,10 @@ export function StudioChatRail({
     if (open && isSheet) setDetent((current) => (current === 'peek' ? 'half' : current));
   }, [open, isSheet]);
 
-  const visiblyOpen = visible && !(isSheet && detent === 'peek');
-  const popOutLabel = t('studioPanel.rail.popOut', { defaultValue: 'Open as page' });
+  const visiblyOpen = visible && !peeking;
   const closeLabel = t('studioPanel.rail.closeThread', { defaultValue: 'Close chat' });
+  const expandLabel = t('studioPanel.rail.fullScreen', { defaultValue: 'Full screen' });
+  const exitFullLabel = t('studioPanel.rail.exitFullScreen', { defaultValue: 'Exit full screen' });
   useEffect(() => {
     onVisiblyOpenChange?.(visiblyOpen);
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -115,14 +125,62 @@ export function StudioChatRail({
     };
   }, []);
 
-  const detentClass = isSheet ? ` is-sheet is-${detent}` : '';
+  const onGrabPointerDown = (event: PointerEvent<HTMLButtonElement>) => {
+    if (!isSheet || event.button !== 0) return;
+    const rail = asideRef.current;
+    if (!rail) return;
+    event.currentTarget.setPointerCapture(event.pointerId);
+    dragRef.current = {
+      pointerId: event.pointerId,
+      startY: event.clientY,
+      startH: rail.getBoundingClientRect().height,
+      moved: false,
+    };
+  };
+
+  const onGrabPointerMove = (event: PointerEvent<HTMLButtonElement>) => {
+    const drag = dragRef.current;
+    if (!drag || drag.pointerId !== event.pointerId) return;
+    const dy = drag.startY - event.clientY;
+    if (!drag.moved && Math.abs(dy) < SHEET_DRAG_CLICK_SLOP_PX) return;
+    drag.moved = true;
+    setDragHeight(clampSheetDragHeight(drag.startH + dy, window.innerHeight));
+  };
+
+  const endGrab = (event: PointerEvent<HTMLButtonElement>) => {
+    const drag = dragRef.current;
+    if (!drag || drag.pointerId !== event.pointerId) return;
+    dragRef.current = null;
+    if (event.currentTarget.hasPointerCapture(event.pointerId)) {
+      event.currentTarget.releasePointerCapture(event.pointerId);
+    }
+    if (!drag.moved) return;
+    ignoreGrabClickRef.current = true;
+    const height = dragHeight ?? asideRef.current?.getBoundingClientRect().height ?? drag.startH;
+    setDetent(snapSheetDetent(height, window.innerHeight));
+    setDragHeight(null);
+  };
+
+  const onGrabClick = () => {
+    if (ignoreGrabClickRef.current) {
+      ignoreGrabClickRef.current = false;
+      return;
+    }
+    setDetent(nextSheetDetent(detent));
+  };
+
+  const dragging = dragHeight != null;
+  const detentClass = isSheet ? ` is-sheet is-${detent}${dragging ? ' is-dragging' : ''}` : '';
+  const sheetStyle = dragging
+    ? ({ '--studio-chat-rail-drag-height': `${dragHeight}px` } as CSSProperties)
+    : undefined;
 
   // The thread stays mounted whether collapsed, peeking, or fully open — a collapse
   // must never unmount `SubmissionStatusView` (its poll and unsent composer text would
   // be lost). The aside + children remain present and are hidden via CSS.
   return (
     <>
-      {visible && isSheet && detent !== 'peek' ? (
+      {visible && isSheet && !peeking ? (
         <div
           className="modal-backdrop studio-chat-rail-backdrop"
           role="presentation"
@@ -132,39 +190,42 @@ export function StudioChatRail({
       <aside
         ref={asideRef}
         className={`studio-chat-rail${detentClass}${visible ? '' : ' is-collapsed'}`}
+        style={sheetStyle}
         aria-label={title}
         aria-hidden={visible ? undefined : true}
-        {...(visible && isSheet && detent !== 'peek' ? { role: 'dialog', 'aria-modal': true } : {})}
+        {...(visible && isSheet && !peeking ? { role: 'dialog', 'aria-modal': true } : {})}
       >
+        {open && isSheet ? (
+          <button
+            type="button"
+            className="studio-chat-rail-grab"
+            onPointerDown={onGrabPointerDown}
+            onPointerMove={onGrabPointerMove}
+            onPointerUp={endGrab}
+            onPointerCancel={endGrab}
+            onClick={onGrabClick}
+            aria-label={
+              detent === 'full'
+                ? t('studioPanel.rail.collapse', { defaultValue: 'Collapse' })
+                : t('studioPanel.rail.expand', { defaultValue: 'Expand' })
+            }
+          >
+            <span className="studio-chat-rail-grab-bar" aria-hidden="true" />
+          </button>
+        ) : null}
         <div className="studio-chat-rail-head">
-          {open && isSheet ? (
-            <button
-              type="button"
-              className="studio-chat-rail-grab"
-              // Cycles peek -> half -> full -> peek — the only way to reach `full`
-              // (and its `.is-full` CSS) short of a drag gesture this sheet doesn't
-              // implement.
-              onClick={() => setDetent(detent === 'peek' ? 'half' : detent === 'half' ? 'full' : 'peek')}
-              aria-label={
-                detent === 'full'
-                  ? t('studioPanel.rail.collapse', { defaultValue: 'Collapse' })
-                  : t('studioPanel.rail.expand', { defaultValue: 'Expand' })
-              }
-            >
-              <span className="studio-chat-rail-grab-bar" aria-hidden="true" />
-            </button>
-          ) : null}
           <h3 className="studio-chat-rail-title">{title}</h3>
           <div className="studio-chat-rail-head-actions">
-            {standaloneHref ? (
-              <a
-                className="studio-chat-rail-head-action studio-chat-rail-popout"
-                href={standaloneHref}
-                aria-label={popOutLabel}
-                data-tooltip={popOutLabel}
+            {open && isSheet ? (
+              <button
+                type="button"
+                className="studio-chat-rail-head-action studio-chat-rail-expand"
+                onClick={() => setDetent(detent === 'full' ? 'half' : 'full')}
+                aria-label={detent === 'full' ? exitFullLabel : expandLabel}
+                data-tooltip={detent === 'full' ? exitFullLabel : expandLabel}
               >
-                <PixelIcon name="expand" size={14} />
-              </a>
+                <PixelIcon name={detent === 'full' ? 'collapse' : 'expand'} size={14} />
+              </button>
             ) : null}
             <button
               type="button"
@@ -178,7 +239,7 @@ export function StudioChatRail({
           </div>
         </div>
 
-        {open && isSheet && detent === 'peek' ? (
+        {open && isSheet && peeking ? (
           <button type="button" className="studio-chat-rail-peek" onClick={() => setDetent('half')}>
             <span className="studio-chat-rail-peek-line">
               {latestEntryLabel ?? t('studioPanel.rail.peekEmpty', { defaultValue: 'No updates yet' })}
@@ -188,7 +249,7 @@ export function StudioChatRail({
             ) : null}
           </button>
         ) : null}
-        <div className="studio-chat-rail-body" hidden={open && isSheet && detent === 'peek'}>
+        <div className="studio-chat-rail-body" hidden={open && isSheet && peeking}>
           {children}
         </div>
       </aside>

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -421,8 +421,8 @@
       "chat": "Chat",
       "collapse": "Collapse",
       "expand": "Expand",
-      "popOut": "Open as page",
-      "closeThread": "Close chat",
+      "fullScreen": "Full screen",
+      "exitFullScreen": "Exit full screen",
       "peekEmpty": "No updates yet"
     },
     "share": {

--- a/apps/web/src/i18n/locales/pl.json
+++ b/apps/web/src/i18n/locales/pl.json
@@ -425,8 +425,8 @@
       "chat": "Czat",
       "collapse": "Zwiń",
       "expand": "Rozwiń",
-      "popOut": "Otwórz jako stronę",
-      "closeThread": "Zamknij czat",
+      "fullScreen": "Pełny ekran",
+      "exitFullScreen": "Zamknij pełny ekran",
       "peekEmpty": "Brak nowości"
     },
     "share": {

--- a/apps/web/src/studioChatSheet.test.ts
+++ b/apps/web/src/studioChatSheet.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+import { clampSheetDragHeight, nextSheetDetent, snapSheetDetent } from './studioChatSheet.js';
+
+describe('studio chat sheet detents', () => {
+  it('cycles peek → half → full → peek', () => {
+    expect(nextSheetDetent('peek')).toBe('half');
+    expect(nextSheetDetent('half')).toBe('full');
+    expect(nextSheetDetent('full')).toBe('peek');
+  });
+
+  it('snaps a dragged height to the nearest detent', () => {
+    expect(snapSheetDetent(80, 800)).toBe('peek');
+    expect(snapSheetDetent(380, 800)).toBe('half');
+    expect(snapSheetDetent(700, 800)).toBe('full');
+  });
+
+  it('clamps a live drag between peek and nearly the viewport', () => {
+    expect(clampSheetDragHeight(10, 800)).toBe(72);
+    expect(clampSheetDragHeight(900, 800)).toBe(752);
+    expect(clampSheetDragHeight(400, 800)).toBe(400);
+  });
+});

--- a/apps/web/src/studioChatSheet.test.ts
+++ b/apps/web/src/studioChatSheet.test.ts
@@ -9,13 +9,13 @@ describe('studio chat sheet detents', () => {
   });
 
   it('snaps a dragged height to the nearest detent', () => {
-    expect(snapSheetDetent(80, 800)).toBe('peek');
+    expect(snapSheetDetent(130, 800)).toBe('peek');
     expect(snapSheetDetent(380, 800)).toBe('half');
     expect(snapSheetDetent(700, 800)).toBe('full');
   });
 
   it('clamps a live drag between peek and nearly the viewport', () => {
-    expect(clampSheetDragHeight(10, 800)).toBe(72);
+    expect(clampSheetDragHeight(10, 800)).toBe(124);
     expect(clampSheetDragHeight(900, 800)).toBe(752);
     expect(clampSheetDragHeight(400, 800)).toBe(400);
   });

--- a/apps/web/src/studioChatSheet.ts
+++ b/apps/web/src/studioChatSheet.ts
@@ -2,7 +2,7 @@ export type SheetDetent = 'peek' | 'half' | 'full';
 
 export const SHEET_HALF_VH = 48;
 export const SHEET_FULL_VH = 88;
-export const SHEET_PEEK_PX = 72;
+export const SHEET_PEEK_PX = 124;
 export const SHEET_DRAG_CLICK_SLOP_PX = 12;
 
 export function nextSheetDetent(current: SheetDetent): SheetDetent {
@@ -12,7 +12,7 @@ export function nextSheetDetent(current: SheetDetent): SheetDetent {
 }
 
 export function snapSheetDetent(heightPx: number, viewportH: number): SheetDetent {
-  const peek = Math.min(SHEET_PEEK_PX, viewportH * 0.22);
+  const peek = Math.min(SHEET_PEEK_PX, Math.max(0, viewportH * 0.9));
   const half = viewportH * (SHEET_HALF_VH / 100);
   const full = viewportH * (SHEET_FULL_VH / 100);
   const dPeek = Math.abs(heightPx - peek);
@@ -24,7 +24,7 @@ export function snapSheetDetent(heightPx: number, viewportH: number): SheetDeten
 }
 
 export function clampSheetDragHeight(heightPx: number, viewportH: number): number {
-  const min = Math.min(SHEET_PEEK_PX, viewportH * 0.22);
-  const max = viewportH * 0.94;
+  const min = Math.min(SHEET_PEEK_PX, Math.max(0, viewportH * 0.9));
+  const max = Math.max(min, viewportH * 0.94);
   return Math.min(max, Math.max(min, heightPx));
 }

--- a/apps/web/src/studioChatSheet.ts
+++ b/apps/web/src/studioChatSheet.ts
@@ -1,0 +1,30 @@
+export type SheetDetent = 'peek' | 'half' | 'full';
+
+export const SHEET_HALF_VH = 48;
+export const SHEET_FULL_VH = 88;
+export const SHEET_PEEK_PX = 72;
+export const SHEET_DRAG_CLICK_SLOP_PX = 12;
+
+export function nextSheetDetent(current: SheetDetent): SheetDetent {
+  if (current === 'peek') return 'half';
+  if (current === 'half') return 'full';
+  return 'peek';
+}
+
+export function snapSheetDetent(heightPx: number, viewportH: number): SheetDetent {
+  const peek = Math.min(SHEET_PEEK_PX, viewportH * 0.22);
+  const half = viewportH * (SHEET_HALF_VH / 100);
+  const full = viewportH * (SHEET_FULL_VH / 100);
+  const dPeek = Math.abs(heightPx - peek);
+  const dHalf = Math.abs(heightPx - half);
+  const dFull = Math.abs(heightPx - full);
+  if (dPeek <= dHalf && dPeek <= dFull) return 'peek';
+  if (dHalf <= dFull) return 'half';
+  return 'full';
+}
+
+export function clampSheetDragHeight(heightPx: number, viewportH: number): number {
+  const min = Math.min(SHEET_PEEK_PX, viewportH * 0.22);
+  const max = viewportH * 0.94;
+  return Math.min(max, Math.max(min, heightPx));
+}

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -6865,6 +6865,12 @@ button.builder-mode-selector:disabled {
   margin: 4px 0 0;
   font-size: 0.74rem;
 }
+/* Phone chat sheet is z-index 1100; the default .modal-backdrop (1000) would
+   open this picker behind the composer that launched it. */
+.builder-choice-modal-backdrop {
+  z-index: 1300;
+}
+
 .builder-choice-modal {
   background: var(--panel);
   border: 1px solid var(--panel-border);
@@ -12043,6 +12049,7 @@ button.builder-mode-selector:disabled {
   display: flex;
   flex-direction: column;
   overflow: hidden;
+  touch-action: pan-y;
 }
 
 .studio-chat-rail-body .studio-thread {
@@ -12053,6 +12060,16 @@ button.builder-mode-selector:disabled {
   max-width: none;
   margin: 0;
   padding: 8px 12px 12px;
+}
+
+.studio-chat-rail-body .studio-thread-scroll {
+  -webkit-overflow-scrolling: touch;
+  touch-action: pan-y;
+  overscroll-behavior: contain;
+}
+
+.studio-chat-rail .studio-thread-scroll-pad {
+  pointer-events: auto;
 }
 
 .studio-chat-rail-grab {
@@ -12109,6 +12126,7 @@ button.builder-mode-selector:disabled {
     max-height: 85vh;
     border-radius: 16px 16px 0 0;
     animation: fadeIn 0.2s ease;
+    transition: height 180ms ease;
   }
 
   /* Install / update banners pin to the bottom edge too — lift the sheet above them
@@ -12119,13 +12137,25 @@ button.builder-mode-selector:disabled {
     bottom: var(--studio-chat-rail-overlay-lift, 5.5rem);
   }
 
+  .studio-chat-rail.is-sheet .studio-chat-rail-head {
+    padding-top: 4px;
+  }
+
   .studio-chat-rail.is-sheet .studio-chat-rail-grab {
     display: flex;
     justify-content: center;
-    padding: 8px 0 0;
+    align-items: center;
+    width: 100%;
+    min-height: 28px;
+    padding: 10px 0 2px;
     border: 0;
     background: transparent;
-    cursor: pointer;
+    cursor: grab;
+    touch-action: none;
+  }
+
+  .studio-chat-rail.is-sheet.is-dragging .studio-chat-rail-grab {
+    cursor: grabbing;
   }
 
   .studio-chat-rail.is-sheet .studio-chat-rail-grab-bar {
@@ -12145,6 +12175,13 @@ button.builder-mode-selector:disabled {
 
   .studio-chat-rail.is-full {
     height: 88vh;
+    max-height: none;
+  }
+
+  .studio-chat-rail.is-sheet.is-dragging {
+    height: var(--studio-chat-rail-drag-height);
+    max-height: none;
+    transition: none;
   }
 }
 

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -12167,6 +12167,7 @@ button.builder-mode-selector:disabled {
 
   .studio-chat-rail.is-peek {
     max-height: none;
+    height: var(--studio-chat-rail-peek-height, 124px);
   }
 
   .studio-chat-rail.is-half {

--- a/apps/web/src/styles.studioChatRail.test.ts
+++ b/apps/web/src/styles.studioChatRail.test.ts
@@ -33,6 +33,12 @@ describe('Studio chat rail header', () => {
     expect(css).toMatch(/\.studio-chat-rail\.is-sheet\.is-dragging\s*\{[^}]*--studio-chat-rail-drag-height/s);
   });
 
+  it('gives peek a height that fits its mandatory chrome', () => {
+    expect(declarations('.studio-chat-rail.is-peek')).toMatch(
+      /max-height:\s*none[^}]*height:\s*var\(--studio-chat-rail-peek-height,\s*124px\)/s,
+    );
+  });
+
   it('keeps the builder choice modal above the phone chat sheet', () => {
     expect(declarations('.builder-choice-modal-backdrop')).toMatch(/z-index:\s*1300/);
     expect(css).toMatch(/\.studio-chat-rail\.is-sheet\s*\{[^}]*z-index:\s*1100/s);

--- a/apps/web/src/styles.studioChatRail.test.ts
+++ b/apps/web/src/styles.studioChatRail.test.ts
@@ -27,4 +27,19 @@ describe('Studio chat rail header', () => {
       /\.studio-chat-rail-head-action:hover::after,\s*\.studio-chat-rail-head-action:focus-visible::after\s*{[^}]*opacity:\s*1[^}]*visibility:\s*visible/s,
     );
   });
+
+  it('gives the phone grab a full-width drag target', () => {
+    expect(css).toMatch(/\.studio-chat-rail\.is-sheet \.studio-chat-rail-grab\s*\{[^}]*width:\s*100%[^}]*touch-action:\s*none/s);
+    expect(css).toMatch(/\.studio-chat-rail\.is-sheet\.is-dragging\s*\{[^}]*--studio-chat-rail-drag-height/s);
+  });
+
+  it('keeps the builder choice modal above the phone chat sheet', () => {
+    expect(declarations('.builder-choice-modal-backdrop')).toMatch(/z-index:\s*1300/);
+    expect(css).toMatch(/\.studio-chat-rail\.is-sheet\s*\{[^}]*z-index:\s*1100/s);
+  });
+
+  it('lets the transcript take vertical pans inside the sheet', () => {
+    expect(declarations('.studio-chat-rail-body')).toMatch(/touch-action:\s*pan-y/);
+    expect(declarations('.studio-chat-rail-body .studio-thread-scroll')).toMatch(/touch-action:\s*pan-y/);
+  });
 });

--- a/eslint-rules/comment-prose-baseline.json
+++ b/eslint-rules/comment-prose-baseline.json
@@ -528,7 +528,7 @@
     "apps/web/src/splashMascotPullups.test.ts": 34,
     "apps/web/src/SplitHero.tsx": 10,
     "apps/web/src/studioApi.ts": 835,
-    "apps/web/src/StudioChatRail.tsx": 256,
+    "apps/web/src/StudioChatRail.tsx": 230,
     "apps/web/src/StudioConnectCard.test.tsx": 66,
     "apps/web/src/StudioConnectCard.tsx": 472,
     "apps/web/src/StudioCreatorAgentKeyPanel.tsx": 37,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Addressed both Codex P2 review comments:

- Drag release snapping now derives the final height from `drag.startH`, `drag.startY`, and the release event's `clientY`, so a fast flick cannot snap using stale React state.
- Peek now has an explicit 124px height contract shared from the component, which fits the grab handle, header, and preview row; drag clamping and snapping use the same minimum.

Added regression coverage for batched pointermove + pointerup and the peek CSS contract.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019ff710-a289-725a-9403-7dcf95b37020?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019ff710-a289-725a-9403-7dcf95b37020&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

