### PR TITLE
Upgrade default Gemini model from 3.6-flash to 3.7-flash

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -73,7 +73,7 @@
 # read token, which a laptop has neither of. Seeding always fails open — when anything
 # here is missing or broken the build dispatches unseeded, exactly as it did before.
 # SEED_DISPATCH=true
-# SEED_MODEL=gemini-3.6-flash  # flash is the measured choice; pro tier was worse and slower
+# SEED_MODEL=gemini-3.7-flash  # flash is the measured choice; pro tier was worse and slower
 # SEED_REFERENCES=3            # reference games in context; 5 cost more for the same result
 # SEED_PICK_TIMEOUT_MS=30000
 # SEED_GENERATE_TIMEOUT_MS=180000

--- a/apps/api/scripts/managed-probe.ts
+++ b/apps/api/scripts/managed-probe.ts
@@ -185,7 +185,7 @@ const model =
     : vendor === 'copilot'
       ? 'claude-sonnet-4.6'
       : vendor === 'gemini'
-        ? 'gemini-3.6-flash'
+        ? 'gemini-3.7-flash'
         : undefined);
 if (vendor && (!apiKey || !model)) {
   console.error(`--vendor ${vendor} needs an API key and model`);

--- a/apps/api/src/agent-backend-env.test.ts
+++ b/apps/api/src/agent-backend-env.test.ts
@@ -135,7 +135,7 @@ describe('createAgentBackendRegistryFromEnv', () => {
 
     expect(registry.platform?.name).toBe('managed:gemini');
     expect(info).toHaveBeenCalledWith(
-      expect.objectContaining({ vendor: 'gemini', model: 'gemini-3.6-flash' }),
+      expect.objectContaining({ vendor: 'gemini', model: 'gemini-3.7-flash' }),
       'managed agent dispatch enabled',
     );
   });

--- a/apps/api/src/chat-agent.ts
+++ b/apps/api/src/chat-agent.ts
@@ -7,7 +7,7 @@ import type { JobStall } from './job-state.js';
 
 // decide() throws on any failure; callers must fail open.
 
-export const DEFAULT_CHAT_MODEL = 'gemini-3.6-flash';
+export const DEFAULT_CHAT_MODEL = 'gemini-3.7-flash';
 // Live Vertex ran slower than the API key it was tuned on.
 export const DEFAULT_CHAT_TIMEOUT_MS = 8000;
 // Enough for genre/premise, not a spec dump.

--- a/apps/api/src/code-lane.ts
+++ b/apps/api/src/code-lane.ts
@@ -40,7 +40,7 @@ import { formatRemixTurns } from './remix-turns.js';
  * compile. No agent, no tools, no credentials in a runtime.
  */
 
-export const DEFAULT_CODE_MODEL = 'gemini-3.6-flash';
+export const DEFAULT_CODE_MODEL = 'gemini-3.7-flash';
 export const DEFAULT_PICK_TIMEOUT_MS = 8000;
 export const DEFAULT_EDIT_TIMEOUT_MS = 20000;
 /** Rounds of "here is the compiler error, try again" before giving up. */

--- a/apps/api/src/editor-assist.ts
+++ b/apps/api/src/editor-assist.ts
@@ -35,7 +35,7 @@ import { formatRemixTurns } from './remix-turns.js';
 export const ASSIST_LANES = ['params', 'content', 'code', 'reject'] as const;
 export type AssistLane = (typeof ASSIST_LANES)[number];
 
-export const DEFAULT_ASSIST_MODEL = 'gemini-3.6-flash';
+export const DEFAULT_ASSIST_MODEL = 'gemini-3.7-flash';
 export const DEFAULT_ASSIST_TIMEOUT_MS = 8000;
 /** Utterances are one-liners; a wall of text is a prompt-injection vehicle, not a tweak. */
 export const MAX_UTTERANCE_LENGTH = 240;

--- a/apps/api/src/feedback-themes.ts
+++ b/apps/api/src/feedback-themes.ts
@@ -175,7 +175,7 @@ export class VertexThemeExtractor implements ThemeExtractor {
         region: this.options.region,
         defaultRegion: 'global',
         model: this.options.model,
-        defaultModel: 'gemini-3.6-flash',
+        defaultModel: 'gemini-3.7-flash',
         generationConfig: {
           responseMimeType: 'application/json',
           thinkingConfig: { thinkingLevel: this.thinkingLevel.toUpperCase() },

--- a/apps/api/src/game-seed.test.ts
+++ b/apps/api/src/game-seed.test.ts
@@ -297,7 +297,7 @@ function stubClient(responses: { text: string; inputTokens?: number; outputToken
       signal: () => chain,
       run: async () => ({
         parts: [{ type: 'text' as const, text: response.text }],
-        model: 'gemini-3.6-flash',
+        model: 'gemini-3.7-flash',
         usage: { inputTokens: response.inputTokens ?? 100, outputTokens: response.outputTokens ?? 50 },
       }),
     };
@@ -318,7 +318,7 @@ function stubClientWithPrompts(responses: { text: string }[]) {
       signal: () => chain,
       run: async () => ({
         parts: [{ type: 'text' as const, text: response.text }],
-        model: 'gemini-3.6-flash',
+        model: 'gemini-3.7-flash',
         usage: { inputTokens: 100, outputTokens: 50 },
       }),
     };
@@ -397,14 +397,11 @@ describe('VertexGameSeeder', () => {
     expect(draft!.typeChecked).toBe(false);
     expect(draft!.typeErrors).toBe(0);
     // Both calls are billed to the job, not just the expensive one.
-    expect(draft!.usage).toEqual({ inputTokens: 30_400, outputTokens: 8_010, model: 'gemini-3.6-flash' });
+    expect(draft!.usage).toEqual({ inputTokens: 30_400, outputTokens: 8_010, model: 'gemini-3.7-flash' });
   });
 
   it('combines bundle and GameKit validation errors into one repair round', async () => {
-    const bundleVerdicts = [
-      { ok: false as const, errors: ['bundle: missing game/render.ts'] },
-      { ok: true as const },
-    ];
+    const bundleVerdicts = [{ ok: false as const, errors: ['bundle: missing game/render.ts'] }, { ok: true as const }];
     const typeCheckVerdicts = [
       { ok: false as const, errors: ['game.ts:1: error TS2339: draw.flash'] },
       { ok: true as const },
@@ -585,7 +582,12 @@ describe('VertexGameSeeder', () => {
     expect(draft!.files.some((file) => file.path.includes('shared'))).toBe(false);
   });
 
-  const ENV_KEYS = ['SEED_REFERENCES', 'SEED_PICK_TIMEOUT_MS', 'SEED_GENERATE_TIMEOUT_MS', 'SEED_TYPECHECK_TIMEOUT_MS'] as const;
+  const ENV_KEYS = [
+    'SEED_REFERENCES',
+    'SEED_PICK_TIMEOUT_MS',
+    'SEED_GENERATE_TIMEOUT_MS',
+    'SEED_TYPECHECK_TIMEOUT_MS',
+  ] as const;
   const saved: Record<string, string | undefined> = {};
 
   beforeEach(() => {
@@ -686,7 +688,7 @@ describe('knowledge context injection (KQ-11)', () => {
         signal: () => chain,
         run: async () => ({
           parts: [{ type: 'text' as const, text: response.text }],
-          model: 'gemini-3.6-flash',
+          model: 'gemini-3.7-flash',
           usage: { inputTokens: 100, outputTokens: 50 },
         }),
       };

--- a/apps/api/src/game-seed.ts
+++ b/apps/api/src/game-seed.ts
@@ -82,7 +82,7 @@ export const DEFAULT_SEED_GENERATE_TIMEOUT_MS = 180_000;
 export const DEFAULT_SEED_TYPECHECK_TIMEOUT_MS = TYPECHECK_PREFLIGHT_BUDGET_MS;
 
 /** Same model family as the rest of our Vertex call sites; flash is the measured choice. */
-const DEFAULT_SEED_MODEL = 'gemini-3.6-flash';
+const DEFAULT_SEED_MODEL = 'gemini-3.7-flash';
 
 /** Bound the untrusted spec the same way the dispatch prompt does. */
 const MAX_SPEC_CHARS = 8000;
@@ -514,10 +514,7 @@ export class VertexGameSeeder implements GameSeeder {
     }
   }
 
-  private typeCheck(
-    files: SeedFile[],
-    kitDeclaration: string | null,
-  ): { verdict: TypeCheckResult; checked: boolean } {
+  private typeCheck(files: SeedFile[], kitDeclaration: string | null): { verdict: TypeCheckResult; checked: boolean } {
     if (!kitDeclaration) return { verdict: { ok: true }, checked: false };
 
     const startedAt = Date.now();
@@ -630,9 +627,7 @@ export class VertexGameSeeder implements GameSeeder {
         }
         checks = await checkDraft(files);
       }
-      const typeErrors = checks.typeCheckResult.verdict.ok
-        ? 0
-        : checks.typeCheckResult.verdict.errors.length;
+      const typeErrors = checks.typeCheckResult.verdict.ok ? 0 : checks.typeCheckResult.verdict.errors.length;
 
       const draft: SeedDraft = {
         slug,

--- a/apps/api/src/managed-provider-gemini.ts
+++ b/apps/api/src/managed-provider-gemini.ts
@@ -12,7 +12,7 @@ import {
 
 export const GEMINI_VENDOR = 'gemini';
 export const GEMINI_DEFAULT_AGENT = 'antigravity-preview-05-2026';
-export const GEMINI_DEFAULT_MODEL = 'gemini-3.6-flash';
+export const GEMINI_DEFAULT_MODEL = 'gemini-3.7-flash';
 
 const DEFAULT_BASE_URL = 'https://generativelanguage.googleapis.com/v1beta';
 const DEFAULT_TIMEOUT_MS = 30_000;

--- a/apps/api/src/moderation.ts
+++ b/apps/api/src/moderation.ts
@@ -162,7 +162,7 @@ export class VertexChecker implements ContentChecker {
         region: this.options.region,
         defaultRegion: 'global',
         model: this.options.model,
-        defaultModel: 'gemini-3.6-flash',
+        defaultModel: 'gemini-3.7-flash',
         generationConfig: {
           responseMimeType: 'application/json',
           // Gemini 3 defaults to dynamic ("high") thinking; force it low for this

--- a/apps/api/src/refine.ts
+++ b/apps/api/src/refine.ts
@@ -160,7 +160,7 @@ export class VertexSpecRefiner implements SpecRefiner {
         region: this.options.region,
         defaultRegion: 'global',
         model: this.options.model,
-        defaultModel: 'gemini-3.6-flash',
+        defaultModel: 'gemini-3.7-flash',
         // Thinking off: the prompt asks for a fixed JSON shape, not reasoning, and
         // the latency it adds is what pushed this call past its abort budget in
         // production. Moderation keeps its own config — this one is refine-only.
@@ -180,7 +180,7 @@ export class VertexSpecRefiner implements SpecRefiner {
         region: this.options.region,
         defaultRegion: 'global',
         model: this.options.model,
-        defaultModel: 'gemini-3.6-flash',
+        defaultModel: 'gemini-3.7-flash',
       });
     return this.groundingClient;
   }

--- a/apps/api/src/store.ts
+++ b/apps/api/src/store.ts
@@ -443,7 +443,7 @@ export interface JobCostEntry {
   at: string;
   /**
    * Who charged for it: an agent backend (`copilot`), a service (`cloud-build`), or —
-   * for a `seed` entry — the model id that billed the tokens (`gemini-3.6-flash`).
+   * for a `seed` entry — the model id that billed the tokens (`gemini-3.7-flash`).
    * A model id here is a well-formed entry, not corrupt data.
    */
   by: string;

--- a/apps/api/src/submissions.test.ts
+++ b/apps/api/src/submissions.test.ts
@@ -1128,7 +1128,10 @@ describe('submission routes', () => {
       payload: { title: 'A game', concept: 'A sufficiently long concept about delivering parcels in space.' },
     });
     const [job] = await store.listSubmissionsByOwner('g:test-user');
-    await store.appendCreatorMessage(job.issueNumber, 'The first draft had the right controls; keep them in the revision.');
+    await store.appendCreatorMessage(
+      job.issueNumber,
+      'The first draft had the right controls; keep them in the revision.',
+    );
     await store.setSubmissionDeliveredVersion(job.issueNumber, 'v20260731T153306124Z');
     await store.recordJobTransition(job.issueNumber, {
       to: 'ready_for_review',
@@ -3617,7 +3620,7 @@ describe('the Studio mini chat agent (feedback route)', () => {
       kind: 'reply' as const,
       text: 'Still building.',
       tokens: { input: 500, output: 40 },
-      model: 'gemini-3.6-flash',
+      model: 'gemini-3.7-flash',
     }));
     const { app, authHeaders, store } = await createApp({
       githubClient: createGithubClientStub({ issueNumber: 90 }).githubClient,
@@ -3643,7 +3646,7 @@ describe('the Studio mini chat agent (feedback route)', () => {
 
     const record = await store.getSubmission(job.issueNumber);
     const entry = record?.costs?.find((cost) => cost.kind === 'chat');
-    expect(entry).toMatchObject({ by: 'gemini-3.6-flash', tokens: { input: 500, output: 40 } });
+    expect(entry).toMatchObject({ by: 'gemini-3.7-flash', tokens: { input: 500, output: 40 } });
     await app.close();
   });
 
@@ -5719,7 +5722,7 @@ describe('seeded dispatch', () => {
           slug,
           files: [{ path: 'game.ts', content: 'export {};\n' }],
           references: ['apex-sprint'],
-          usage: { inputTokens: 30_000, outputTokens: 9_000, model: 'gemini-3.6-flash' },
+          usage: { inputTokens: 30_000, outputTokens: 9_000, model: 'gemini-3.7-flash' },
           elapsedMs: 41_000,
           compiles: false,
           repaired: false,
@@ -5770,7 +5773,7 @@ describe('seeded dispatch', () => {
     // premium request with no numbers behind it.
     const seedCost = record?.costs?.find((entry) => entry.kind === 'seed');
     expect(seedCost?.tokens).toEqual({ input: 30_000, output: 9_000 });
-    expect(seedCost?.by).toBe('gemini-3.6-flash');
+    expect(seedCost?.by).toBe('gemini-3.7-flash');
 
     await app.close();
   });
@@ -6009,7 +6012,7 @@ describe('seeded dispatch', () => {
             slug,
             files: [{ path: 'game.ts', content: 'export {};\n' }],
             references: ['apex-sprint'],
-            usage: { inputTokens: 30_000, outputTokens: 9_000, model: 'gemini-3.6-flash' },
+            usage: { inputTokens: 30_000, outputTokens: 9_000, model: 'gemini-3.7-flash' },
             elapsedMs: 156_000,
             compiles: false,
             repaired: true,

--- a/apps/api/src/translate.ts
+++ b/apps/api/src/translate.ts
@@ -63,11 +63,7 @@ export interface Translator {
    * Returns null when nothing could be produced. Callers must then store the source text
    * unchanged and must not retry — see localize-intake.ts.
    */
-  toBilingual(
-    text: string,
-    targetLocale: string,
-    opts?: { kind?: TranslationKind },
-  ): Promise<BilingualText | null>;
+  toBilingual(text: string, targetLocale: string, opts?: { kind?: TranslationKind }): Promise<BilingualText | null>;
 }
 
 /** Language tag → the language name we ask the model for. */
@@ -192,7 +188,7 @@ export class VertexTranslator implements Translator {
         // Prefer the translate-specific model env, then fall through to the shared
         // VERTEX_MODEL / defaultModel inside createVertexClient.
         model: this.options.model ?? process.env.VERTEX_TRANSLATE_MODEL,
-        defaultModel: 'gemini-3.6-flash',
+        defaultModel: 'gemini-3.7-flash',
         generationConfig: {
           responseMimeType: 'application/json',
           // Thinking off: short string translation does not benefit from reasoning,
@@ -261,7 +257,6 @@ export class VertexTranslator implements Translator {
       return null;
     }
   }
-
 }
 
 /**

--- a/docs/managed-agent-backend.md
+++ b/docs/managed-agent-backend.md
@@ -405,7 +405,7 @@ npm run managed:probe -w @gamedevpl/api -- --vendor gemini --mcp --wait \
   --wait-seconds 120 --budget-tokens 50000
 ```
 
-`--vendor gemini` defaults to `gemini-3.6-flash`; `GEMINI_API_KEY` or
+`--vendor gemini` defaults to `gemini-3.7-flash`; `GEMINI_API_KEY` or
 `MANAGED_AGENT_API_KEY` supplies the credential and `--model` overrides the model label.
 The provider records native interaction usage and does not attempt to pull files from the
 session.


### PR DESCRIPTION
## Summary
Updates all default Gemini model references across the codebase from `gemini-3.6-flash` to `gemini-3.7-flash`. This is a straightforward model version upgrade that affects all Vertex AI client configurations.

## Key Changes
- Updated `DEFAULT_SEED_MODEL` in `game-seed.ts` from `gemini-3.6-flash` to `gemini-3.7-flash`
- Updated `DEFAULT_CHAT_MODEL` in `chat-agent.ts` to use the new model version
- Updated `DEFAULT_CODE_MODEL` in `code-lane.ts` to use the new model version
- Updated `DEFAULT_ASSIST_MODEL` in `editor-assist.ts` to use the new model version
- Updated default models in `translate.ts`, `refine.ts`, `feedback-themes.ts`, and `moderation.ts`
- Updated `GEMINI_DEFAULT_MODEL` in `managed-provider-gemini.ts`
- Updated all test fixtures and mock client stubs to expect the new model version
- Updated environment variable examples in `.env.example` and documentation
- Updated managed probe script to use the new model version
- Minor code formatting improvements (line wrapping for consistency)

## Implementation Details
- All changes are configuration-only; no functional logic modifications
- Test expectations updated to match the new model identifier
- Documentation and comments updated to reflect the new default
- The model upgrade is applied consistently across all Vertex AI client instantiations (seeding, chat, code assistance, translation, refinement, theme extraction, and content moderation)

https://claude.ai/code/session_017L1zycLMSxfF8WXdgcSQC8