### PR TITLE
test(e2e): scale Studio shell probe to phone viewport

### DIFF
--- a/apps/e2e/src/studio-shell.test.ts
+++ b/apps/e2e/src/studio-shell.test.ts
@@ -236,8 +236,8 @@ describe.skipIf(!prereq.ok)('the studio thread as an app screen', () => {
           scrollerClientHeight = scroller.clientHeight;
           const turn = document.createElement('div');
           turn.dataset.e2eInjected = 'true';
-          // Probe must fit the scrollport (phone half-sheet is ~150px tall).
-          const turnHeight = Math.min(200, Math.max(48, Math.floor(scrollerClientHeight * 0.3) || 48));
+          // Scale the probe to the available scrollport, including compact phone sheets.
+          const turnHeight = Math.min(200, Math.max(1, Math.floor(scrollerClientHeight * 0.3) || 1));
           turn.style.cssText = `height:${turnHeight}px;flex:none;`;
           const mount = body ?? pad.parentElement;
           if (mount && body) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- scale the synthetic Studio transcript turn to the measured scrollport
- keep the phone half-sheet browser gate checking content-end stick behavior without a fixed-size probe that overwhelms the pane

## Root cause
The expanded 390px chat sheet leaves an 82px transcript viewport. The probe’s 48px minimum made it 59% of that viewport, so its top fell below the gate’s lower-half threshold even though content-end stick behavior was correct.

## Validation
- `npm run type-check`
- `npm run lint`
- `npm run test`
- `npm run build`
- Local Playwright fixture probe across phone, narrow tablet, wide tablet, and desktop geometry
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e7ae3e12-7440-469a-9f42-69a0318fa0bb?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e7ae3e12-7440-469a-9f42-69a0318fa0bb&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

