### PR TITLE
docs: close audio-moderation deferral for curated generated effects

### DIFF
--- a/.claude/skills/game-asset-generation/SKILL.md
+++ b/.claude/skills/game-asset-generation/SKILL.md
@@ -21,8 +21,10 @@ Orientation for coding agents working on assets for `gamedev.pl` games.
 Games ship as a **single self-contained HTML document** rendered in a sandboxed iframe with
 `default-src 'none'` CSP and no network access. Graphics are **drawn procedurally in code**
 — there are no bitmap assets in any shipped game. Audio comes from a **shared, pre-rendered
-catalog** that every game selects from; games do not author their own audio. Both rules are
-enforced by `npm run validate` in the games repo, not left to taste.
+catalog** that every game selects from by default; sound effects are always shared-catalog
+only, and a game may ship a custom-scored optional per-game `music.json` beside `GAME.json`
+for its own tracker music. Both rules are enforced by `npm run validate` in the games repo,
+not left to taste.
 
 ## Hard rules
 
@@ -68,6 +70,14 @@ Two data-driven catalogs in the games repo, both rendered/validated by `tools/au
 - **`shared/audio/music.json`** — tracker-style looping tracks (`bpm`, `steps`, up to four
   channels). Data only, no WAV render. All moods together cost under 8 KB, which is why
   music is patterns rather than recordings.
+
+A game that needs a score the shared moods don't cover may ship its own optional
+`music.json` beside `GAME.json` (same `{ version, tracks }` shape). Assemble merges it onto
+the shared catalog; a per-game track name that collides with a shared id is refused. This
+applies to **music only** — sound effects always come from the shared `sounds.json` catalog,
+no per-game exception exists there. Prefer a shared mood when one fits; see
+`develop-game-audio` in the games repo and `byoca-mcp`'s "Custom music" section for the
+self-build-agent path.
 
 Reuse an existing semantic sound before adding a patch. Keep effects under a second, gains
 conservative. Select only the sounds a game uses, always include `ui-toggle`, and pick one

--- a/.claude/skills/game-asset-generation/SKILL.md
+++ b/.claude/skills/game-asset-generation/SKILL.md
@@ -1,110 +1,99 @@
 ---
 name: game-asset-generation
-description: Skill for coding agents to dynamically generate, style, and compose 2D game assets (sprites, audio, UI) tailored to any game specification.
+description: How game assets (sprites, audio, UI) are produced for gamedev.pl games — the procedural-drawing and shared-audio-catalog model, and the rules that constrain it. Use when planning or reviewing asset work for games in the games repo.
 ---
 
-# Game Asset Generation Skill
+# Game Asset Generation
 
-Guidance for coding agents (Claude Code, GitHub Copilot, Codex, Antigravity) generating HTML5 games for `gamedev.pl`.
+Orientation for coding agents working on assets for `gamedev.pl` games.
 
-Instead of hardcoding fixed workflows or static asset files, use this skill to dynamically analyze a game spec, determine required visual and audio assets, and synthesize them on-the-fly.
-
----
-
-## 🎨 Asset Generation Workflow
-
-When given a game spec (e.g., "A retro space shooter with laser beams and asteroid fields"):
-
-### 1. Identify Required Asset Categories
-
-Break down the spec into core game entities:
-
-- **Player Character**: Ship, hero, vehicle, or avatar.
-- **Enemies / Obstacles**: Asteroids, aliens, traps, falling rocks.
-- **Collectibles**: Coins, gems, power-ups, energy cells.
-- **Environment & Particles**: Starfield, parallax background, explosions, trails.
-- **Audio Sound Effects**: Action feedback (`shoot`, `collect`, `hit`, `explosion`).
-
-### 2. Choose the Optimal Asset Strategy
-
-| Requirement                       | Best Technique                 | Implementation                                              |
-| :-------------------------------- | :----------------------------- | :---------------------------------------------------------- |
-| **Pixel Art / Retro Sprites**     | Procedural Canvas Rendering    | Pre-render onto an offscreen canvas at boot.                |
-| **Vector / Smooth Graphics**      | SVG / Canvas Paths             | Render clean geometric paths with gradients & glows.        |
-| **Rich Textures / Illustrations** | `generate_image` Tool / AI Art | Generate raster images & embed as data URLs or local files. |
-| **Sound Effects**                 | Web Audio API Synthesizer      | Synthesize in-memory audio without network calls.           |
+> **The canonical, authoritative guidance lives in the games repo** (`www.gamedev.pl-games`),
+> not here: `.github/skills/develop-canvas-game`, `.github/skills/develop-scene3d-game`, and
+> `.github/skills/develop-game-audio`, plus `.github/copilot-instructions.md` and
+> `references/game-kit.md`. When this file and those disagree, **those win** — they sit next
+> to the validator that enforces them. Use this file to understand the model and its
+> constraints; use those to actually build.
 
 ---
 
-## 🖌️ Procedural Canvas Asset Pattern
+## The model in one paragraph
 
-When generating sprites via Canvas code, pre-render animation frames onto offscreen canvases at boot for 60fps performance:
+Games ship as a **single self-contained HTML document** rendered in a sandboxed iframe with
+`default-src 'none'` CSP and no network access. Graphics are **drawn procedurally in code**
+— there are no bitmap assets in any shipped game. Audio comes from a **shared, pre-rendered
+catalog** that every game selects from; games do not author their own audio. Both rules are
+enforced by `npm run validate` in the games repo, not left to taste.
 
-```javascript
-// Pre-render sprite frames in-memory
-function createShipSprite() {
-  const canvas = document.createElement('canvas');
-  canvas.width = 32;
-  canvas.height = 32;
-  const ctx = canvas.getContext('2d');
+## Hard rules
 
-  // Draw vibrant ship
-  ctx.fillStyle = '#29ADFF';
-  ctx.beginPath();
-  ctx.moveTo(16, 2);
-  ctx.lineTo(30, 28);
-  ctx.lineTo(16, 22);
-  ctx.lineTo(2, 28);
-  ctx.closePath();
-  ctx.fill();
+1. **No runtime network, ever.** No `fetch`, `XMLHttpRequest`, `<script src>`, `<link>`,
+   `@import`, remote fonts or images. Builds must work offline once assembled.
+2. **Never `ctx` / `getContext` / GLSL inside a game.** Canvas entry is always
+   `GameKit.createRenderer` (`gfx` module); you paint only through the returned `draw`
+   surface (`clear`, `rect`, `circle`, `text`, `with`, `panel`, `overlay`, `actor`). 3D goes
+   through `GameKit.createScene3dGame` (`gfx3d`). Enforced by validate Check 3 and
+   `npm run check:gfx`.
+3. **Never hand-roll `new AudioContext()` or oscillators in game code.** All audio goes
+   through the `audio` module (`GameKit.createAudio`). Enforced by validate Checks 9 and 17.
+4. **Byte budget is real.** 200 KiB author budget per game; platform ceiling and serve cap
+   are contract-locked across two repos. Assets are not free.
+5. **Reference art packs are study-only.** `references/packs/` (CC0 Kenney/itch material)
+   must never be shipped into a bundle or inlined as `data:image` — validate Checks 15/16.
 
-  ctx.fillStyle = '#FFA300';
-  ctx.fillRect(12, 22, 8, 8); // Thruster glow
+## Graphics: procedural, pre-rendered at boot
 
-  return canvas;
-}
+Draw sprites once into offscreen surfaces at boot rather than re-drawing per frame, then
+blit. Express the drawing through the `draw` surface — the renderer owns the canvas.
+
+Practical guidance that survives the rules:
+
+- **Harmonious palettes.** Cohesive schemes (PICO-8 16-colour, a tailored HSL ramp), never
+  raw primary red/green/blue.
+- **Fixed virtual resolution**, letterboxed via `object-fit: contain`; `image-rendering:
+  pixelated` for pixel-art looks.
+- **Screen juice.** Camera shake on impact, particle bursts on destruction, floating score
+  popups. This is where perceived asset quality actually comes from.
+- Study `references/visual-lineage.md` and keep `games/<slug>/VISUAL.md` current when
+  polishing visuals.
+
+## Audio: select from the shared catalog
+
+Two data-driven catalogs in the games repo, both rendered/validated by `tools/audio.ts`:
+
+- **`shared/audio/sounds.json`** — synth patches (`duration`, `voices[]` of
+  `sine`/`square`/`triangle`/`saw`/`noise` with `from`/`to`/`gain`/`attack`/`release`).
+  `npm run audio` renders these to `shared/audio/assets/*.wav`; `npm run audio:check`
+  **byte-compares** the committed WAVs against a fresh render and fails CI on drift, so
+  catalog edits and regenerated WAVs must be committed together.
+- **`shared/audio/music.json`** — tracker-style looping tracks (`bpm`, `steps`, up to four
+  channels). Data only, no WAV render. All moods together cost under 8 KB, which is why
+  music is patterns rather than recordings.
+
+Reuse an existing semantic sound before adding a patch. Keep effects under a second, gains
+conservative. Select only the sounds a game uses, always include `ui-toggle`, and pick one
+music track:
+
+```ts
+const audio = GameKit.createAudio({ volume: 0.7 });
+audio.playMusic();
+audio.play('coin');
 ```
 
----
+⚠️ **Adding a synth patch: append it at the end of `sounds.json`.** The renderer seeds its
+noise generator from each sound's *positional index*, so inserting an entry mid-catalog
+silently restales every later noise-using WAV.
 
-## 🎵 Web Audio Sound Effect Patterns
+See `develop-game-audio` in the games repo for sound-design guidance, the mood table, mute
+behaviour, and where to trigger cues.
 
-Always generate sound effects in-memory using the Web Audio API. Never require external `.wav`/`.mp3` downloads.
+## What this skill used to say, and why it changed
 
-```javascript
-const audioCtx = new (window.AudioContext || window.webkitAudioContext)();
+Earlier revisions told agents to call `getContext('2d')`, hand-roll `new AudioContext()`
+oscillators inside game code, avoid external `.wav`/`.mp3` entirely, and reach for a
+`generate_image` tool. All four were wrong: the first two are banned by the validator, the
+third misdescribes a platform that ships a pre-rendered WAV catalog, and no `generate_image`
+tool exists in any of the three repos.
 
-function playSound(type) {
-  if (audioCtx.state === 'suspended') audioCtx.resume();
-  const osc = audioCtx.createOscillator();
-  const gain = audioCtx.createGain();
-  osc.connect(gain);
-  gain.connect(audioCtx.destination);
-
-  const now = audioCtx.currentTime;
-
-  if (type === 'coin') {
-    osc.frequency.setValueAtTime(987, now);
-    osc.frequency.setValueAtTime(1318, now + 0.08);
-    gain.gain.setValueAtTime(0.3, now);
-    gain.gain.exponentialRampToValueAtTime(0.01, now + 0.2);
-    osc.start(now);
-    osc.stop(now + 0.2);
-  } else if (type === 'laser') {
-    osc.frequency.setValueAtTime(800, now);
-    osc.frequency.exponentialRampToValueAtTime(100, now + 0.15);
-    gain.gain.setValueAtTime(0.3, now);
-    gain.gain.exponentialRampToValueAtTime(0.01, now + 0.15);
-    osc.start(now);
-    osc.stop(now + 0.15);
-  }
-}
-```
-
----
-
-## 🌈 Design & Palette Rules
-
-1. **Use Harmonious Color Palettes**: Use cohesive palettes (e.g., PICO-8 16-color, Cyberpunk Neon, or HSL-tailored schemes). Avoid raw unstyled primary red/blue/green.
-2. **Resolution Letterboxing**: Use virtual fixed resolution (e.g. 800×600) scaled via CSS `object-fit: contain` and `image-rendering: pixelated`.
-3. **Screen Juice**: Add camera shake on impacts (`camera.shake()`), particle bursts on destruction, and floating score popups for satisfying player feedback.
+AI-generated audio is being planned as a **curated, build-time** addition to the shared
+catalog — never something a game fetches at runtime, and not something an agent generates
+on demand. Until that ships, the catalogs above are the whole audio story.

--- a/docs/content-safety-plan.md
+++ b/docs/content-safety-plan.md
@@ -130,8 +130,36 @@ classifier quality ever needs it.
 
 ## Explicitly NOT in the first slice
 
-- Image/audio moderation (games are canvas-drawn; revisit if generated assets appear).
+- Image moderation (games are canvas-drawn; revisit if generated images appear).
 - Appeals/queue UX — beta scale doesn't need it; rejection + rephrase is enough.
+
+### Audio moderation — revisited 2026-08-12, still not needed
+
+The deferral above said "revisit if generated assets appear." They have: vendor-generated
+sound effects are becoming a second audio asset class alongside the synthesized catalog.
+Revisited, and the answer is that **no automated audio moderation is warranted for this
+scope** — not because the risk is small, but because the pipeline has no opening for it:
+
+- **No creator input reaches the vendor.** Generation is owner-run from a machine holding
+  the API key, which is deliberately never a repository or Actions secret. There is no path
+  by which a creator prompt becomes a generation request, so the untrusted-text problem that
+  L1/L1b exist to solve does not arise here.
+- **Every clip is auditioned before it is committed.** The catalog is curated: generate
+  candidates, listen, keep one, commit it with a provenance record. Human review at commit
+  time is the control, and it is a stronger one than a classifier — a person hears what a
+  clip actually sounds like.
+- **Committed audio is fixed and hash-verified.** Assets are byte-pinned in the repo and
+  checked by SHA-256 in the gate. What shipped is what was reviewed; there is no
+  regeneration at build or run time that could drift away from the reviewed bytes.
+
+This closes the deferral for **curated, owner-generated effects only**. Two changes would
+reopen it, and neither is in scope today:
+
+1. **Creator-driven generation** — a creator prompt reaching a metered vendor puts untrusted
+   text in front of a generator, which needs the same treatment as L1/L1b give game prompts.
+2. **Speech** — narration or character voice carries impersonation and read-aloud-slur risk
+   that sound effects do not. Curated review still applies, but the risk profile is
+   different enough to deserve its own decision rather than inheriting this one.
 
 ## Rollout
 


### PR DESCRIPTION
## Summary
- Revisits `content-safety-plan.md`'s deferred "Image/audio moderation... revisit if generated assets appear" line now that vendor-generated sound effects are becoming a real second audio asset class (see the companion ops-repo audio initiative).
- Records the decision: no automated audio moderation is needed for curated, owner-generated effects — no creator prompt ever reaches the vendor, every clip is auditioned by ear before commit, and committed bytes are SHA-256 pinned, so human review at commit time is the actual control.
- Scopes the closure narrowly: creator-driven generation and speech/voice barks each reopen the question and are called out as needing their own decision later.
- Fixes a stale reference in `game-asset-generation` skill docs to match the games-repo contract.

## Test plan
- Docs-only change; no code paths affected.
- [ ] Skim the updated `content-safety-plan.md` section for accuracy against current pipeline behavior.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VJmJojkzqHwqDdNfgrL25X)_