### PR TITLE
Remove destructive live-build stop control

### DIFF
--- a/apps/web/src/SubmissionStatusView.test.ts
+++ b/apps/web/src/SubmissionStatusView.test.ts
@@ -1017,7 +1017,7 @@ describe('SubmissionStatusView', () => {
       expect(container.querySelector('.studio-turn.is-working')).not.toBeNull();
       expect(container.querySelector<HTMLTextAreaElement>('textarea')?.disabled).toBe(true);
       expect(container.textContent).toContain('The agent is building now');
-      expect(container.querySelector('.studio-turn-working-actions .studio-context-stop')).not.toBeNull();
+      expect(container.querySelector('.studio-turn-working-actions .studio-context-stop')).toBeNull();
 
       await act(async () => {
         control?.querySelector('button')?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
@@ -1071,7 +1071,7 @@ describe('SubmissionStatusView', () => {
     }
   });
 
-  it('locks the active composer but lets the creator stop the build from the live row', async () => {
+  it('does not expose a destructive stop control from the live row', async () => {
     (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
     mockedGetSubmissionStatus.mockResolvedValue({
       status: 'building',
@@ -1079,8 +1079,6 @@ describe('SubmissionStatusView', () => {
       builder: 'platform',
       events: [],
     });
-    mockedAbandonSubmission.mockResolvedValue(undefined);
-
     await i18n.changeLanguage('en');
     const container = document.createElement('div');
     document.body.appendChild(container);
@@ -1093,23 +1091,8 @@ describe('SubmissionStatusView', () => {
         await flushEffects();
       });
 
-      const stop = container.querySelector<HTMLButtonElement>('.studio-turn-working-actions .studio-context-stop');
-      expect(stop?.textContent).toContain('Stop');
-
-      await act(async () => {
-        stop?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
-        await flushEffects();
-      });
-      expect(mockedAbandonSubmission).not.toHaveBeenCalled();
-
-      const confirm = container.querySelector<HTMLButtonElement>('.studio-turn-working-actions .is-danger');
-      expect(confirm?.textContent).toContain('Stop build');
-      await act(async () => {
-        confirm?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
-        await flushEffects();
-        await flushEffects();
-      });
-      expect(mockedAbandonSubmission).toHaveBeenCalledWith('interrupt-token');
+      expect(container.querySelector('.studio-turn-working-actions .studio-context-stop')).toBeNull();
+      expect(container.querySelector<HTMLTextAreaElement>('textarea')?.disabled).toBe(true);
     } finally {
       await act(async () => {
         root.unmount();
@@ -1855,7 +1838,7 @@ describe('SubmissionStatusView', () => {
     // Empty runway under the turns so the last message can scroll to the top of the pane.
     expect(container.querySelector('.studio-thread-scroll-pad')).not.toBeNull();
     expect(container.querySelector('.studio-thread-scroll-body')).not.toBeNull();
-    expect(container.querySelector('.studio-turn-working-actions .studio-context-stop')).not.toBeNull();
+    expect(container.querySelector('.studio-turn-working-actions .studio-context-stop')).toBeNull();
     expect(container.querySelector('.studio-thread-foot .studio-context-stop')).toBeNull();
     expect(container.querySelector('.studio-context-progress')).toBeNull();
     expect(container.querySelector('.status-play-cta')).toBeNull();

--- a/apps/web/src/SubmissionStatusView.tsx
+++ b/apps/web/src/SubmissionStatusView.tsx
@@ -835,7 +835,6 @@ export function SubmissionStatusView({
                         actions: (
                           <span className="studio-turn-working-actions">
                             {liveHandoff}
-                            <AbandonControl token={token} compact intent="stop" />
                           </span>
                         ),
                       }
@@ -1217,20 +1216,8 @@ export function SubmissionStatusView({
   );
 }
 
-/**
- * Stops the build for good. Two-step by design: the first click only arms it, so a
- * mis-tap can't throw away an hour of agent work. Deliberately understated — it is
- * an escape hatch, not something to invite.
- */
-function AbandonControl({
-  token,
-  compact = false,
-  intent = 'abandon',
-}: {
-  token: string;
-  compact?: boolean;
-  intent?: 'abandon' | 'stop';
-}) {
+/** Stops the build for good after an explicit confirmation. */
+function AbandonControl({ token }: { token: string }) {
   const { t } = useTranslation();
   const [armed, setArmed] = useState(false);
   const [state, setState] = useState<'idle' | 'sending'>('idle');
@@ -1257,39 +1244,32 @@ function AbandonControl({
     return (
       <button
         type="button"
-        className={compact ? 'studio-context-stop' : 'status-abandon'}
+        className="status-abandon"
         onClick={() => setArmed(true)}
-        title={t(`statusView.abandon.${intent === 'stop' ? 'stopStart' : 'start'}`)}
-        aria-label={t(`statusView.abandon.${intent === 'stop' ? 'stopStart' : 'start'}`)}
+        title={t('statusView.abandon.start')}
+        aria-label={t('statusView.abandon.start')}
       >
-        {compact ? (
-          <>
-            <PixelIcon name="close" size={11} />{' '}
-            {t(`statusView.abandon.${intent === 'stop' ? 'stopCompact' : 'compact'}`)}
-          </>
-        ) : (
-          t(`statusView.abandon.${intent === 'stop' ? 'stopStart' : 'start'}`)
-        )}
+        {t('statusView.abandon.start')}
       </button>
     );
   }
 
   return (
-    <span className={`status-abandon-confirm${compact ? ' is-compact' : ''}`}>
-      {compact ? null : t(`statusView.abandon.${intent === 'stop' ? 'stopConfirm' : 'confirm'}`)}
+    <span className="status-abandon-confirm">
+      {t('statusView.abandon.confirm')}
       <button
         type="button"
-        className={compact ? 'studio-context-stop is-danger' : 'status-abandon is-danger'}
+        className="status-abandon is-danger"
         disabled={state === 'sending'}
         onClick={() => void abandon()}
       >
         {state === 'sending'
-          ? t(`statusView.abandon.${intent === 'stop' ? 'stopSending' : 'sending'}`)
-          : t(`statusView.abandon.${intent === 'stop' ? 'stopYes' : 'yes'}`)}
+          ? t('statusView.abandon.sending')
+          : t('statusView.abandon.yes')}
       </button>
       <button
         type="button"
-        className={compact ? 'studio-context-stop' : 'status-abandon'}
+        className="status-abandon"
         onClick={() => setArmed(false)}
       >
         {t('statusView.abandon.no')}

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -903,11 +903,6 @@
       "yes": "Yes, abandon it",
       "no": "Keep building",
       "sending": "Abandoning…",
-      "stopStart": "Stop build",
-      "stopCompact": "Stop",
-      "stopConfirm": "Stop this build? Work so far will be discarded.",
-      "stopYes": "Stop build",
-      "stopSending": "Stopping…",
       "error": "We couldn't abandon this build right now. Please try again in a moment."
     },
     "playableHint": "An early build, straight from the workshop — rough, unfinished, and already playable. Tell them what to change while it is easy."

--- a/apps/web/src/i18n/locales/pl.json
+++ b/apps/web/src/i18n/locales/pl.json
@@ -909,11 +909,6 @@
       "yes": "Tak, porzuć",
       "no": "Twórz dalej",
       "sending": "Porzucam…",
-      "stopStart": "Zatrzymaj budowę",
-      "stopCompact": "Zatrzymaj",
-      "stopConfirm": "Zatrzymać budowę? Dotychczasowa praca zostanie odrzucona.",
-      "stopYes": "Zatrzymaj budowę",
-      "stopSending": "Zatrzymuję…",
       "error": "Nie udało się teraz porzucić tego buildu. Spróbuj ponownie za chwilę."
     },
     "playableHint": "Wczesna wersja prosto z warsztatu — surowa, niedokończona i już grywalna. Powiedz, co zmienić, póki to łatwe."

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -6058,36 +6058,6 @@ a.user-name--profile:focus-visible {
   font-variant-numeric: tabular-nums;
 }
 
-/* Quiet stop control on the thread bar — same two-step abandon, sized for the row. */
-.studio-context-stop {
-  display: inline-flex;
-  align-items: center;
-  gap: 5px;
-  min-height: 32px;
-  padding: 4px 10px;
-  border: 1px solid var(--panel-border);
-  border-radius: 8px;
-  background: transparent;
-  color: var(--muted);
-  font-size: 0.78rem;
-  cursor: pointer;
-}
-
-.studio-context-stop:hover {
-  color: #f87171;
-  border-color: rgba(248, 113, 113, 0.4);
-}
-
-.studio-context-stop.is-danger {
-  color: #f87171;
-  border-color: rgba(248, 113, 113, 0.45);
-  font-weight: 600;
-}
-
-.status-abandon-confirm.is-compact {
-  gap: 6px;
-}
-
 .studio-thread-context .primary-btn {
   padding: 6px 14px;
   font-size: 0.82rem;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- remove the compact `Zatrzymaj` / `Stop` action from the active Studio build row
- simplify the remaining explicit abandon control and remove unused stop copy/styles
- keep the explicit two-step abandon action available in the Details/footer surfaces

## Verification
- `npm install`
- `npm run type-check && npm run lint && npm run test && npm run build` — passed

## Instrumentation
This removes a destructive UI action and adds no new user-facing behavior or telemetry event. Existing creator build and abandonment records remain unchanged.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-90dfa5b9-7f4c-474c-a493-e7955b30be63?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-90dfa5b9-7f4c-474c-a493-e7955b30be63&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

