### PR TITLE
Change spec refiner error handling from fail-open to fail-closed

### DIFF
--- a/apps/api/src/refine.test.ts
+++ b/apps/api/src/refine.test.ts
@@ -98,7 +98,7 @@ describe('POST /api/submissions/refine', () => {
     expect(res.json().error).toBe('content_rejected');
   });
 
-  it('fails open (returns 200 with empty questions) when refiner throws an error', async () => {
+  it('fails closed (returns 502) when refiner throws an error', async () => {
     const store = new InMemoryStore();
     await store.upsertUser({ uid: 'g:test-user' });
     const throwingRefiner = {
@@ -120,11 +120,11 @@ describe('POST /api/submissions/refine', () => {
       headers: { cookie: `${SESSION_COOKIE_NAME}=${token}` },
       payload: {
         title: 'Clean Game',
-        concept: 'A completely clean game concept that should fail open if LLM fails',
+        concept: 'A completely clean game concept that should surface an error if the LLM fails',
       },
     });
-    expect(res.statusCode).toBe(200);
-    expect(res.json()).toEqual({ questions: [] });
+    expect(res.statusCode).toBe(502);
+    expect(res.json()).toEqual({ error: 'refine_unavailable' });
     await testApp.close();
   });
 
@@ -178,12 +178,12 @@ describe('POST /api/submissions/refine', () => {
     await testApp.close();
   });
 
-  it('never caches a fail-open, so one slow call cannot pin an empty panel', async () => {
+  it('never caches a totally empty answer, so one flaky call cannot pin an empty panel', async () => {
     const store = new InMemoryStore();
     await store.upsertUser({ uid: 'g:test-user' });
     let call = 0;
     const flakyRefiner = {
-      // First call times out into the fail-open empty answer; the second succeeds.
+      // First call comes back with nothing usable; the second succeeds.
       refine: async () => {
         call += 1;
         return call === 1
@@ -289,9 +289,10 @@ describe('VertexSpecRefiner over a genaicode client', () => {
     expect(result.questions).toEqual([{ id: 'q_0', question: '', options: [], allowFreeText: false, multiple: false }]);
   });
 
-  it('fails open when the call outruns its abort budget', async () => {
+  it('fails closed when the call outruns its abort budget', async () => {
     // The production failure mode this guards: the model answers, just not within
-    // the budget, so the request aborts and the creator silently gets no questions.
+    // the budget, so the request aborts — and now that must surface as an error
+    // rather than a silent "no questions".
     const refiner = makeRefiner({
       timeoutMs: 20,
       client: genaicode({
@@ -303,7 +304,7 @@ describe('VertexSpecRefiner over a genaicode client', () => {
       }),
     });
 
-    expect(await refiner.refine({ title: 'Game', concept: 'Concept' })).toEqual({ questions: [] });
+    await expect(refiner.refine({ title: 'Game', concept: 'Concept' })).rejects.toThrow();
   });
 
   it('budgets far more time than the one-token moderation call', () => {
@@ -312,10 +313,10 @@ describe('VertexSpecRefiner over a genaicode client', () => {
     expect(DEFAULT_REFINE_TIMEOUT_MS).toBeGreaterThanOrEqual(15_000);
   });
 
-  it('fails open on a malformed or non-conforming response', async () => {
+  it('fails closed on a malformed or non-conforming response', async () => {
     for (const body of ['not json at all', '', '{"questions": "nope"}']) {
       const refiner = makeRefiner({ client: stubClient(body) });
-      expect(await refiner.refine({ title: 'Game', concept: 'Concept' })).toEqual({ questions: [] });
+      await expect(refiner.refine({ title: 'Game', concept: 'Concept' })).rejects.toThrow();
     }
   });
 

--- a/apps/api/src/refine.ts
+++ b/apps/api/src/refine.ts
@@ -39,9 +39,7 @@ export interface RefineResponse {
    * mid-word — and that string became the title everywhere: the studio, the catalog, the
    * agent's brief. The model is already reading the concept to write its questions, so
    * naming it costs nothing extra; the creator confirms or replaces it before anything
-   * is built. Absent only when the model itself declines to propose one — a failed
-   * call throws instead of returning a response, so this is never absent because of
-   * an outage.
+   * is built. Absent only when the model itself declines — a failed call throws.
    */
   suggestedTitle?: string;
 }
@@ -285,12 +283,7 @@ ${params.concept}
         })),
       };
     } catch (err) {
-      // Fail-closed: a fail-open here is indistinguishable from "concept is already
-      // fully specified" (both are a 200 with empty questions and no title), which is
-      // exactly how a dead model and then a too-short timeout each survived unnoticed
-      // in production before (see the comments above). Surface the failure to the
-      // route instead so the creator sees an error and can retry, rather than being
-      // silently walked past the questions step with a locally-truncated title.
+      // Fail-closed: an error must not look like a clean, already-specified concept.
       if (process.env.NODE_ENV !== 'test') {
         // The budget is printed because an AbortError alone doesn't say what it
         // was measured against, and that budget is now env-tunable.
@@ -389,11 +382,8 @@ export async function registerRefineRoute(app: FastifyInstance, options: RefineR
   };
 
   const writeCache = (key: string, result: RefineResponse, now: number) => {
-    // A failed call now throws rather than reaching here, but a totally empty
-    // response (no questions, no title) is still not worth pinning for ten minutes —
-    // it is indistinguishable from the model producing nothing usable. A title with
-    // no questions is not that: it is a fully-specified concept the model still
-    // named, so emptiness is only disqualifying when it is total.
+    // A totally empty response is not worth pinning for ten minutes. A title with
+    // no questions is a fully-specified concept, so that alone is still cached.
     if (result.questions.length === 0 && !result.suggestedTitle) return;
     if (refineCache.size >= REFINE_CACHE_MAX_ENTRIES) {
       const oldest = refineCache.keys().next().value;

--- a/apps/api/src/refine.ts
+++ b/apps/api/src/refine.ts
@@ -39,7 +39,9 @@ export interface RefineResponse {
    * mid-word — and that string became the title everywhere: the studio, the catalog, the
    * agent's brief. The model is already reading the concept to write its questions, so
    * naming it costs nothing extra; the creator confirms or replaces it before anything
-   * is built. Absent when the model declines or the call fails open.
+   * is built. Absent only when the model itself declines to propose one — a failed
+   * call throws instead of returning a response, so this is never absent because of
+   * an outage.
    */
   suggestedTitle?: string;
 }
@@ -283,13 +285,18 @@ ${params.concept}
         })),
       };
     } catch (err) {
-      // Fail-open per spec: timeout/error degrades silently to empty questions
+      // Fail-closed: a fail-open here is indistinguishable from "concept is already
+      // fully specified" (both are a 200 with empty questions and no title), which is
+      // exactly how a dead model and then a too-short timeout each survived unnoticed
+      // in production before (see the comments above). Surface the failure to the
+      // route instead so the creator sees an error and can retry, rather than being
+      // silently walked past the questions step with a locally-truncated title.
       if (process.env.NODE_ENV !== 'test') {
         // The budget is printed because an AbortError alone doesn't say what it
         // was measured against, and that budget is now env-tunable.
-        console.warn(`Vertex AI spec refinement failed/timed out (budget ${this.timeoutMs}ms), failing open:`, err);
+        console.warn(`Vertex AI spec refinement failed/timed out (budget ${this.timeoutMs}ms):`, err);
       }
-      return { questions: [] };
+      throw err;
     }
   }
 }
@@ -382,10 +389,11 @@ export async function registerRefineRoute(app: FastifyInstance, options: RefineR
   };
 
   const writeCache = (key: string, result: RefineResponse, now: number) => {
-    // Never cache a fail-open: an empty answer is exactly what a timeout produces,
-    // and pinning that for ten minutes would turn one slow call into a dead panel.
-    // A title with no questions is not that — it is a fully-specified concept that the
-    // model still named — so emptiness is only disqualifying when it is total.
+    // A failed call now throws rather than reaching here, but a totally empty
+    // response (no questions, no title) is still not worth pinning for ten minutes —
+    // it is indistinguishable from the model producing nothing usable. A title with
+    // no questions is not that: it is a fully-specified concept the model still
+    // named, so emptiness is only disqualifying when it is total.
     if (result.questions.length === 0 && !result.suggestedTitle) return;
     if (refineCache.size >= REFINE_CACHE_MAX_ENTRIES) {
       const oldest = refineCache.keys().next().value;
@@ -445,7 +453,8 @@ export async function registerRefineRoute(app: FastifyInstance, options: RefineR
       }
     }
 
-    // 4. Call spec refiner (fail-open)
+    // 4. Call spec refiner (fail-closed: an outage is reported as an error, not
+    // disguised as a zero-question "already fully specified" success — see refine()).
     const startedAt = Date.now();
     try {
       const result = await specRefiner.refine({
@@ -453,11 +462,6 @@ export async function registerRefineRoute(app: FastifyInstance, options: RefineR
         concept: parseResult.data.concept,
         locale: normalizeLocale(parseResult.data.locale),
       });
-      // Fail-open makes an outage look exactly like a fully-specified concept: both
-      // are zero questions and a 200. Without this line there is no way to tell them
-      // apart in logs, which is how a dead model and then a too-short timeout each
-      // survived unnoticed in production. A zero here with a refiner warning
-      // alongside it is a failure; a zero on its own is a clean spec.
       request.log.info(
         { questionCount: result.questions.length, durationMs: Date.now() - startedAt, cached: false },
         'spec refine complete',
@@ -466,9 +470,9 @@ export async function registerRefineRoute(app: FastifyInstance, options: RefineR
       return result;
     } catch (err) {
       if (process.env.NODE_ENV !== 'test') {
-        request.log.warn({ err }, 'Spec refiner failed, failing open with empty questions');
+        request.log.warn({ err }, 'Spec refiner failed');
       }
-      return { questions: [] };
+      return reply.status(502).send({ error: 'refine_unavailable' });
     }
   });
 }

--- a/apps/web/src/App.qa.test.ts
+++ b/apps/web/src/App.qa.test.ts
@@ -286,7 +286,7 @@ describe('the QA gate in App', () => {
     await act(async () => root.unmount());
   });
 
-  it('still asks for a name when the refiner is down, falling back to one from the prompt', async () => {
+  it('fails closed and does not open the naming wizard when the refiner is down', async () => {
     (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
     await i18n.changeLanguage('en');
     const submitted: Array<{ title: string; concept: string }> = [];
@@ -295,13 +295,11 @@ describe('the QA gate in App', () => {
     const { container, root } = await renderApp();
     await submitIdea(container);
 
-    // Failing open must not mean skipping the step — that is how truncated prompts
-    // became titles in the first place. The suggestion degrades; the gate does not.
+    // An outage must not look like a clean, already-specified concept: no silent
+    // truncated-prompt title, no wizard, just a retry-able error.
     expect(submitted).toHaveLength(0);
-    const name = inWizard<HTMLInputElement>('.qa-name-input');
-    expect(name?.value).toBe('A survival game on a desert island with');
-    // No questions came back, so there are no question stages to walk.
-    expect(stageCount()).toBe(3);
+    expect(inWizard('.qa-wizard')).toBeNull();
+    expect(container.querySelector('.error')?.textContent).toMatch(/couldn't analyze your idea/i);
 
     await act(async () => root.unmount());
   });

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -554,7 +554,9 @@ export function App() {
 
   // The generation gate: before spending a submission we run the spec refiner. If it
   // returns clarifying questions, generation pauses on the QA panel until they're
-  // answered; a clean spec (or a refiner error — fail-open) submits straight through.
+  // answered; a clean spec submits straight through. A refiner error stops here too
+  // (fail-closed) rather than silently falling through to a truncated title — see
+  // the catch block below.
   async function handleSubmitSpec(concept: string, displayName: string = '') {
     if (!user) {
       // The wall between "wrote an idea" and "made an account". Everything before this
@@ -583,9 +585,13 @@ export function App() {
       questions = refined.questions;
       suggestedTitle = refined.suggestedTitle;
     } catch {
-      // Fail-open: a refiner outage must never block creation. It does not skip the
-      // naming step either — that would put us back to games named by truncation —
-      // so the confirm panel opens on a title derived from the prompt instead.
+      // Fail-closed: a refiner outage used to be invisible — silently falling through
+      // to a name derived from truncating the prompt, indistinguishable from a
+      // successful "concept is already clear" response. Stop here and let the
+      // creator retry instead.
+      setSubmissionError(t('errors.refineFailed'));
+      setSubmissionStatus('idle');
+      return;
     }
 
     if (questions.length > 0) recordCreateStep('qa_shown');

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -554,9 +554,7 @@ export function App() {
 
   // The generation gate: before spending a submission we run the spec refiner. If it
   // returns clarifying questions, generation pauses on the QA panel until they're
-  // answered; a clean spec submits straight through. A refiner error stops here too
-  // (fail-closed) rather than silently falling through to a truncated title — see
-  // the catch block below.
+  // answered; a clean spec submits straight through. A refiner error stops here too.
   async function handleSubmitSpec(concept: string, displayName: string = '') {
     if (!user) {
       // The wall between "wrote an idea" and "made an account". Everything before this
@@ -578,17 +576,15 @@ export function App() {
     setSubmissionStatus('refining');
     setSubmissionError(null);
 
-    let questions: QAQuestion[] = [];
+    let questions: QAQuestion[];
     let suggestedTitle: string | undefined;
     try {
       const refined = await refineSpec({ concept: trimmedConcept, locale: i18n.language });
       questions = refined.questions;
       suggestedTitle = refined.suggestedTitle;
     } catch {
-      // Fail-closed: a refiner outage used to be invisible — silently falling through
-      // to a name derived from truncating the prompt, indistinguishable from a
-      // successful "concept is already clear" response. Stop here and let the
-      // creator retry instead.
+      // Fail-closed: stop here and let the creator retry, rather than falling
+      // through to a truncated title as if refinement had succeeded.
       setSubmissionError(t('errors.refineFailed'));
       setSubmissionStatus('idle');
       return;

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -984,6 +984,7 @@
     "creationOverCapacity": "We've hit today's ceiling on new games across the whole site, so we can't start another one right now. Your own allowance is untouched and still there tomorrow.",
     "nameUnavailable": "That name was taken while we were setting your game up. Give it a different one and try again.",
     "conceptTooShort": "We don't have enough to go on yet — tell us a bit more about the game (at least {{minLength}} characters): what you do, how you win or lose, what it looks like.",
+    "refineFailed": "We couldn't analyze your idea just now — our AI assistant is having trouble. Please try again in a moment.",
     "contentRejected": {
       "profanity": "That includes language we can't publish. Please rephrase and try again.",
       "adult": "That describes adult content, which we can't generate. Please rephrase and try again.",

--- a/apps/web/src/i18n/locales/pl.json
+++ b/apps/web/src/i18n/locales/pl.json
@@ -994,6 +994,7 @@
     "creationOverCapacity": "Osiągnęliśmy dzisiejszy limit nowych gier w całym serwisie, więc nie możemy teraz zacząć kolejnej. Twój własny limit jest nietknięty i będzie czekał jutro.",
     "nameUnavailable": "Ta nazwa została zajęta, gdy przygotowywaliśmy Twoją grę. Nadaj inną i spróbuj ponownie.",
     "conceptTooShort": "To za mało, żebyśmy wiedzieli, co budować — opisz grę trochę szerzej (co najmniej {{minLength}} znaków): co się w niej robi, jak się wygrywa lub przegrywa, jak wygląda.",
+    "refineFailed": "Nie udało się teraz przeanalizować Twojego pomysłu — nasz asystent AI ma chwilowy problem. Spróbuj ponownie za moment.",
     "contentRejected": {
       "profanity": "To zawiera słownictwo, którego nie możemy opublikować. Popraw treść i spróbuj ponownie.",
       "adult": "To opisuje treści dla dorosłych, których nie możemy wygenerować. Popraw treść i spróbuj ponownie.",


### PR DESCRIPTION
## Summary
This PR changes the spec refiner error handling strategy from "fail-open" (silently returning empty questions on errors) to "fail-closed" (surfacing errors to the user). This prevents outages and timeouts from being indistinguishable from successfully refined specs, which previously allowed issues to go unnoticed in production.

## Key Changes

- **API error handling**: Modified `VertexSpecRefiner.refine()` to throw errors instead of returning empty questions, and updated the route handler to return a 502 error response rather than silently succeeding
- **Route response**: Changed `/api/submissions/refine` to return `{ error: 'refine_unavailable' }` with status 502 when the refiner fails, instead of `{ questions: [] }` with status 200
- **Frontend error handling**: Updated `App.tsx` to catch refiner errors and display an error message to the user, stopping the submission flow instead of silently falling through with a truncated title
- **Documentation**: Updated comments throughout to explain why fail-closed is necessary — a fail-open response is indistinguishable from a successfully refined but already-clear concept, making it impossible to detect when the model is down or timing out
- **Localization**: Added new error message `refineFailed` in English and Polish locales
- **Tests**: Updated test cases to expect 502 errors and thrown exceptions instead of 200 responses with empty questions

## Notable Details

The core issue being fixed: when the refiner timed out or failed, it would return empty questions (fail-open), which looks identical to a successful response where the concept was already fully specified. This made production outages invisible — creators would silently get no clarifying questions and a title derived from truncation instead of AI suggestion. By failing closed, errors are now visible and creators can retry.

https://claude.ai/code/session_012vNgvQ17ZYK6hRhJ3UMhug