### PR TITLE
fix(web): remove duplicate analyzing status

### DIFF
--- a/apps/web/src/HeroPromptSection.test.tsx
+++ b/apps/web/src/HeroPromptSection.test.tsx
@@ -167,7 +167,8 @@ describe('HeroPromptSection', () => {
     expect(container.querySelector('.build-btn.is-busy')).not.toBeNull();
     expect(container.querySelector('.build-btn-spinner')).not.toBeNull();
     expect(container.querySelector('.prompt-busy-status')?.textContent).toMatch(/Analyzing your idea/i);
-    expect(container.querySelector('.creation-card.is-busy .creation-sub')?.textContent).toMatch(
+    expect(container.querySelector('.creation-card.is-busy .creation-sub')?.textContent).toMatch(/Become the creator/i);
+    expect(container.querySelector('.creation-card.is-busy .creation-sub')?.textContent).not.toMatch(
       /Analyzing your idea/i,
     );
     expect(container.querySelector<HTMLInputElement>('.big-prompt-input')?.disabled).toBe(true);

--- a/apps/web/src/HeroPromptSection.tsx
+++ b/apps/web/src/HeroPromptSection.tsx
@@ -522,7 +522,7 @@ export function HeroPromptSection({
                 <span className="smart-badge creation-badge">
                   <PixelIcon name="sparkle" size={14} /> {t('hero.smartNoMatchTitle', { query: promptText.trim() })}
                 </span>
-                <p className="creation-sub">{busyLabel ?? t('hero.smartNoMatchSub')}</p>
+                <p className="creation-sub">{t('hero.smartNoMatchSub')}</p>
               </div>
             </div>
           )}


### PR DESCRIPTION
## What changed

Remove the duplicate “Analyzing your idea” message from the no-match creation card.

## Why

The dedicated busy status already reports the refiner state. Reusing that label in the no-match card rendered the same status twice during analysis.

## Validation

- `npm run type-check` passed
- `npm run lint` passed
- `npm run build` passed
- `npm run test -w @gamedevpl/web -- src/HeroPromptSection.test.tsx` passed (8 tests)
- Added a regression assertion that the card keeps its normal explanatory copy while analysis is in flight

The full workspace test run also encountered unrelated sandbox socket restrictions and existing timeout failures.