### PR TITLE
fix(web): send the selected editor item to the game preview

### DIFF
--- a/apps/web/src/CodeSurface.tsx
+++ b/apps/web/src/CodeSurface.tsx
@@ -34,6 +34,7 @@ import { type CodeLanguage, tokenizeLine } from './codeTokens.js';
 import { declaredParamDefaultChanges, type DeclaredParamChange } from './editorJsonLiveDiff.js';
 import { PixelIcon } from './PixelIcon.js';
 import { fetchGameEditor, type EditorContentDoc, type EditorParamValue } from './studioApi.js';
+import type { EditorContentPush } from './editorBridge.js';
 import { recordCodeStep } from './visitTelemetry.js';
 
 /**
@@ -90,7 +91,7 @@ export type CodeSurfaceProps = {
   slug: string;
   onBack: () => void;
   /** Filled in by `StudioStage`; lets a live param edit reach the running game. */
-  editorPushRef?: MutableRefObject<((content: EditorContentDoc) => void) | null>;
+  editorPushRef?: MutableRefObject<EditorContentPush | null>;
 };
 
 const LOCKED_DIRS = ['shared/', 'tools/'] as const;
@@ -657,9 +658,7 @@ export function CodeSurface({ slug, onBack, editorPushRef }: CodeSurfaceProps) {
             title={t('studioPanel.code.agentRound')}
           >
             <span className="code-surface-readonly-banner-full">{t('studioPanel.code.agentRound')}</span>
-            <span className="code-surface-readonly-banner-compact">
-              {t('studioPanel.code.agentRoundCompact')}
-            </span>
+            <span className="code-surface-readonly-banner-compact">{t('studioPanel.code.agentRoundCompact')}</span>
           </span>
         ) : null}
       </header>
@@ -676,9 +675,7 @@ export function CodeSurface({ slug, onBack, editorPushRef }: CodeSurfaceProps) {
           onClick={() => setFilePickerOpen(true)}
         >
           <PixelIcon name="code" size={13} />
-          <span className="code-surface-file-trigger-path">
-            {file?.path ?? t('studioPanel.code.noFiles')}
-          </span>
+          <span className="code-surface-file-trigger-path">{file?.path ?? t('studioPanel.code.noFiles')}</span>
           <PixelIcon name="chevronDown" size={11} />
         </button>
       </div>

--- a/apps/web/src/CreatorStudioView.tsx
+++ b/apps/web/src/CreatorStudioView.tsx
@@ -56,8 +56,8 @@ import {
   type StudioScorecard,
   type StudioSuggestion,
   type AutonomyMode,
-  type EditorContentDoc,
 } from './studioApi.js';
+import type { EditorContentPush } from './editorBridge.js';
 
 /**
  * Creator control panel (docs/improvement-loop-plan.md IL-2 creator surface).
@@ -215,7 +215,7 @@ export function CreatorStudioView({
   }, [selected]);
   const [tab, setTab] = useState<StudioTab>(selectedTab ?? 'thread');
   // Lets the Code surface push a live param edit into the stage's frame (§E tier 1).
-  const editorPushRef = useRef<((content: EditorContentDoc) => void) | null>(null);
+  const editorPushRef = useRef<EditorContentPush | null>(null);
   const [shelfQuery, setShelfQuery] = useState('');
   const [shelfFilter, setShelfFilter] = useState<StudioShelfFilter>('all');
   /** Desktop rail expand, or mobile drawer open. Closed by default once a game is open. */

--- a/apps/web/src/EditorCollections.test.tsx
+++ b/apps/web/src/EditorCollections.test.tsx
@@ -26,6 +26,7 @@ vi.mock('./visitTelemetry.js', () => ({ recordAssistStep: vi.fn(), recordEditorS
 
 import { EditorPanel } from './EditorPanel.js';
 import { RemixPainter } from './RemixPainter.js';
+import type { EditorContentDoc } from './studioApi.js';
 
 const mapItem: EditorItemContent = { properties: { name: 'Map 1' }, rows: ['..', '..'] };
 const routeItem: EditorItemContent = { properties: { name: 'Route 1' }, rows: ['##', '##'] };
@@ -163,6 +164,61 @@ describe('multi-collection editor surfaces', () => {
       root!.render(<RemixPainter content={single} doc={{ maps: [mapItem] }} onChange={vi.fn()} />);
     });
     expect(container.querySelector('.editor-collection-selector')).toBeNull();
+  });
+});
+
+describe('selected collection item reaches the preview', () => {
+  const mapTwo: EditorItemContent = { properties: { name: 'Map 2' }, rows: ['##', '##'] };
+  const twoMaps = { maps: [mapItem, mapTwo], routes: [routeItem] };
+
+  it('studio item picks push the selected collection index without writing a draft', async () => {
+    fetchGameEditor.mockResolvedValue(editorState({ content: twoMaps }));
+    const push = vi.fn();
+    const editorPushRef = {
+      current: push as (content: EditorContentDoc, selection?: { collection: string; index: number }) => void,
+    };
+    root = createRoot(container);
+    await act(async () => {
+      root!.render(<EditorPanel game={game} editorPushRef={editorPushRef} onOpenPlaytest={vi.fn()} onBack={vi.fn()} />);
+      await Promise.resolve();
+    });
+    push.mockClear();
+
+    const items = container.querySelectorAll('.editor-item-list button');
+    const second = Array.from(items).find((button) => button.textContent === 'Map 2') as HTMLButtonElement;
+    expect(second).not.toBeUndefined();
+    await act(async () => {
+      second.click();
+    });
+
+    expect(push).toHaveBeenCalledWith(twoMaps, { collection: 'maps', index: 1 });
+    expect(putEditorDraft).not.toHaveBeenCalled();
+  });
+
+  it('remix painter reports the selected item when the player switches maps', async () => {
+    const onChange = vi.fn();
+    const onSelectionChange = vi.fn();
+    root = createRoot(container);
+    await act(async () => {
+      root!.render(
+        <RemixPainter
+          content={definition.content}
+          doc={twoMaps}
+          onChange={onChange}
+          onSelectionChange={onSelectionChange}
+        />,
+      );
+    });
+    expect(onSelectionChange).toHaveBeenLastCalledWith({ collection: 'maps', index: 0 });
+
+    const second = Array.from(container.querySelectorAll('.remix-painter-item')).find(
+      (button) => button.textContent === 'Map 2',
+    ) as HTMLButtonElement;
+    await act(async () => {
+      second.click();
+    });
+    expect(onSelectionChange).toHaveBeenLastCalledWith({ collection: 'maps', index: 1 });
+    expect(onChange).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/web/src/EditorCollections.test.tsx
+++ b/apps/web/src/EditorCollections.test.tsx
@@ -26,7 +26,7 @@ vi.mock('./visitTelemetry.js', () => ({ recordAssistStep: vi.fn(), recordEditorS
 
 import { EditorPanel } from './EditorPanel.js';
 import { RemixPainter } from './RemixPainter.js';
-import type { EditorContentDoc } from './studioApi.js';
+import type { EditorContentPush } from './editorBridge.js';
 
 const mapItem: EditorItemContent = { properties: { name: 'Map 1' }, rows: ['..', '..'] };
 const routeItem: EditorItemContent = { properties: { name: 'Route 1' }, rows: ['##', '##'] };
@@ -174,9 +174,7 @@ describe('selected collection item reaches the preview', () => {
   it('studio item picks push the selected collection index without writing a draft', async () => {
     fetchGameEditor.mockResolvedValue(editorState({ content: twoMaps }));
     const push = vi.fn();
-    const editorPushRef = {
-      current: push as (content: EditorContentDoc, selection?: { collection: string; index: number }) => void,
-    };
+    const editorPushRef = { current: push as EditorContentPush };
     root = createRoot(container);
     await act(async () => {
       root!.render(<EditorPanel game={game} editorPushRef={editorPushRef} onOpenPlaytest={vi.fn()} onBack={vi.fn()} />);

--- a/apps/web/src/EditorPanel.tsx
+++ b/apps/web/src/EditorPanel.tsx
@@ -10,6 +10,7 @@ import {
   setCell,
 } from './editorContentTools.js';
 import { recordAssistStep, recordEditorStep } from './visitTelemetry.js';
+import type { EditorContentPush, EditorSelection } from './editorBridge.js';
 import {
   deleteEditorDraft,
   fetchGameEditor,
@@ -111,14 +112,22 @@ function tilemapCollection(
 export function EditorPanel(props: {
   game: StudioGame;
   /** The stage's live-push channel (§E tier 1). */
-  editorPushRef?: MutableRefObject<((content: EditorContentDoc) => void) | null>;
+  editorPushRef?: MutableRefObject<EditorContentPush | null>;
   onOpenPlaytest: () => void;
   onBack: () => void;
 }) {
   const { t, i18n } = useTranslation();
   const name = useLabel();
   const slug = props.game.slug as string;
-  const pushLive = useCallback((next: EditorContentDoc) => props.editorPushRef?.current?.(next), [props.editorPushRef]);
+  const pushLive = useCallback(
+    (next: EditorContentDoc, selection?: EditorSelection | null) => {
+      const push = props.editorPushRef?.current;
+      if (!push) return;
+      if (selection) push(next, selection);
+      else push(next);
+    },
+    [props.editorPushRef],
+  );
 
   const [state, setState] = useState<'loading' | 'error' | 'ready'>('loading');
   const [editor, setEditor] = useState<GameEditorState | null>(null);
@@ -153,10 +162,10 @@ export function EditorPanel(props: {
         setEditor(loaded);
         const merged = mergeDraft(loaded);
         setContent(merged);
-        pushLive(merged);
+        const defaultKey = defaultCollectionKey(loaded.definition.content);
+        pushLive(merged, defaultKey ? { collection: defaultKey, index: 0 } : undefined);
         setRevision(loaded.draft?.revision ?? 0);
         setSaveState('clean');
-        const defaultKey = defaultCollectionKey(loaded.definition.content);
         setSelectedCollectionKey(defaultKey);
         setItemIndex(0);
         setTileKey(defaultKey ? firstTileKey(loaded.definition.content[defaultKey]) : null);
@@ -237,7 +246,7 @@ export function EditorPanel(props: {
       const list = itemsOf(current, collectionKey).slice();
       list[itemIndex] = next;
       const nextContent = { ...current, [collectionKey]: list };
-      pushLive(nextContent);
+      pushLive(nextContent, { collection: collectionKey, index: itemIndex });
       return nextContent;
     });
     scheduleSave();
@@ -331,9 +340,9 @@ export function EditorPanel(props: {
       setEditor(loaded);
       const merged = mergeDraft(loaded);
       setContent(merged);
-      pushLive(merged);
-      setRevision(loaded.draft?.revision ?? 0);
       const defaultKey = defaultCollectionKey(loaded.definition.content);
+      pushLive(merged, defaultKey ? { collection: defaultKey, index: 0 } : undefined);
+      setRevision(loaded.draft?.revision ?? 0);
       setSelectedCollectionKey(defaultKey);
       setItemIndex(0);
       setTileKey(defaultKey ? firstTileKey(loaded.definition.content[defaultKey]) : null);
@@ -349,6 +358,7 @@ export function EditorPanel(props: {
     setSelectedCollectionKey(nextKey);
     setItemIndex(0);
     setTileKey(firstTileKey(nextSpec));
+    pushLive(content, { collection: nextKey, index: 0 });
   }
 
   async function discardDraft() {
@@ -357,7 +367,8 @@ export function EditorPanel(props: {
       if (!mountedRef.current) return;
       if (editor) {
         setContent(editor.content);
-        pushLive(editor.content);
+        const defaultKey = defaultCollectionKey(editor.definition.content);
+        pushLive(editor.content, defaultKey ? { collection: defaultKey, index: 0 } : undefined);
         setRevision(0);
         setItemIndex(0);
         setSaveState('clean');
@@ -711,7 +722,11 @@ export function EditorPanel(props: {
                     <button
                       type="button"
                       className={index === itemIndex ? 'is-active' : ''}
-                      onClick={() => setItemIndex(index)}
+                      onClick={() => {
+                        if (index === itemIndex) return;
+                        setItemIndex(index);
+                        pushLive(content, { collection: collectionKey, index });
+                      }}
                     >
                       {typeof entry.properties.name === 'string' && entry.properties.name
                         ? entry.properties.name
@@ -723,15 +738,17 @@ export function EditorPanel(props: {
                         className="editor-item-remove"
                         aria-label={t('studioPanel.editor.removeItem')}
                         onClick={() => {
+                          const nextIndex = Math.max(
+                            0,
+                            itemIndex > index ? itemIndex - 1 : Math.min(itemIndex, items.length - 2),
+                          );
                           setContent((current) => {
                             const list = itemsOf(current, collectionKey).filter((_, i) => i !== index);
                             const nextContent = { ...current, [collectionKey]: list };
-                            pushLive(nextContent);
+                            pushLive(nextContent, { collection: collectionKey, index: nextIndex });
                             return nextContent;
                           });
-                          setItemIndex((current) =>
-                            Math.max(0, current > index ? current - 1 : Math.min(current, items.length - 2)),
-                          );
+                          setItemIndex(nextIndex);
                           scheduleSave();
                         }}
                       >
@@ -746,15 +763,16 @@ export function EditorPanel(props: {
                   type="button"
                   className="editor-add"
                   onClick={() => {
+                    const nextIndex = items.length;
                     setContent((current) => {
                       const nextContent = {
                         ...current,
                         [collectionKey]: [...itemsOf(current, collectionKey), blankItem(spec.item)],
                       };
-                      pushLive(nextContent);
+                      pushLive(nextContent, { collection: collectionKey, index: nextIndex });
                       return nextContent;
                     });
-                    setItemIndex(items.length);
+                    setItemIndex(nextIndex);
                     scheduleSave();
                   }}
                 >

--- a/apps/web/src/RemixPainter.tsx
+++ b/apps/web/src/RemixPainter.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
   blankItem,
@@ -15,6 +15,7 @@ import type {
   EditorLabel,
   EditorTilemapSpec,
 } from './studioApi.js';
+import type { EditorSelection } from './editorBridge.js';
 
 /** Narrows a collection to its tilemap spec — entities render no board. */
 function tilemapCollection(
@@ -47,6 +48,7 @@ export function RemixPainter(props: {
   onChange: (next: EditorContentDoc) => void;
   selectedCollectionKey?: string | null;
   onCollectionChange?: (key: string) => void;
+  onSelectionChange?: (selection: EditorSelection) => void;
 }) {
   const { t, i18n } = useTranslation();
   const name = (label: EditorLabel) => (i18n.language?.startsWith('pl') ? label.pl : label.en);
@@ -73,6 +75,13 @@ export function RemixPainter(props: {
 
   const item = items[Math.min(itemIndex, Math.max(0, items.length - 1))] ?? null;
   const activeIndex = Math.min(itemIndex, Math.max(0, items.length - 1));
+  const onSelectionChangeRef = useRef(props.onSelectionChange);
+  onSelectionChangeRef.current = props.onSelectionChange;
+
+  useEffect(() => {
+    if (!collectionKey) return;
+    onSelectionChangeRef.current?.({ collection: collectionKey, index: activeIndex });
+  }, [collectionKey, activeIndex]);
 
   if (!spec || !collectionKey) return null;
   const activeCollectionKey = collectionKey;

--- a/apps/web/src/RemixPanel.test.tsx
+++ b/apps/web/src/RemixPanel.test.tsx
@@ -518,9 +518,13 @@ describe('RemixPanel', () => {
     });
     await send('bigger dog');
 
-    const pushed = postMessage.mock.calls.at(-1)?.[0] as { content: Record<string, unknown> };
+    const pushed = postMessage.mock.calls.at(-1)?.[0] as {
+      content: Record<string, unknown>;
+      selection?: { collection: string; index: number };
+    };
     expect(pushed.content.params).toEqual({ dogScale: 2 });
     expect(pushed.content.maps).toEqual([{ properties: {}, rows: ['...', '...', '...'] }]);
+    expect(pushed.selection).toEqual({ collection: 'maps', index: 0 });
   });
 
   it('flushes a stroke still on the debounce when the sheet closes', async () => {

--- a/apps/web/src/RemixPanel.tsx
+++ b/apps/web/src/RemixPanel.tsx
@@ -9,7 +9,7 @@ import {
 } from 'react';
 import { useTranslation } from 'react-i18next';
 import { PixelIcon } from './PixelIcon.js';
-import { BRIDGE_NAMESPACE, PROTOCOL_VERSION } from './mp/protocol.js';
+import { editorContentMessage, type EditorSelection } from './editorBridge.js';
 import { recordRemixStep } from './visitTelemetry.js';
 import { useAuth } from './AuthContext.js';
 import { AuthModal } from './AuthModal.js';
@@ -329,6 +329,8 @@ export function RemixPanel(props: {
   const contentDocRef = useRef(contentDoc);
   contentDocRef.current = contentDoc;
   const [selectedCollectionKey, setSelectedCollectionKey] = useState<string | null>(null);
+  const [selectedItemIndex, setSelectedItemIndex] = useState(0);
+  const selectionRef = useRef<EditorSelection | null>(null);
   const [painterOpen, setPainterOpen] = useState(false);
   /** After the stage has opened once, Done leaves a door back on the sheet. */
   const [painterSeen, setPainterSeen] = useState(false);
@@ -373,7 +375,7 @@ export function RemixPanel(props: {
     (next: Record<string, EditorParamValue>, contentOverride?: EditorContentDoc) => {
       const collections = contentOverride ?? contentDocRef.current;
       props.frameRef.current?.contentWindow?.postMessage(
-        { ns: BRIDGE_NAMESPACE, v: PROTOCOL_VERSION, t: 'editor:content', content: { ...collections, params: next } },
+        editorContentMessage({ ...collections, params: next }, selectionRef.current),
         '*',
       );
     },
@@ -508,7 +510,10 @@ export function RemixPanel(props: {
           : {};
         contentDocRef.current = contentDefaults;
         setContentDoc(contentDefaults);
-        setSelectedCollectionKey(started.content ? defaultCollectionKey(started.content) : null);
+        const defaultKey = started.content ? defaultCollectionKey(started.content) : null;
+        setSelectedCollectionKey(defaultKey);
+        selectionRef.current = defaultKey ? { collection: defaultKey, index: 0 } : null;
+        setSelectedItemIndex(0);
         onCapabilities?.({ painter: Boolean(started.content) });
         // A shared link's values are live the moment the game is listening.
         if (props.initialParams) window.setTimeout(() => pushToGame(merged), 300);
@@ -792,6 +797,15 @@ export function RemixPanel(props: {
       text: t('remix.changeStanding'),
       canShare: hasShareableValues(session?.params ?? null, next),
     });
+  }
+
+  function rememberSelection(selection: EditorSelection) {
+    const previous = selectionRef.current;
+    selectionRef.current = selection;
+    setSelectedCollectionKey(selection.collection);
+    setSelectedItemIndex(selection.index);
+    if (previous?.collection === selection.collection && previous?.index === selection.index) return;
+    pushToGame(valuesRef.current);
   }
 
   /** The player painted — update the doc, tell the funnel, and land it after the stroke. */
@@ -1309,8 +1323,11 @@ export function RemixPanel(props: {
   if (painterStageActive && session?.content) {
     const collectionKey = activeCollectionKey;
     const items = collectionKey ? ((contentDoc[collectionKey] as EditorItemContent[] | undefined) ?? []) : [];
+    const selectedItem = items[selectedItemIndex] ?? items[0];
     const levelName =
-      typeof items[0]?.properties.name === 'string' && items[0].properties.name ? items[0].properties.name : null;
+      typeof selectedItem?.properties.name === 'string' && selectedItem.properties.name
+        ? selectedItem.properties.name
+        : null;
 
     return (
       <>
@@ -1380,6 +1397,7 @@ export function RemixPanel(props: {
               onChange={paintContent}
               selectedCollectionKey={activeCollectionKey}
               onCollectionChange={setSelectedCollectionKey}
+              onSelectionChange={rememberSelection}
             />
             {editorFocus === 'play' ? <span className="remix-editor-pip-cta">{t('remix.editorFocusEdit')}</span> : null}
           </div>

--- a/apps/web/src/StudioStage.tsx
+++ b/apps/web/src/StudioStage.tsx
@@ -5,7 +5,7 @@ import { useCreatorPlaytest, useGamePlayer, postGameHostMessage, type PlaytestIn
 import { useEditorDraftBridge, type EditorContentPush } from './editorBridge.js';
 import { PixelIcon } from './PixelIcon.js';
 import { submitFeedback, type FeedbackContext, type SubmissionApiError } from './submissionApi.js';
-import { submitImprovement, type EditorContentDoc } from './studioApi.js';
+import { submitImprovement } from './studioApi.js';
 import type { StageOrigin, StageSource } from './useStageSource.js';
 
 /**

--- a/apps/web/src/StudioStage.tsx
+++ b/apps/web/src/StudioStage.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useRef, useState, type MutableRefObject } from 
 import { useTranslation } from 'react-i18next';
 import { GameFrame } from './GameFrame.js';
 import { useCreatorPlaytest, useGamePlayer, postGameHostMessage, type PlaytestInstrumentation } from './gamePlayer.js';
-import { useEditorDraftBridge } from './editorBridge.js';
+import { useEditorDraftBridge, type EditorContentPush } from './editorBridge.js';
 import { PixelIcon } from './PixelIcon.js';
 import { submitFeedback, type FeedbackContext, type SubmissionApiError } from './submissionApi.js';
 import { submitImprovement, type EditorContentDoc } from './studioApi.js';
@@ -78,7 +78,7 @@ export type StudioStageProps = {
    * document on screen, not the one waiting in the wings. */
   onDisplayedOriginChange?: (origin: StageOrigin) => void;
   /** Filled in with the editor bridge's live-push function, for the Code surface (§E tier 1). */
-  editorPushRef?: MutableRefObject<((content: EditorContentDoc) => void) | null>;
+  editorPushRef?: MutableRefObject<EditorContentPush | null>;
 };
 
 export function StudioStage({

--- a/apps/web/src/editorBridge.test.ts
+++ b/apps/web/src/editorBridge.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+import { editorContentMessage } from './editorBridge.js';
+
+describe('editor content bridge payload', () => {
+  it('omits selection when the shell has not named an item', () => {
+    expect(editorContentMessage({ params: { width: 1 } })).toEqual({
+      ns: 'gdp',
+      v: 1,
+      t: 'editor:content',
+      content: { params: { width: 1 } },
+    });
+  });
+
+  it('names the selected collection item so the preview can open it', () => {
+    expect(editorContentMessage({ maps: [] }, { collection: 'maps', index: 15 })).toEqual({
+      ns: 'gdp',
+      v: 1,
+      t: 'editor:content',
+      content: { maps: [] },
+      selection: { collection: 'maps', index: 15 },
+    });
+  });
+});

--- a/apps/web/src/editorBridge.ts
+++ b/apps/web/src/editorBridge.ts
@@ -2,11 +2,7 @@ import { useCallback, useEffect, useRef, type MutableRefObject } from 'react';
 import { BRIDGE_NAMESPACE, PROTOCOL_VERSION } from './mp/protocol.js';
 import { fetchGameEditor, type EditorContentDoc } from './studioApi.js';
 
-/**
- * The collection item the painter is showing. Optional on the wire so
- * params-only and single-item games keep working; campaign games use it to
- * open the preview on that item instead of always restarting at index 0.
- */
+// Collection item the painter is showing.
 export type EditorSelection = {
   collection: string;
   index: number;
@@ -44,8 +40,6 @@ export function editorContentMessage(content: EditorContentDoc, selection?: Edit
  * edits): posts straight to the frame regardless of the `active` gate, since
  * the stage stays mounted under every posture. Also updates what the next
  * `editor:hello` gets answered with, so a later restart cannot regress it.
- * A later content-only push (Code surface params) keeps the last selection so
- * a slider does not kick the preview back to item 0.
  */
 export function useEditorDraftBridge(
   frameRef: MutableRefObject<HTMLIFrameElement | null>,

--- a/apps/web/src/editorBridge.ts
+++ b/apps/web/src/editorBridge.ts
@@ -3,6 +3,28 @@ import { BRIDGE_NAMESPACE, PROTOCOL_VERSION } from './mp/protocol.js';
 import { fetchGameEditor, type EditorContentDoc } from './studioApi.js';
 
 /**
+ * The collection item the painter is showing. Optional on the wire so
+ * params-only and single-item games keep working; campaign games use it to
+ * open the preview on that item instead of always restarting at index 0.
+ */
+export type EditorSelection = {
+  collection: string;
+  index: number;
+};
+
+export type EditorContentPush = (content: EditorContentDoc, selection?: EditorSelection | null) => void;
+
+export function editorContentMessage(content: EditorContentDoc, selection?: EditorSelection | null) {
+  return {
+    ns: BRIDGE_NAMESPACE,
+    v: PROTOCOL_VERSION,
+    t: 'editor:content' as const,
+    content,
+    ...(selection ? { selection } : {}),
+  };
+}
+
+/**
  * The shell half of EditorKit's draft hot-apply (the game half is the games
  * repo's `shared/modules/editor.ts`).
  *
@@ -22,15 +44,23 @@ import { fetchGameEditor, type EditorContentDoc } from './studioApi.js';
  * edits): posts straight to the frame regardless of the `active` gate, since
  * the stage stays mounted under every posture. Also updates what the next
  * `editor:hello` gets answered with, so a later restart cannot regress it.
+ * A later content-only push (Code surface params) keeps the last selection so
+ * a slider does not kick the preview back to item 0.
  */
 export function useEditorDraftBridge(
   frameRef: MutableRefObject<HTMLIFrameElement | null>,
   active: boolean,
   slug: string | undefined,
   editable: boolean,
-): { push: (content: EditorContentDoc) => void } {
+): { push: EditorContentPush } {
   /** What the next `editor:hello` gets answered with. */
   const lastContentRef = useRef<EditorContentDoc | null>(null);
+  const lastSelectionRef = useRef<EditorSelection | null>(null);
+
+  useEffect(() => {
+    lastContentRef.current = null;
+    lastSelectionRef.current = null;
+  }, [slug]);
 
   useEffect(() => {
     if (!active || !slug || !editable) return;
@@ -46,6 +76,10 @@ export function useEditorDraftBridge(
       return draftPromise;
     }
 
+    function post(content: EditorContentDoc, selection: EditorSelection | null) {
+      frameRef.current?.contentWindow?.postMessage(editorContentMessage(content, selection), '*');
+    }
+
     function onMessage(event: MessageEvent) {
       // Opaque-origin frame: origin is "null" and the source must be our iframe.
       if (event.origin !== 'null') return;
@@ -57,19 +91,13 @@ export function useEditorDraftBridge(
 
       // A push already sent fresher content than the fetch would — that wins.
       if (lastContentRef.current !== null) {
-        frameRef.current?.contentWindow?.postMessage(
-          { ns: BRIDGE_NAMESPACE, v: PROTOCOL_VERSION, t: 'editor:content', content: lastContentRef.current },
-          '*',
-        );
+        post(lastContentRef.current, lastSelectionRef.current);
         return;
       }
       void loadDraft().then((content) => {
         if (disposed || content === null) return;
         lastContentRef.current = content;
-        frameRef.current?.contentWindow?.postMessage(
-          { ns: BRIDGE_NAMESPACE, v: PROTOCOL_VERSION, t: 'editor:content', content },
-          '*',
-        );
+        post(content, lastSelectionRef.current);
       });
     }
 
@@ -80,13 +108,11 @@ export function useEditorDraftBridge(
     };
   }, [frameRef, active, slug, editable]);
 
-  const push = useCallback(
-    (content: EditorContentDoc) => {
+  const push = useCallback<EditorContentPush>(
+    (content, selection) => {
       lastContentRef.current = content;
-      frameRef.current?.contentWindow?.postMessage(
-        { ns: BRIDGE_NAMESPACE, v: PROTOCOL_VERSION, t: 'editor:content', content },
-        '*',
-      );
+      if (selection !== undefined) lastSelectionRef.current = selection;
+      frameRef.current?.contentWindow?.postMessage(editorContentMessage(content, lastSelectionRef.current), '*');
     },
     [frameRef],
   );


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Paired with the games-repo fix for [gamedevpl/www.gamedev.pl-games#711](https://github.com/gamedevpl/www.gamedev.pl-games/issues/711).

Studio and remix painters already highlighted the chosen collection item, but `editor:content` only pushed the document. Campaign games such as March of Mites therefore restarted the playtest at item 0.

## What changed

- The shell now sends `selection: { collection, index }` on `editor:content`.
- Switching items in EditorPanel / RemixPainter pushes that context immediately, without waiting for a paint.
- A content-only push (Code-surface params, a slider) keeps the last selection so tuning does not reset the preview.
- `editor:hello` replies with the last selection as well as the last draft.

Depends on the games-repo protocol change (`createEditor.selection` / `selectedIndex`). Safe to merge either order: old games ignore the extra field; old Studio simply does not send it.

Games PR: https://github.com/gamedevpl/www.gamedev.pl-games/pull/712

## Checklist

- [x] Include selection on the editor content bridge
- [x] Studio item picks update the live preview
- [x] Remix painter reports the selected item
- [x] Type-check, lint, test, and build
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-02eb1bb7-8dab-443e-b7f8-d4508c81686e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-02eb1bb7-8dab-443e-b7f8-d4508c81686e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

