### PR TITLE
fix(api): restore Anthropic managed-agent session dispatch

### DIFF
--- a/apps/api/src/managed-provider-anthropic.test.ts
+++ b/apps/api/src/managed-provider-anthropic.test.ts
@@ -48,7 +48,7 @@ describe('anthropic managed provider', () => {
 
     const [url, init] = fetchImpl.mock.calls[0] as [string, RequestInit];
     expect(url).not.toContain('secret-key');
-    expect(url).toBe('https://api.anthropic.com/v1/sessions');
+    expect(url).toBe('https://api.anthropic.com/v1/sessions?beta=true');
     const headers = init.headers as Record<string, string>;
     expect(headers['x-api-key']).toBe('secret-key');
     expect(headers['anthropic-beta']).toBe('managed-agents-2026-04-01');
@@ -72,7 +72,7 @@ describe('anthropic managed provider', () => {
     const fetchImpl = vi.fn(async (url: string) => {
       if (url.endsWith('/v1/vaults')) return jsonResponse({ id: 'vlt_round' });
       if (url.endsWith('/credentials')) return jsonResponse({ id: 'cred_round' });
-      if (url.endsWith('/v1/sessions')) return jsonResponse({ id: 'sess_round', status: 'queued' });
+      if (url.endsWith('/v1/sessions?beta=true')) return jsonResponse({ id: 'sess_round', status: 'queued' });
       throw new Error(`unexpected request ${url}`);
     });
     const provider = createAnthropicManagedProvider({

--- a/apps/api/src/managed-provider-anthropic.ts
+++ b/apps/api/src/managed-provider-anthropic.ts
@@ -18,6 +18,7 @@ const DEFAULT_TIMEOUT_MS = 30_000;
 const API_VERSION = '2023-06-01';
 
 const BETA_HEADER = 'managed-agents-2026-04-01';
+const BETA_QUERY = '?beta=true';
 const MCP_EAGER_TOOLS = [
   'create_game',
   'start',
@@ -260,7 +261,7 @@ export function createAnthropicManagedProvider(config: ManagedProviderConfig): M
       };
       try {
         const parsed = SessionSchema.safeParse(
-          await call('/v1/sessions', { method: 'POST', body: JSON.stringify(body) }),
+          await call(`/v1/sessions${BETA_QUERY}`, { method: 'POST', body: JSON.stringify(body) }),
         );
         if (!parsed.success) throw new ManagedAgentError('anthropic managed agents returned an unreadable session');
         return { ...toSession(parsed.data), ...(credentialRef ? { credentialRef } : {}) };
@@ -275,7 +276,7 @@ export function createAnthropicManagedProvider(config: ManagedProviderConfig): M
     },
 
     async getSession(sessionId: string): Promise<ManagedSession | null> {
-      const raw = await call(`/v1/sessions/${encodeURIComponent(sessionId)}`);
+      const raw = await call(`/v1/sessions/${encodeURIComponent(sessionId)}${BETA_QUERY}`);
       if (raw === null) return null;
       const parsed = SessionSchema.safeParse(raw);
       if (!parsed.success) throw new ManagedAgentError('anthropic managed agents returned an unreadable session');
@@ -303,7 +304,7 @@ export function createAnthropicManagedProvider(config: ManagedProviderConfig): M
     },
 
     async sendMessage(sessionId: string, message: string): Promise<void> {
-      await call(`/v1/sessions/${encodeURIComponent(sessionId)}/events`, {
+      await call(`/v1/sessions/${encodeURIComponent(sessionId)}/events${BETA_QUERY}`, {
         method: 'POST',
         body: JSON.stringify({
           events: [{ type: 'user.message', content: [{ type: 'text', text: message }] }],
@@ -312,7 +313,7 @@ export function createAnthropicManagedProvider(config: ManagedProviderConfig): M
     },
 
     async cancelSession(sessionId: string): Promise<{ enforced: boolean }> {
-      await call(`/v1/sessions/${encodeURIComponent(sessionId)}/events`, {
+      await call(`/v1/sessions/${encodeURIComponent(sessionId)}/events${BETA_QUERY}`, {
         method: 'POST',
         body: JSON.stringify({ events: [{ type: 'user.interrupt' }] }),
       });
@@ -320,7 +321,9 @@ export function createAnthropicManagedProvider(config: ManagedProviderConfig): M
     },
 
     async deleteSession(sessionId: string): Promise<void> {
-      await call(`/v1/sessions/${encodeURIComponent(sessionId)}`, { method: 'DELETE' }).catch(() => undefined);
+      await call(`/v1/sessions/${encodeURIComponent(sessionId)}${BETA_QUERY}`, { method: 'DELETE' }).catch(
+        () => undefined,
+      );
     },
 
     async releaseCredential(credentialRef: string): Promise<void> {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add Anthropic’s required `beta=true` query to managed-agent session and event requests
- keep the provider regression tests aligned with the official session endpoint

## Verification
- `npm run test -w @gamedevpl/api -- src/managed-provider-anthropic.test.ts`
- `npm run type-check && npm run lint && npm run test && npm run build`
- `E2E_CHROMIUM_PATH=/usr/local/bin/google-chrome npm run e2e -w @gamedevpl/e2e -- src/studio-shell.test.ts` (8 tests)
- read-only production status/log inspection confirmed the affected round was queued after Anthropic returned HTTP 400; no new production round was started during verification

## Product instrumentation
- This restores the existing creator build-start path; no new telemetry event is needed. Existing job transitions and dispatch logs continue to measure the creator funnel and build economics.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f37cc36d-f1cf-4b57-b861-df7409956b45?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f37cc36d-f1cf-4b57-b861-df7409956b45&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

