### PR TITLE
fix(api): duplicate start()'s sessionKey into the last MCP content block

### DIFF
--- a/apps/api/src/mcp-server.test.ts
+++ b/apps/api/src/mcp-server.test.ts
@@ -922,6 +922,40 @@ describe('POST /api/mcp (BY-05)', () => {
     expect(body).toMatch(/If a call is refused:/i);
   });
 
+  // A real Gemini antigravity session (job 1000056, 2026-08-12) surfaced only the LAST
+  // item of start's multi-block content to the model, and never read structuredContent
+  // at all — so a client with that behaviour could never learn its own sessionKey and
+  // was stuck after the first call. This locks the fix: the sessionKey must be
+  // recoverable from content's last item alone, with nothing else read.
+  it('keeps sessionKey recoverable from only the last content item (last-item-only MCP clients)', async () => {
+    const store = new InMemoryStore();
+    await seedJob(store);
+    app = await createApp(store);
+    const sessionId = await initialize(app);
+
+    const res = await mcpCall(
+      app,
+      'tools/call',
+      { name: 'start', arguments: { key: roundKey() } },
+      { 'mcp-session-id': sessionId },
+    );
+    expect(res.statusCode).toBe(200);
+    const result = res.json().result as {
+      content: Array<{ type: string; text: string }>;
+      structuredContent: { sessionKey: string };
+    };
+
+    expect(result.content.length).toBeGreaterThanOrEqual(2);
+    const lastItem = result.content[result.content.length - 1];
+    expect(lastItem.type).toBe('text');
+    expect(lastItem.text).toContain(result.structuredContent.sessionKey);
+    // The other, pre-existing blocks (content[0]'s JSON, the workflow text) must be
+    // untouched — this is additive only, for ChatGPT Apps / Claude connectors / Studio,
+    // which already parse this shape correctly in production.
+    expect(JSON.parse(result.content[0].text)).toMatchObject({ sessionKey: result.structuredContent.sessionKey });
+    expect(result.content[1].text).toMatch(/Session workflow/i);
+  });
+
   it('opens a platform round from its vault-injected round capability', async () => {
     const store = new InMemoryStore();
     await seedJob(store);

--- a/apps/api/src/mcp-server.test.ts
+++ b/apps/api/src/mcp-server.test.ts
@@ -922,11 +922,7 @@ describe('POST /api/mcp (BY-05)', () => {
     expect(body).toMatch(/If a call is refused:/i);
   });
 
-  // A real Gemini antigravity session (job 1000056, 2026-08-12) surfaced only the LAST
-  // item of start's multi-block content to the model, and never read structuredContent
-  // at all — so a client with that behaviour could never learn its own sessionKey and
-  // was stuck after the first call. This locks the fix: the sessionKey must be
-  // recoverable from content's last item alone, with nothing else read.
+  // Regression: real Gemini agents only read content's last item, never structuredContent.
   it('keeps sessionKey recoverable from only the last content item (last-item-only MCP clients)', async () => {
     const store = new InMemoryStore();
     await seedJob(store);
@@ -949,9 +945,7 @@ describe('POST /api/mcp (BY-05)', () => {
     const lastItem = result.content[result.content.length - 1];
     expect(lastItem.type).toBe('text');
     expect(lastItem.text).toContain(result.structuredContent.sessionKey);
-    // The other, pre-existing blocks (content[0]'s JSON, the workflow text) must be
-    // untouched — this is additive only, for ChatGPT Apps / Claude connectors / Studio,
-    // which already parse this shape correctly in production.
+    // content[0]/content[1] stay unchanged for existing clients (ChatGPT, Claude, Studio).
     expect(JSON.parse(result.content[0].text)).toMatchObject({ sessionKey: result.structuredContent.sessionKey });
     expect(result.content[1].text).toMatch(/Session workflow/i);
   });

--- a/apps/api/src/mcp-server.ts
+++ b/apps/api/src/mcp-server.ts
@@ -739,6 +739,34 @@ function withoutRepeatedContract(description: string): string {
 }
 
 /**
+ * `start`'s success shape, shared by both auth paths (creator-key bind and legacy
+ * round-scoped key). `toolOk` puts the machine JSON — including `sessionKey` — in
+ * `content[0]` and in `structuredContent`; the human workflow text is appended after as
+ * `content[1]`.
+ *
+ * Some MCP clients only surface the LAST item of a multi-block `content` array to the
+ * model and never read `structuredContent` at all — confirmed against a real Gemini
+ * antigravity session, 2026-08-12 (job 1000056, and isolated with a throwaway probe MCP
+ * server): both `content[0]` and `structuredContent` were dropped, so the model never
+ * learned its own `sessionKey` and could not call a second tool for the rest of the
+ * round. This appends one more trailing block carrying just the key, so a client that
+ * keeps only the last item still gets it. Additive only — `content[0]` and
+ * `structuredContent` are unchanged, since ChatGPT Apps, Claude connectors and Studio's
+ * connect snippets already parse this shape correctly in production.
+ */
+function startToolResult(structured: { sessionKey: string } & Record<string, unknown>): ToolResult {
+  const base = toolOk(structured);
+  return {
+    ...base,
+    content: [
+      ...base.content,
+      { type: 'text', text: SESSION_WORKFLOW_TEXT },
+      { type: 'text', text: `sessionKey: ${structured.sessionKey}` },
+    ],
+  };
+}
+
+/**
  * `BUILD_STEPS` widened to plain strings, for validating input that is `unknown`.
  *
  * `BUILD_STEPS.includes(x)` only accepts the `BuildStep` union, so checking a raw
@@ -1529,11 +1557,7 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
             ...seed,
             ...gateField,
           };
-          const base = toolOk(structured);
-          return {
-            ...base,
-            content: [...base.content, { type: 'text' as const, text: SESSION_WORKFLOW_TEXT }],
-          };
+          return startToolResult(structured);
         };
 
         if (!key && bearer && looksLikeCreatorAgentKey(bearer)) {
@@ -1722,13 +1746,7 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
           ...seed,
           ...gateField,
         };
-        // Base shape via toolOk so we do not drift from other tools; append the human-
-        // readable loop so an agent reading either form knows when to stop.
-        const base = toolOk(structured);
-        return {
-          ...base,
-          content: [...base.content, { type: 'text', text: SESSION_WORKFLOW_TEXT }],
-        };
+        return startToolResult(structured);
       },
     },
 

--- a/apps/api/src/mcp-server.ts
+++ b/apps/api/src/mcp-server.ts
@@ -738,22 +738,7 @@ function withoutRepeatedContract(description: string): string {
   return description.endsWith(suffix) ? description.slice(0, -suffix.length).trimEnd() : description;
 }
 
-/**
- * `start`'s success shape, shared by both auth paths (creator-key bind and legacy
- * round-scoped key). `toolOk` puts the machine JSON — including `sessionKey` — in
- * `content[0]` and in `structuredContent`; the human workflow text is appended after as
- * `content[1]`.
- *
- * Some MCP clients only surface the LAST item of a multi-block `content` array to the
- * model and never read `structuredContent` at all — confirmed against a real Gemini
- * antigravity session, 2026-08-12 (job 1000056, and isolated with a throwaway probe MCP
- * server): both `content[0]` and `structuredContent` were dropped, so the model never
- * learned its own `sessionKey` and could not call a second tool for the rest of the
- * round. This appends one more trailing block carrying just the key, so a client that
- * keeps only the last item still gets it. Additive only — `content[0]` and
- * `structuredContent` are unchanged, since ChatGPT Apps, Claude connectors and Studio's
- * connect snippets already parse this shape correctly in production.
- */
+// Shared `start` success shape — a trailing block repeats sessionKey for last-item-only MCP clients.
 function startToolResult(structured: { sessionKey: string } & Record<string, unknown>): ToolResult {
   const base = toolOk(structured);
   return {


### PR DESCRIPTION
## Summary
- `start()`'s real payload (sessionKey, gate state, seed info) lives in `content[0]` + `structuredContent`; a real Gemini antigravity managed round (job 1000056) only surfaces the LAST item of a multi-block `tools/call` result and never reads `structuredContent` at all — confirmed live, and isolated with a throwaway MCP probe server (two synthetic tools, one duplicated shape, one single-block) to rule out anything gamedev.pl-specific.
- Consequence: the agent never learns its own `sessionKey`, hallucinates one, and every later tool call fails with `invalid sessionKey — call start() again` or `this session opener only opens a session via start()`.
- Fix is additive only — `content[0]` and `structuredContent` are byte-identical to before, since ChatGPT Apps / Claude connectors / Studio connect snippets already parse that shape correctly in production. Adds one more trailing text block with just `sessionKey`, so a last-item-only client still gets it. Factored both `start` auth paths (creator-key bind + legacy round key) through one `startToolResult()` helper so they can't drift again.

## Test plan
- [x] `npx vitest run src/mcp-server.test.ts` — 87/87 pass, including a new regression test asserting `sessionKey` is recoverable from `content`'s last item alone (and that `content[0]`/`content[1]` stay untouched)
- [x] `npx tsc -p tsconfig.json --noEmit` — clean
- [x] Re-verified end to end against a real Gemini antigravity session (local `apps/api` + public tunnel, throwaway in-memory job, no prod data touched): `start` -> `get_brief` -> `get_seed` all succeeded, model's final answer matched the seeded brief/seed state exactly

🤖 Generated with [Claude Code](https://claude.com/claude-code)