### PR TITLE
fix(web): keep Code surface full width

### DIFF
--- a/apps/web/src/styles.codeSurfaceButtons.test.ts
+++ b/apps/web/src/styles.codeSurfaceButtons.test.ts
@@ -39,6 +39,13 @@ describe('the Code surface Publish button', () => {
     expect(ruleFor('.studio-stage-layout:has(.studio-code-overlay) .studio-fullbleed')).toMatch(/top:\s*10px/);
   });
 
+  it('keeps Code full-bleed when params-only Edit docks beside the stage', () => {
+    expect(ruleFor('.studio-edit-overlay:not(.studio-code-overlay):not(:has(.editor-board-col))')).toMatch(
+      /width:\s*min\(360px,\s*100%\)/,
+    );
+    expect(css).not.toMatch(/\.studio-edit-overlay:not\(:has\(\.editor-board-col\)\)/);
+  });
+
   it('gives the global escape its own row below desktop widths', () => {
     expect(css).toMatch(
       /@media \(max-width: 1099px\)[\s\S]*?\.studio-stage-layout:has\(\.studio-code-overlay\) \.code-surface-head \{\s*padding: 52px 14px 10px;/,

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -11685,12 +11685,8 @@ button.builder-mode-selector:disabled {
   overflow: hidden;
 }
 
-/* A definition with no board (tuning params and/or a property sheet only)
-   docks to a side panel instead of covering the stage — the running game
-   stays visible next to the sliders, which is the point of a live tuning UI.
-   A board needs the full canvas, so it keeps the full-cover shape above;
-   switching collections toggles this live since `:has()` tracks the DOM. */
-.studio-edit-overlay:not(:has(.editor-board-col)) {
+/* Edit definitions without a board dock beside the running game. */
+.studio-edit-overlay:not(.studio-code-overlay):not(:has(.editor-board-col)) {
   inset: 0 0 0 auto;
   width: min(360px, 100%);
   border-left: 1px solid var(--panel-border);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- scope the params-only Edit side-panel rule to Edit overlays
- keep the Code surface full-bleed so its file tree and editor have usable width
- add a regression assertion for the selector

## Verification
- Pending local green gate
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-92f16873-b812-45ad-97e6-5f5d564fbd66?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-92f16873-b812-45ad-97e6-5f5d564fbd66&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

