### PR TITLE
Improve MCP channel: preview delivery warning, multi-patch, and inbox ack

### DIFF
--- a/.claude/skills/byoca-mcp/SKILL.md
+++ b/.claude/skills/byoca-mcp/SKILL.md
@@ -34,7 +34,8 @@ Source of truth: `SESSION_WORKFLOW` + `BEHAVIOURAL_CONTRACT` in
      `curl --upload-file <file> "$url"` — bytes never re-enter the model
    - **New/full rewrite without shell:** `stage_source_file({ path, content })`
    - **Edits:** prefer `patch_source_file({ path, old, new })` (exact unique substring
-     replace — no diff format). Or `patch_source_file({ path, patch })` with a unified
+     replace — no diff format), or `patch_source_file({ path, patches: [{ old, new }, ...] })`
+     for multiple sequential replacements in one call. Or `patch_source_file({ path, patch })` with a unified
      diff (`---` / `+++` + `@@` hunks; bare `@@` ok). Do not re-emit whole `render.ts` /
      `model.ts` files through `stage_source_file`
    - **Modules:** soft budget ~350 lines / ~12 KiB per `game/*.ts`. Honour
@@ -556,7 +557,7 @@ still be iterating locally and clear it with its next channel write. Feedback ro
 distinguish the submit marker from an explicit `end` (or a confirmed terminal vendor state)
 before superseding a platform session. The API records this as `agentEndedBy: submit | end`.
 
-### `end({ summary })` is the only channel for a closing answer
+### `end({ summary, ackInboxIds })` is the only channel for a closing answer
 
 The platform reads tool calls, never the agent's transcript. An agent that answers
 the creator in ordinary assistant prose — "this is an arcade game", "nothing needed
@@ -566,6 +567,9 @@ model.
 
 - `end` takes optional `summary` (≤300 chars), plus `summaryLocalized` + `locale`
   on the same zero-cost pair contract as `report_progress`
+- `end` also accepts optional `ackInboxIds` (array of message IDs) to acknowledge
+  handled creator inbox messages concurrently when closing the round, saving an
+  extra turn calling `ack_inbox`
 - Stored as a `BuildEvent` with `kind: 'done'` — the same feed Studio already
   renders, so nothing new was needed on the web side
 - Reply carries `summaryShown: true` when it landed. Best-effort by design: a

--- a/.claude/skills/byoca-mcp/SKILL.md
+++ b/.claude/skills/byoca-mcp/SKILL.md
@@ -35,7 +35,10 @@ Source of truth: `SESSION_WORKFLOW` + `BEHAVIOURAL_CONTRACT` in
    - **New/full rewrite without shell:** `stage_source_file({ path, content })`
    - **Edits:** prefer `patch_source_file({ path, old, new })` (exact unique substring
      replace — no diff format), or `patch_source_file({ path, patches: [{ old, new }, ...] })`
-     for multiple sequential replacements in one call. Or `patch_source_file({ path, patch })` with a unified
+     for multiple sequential replacements in one file, or
+     `patch_source_file({ files: [{ path, old, new }, { path, patches: [{ old, new }] }] })`
+     to edit several files in one call (applies every file in memory first; one miss
+     leaves the buffer unchanged). Or `patch_source_file({ path, patch })` with a unified
      diff (`---` / `+++` + `@@` hunks; bare `@@` ok). Do not re-emit whole `render.ts` /
      `model.ts` files through `stage_source_file`
    - **Modules:** soft budget ~350 lines / ~12 KiB per `game/*.ts`. Honour

--- a/.claude/skills/byoca-mcp/SKILL.md
+++ b/.claude/skills/byoca-mcp/SKILL.md
@@ -37,8 +37,9 @@ Source of truth: `SESSION_WORKFLOW` + `BEHAVIOURAL_CONTRACT` in
      replace — no diff format), or `patch_source_file({ path, patches: [{ old, new }, ...] })`
      for multiple sequential replacements in one file, or
      `patch_source_file({ files: [{ path, old, new }, { path, patches: [{ old, new }] }] })`
-     to edit several files in one call (applies every file in memory first; one miss
-     leaves the buffer unchanged). Or `patch_source_file({ path, patch })` with a unified
+     to edit several files in one call. Edits that apply are kept even if later ones
+     miss — retry only `failed[]` (path + index); do not resend ones that landed.
+     Or `patch_source_file({ path, patch })` with a unified
      diff (`---` / `+++` + `@@` hunks; bare `@@` ok). Do not re-emit whole `render.ts` /
      `model.ts` files through `stage_source_file`
    - **Modules:** soft budget ~350 lines / ~12 KiB per `game/*.ts`. Honour
@@ -653,6 +654,7 @@ Merged by `applySessionNudges` / submit handler. Act, then continue:
 | `inbox_pending`         | `read_inbox` → apply → `ack_inbox`                                                                                                                                         |
 | `seed_unread`           | Call `get_seed` before scaffolding from the kit                                                                                                                            |
 | `game_manifest_invalid` | Just-staged/patched `GAME.json` has a shape that crashes the gate before typecheck (e.g. missing `engine.modules`) — fix it now, in the same session, before submitting    |
+| `patch_incomplete`      | Some `patch_source_file` edits landed and some did not — retry only `failed[]` (path + index); do not resend the ones that applied                                         |
 
 ## Builder handoff (Studio)
 

--- a/apps/api/src/agent-channel.test.ts
+++ b/apps/api/src/agent-channel.test.ts
@@ -627,9 +627,10 @@ describe('agent build channel', () => {
     });
   });
 
-  it('drops the summary when the round is already stopped, like a progress report', async () => {
+  it('drops the summary and does not ack the inbox when the round is already stopped', async () => {
     const store = new InMemoryStore();
     await seedSubmission(store);
+    const msg = await store.appendCreatorMessage(ISSUE, 'please make the ship faster');
     await store.setSubmissionAbandoned(ISSUE, new Date().toISOString());
     app = await createApp(store);
 
@@ -637,11 +638,76 @@ describe('agent build channel', () => {
       method: 'POST',
       url: '/api/agent/build/end',
       headers: agentHeaders(),
-      payload: { summary: 'One last word the creator did not ask for.' },
+      payload: { summary: 'One last word the creator did not ask for.', ackInboxIds: [msg.id] },
     });
 
     expect(end.json()).toMatchObject({ accepted: false, rejected: 'stopped' });
     expect(await store.listBuildEvents(ISSUE)).toHaveLength(0);
+    expect(await store.listPendingCreatorMessages(ISSUE)).toHaveLength(1);
+  });
+
+  it('acknowledges inbox messages on a successful end call', async () => {
+    const store = new InMemoryStore();
+    await seedSubmission(store);
+    const msg1 = await store.appendCreatorMessage(ISSUE, 'feedback 1');
+    const msg2 = await store.appendCreatorMessage(ISSUE, 'feedback 2');
+    app = await createApp(store);
+
+    const end = await app.inject({
+      method: 'POST',
+      url: '/api/agent/build/end',
+      headers: agentHeaders(),
+      payload: { summary: 'Addressed feedback.', ackInboxIds: [msg1.id] },
+    });
+
+    expect(end.json()).toMatchObject({ accepted: true, ended: true });
+    const pending = await store.listPendingCreatorMessages(ISSUE);
+    expect(pending).toHaveLength(1);
+    expect(pending[0]?.id).toBe(msg2.id);
+  });
+
+  it('acknowledges inbox messages on builder handoff ack', async () => {
+    const store = new InMemoryStore();
+    await seedSubmission(store);
+    const msg = await store.appendCreatorMessage(ISSUE, 'feedback');
+    await store.requestBuilderHandoff(ISSUE, 'self', new Date().toISOString());
+    app = await createApp(store, {
+      onBuilderHandoffAcknowledged: async ({ issueNumber, acknowledgedAt }) => {
+        const handoff = await store.acknowledgeBuilderHandoff(issueNumber, acknowledgedAt);
+        await store.clearBuilderHandoff(issueNumber);
+        return { started: handoff !== null };
+      },
+    });
+
+    const end = await app.inject({
+      method: 'POST',
+      url: '/api/agent/build/end',
+      headers: agentHeaders(),
+      payload: { summary: 'Handing over.', ackInboxIds: [msg.id] },
+    });
+
+    expect(end.json()).toMatchObject({ accepted: true, handoffAcknowledged: true });
+    expect(await store.listPendingCreatorMessages(ISSUE)).toHaveLength(0);
+  });
+
+  it('does not ack the inbox when a builder handoff fails to start', async () => {
+    const store = new InMemoryStore();
+    await seedSubmission(store);
+    const msg = await store.appendCreatorMessage(ISSUE, 'please make the ship faster');
+    await store.requestBuilderHandoff(ISSUE, 'self', new Date().toISOString());
+    app = await createApp(store, {
+      onBuilderHandoffAcknowledged: async () => ({ started: false, reason: 'handoff_not_started' }),
+    });
+
+    const end = await app.inject({
+      method: 'POST',
+      url: '/api/agent/build/end',
+      headers: agentHeaders(),
+      payload: { summary: 'Handing over.', ackInboxIds: [msg.id] },
+    });
+
+    expect(end.json()).toMatchObject({ accepted: false, rejected: 'handoff_not_started' });
+    expect(await store.listPendingCreatorMessages(ISSUE)).toHaveLength(1);
   });
 
   it('rejects the pre-cancel token after operator cancel bumps the round generation', async () => {

--- a/apps/api/src/agent-channel.test.ts
+++ b/apps/api/src/agent-channel.test.ts
@@ -690,14 +690,13 @@ describe('agent build channel', () => {
     expect(await store.listPendingCreatorMessages(ISSUE)).toHaveLength(0);
   });
 
-  it('does not ack the inbox when a builder handoff fails to start', async () => {
+  it('does not ack the inbox when a builder handoff is already acknowledged', async () => {
     const store = new InMemoryStore();
     await seedSubmission(store);
     const msg = await store.appendCreatorMessage(ISSUE, 'please make the ship faster');
     await store.requestBuilderHandoff(ISSUE, 'self', new Date().toISOString());
-    app = await createApp(store, {
-      onBuilderHandoffAcknowledged: async () => ({ started: false, reason: 'handoff_not_started' }),
-    });
+    await store.acknowledgeBuilderHandoff(ISSUE, new Date().toISOString());
+    app = await createApp(store);
 
     const end = await app.inject({
       method: 'POST',
@@ -706,7 +705,7 @@ describe('agent build channel', () => {
       payload: { summary: 'Handing over.', ackInboxIds: [msg.id] },
     });
 
-    expect(end.json()).toMatchObject({ accepted: false, rejected: 'handoff_not_started' });
+    expect(end.json()).toMatchObject({ accepted: false, rejected: 'handoff_already_acknowledged' });
     expect(await store.listPendingCreatorMessages(ISSUE)).toHaveLength(1);
   });
 

--- a/apps/api/src/agent-channel.test.ts
+++ b/apps/api/src/agent-channel.test.ts
@@ -2051,7 +2051,7 @@ describe('agent build channel', () => {
       expect(staged.get('game/sim.ts')).toBe('export const SPEED = 6;\nexport const LIVES = 5;\n');
     });
 
-    it('does not write any file when a later files[] entry fails to apply', async () => {
+    it('keeps successful files[] edits and reports the ones that missed', async () => {
       const store = new InMemoryStore();
       await seedSubmission(store);
       const { gamesStore, staged } = stubGamesStore();
@@ -2089,9 +2089,98 @@ describe('agent build channel', () => {
           ],
         },
       });
+      expect(patched.statusCode).toBe(200);
+      expect(patched.json()).toMatchObject({
+        accepted: true,
+        incomplete: true,
+        replacements: 1,
+        files: [{ path: 'game/render.ts', replacements: 1 }],
+        failed: [{ path: 'game/sim.ts', index: 0 }],
+      });
+      expect(patched.json().failed[0].error).toMatch(/not found in game\/sim\.ts/);
+      expect(staged.get('game/render.ts')).toContain('drawHud()');
+      expect(staged.get('game/sim.ts')).toBe('export const SPEED = 4;\n');
+    });
+
+    it('keeps earlier patches[] on a file when a later fragment misses', async () => {
+      const store = new InMemoryStore();
+      await seedSubmission(store);
+      const { gamesStore, staged } = stubGamesStore();
+      app = await createApp(store, { gamesStore });
+
+      await app.inject({
+        method: 'PUT',
+        url: '/api/agent/build/sources/stage',
+        headers: agentHeaders(),
+        payload: {
+          slug: 'comet-courier',
+          path: 'game/sim.ts',
+          content: 'export const SPEED = 4;\nexport const LIVES = 3;\nexport const FUEL = 9;\n',
+        },
+      });
+
+      const patched = await app.inject({
+        method: 'POST',
+        url: '/api/agent/build/sources/stage/patch',
+        headers: agentHeaders(),
+        payload: {
+          path: 'game/sim.ts',
+          patches: [
+            { old: 'SPEED = 4', new: 'SPEED = 6' },
+            { old: 'missing snippet', new: 'x' },
+            { old: 'FUEL = 9', new: 'FUEL = 1' },
+          ],
+        },
+      });
+      expect(patched.statusCode).toBe(200);
+      expect(patched.json()).toMatchObject({
+        accepted: true,
+        incomplete: true,
+        replacements: 2,
+        failed: [{ path: 'game/sim.ts', index: 1 }],
+      });
+      expect(staged.get('game/sim.ts')).toBe(
+        'export const SPEED = 6;\nexport const LIVES = 3;\nexport const FUEL = 1;\n',
+      );
+    });
+
+    it('returns 400 with failed[] when no edit in the batch applied', async () => {
+      const store = new InMemoryStore();
+      await seedSubmission(store);
+      const { gamesStore, staged } = stubGamesStore();
+      app = await createApp(store, { gamesStore });
+
+      await app.inject({
+        method: 'PUT',
+        url: '/api/agent/build/sources/stage',
+        headers: agentHeaders(),
+        payload: {
+          slug: 'comet-courier',
+          path: 'game/sim.ts',
+          content: 'export const SPEED = 4;\n',
+        },
+      });
+
+      const patched = await app.inject({
+        method: 'POST',
+        url: '/api/agent/build/sources/stage/patch',
+        headers: agentHeaders(),
+        payload: {
+          files: [
+            { path: 'game/sim.ts', old: 'missing one', new: 'x' },
+            { path: 'game/missing.ts', old: 'also missing', new: 'y' },
+          ],
+        },
+      });
       expect(patched.statusCode).toBe(400);
-      expect(patched.json().error).toMatch(/not found in game\/sim\.ts/);
-      expect(staged.get('game/render.ts')).toBe('export function paint() {\n  drawSky();\n}\n');
+      expect(patched.json()).toMatchObject({
+        accepted: false,
+        replacements: 0,
+        failed: [
+          { path: 'game/sim.ts', index: 0 },
+          { path: 'game/missing.ts', index: 0 },
+        ],
+      });
       expect(staged.get('game/sim.ts')).toBe('export const SPEED = 4;\n');
     });
 

--- a/apps/api/src/agent-channel.test.ts
+++ b/apps/api/src/agent-channel.test.ts
@@ -7,7 +7,7 @@ import { buildApp } from './app.js';
 import { mintSessionToken, SESSION_COOKIE_NAME } from './auth.js';
 import type { CatalogGameEntry, GameSources, GitHubClient, LinkedPullRequest } from './github-client.js';
 import type { GameSeeder } from './game-seed.js';
-import type { GamesStore } from './games-store.js';
+import { InvalidUploadError, type GamesStore } from './games-store.js';
 import type { KnowledgeQueryResult } from './knowledge-search.js';
 import { InMemoryStore } from './store.js';
 import { mintToken } from './submission-token.js';
@@ -2182,6 +2182,72 @@ describe('agent build channel', () => {
         ],
       });
       expect(staged.get('game/sim.ts')).toBe('export const SPEED = 4;\n');
+    });
+
+    it('reports every applied index when staging a patched file is refused', async () => {
+      const store = new InMemoryStore();
+      await seedSubmission(store);
+      const { gamesStore, staged } = stubGamesStore();
+      const put = gamesStore.putStagedSourceFile.bind(gamesStore);
+      gamesStore.putStagedSourceFile = async (input: { path: string; content: string }) => {
+        if (input.path === 'game/sim.ts' && input.content.includes('SPEED = 6')) {
+          throw new InvalidUploadError('game/sim.ts is too large');
+        }
+        return put(input);
+      };
+      app = await createApp(store, { gamesStore });
+
+      await app.inject({
+        method: 'PUT',
+        url: '/api/agent/build/sources/stage',
+        headers: agentHeaders(),
+        payload: {
+          slug: 'comet-courier',
+          path: 'game/render.ts',
+          content: 'export function paint() {\n  drawSky();\n}\n',
+        },
+      });
+      await app.inject({
+        method: 'PUT',
+        url: '/api/agent/build/sources/stage',
+        headers: agentHeaders(),
+        payload: {
+          slug: 'comet-courier',
+          path: 'game/sim.ts',
+          content: 'export const SPEED = 4;\nexport const LIVES = 3;\n',
+        },
+      });
+
+      const patched = await app.inject({
+        method: 'POST',
+        url: '/api/agent/build/sources/stage/patch',
+        headers: agentHeaders(),
+        payload: {
+          files: [
+            { path: 'game/render.ts', old: '  drawSky();\n', new: '  drawHud();\n' },
+            {
+              path: 'game/sim.ts',
+              patches: [
+                { old: 'SPEED = 4', new: 'SPEED = 6' },
+                { old: 'LIVES = 3', new: 'LIVES = 5' },
+              ],
+            },
+          ],
+        },
+      });
+      expect(patched.statusCode).toBe(200);
+      expect(patched.json()).toMatchObject({
+        accepted: true,
+        incomplete: true,
+        replacements: 1,
+        files: [{ path: 'game/render.ts', replacements: 1 }],
+        failed: [
+          { path: 'game/sim.ts', index: 0 },
+          { path: 'game/sim.ts', index: 1 },
+        ],
+      });
+      expect(staged.get('game/render.ts')).toContain('drawHud()');
+      expect(staged.get('game/sim.ts')).toBe('export const SPEED = 4;\nexport const LIVES = 3;\n');
     });
 
     it('refuses files[] mixed with a top-level path', async () => {

--- a/apps/api/src/agent-channel.test.ts
+++ b/apps/api/src/agent-channel.test.ts
@@ -2404,11 +2404,30 @@ describe('the delivery reminder on every channel call', () => {
     await app.close();
   });
 
-  it('stops nagging once the build has actually delivered', async () => {
+  it('stops nagging once the build has actually delivered (deliveredVersion or previewVersion)', async () => {
     // Derived from what we stored, not from anything the session claims about itself.
     const store = new InMemoryStore();
     await seedSubmission(store);
     await store.setSubmissionDeliveredVersion(ISSUE, 'v1');
+    const app = await createApp(store);
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/agent/build/progress',
+      headers: agentHeaders(),
+      payload: { text: 'Polishing.' },
+    });
+
+    expect(response.json().control.delivered).toBe(true);
+    expect(response.json().control.mustDeliver).toBeUndefined();
+
+    await app.close();
+  });
+
+  it('stops nagging when a previewVersion was delivered', async () => {
+    const store = new InMemoryStore();
+    await seedSubmission(store);
+    await store.setSubmissionPreviewVersion(ISSUE, 'v1-preview');
     const app = await createApp(store);
 
     const response = await app.inject({

--- a/apps/api/src/agent-channel.test.ts
+++ b/apps/api/src/agent-channel.test.ts
@@ -1993,6 +1993,129 @@ describe('agent build channel', () => {
       expect(staged.get('game/render.ts')).toContain('drawHud()');
     });
 
+    it('patches several files in one call via files[]', async () => {
+      const store = new InMemoryStore();
+      await seedSubmission(store);
+      const { gamesStore, staged } = stubGamesStore();
+      app = await createApp(store, { gamesStore });
+
+      await app.inject({
+        method: 'PUT',
+        url: '/api/agent/build/sources/stage',
+        headers: agentHeaders(),
+        payload: {
+          slug: 'comet-courier',
+          path: 'game/render.ts',
+          content: 'export function paint() {\n  drawSky();\n}\n',
+        },
+      });
+      await app.inject({
+        method: 'PUT',
+        url: '/api/agent/build/sources/stage',
+        headers: agentHeaders(),
+        payload: {
+          slug: 'comet-courier',
+          path: 'game/sim.ts',
+          content: 'export const SPEED = 4;\nexport const LIVES = 3;\n',
+        },
+      });
+
+      const patched = await app.inject({
+        method: 'POST',
+        url: '/api/agent/build/sources/stage/patch',
+        headers: agentHeaders(),
+        payload: {
+          files: [
+            { path: 'game/render.ts', old: '  drawSky();\n', new: '  drawSky();\n  drawHud();\n' },
+            {
+              path: 'game/sim.ts',
+              patches: [
+                { old: 'SPEED = 4', new: 'SPEED = 6' },
+                { old: 'LIVES = 3', new: 'LIVES = 5' },
+              ],
+            },
+          ],
+        },
+      });
+      expect(patched.statusCode).toBe(200);
+      expect(patched.json()).toMatchObject({
+        accepted: true,
+        replacements: 3,
+        path: 'game/render.ts',
+        files: [
+          { path: 'game/render.ts', replacements: 1, baseFrom: 'staged' },
+          { path: 'game/sim.ts', replacements: 2, baseFrom: 'staged' },
+        ],
+      });
+      expect(staged.get('game/render.ts')).toContain('drawHud()');
+      expect(staged.get('game/sim.ts')).toBe('export const SPEED = 6;\nexport const LIVES = 5;\n');
+    });
+
+    it('does not write any file when a later files[] entry fails to apply', async () => {
+      const store = new InMemoryStore();
+      await seedSubmission(store);
+      const { gamesStore, staged } = stubGamesStore();
+      app = await createApp(store, { gamesStore });
+
+      await app.inject({
+        method: 'PUT',
+        url: '/api/agent/build/sources/stage',
+        headers: agentHeaders(),
+        payload: {
+          slug: 'comet-courier',
+          path: 'game/render.ts',
+          content: 'export function paint() {\n  drawSky();\n}\n',
+        },
+      });
+      await app.inject({
+        method: 'PUT',
+        url: '/api/agent/build/sources/stage',
+        headers: agentHeaders(),
+        payload: {
+          slug: 'comet-courier',
+          path: 'game/sim.ts',
+          content: 'export const SPEED = 4;\n',
+        },
+      });
+
+      const patched = await app.inject({
+        method: 'POST',
+        url: '/api/agent/build/sources/stage/patch',
+        headers: agentHeaders(),
+        payload: {
+          files: [
+            { path: 'game/render.ts', old: '  drawSky();\n', new: '  drawHud();\n' },
+            { path: 'game/sim.ts', old: 'missing snippet', new: 'x' },
+          ],
+        },
+      });
+      expect(patched.statusCode).toBe(400);
+      expect(patched.json().error).toMatch(/not found in game\/sim\.ts/);
+      expect(staged.get('game/render.ts')).toBe('export function paint() {\n  drawSky();\n}\n');
+      expect(staged.get('game/sim.ts')).toBe('export const SPEED = 4;\n');
+    });
+
+    it('refuses files[] mixed with a top-level path', async () => {
+      const store = new InMemoryStore();
+      await seedSubmission(store);
+      const { gamesStore } = stubGamesStore();
+      app = await createApp(store, { gamesStore });
+
+      const patched = await app.inject({
+        method: 'POST',
+        url: '/api/agent/build/sources/stage/patch',
+        headers: agentHeaders(),
+        payload: {
+          path: 'game/render.ts',
+          old: 'a',
+          new: 'b',
+          files: [{ path: 'game/sim.ts', old: 'c', new: 'd' }],
+        },
+      });
+      expect(patched.statusCode).toBe(400);
+      expect(patched.json().error).toMatch(/files\[\] alone/);
+    });
+
     it('accepts a bare @@ patch (no line numbers) matched by context', async () => {
       const store = new InMemoryStore();
       await seedSubmission(store);

--- a/apps/api/src/agent-channel.ts
+++ b/apps/api/src/agent-channel.ts
@@ -70,8 +70,8 @@ import { BUILD_EVENT_KINDS, BUILD_STEPS, sanitizeCreatorText, type BuildEvent } 
 import { normalizeAtIntake, type IntakeText } from './localize-intake.js';
 import { createTranslatorFromEnv, type Translator } from './translate.js';
 
-// The build channel (docs/agent-live-channel-plan.md).
-// Direct route for progress, staging, submission, and status.
+// The build channel (docs/agent-live-channel-plan.md). Direct route for progress, staging, and status.
+// Invariant: agent input is untrusted, prompt-influenced text — sanitized, escaped on render, never model instructions.
 
 const MAX_EVENT_TEXT = 300;
 
@@ -2032,10 +2032,6 @@ export async function registerAgentChannelRoutes(
         return true;
       };
 
-      if (parsed.data.ackInboxIds && parsed.data.ackInboxIds.length > 0) {
-        await store!.markCreatorMessagesDelivered(issueNumber, parsed.data.ackInboxIds).catch(() => {});
-      }
-
       if (
         record.builderHandoff &&
         record.builderHandoff.awaitsAgentAck !== false &&
@@ -2055,6 +2051,9 @@ export async function registerAgentChannelRoutes(
             ...(await channelState(issueNumber, fresh)),
           });
         }
+        if (parsed.data.ackInboxIds && parsed.data.ackInboxIds.length > 0) {
+          await store!.markCreatorMessagesDelivered(issueNumber, parsed.data.ackInboxIds);
+        }
         const summarized = await recordSummary();
         const state = await channelState(issueNumber, fresh);
         return reply.send({
@@ -2069,6 +2068,10 @@ export async function registerAgentChannelRoutes(
 
       if (stopReason(record)) {
         return reply.send({ accepted: false, rejected: 'stopped', ...(await channelState(issueNumber, record)) });
+      }
+
+      if (parsed.data.ackInboxIds && parsed.data.ackInboxIds.length > 0) {
+        await store!.markCreatorMessagesDelivered(issueNumber, parsed.data.ackInboxIds);
       }
 
       // Submit-ended still records; a prior or legacy end does not.

--- a/apps/api/src/agent-channel.ts
+++ b/apps/api/src/agent-channel.ts
@@ -62,7 +62,7 @@ import { seedPayload } from './seed-status.js';
 import { largeSourceFileHint } from './module-size.js';
 import { gameManifestHint } from './game-manifest-hint.js';
 import { computeStageAdvisories } from './stage-hints.js';
-import { applyExactReplace, applyMultipleExactReplaces, applySourcePatch, SourcePatchError } from './source-patch.js';
+import { applyExactReplace, applySourcePatch, SourcePatchError } from './source-patch.js';
 import { overlayGameSources } from './staged-preview.js';
 import { SourceDeliveryValidationError, type SourceDeliveryService } from './source-delivery.js';
 import { type BuilderHandoff, type CreatorMessage, type Store, type SubmissionRecord } from './store.js';
@@ -322,7 +322,7 @@ const StageSourcePatchInputSchema = z
     old: z.string().max(200_000).optional(),
     new: z.string().max(200_000).optional(),
     patches: z.array(ExactPatchPairSchema).min(1).max(50).optional(),
-    files: z.array(FileExactPatchSchema).min(1).max(20).optional(),
+    files: z.array(FileExactPatchSchema).min(1).max(100).optional(),
     slug: z
       .string()
       .trim()
@@ -391,14 +391,44 @@ type PatchFileSpec = {
 
 type PatchBaseFrom = 'staged' | 'delivery' | 'seed';
 
-function applyPatchFile(content: string, file: PatchFileSpec) {
-  if (file.patches !== undefined) {
-    return applyMultipleExactReplaces({ content, path: file.path, patches: file.patches });
+type PatchFailure = {
+  path: string;
+  index: number;
+  error: string;
+};
+
+function applyPatchFileBestEffort(
+  content: string,
+  file: PatchFileSpec,
+): { content: string; replacements: number; failed: PatchFailure[] } {
+  const edits: Array<{ old?: string; new?: string; patch?: string }> =
+    file.patches !== undefined
+      ? file.patches
+      : file.old !== undefined && file.new !== undefined
+        ? [{ old: file.old, new: file.new }]
+        : [{ patch: file.patch }];
+
+  let current = content;
+  let replacements = 0;
+  const failed: PatchFailure[] = [];
+  for (let i = 0; i < edits.length; i++) {
+    const edit = edits[i]!;
+    try {
+      const result =
+        edit.patch !== undefined
+          ? applySourcePatch({ content: current, path: file.path, patch: edit.patch })
+          : applyExactReplace({ content: current, path: file.path, old: edit.old!, new: edit.new! });
+      current = result.content;
+      replacements += result.replacements;
+    } catch (error) {
+      if (error instanceof SourcePatchError) {
+        failed.push({ path: file.path, index: i, error: error.message });
+        continue;
+      }
+      throw error;
+    }
   }
-  if (file.old !== undefined && file.new !== undefined) {
-    return applyExactReplace({ content, path: file.path, old: file.old, new: file.new });
-  }
-  return applySourcePatch({ content, path: file.path, patch: file.patch! });
+  return { content: current, replacements, failed };
 }
 
 async function resolvePatchBase(input: {
@@ -1482,7 +1512,7 @@ export async function registerAgentChannelRoutes(
     },
   );
 
-  // Patch into staging. Base is staged → delivery → seed. Apply all files first; write only if every patch applies.
+  // Patch into staging. Base is staged → delivery → seed. Keep every edit that applies; report failed[] for the rest.
   app.post(
     '/api/agent/build/sources/stage/patch',
     {
@@ -1542,6 +1572,7 @@ export async function registerAgentChannelRoutes(
           replacements: number;
           baseFrom: PatchBaseFrom;
         }> = [];
+        const failed: PatchFailure[] = [];
         for (const spec of specs) {
           const base = await resolvePatchBase({
             gamesStore: options.gamesStore,
@@ -1553,13 +1584,18 @@ export async function registerAgentChannelRoutes(
             path: spec.path,
           });
           if (!base) {
-            return reply.status(400).send({
+            failed.push({
+              path: spec.path,
+              index: 0,
               error:
                 `cannot patch ${spec.path}: no base content in staging, the latest delivery, or the seed — ` +
                 'stage_source_file the full file first (or get_sources / get_seed), then patch',
             });
+            continue;
           }
-          const patched = applyPatchFile(base.content, spec);
+          const patched = applyPatchFileBestEffort(base.content, spec);
+          failed.push(...patched.failed);
+          if (patched.replacements === 0) continue;
           prepared.push({
             path: spec.path,
             content: patched.content,
@@ -1571,18 +1607,35 @@ export async function registerAgentChannelRoutes(
         let staged;
         const files: Array<{ path: string; bytes: number; replacements: number; baseFrom: PatchBaseFrom }> = [];
         for (const item of prepared) {
-          staged = await options.gamesStore.putStagedSourceFile({
-            slug,
-            issueNumber,
-            roundGeneration,
-            path: item.path,
-            content: item.content,
-          });
-          files.push({
-            path: staged.path,
-            bytes: staged.bytes,
-            replacements: item.replacements,
-            baseFrom: item.baseFrom,
+          try {
+            staged = await options.gamesStore.putStagedSourceFile({
+              slug,
+              issueNumber,
+              roundGeneration,
+              path: item.path,
+              content: item.content,
+            });
+            files.push({
+              path: staged.path,
+              bytes: staged.bytes,
+              replacements: item.replacements,
+              baseFrom: item.baseFrom,
+            });
+          } catch (error) {
+            if (error instanceof InvalidUploadError) {
+              failed.push({ path: item.path, index: 0, error: error.message });
+              continue;
+            }
+            throw error;
+          }
+        }
+
+        if (files.length === 0) {
+          return reply.status(400).send({
+            error: failed[0]?.error ?? 'no edits applied',
+            accepted: false,
+            replacements: 0,
+            failed,
           });
         }
         await markBuildingFromChannel(issueNumber, record);
@@ -1639,6 +1692,7 @@ export async function registerAgentChannelRoutes(
           replacements: files.reduce((sum, file) => sum + file.replacements, 0),
           baseFrom: first.baseFrom,
           files,
+          ...(failed.length > 0 ? { incomplete: true, failed } : {}),
           staged: {
             files: staged!.files,
             totalBytes: staged!.totalBytes,

--- a/apps/api/src/agent-channel.ts
+++ b/apps/api/src/agent-channel.ts
@@ -285,9 +285,35 @@ const ExactPatchPairSchema = z.object({
   new: z.string().max(200_000),
 });
 
-const StageSourcePatchInputSchema = z
+const FileExactPatchSchema = z
   .object({
     path: z.string().trim().min(1).max(120),
+    old: z.string().max(200_000).optional(),
+    new: z.string().max(200_000).optional(),
+    patches: z.array(ExactPatchPairSchema).min(1).max(50).optional(),
+  })
+  .superRefine((value, ctx) => {
+    const hasOld = value.old !== undefined;
+    const hasNew = value.new !== undefined;
+    const hasPatches = value.patches !== undefined && value.patches.length > 0;
+    if (hasOld !== hasNew) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'old and new must be passed together for exact replace',
+      });
+      return;
+    }
+    if ([hasOld && hasNew, hasPatches].filter(Boolean).length !== 1) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'each files[] entry needs old+new or patches[]',
+      });
+    }
+  });
+
+const StageSourcePatchInputSchema = z
+  .object({
+    path: z.string().trim().min(1).max(120).optional(),
     patch: z
       .string()
       .transform((value) => value.trim())
@@ -296,6 +322,7 @@ const StageSourcePatchInputSchema = z
     old: z.string().max(200_000).optional(),
     new: z.string().max(200_000).optional(),
     patches: z.array(ExactPatchPairSchema).min(1).max(50).optional(),
+    files: z.array(FileExactPatchSchema).min(1).max(20).optional(),
     slug: z
       .string()
       .trim()
@@ -304,11 +331,32 @@ const StageSourcePatchInputSchema = z
       .optional(),
   })
   .superRefine((value, ctx) => {
+    const hasFiles = value.files !== undefined && value.files.length > 0;
     const hasPatch = value.patch !== undefined;
     const hasOld = value.old !== undefined;
     const hasNew = value.new !== undefined;
     const hasPatches = value.patches !== undefined && value.patches.length > 0;
-
+    if (hasFiles && (hasPatch || hasOld || hasNew || hasPatches || value.path !== undefined)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'pass files[] alone, or a single-file path with old+new / patches[] / patch',
+      });
+      return;
+    }
+    if (hasFiles) {
+      const paths = value.files!.map((file) => file.path);
+      if (new Set(paths).size !== paths.length) {
+        ctx.addIssue({ code: z.ZodIssueCode.custom, message: 'files[] paths must be unique' });
+      }
+      return;
+    }
+    if (!value.path) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'path is required unless files[] is passed',
+      });
+      return;
+    }
     const modes = [hasPatch, hasOld || hasNew, hasPatches].filter(Boolean).length;
     if (modes > 1) {
       ctx.addIssue({
@@ -328,10 +376,62 @@ const StageSourcePatchInputSchema = z
     if (modes === 0) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
-        message: 'pass old+new (exact replace, preferred), patches[] (multi-replace), or patch (unified diff)',
+        message: 'pass old+new (exact replace, preferred), patches[] (multi-replace), files[], or patch (unified diff)',
       });
     }
   });
+
+type PatchFileSpec = {
+  path: string;
+  old?: string;
+  new?: string;
+  patches?: Array<{ old: string; new: string }>;
+  patch?: string;
+};
+
+type PatchBaseFrom = 'staged' | 'delivery' | 'seed';
+
+function applyPatchFile(content: string, file: PatchFileSpec) {
+  if (file.patches !== undefined) {
+    return applyMultipleExactReplaces({ content, path: file.path, patches: file.patches });
+  }
+  if (file.old !== undefined && file.new !== undefined) {
+    return applyExactReplace({ content, path: file.path, old: file.old, new: file.new });
+  }
+  return applySourcePatch({ content, path: file.path, patch: file.patch! });
+}
+
+async function resolvePatchBase(input: {
+  gamesStore: GamesStore;
+  store: Store;
+  record: SubmissionRecord;
+  slug: string;
+  issueNumber: number;
+  roundGeneration: number;
+  path: string;
+}): Promise<{ content: string; baseFrom: PatchBaseFrom } | null> {
+  const stagedContent = await input.gamesStore.getStagedSourceFile({
+    slug: input.slug,
+    issueNumber: input.issueNumber,
+    roundGeneration: input.roundGeneration,
+    path: input.path,
+  });
+  if (stagedContent !== null) return { content: stagedContent, baseFrom: 'staged' };
+
+  let version = input.record.previewVersion ?? input.record.deliveredVersion;
+  if (!version) {
+    const publication = await input.store.getPublication(input.slug);
+    if (publication?.state === 'published') version = publication.currentVersion;
+  }
+  if (version) {
+    const delivered = await input.gamesStore.getSourceFile(input.slug, version, input.path);
+    if (delivered !== null) return { content: delivered, baseFrom: 'delivery' };
+  }
+
+  const seedFile = input.record.seed?.files.find((file) => file.path === input.path);
+  if (seedFile) return { content: seedFile.content, baseFrom: 'seed' };
+  return null;
+}
 
 const BuildPreviewInputSchema = z.object({
   html: z
@@ -1382,14 +1482,7 @@ export async function registerAgentChannelRoutes(
     },
   );
 
-  /**
-   * Unified-diff patch into the staging buffer.
-   *
-   * Base content is staged → latest delivery → seed (same overlay order as the live
-   * staged preview). The patched file is then written with putStagedSourceFile, so a
-   * later fromStaged submit (which overlays the same way) only needs the changed paths
-   * in the buffer — chat-thin agents never re-emit a 40 KB render.ts for a one-line fix.
-   */
+  // Patch into staging. Base is staged → delivery → seed. Apply all files first; write only if every patch applies.
   app.post(
     '/api/agent/build/sources/stage/patch',
     {
@@ -1430,108 +1523,133 @@ export async function registerAgentChannelRoutes(
         ? ((await store.ensureRoundGeneration(issueNumber)) ?? record.roundGeneration ?? 1)
         : (record.roundGeneration ?? 1);
 
+      const specs: PatchFileSpec[] = parsed.data.files
+        ? parsed.data.files
+        : [
+            {
+              path: parsed.data.path!,
+              old: parsed.data.old,
+              new: parsed.data.new,
+              patches: parsed.data.patches,
+              patch: parsed.data.patch,
+            },
+          ];
+
       try {
-        const stagedContent = await options.gamesStore.getStagedSourceFile({
-          slug,
-          issueNumber,
-          roundGeneration,
-          path: parsed.data.path,
-        });
-
-        let base = stagedContent;
-        let baseFrom: 'staged' | 'delivery' | 'seed' | null = stagedContent !== null ? 'staged' : null;
-
-        if (base === null) {
-          let version = record.previewVersion ?? record.deliveredVersion;
-          if (!version) {
-            const publication = await store!.getPublication(slug);
-            if (publication?.state === 'published') version = publication.currentVersion;
+        const prepared: Array<{
+          path: string;
+          content: string;
+          replacements: number;
+          baseFrom: PatchBaseFrom;
+        }> = [];
+        for (const spec of specs) {
+          const base = await resolvePatchBase({
+            gamesStore: options.gamesStore,
+            store: store!,
+            record,
+            slug,
+            issueNumber,
+            roundGeneration,
+            path: spec.path,
+          });
+          if (!base) {
+            return reply.status(400).send({
+              error:
+                `cannot patch ${spec.path}: no base content in staging, the latest delivery, or the seed — ` +
+                'stage_source_file the full file first (or get_sources / get_seed), then patch',
+            });
           }
-          if (version) {
-            base = await options.gamesStore.getSourceFile(slug, version, parsed.data.path);
-            if (base !== null) baseFrom = 'delivery';
-          }
-        }
-
-        if (base === null && record.seed?.files) {
-          const seedFile = record.seed.files.find((file) => file.path === parsed.data.path);
-          if (seedFile) {
-            base = seedFile.content;
-            baseFrom = 'seed';
-          }
-        }
-
-        if (base === null || baseFrom === null) {
-          return reply.status(400).send({
-            error:
-              `cannot patch ${parsed.data.path}: no base content in staging, the latest delivery, or the seed — ` +
-              'stage_source_file the full file first (or get_sources / get_seed), then patch',
+          const patched = applyPatchFile(base.content, spec);
+          prepared.push({
+            path: spec.path,
+            content: patched.content,
+            replacements: patched.replacements,
+            baseFrom: base.baseFrom,
           });
         }
 
-        const patched =
-          parsed.data.patches !== undefined
-            ? applyMultipleExactReplaces({
-                content: base,
-                path: parsed.data.path,
-                patches: parsed.data.patches,
-              })
-            : parsed.data.old !== undefined && parsed.data.new !== undefined
-              ? applyExactReplace({
-                  content: base,
-                  path: parsed.data.path,
-                  old: parsed.data.old,
-                  new: parsed.data.new,
-                })
-              : applySourcePatch({
-                  content: base,
-                  path: parsed.data.path,
-                  patch: parsed.data.patch!,
-                });
-
-        const staged = await options.gamesStore.putStagedSourceFile({
-          slug,
-          issueNumber,
-          roundGeneration,
-          path: parsed.data.path,
-          content: patched.content,
-        });
+        let staged;
+        const files: Array<{ path: string; bytes: number; replacements: number; baseFrom: PatchBaseFrom }> = [];
+        for (const item of prepared) {
+          staged = await options.gamesStore.putStagedSourceFile({
+            slug,
+            issueNumber,
+            roundGeneration,
+            path: item.path,
+            content: item.content,
+          });
+          files.push({
+            path: staged.path,
+            bytes: staged.bytes,
+            replacements: item.replacements,
+            baseFrom: item.baseFrom,
+          });
+        }
         await markBuildingFromChannel(issueNumber, record);
         await store?.touchLastAgentSignalAt(issueNumber, undefined, { key: 'staging_sources' });
         options.onEvent?.(issueNumber);
         options.onSourcesStaged?.({ issueNumber, slug, roundGeneration });
 
-        const hint = largeSourceFileHint(staged.path, staged.bytes, patched.content);
-        const manifestHint = gameManifestHint(staged.path, patched.content);
-        const advisories = await computeStageAdvisories({
-          kitFileStore,
-          gamesStore: options.gamesStore,
-          store: store!,
-          record,
-          slug,
-          issueNumber,
-          roundGeneration,
-          engineRef: record.roundKitEngineRef,
-          path: staged.path,
-          content: patched.content,
-        });
+        let hint: string | null = null;
+        let manifestHint: string | null = null;
+        for (const item of prepared) {
+          hint ??= largeSourceFileHint(item.path, Buffer.byteLength(item.content, 'utf8'), item.content);
+          manifestHint ??= gameManifestHint(item.path, item.content);
+        }
+        const tsFile = [...prepared].reverse().find((item) => item.path.endsWith('.ts') || item.path.endsWith('.tsx'));
+        const gameJson = prepared.find((item) => item.path === 'GAME.json');
+        const typecheckHint = tsFile
+          ? (
+              await computeStageAdvisories({
+                kitFileStore,
+                gamesStore: options.gamesStore,
+                store: store!,
+                record,
+                slug,
+                issueNumber,
+                roundGeneration,
+                engineRef: record.roundKitEngineRef,
+                path: tsFile.path,
+                content: tsFile.content,
+              })
+            ).typecheckHint
+          : undefined;
+        const audioHint = gameJson
+          ? (
+              await computeStageAdvisories({
+                kitFileStore,
+                gamesStore: options.gamesStore,
+                store: store!,
+                record,
+                slug,
+                issueNumber,
+                roundGeneration,
+                engineRef: record.roundKitEngineRef,
+                path: gameJson.path,
+                content: gameJson.content,
+              })
+            ).audioHint
+          : undefined;
+
+        const first = files[0]!;
         return reply.send({
           accepted: true,
-          path: staged.path,
-          bytes: staged.bytes,
-          replacements: patched.replacements,
-          baseFrom,
+          path: first.path,
+          bytes: first.bytes,
+          replacements: files.reduce((sum, file) => sum + file.replacements, 0),
+          baseFrom: first.baseFrom,
+          files,
           staged: {
-            files: staged.files,
-            totalBytes: staged.totalBytes,
-            maxBytes: staged.maxBytes,
-            maxFiles: staged.maxFiles,
-            updatedAt: staged.updatedAt,
+            files: staged!.files,
+            totalBytes: staged!.totalBytes,
+            maxBytes: staged!.maxBytes,
+            maxFiles: staged!.maxFiles,
+            updatedAt: staged!.updatedAt,
           },
           ...(manifestHint ? { manifestHint } : {}),
           ...(hint ? { hint } : {}),
-          ...(advisories.typecheckHint ? { typecheckHint: advisories.typecheckHint } : {}),
-          ...(advisories.audioHint ? { audioHint: advisories.audioHint } : {}),
+          ...(typecheckHint ? { typecheckHint } : {}),
+          ...(audioHint ? { audioHint } : {}),
           ...(await channelState(issueNumber, (await store!.getSubmission(issueNumber)) ?? record)),
         });
       } catch (error) {

--- a/apps/api/src/agent-channel.ts
+++ b/apps/api/src/agent-channel.ts
@@ -62,7 +62,7 @@ import { seedPayload } from './seed-status.js';
 import { largeSourceFileHint } from './module-size.js';
 import { gameManifestHint } from './game-manifest-hint.js';
 import { computeStageAdvisories } from './stage-hints.js';
-import { applyExactReplace, applySourcePatch, SourcePatchError } from './source-patch.js';
+import { applyExactReplace, applyMultipleExactReplaces, applySourcePatch, SourcePatchError } from './source-patch.js';
 import { overlayGameSources } from './staged-preview.js';
 import { SourceDeliveryValidationError, type SourceDeliveryService } from './source-delivery.js';
 import { type BuilderHandoff, type CreatorMessage, type Store, type SubmissionRecord } from './store.js';
@@ -70,24 +70,8 @@ import { BUILD_EVENT_KINDS, BUILD_STEPS, sanitizeCreatorText, type BuildEvent } 
 import { normalizeAtIntake, type IntakeText } from './localize-intake.js';
 import { createTranslatorFromEnv, type Translator } from './translate.js';
 
-/**
- * The build channel (docs/agent-live-channel-plan.md).
- *
- * Before this existed, everything the creator saw about their build had to travel by
- * git: the agent wrote a note, committed it, pushed it, waited for CI, and we read it
- * back through a 60-second-cached contents API. The transport charged a CI run per
- * sentence, so agents batched — which is why the status page sat still for ten minutes
- * at a time. This is the direct route: one authenticated POST, visible in seconds.
- *
- * It is also the *return* path. Every call answers with the creator's queued change
- * requests and a control block, so an agent that reports progress gets its instructions
- * back for free. Note the limit: this makes a *working* agent responsive, but it cannot
- * wake a stopped one — nothing is polling between sessions. Creator feedback therefore
- * still goes out as a PR comment, which is both the durable record and the wake-up.
- *
- * Everything the agent sends is untrusted, prompt-influenced text: sanitized here,
- * escaped on render, and never fed back to any model as instructions.
- */
+// The build channel (docs/agent-live-channel-plan.md).
+// Direct route for progress, staging, submission, and status.
 
 const MAX_EVENT_TEXT = 300;
 
@@ -153,6 +137,7 @@ const EndRequestSchema = z.object({
     .max(10)
     .regex(/^[a-z]{2}(-[A-Za-z0-9]{2,8})?$/, 'invalid locale')
     .optional(),
+  ackInboxIds: z.array(z.string().trim().min(1).max(64)).max(50).optional(),
 });
 
 const MAX_SHOT_LABEL = 120;
@@ -295,19 +280,22 @@ const DeleteSourceInputSchema = z.object({
   path: z.string().trim().min(1).max(120),
 });
 
+const ExactPatchPairSchema = z.object({
+  old: z.string().max(200_000),
+  new: z.string().max(200_000),
+});
+
 const StageSourcePatchInputSchema = z
   .object({
     path: z.string().trim().min(1).max(120),
-    /** Unified diff for this one path (`---` / `+++` + `@@` hunks). */
     patch: z
       .string()
       .transform((value) => value.trim())
       .pipe(z.string().min(1, 'patch must not be empty').max(400_000))
       .optional(),
-    /** Exact unique substring to replace (pair with `new`). Prefer this over `patch` in chat. */
     old: z.string().max(200_000).optional(),
-    /** Replacement for `old` (may be empty to delete). */
     new: z.string().max(200_000).optional(),
+    patches: z.array(ExactPatchPairSchema).min(1).max(50).optional(),
     slug: z
       .string()
       .trim()
@@ -319,10 +307,14 @@ const StageSourcePatchInputSchema = z
     const hasPatch = value.patch !== undefined;
     const hasOld = value.old !== undefined;
     const hasNew = value.new !== undefined;
-    if (hasPatch && (hasOld || hasNew)) {
+    const hasPatches = value.patches !== undefined && value.patches.length > 0;
+
+    const modes = [hasPatch, hasOld || hasNew, hasPatches].filter(Boolean).length;
+    if (modes > 1) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
-        message: 'pass either patch (unified diff) or old+new (exact replace), not both',
+        message:
+          'pass either old+new (single exact replace), patches[] (multiple exact replaces), or patch (unified diff)',
       });
       return;
     }
@@ -333,10 +325,10 @@ const StageSourcePatchInputSchema = z
       });
       return;
     }
-    if (!hasPatch && !hasOld) {
+    if (modes === 0) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
-        message: 'pass old+new (exact replace, preferred) or patch (unified diff)',
+        message: 'pass old+new (exact replace, preferred), patches[] (multi-replace), or patch (unified diff)',
       });
     }
   });
@@ -846,7 +838,7 @@ export async function registerAgentChannelRoutes(
         // a tool that felt like finishing. This rides along with something the agent
         // is already doing, and it is derived from what we actually stored rather than
         // from anything the session believes about itself.
-        delivered: Boolean(record.deliveredVersion),
+        delivered: Boolean(record.deliveredVersion || record.previewVersion),
         // Delivering is not finishing. The gate runs *after* the upload, against our
         // engine, and it is the thing that decides whether any of this can be published
         // — so an agent that delivers and stops has handed over a game nobody can ship
@@ -872,7 +864,7 @@ export async function registerAgentChannelRoutes(
                       'sandbox). Re-delivering without a fix just stores another version that fails the same way.',
             }
           : {}),
-        ...(record.deliveredVersion
+        ...(record.deliveredVersion || record.previewVersion
           ? {}
           : {
               mustDeliver:
@@ -1478,18 +1470,24 @@ export async function registerAgentChannelRoutes(
         }
 
         const patched =
-          parsed.data.old !== undefined && parsed.data.new !== undefined
-            ? applyExactReplace({
+          parsed.data.patches !== undefined
+            ? applyMultipleExactReplaces({
                 content: base,
                 path: parsed.data.path,
-                old: parsed.data.old,
-                new: parsed.data.new,
+                patches: parsed.data.patches,
               })
-            : applySourcePatch({
-                content: base,
-                path: parsed.data.path,
-                patch: parsed.data.patch!,
-              });
+            : parsed.data.old !== undefined && parsed.data.new !== undefined
+              ? applyExactReplace({
+                  content: base,
+                  path: parsed.data.path,
+                  old: parsed.data.old,
+                  new: parsed.data.new,
+                })
+              : applySourcePatch({
+                  content: base,
+                  path: parsed.data.path,
+                  patch: parsed.data.patch!,
+                });
 
         const staged = await options.gamesStore.putStagedSourceFile({
           slug,
@@ -2033,6 +2031,10 @@ export async function registerAgentChannelRoutes(
         await store!.appendBuildEvent(issueNumber, event);
         return true;
       };
+
+      if (parsed.data.ackInboxIds && parsed.data.ackInboxIds.length > 0) {
+        await store!.markCreatorMessagesDelivered(issueNumber, parsed.data.ackInboxIds).catch(() => {});
+      }
 
       if (
         record.builderHandoff &&

--- a/apps/api/src/agent-channel.ts
+++ b/apps/api/src/agent-channel.ts
@@ -397,10 +397,14 @@ type PatchFailure = {
   error: string;
 };
 
+function patchEditCount(file: PatchFileSpec): number {
+  return file.patches?.length ?? 1;
+}
+
 function applyPatchFileBestEffort(
   content: string,
   file: PatchFileSpec,
-): { content: string; replacements: number; failed: PatchFailure[] } {
+): { content: string; replacements: number; applied: number[]; failed: PatchFailure[] } {
   const edits: Array<{ old?: string; new?: string; patch?: string }> =
     file.patches !== undefined
       ? file.patches
@@ -410,6 +414,7 @@ function applyPatchFileBestEffort(
 
   let current = content;
   let replacements = 0;
+  const applied: number[] = [];
   const failed: PatchFailure[] = [];
   for (let i = 0; i < edits.length; i++) {
     const edit = edits[i]!;
@@ -420,6 +425,7 @@ function applyPatchFileBestEffort(
           : applyExactReplace({ content: current, path: file.path, old: edit.old!, new: edit.new! });
       current = result.content;
       replacements += result.replacements;
+      applied.push(i);
     } catch (error) {
       if (error instanceof SourcePatchError) {
         failed.push({ path: file.path, index: i, error: error.message });
@@ -428,7 +434,7 @@ function applyPatchFileBestEffort(
       throw error;
     }
   }
-  return { content: current, replacements, failed };
+  return { content: current, replacements, applied, failed };
 }
 
 async function resolvePatchBase(input: {
@@ -1570,6 +1576,7 @@ export async function registerAgentChannelRoutes(
           path: string;
           content: string;
           replacements: number;
+          applied: number[];
           baseFrom: PatchBaseFrom;
         }> = [];
         const failed: PatchFailure[] = [];
@@ -1584,22 +1591,22 @@ export async function registerAgentChannelRoutes(
             path: spec.path,
           });
           if (!base) {
-            failed.push({
-              path: spec.path,
-              index: 0,
-              error:
-                `cannot patch ${spec.path}: no base content in staging, the latest delivery, or the seed — ` +
-                'stage_source_file the full file first (or get_sources / get_seed), then patch',
-            });
+            const error =
+              `cannot patch ${spec.path}: no base content in staging, the latest delivery, or the seed — ` +
+              'stage_source_file the full file first (or get_sources / get_seed), then patch';
+            for (let i = 0; i < patchEditCount(spec); i++) {
+              failed.push({ path: spec.path, index: i, error });
+            }
             continue;
           }
           const patched = applyPatchFileBestEffort(base.content, spec);
           failed.push(...patched.failed);
-          if (patched.replacements === 0) continue;
+          if (patched.applied.length === 0) continue;
           prepared.push({
             path: spec.path,
             content: patched.content,
             replacements: patched.replacements,
+            applied: patched.applied,
             baseFrom: base.baseFrom,
           });
         }
@@ -1623,7 +1630,9 @@ export async function registerAgentChannelRoutes(
             });
           } catch (error) {
             if (error instanceof InvalidUploadError) {
-              failed.push({ path: item.path, index: 0, error: error.message });
+              for (const index of item.applied) {
+                failed.push({ path: item.path, index, error: error.message });
+              }
               continue;
             }
             throw error;

--- a/apps/api/src/build-prompt.test.ts
+++ b/apps/api/src/build-prompt.test.ts
@@ -187,6 +187,7 @@ describe('buildPrompt', () => {
     expect(prompt).not.toContain('npm run restore');
     expect(prompt).toContain('`start` then `get_sources`');
     expect(prompt).toContain('Do not run bash exploration commands');
+    expect(prompt).toContain('If get_sources reports nothing delivered yet');
   });
 
   it('does not send a first build looking for a delivery that cannot exist', () => {

--- a/apps/api/src/build-prompt.test.ts
+++ b/apps/api/src/build-prompt.test.ts
@@ -182,6 +182,13 @@ describe('buildPrompt', () => {
     expect(prompt).toContain('This checkout may not contain it');
   });
 
+  it('points a fastLane MCP revision round at start and get_sources without restore or exploration', () => {
+    const prompt = buildPrompt({ ...BRIEF, feedback: 'make the bubbles bigger' }, { kind: 'channel', fast: true });
+    expect(prompt).not.toContain('npm run restore');
+    expect(prompt).toContain('`start` then `get_sources`');
+    expect(prompt).toContain('Do not run bash exploration commands');
+  });
+
   it('does not send a first build looking for a delivery that cannot exist', () => {
     expect(buildPrompt(BRIEF)).not.toContain('npm run restore');
   });

--- a/apps/api/src/build-prompt.ts
+++ b/apps/api/src/build-prompt.ts
@@ -61,7 +61,7 @@ export function buildPrompt(brief: BuildBrief, delivery: DeliveryContract = { ki
           '',
         ]
       : []),
-    ...(brief.feedback && !brief.undelivered && channel
+    ...(brief.feedback && !brief.undelivered && channel && !fastLane
       ? [
           '## Before you change anything',
           '',
@@ -77,6 +77,16 @@ export function buildPrompt(brief: BuildBrief, delivery: DeliveryContract = { ki
           'It writes back the exact files that were delivered. Read them, then make the',
           'creator’s changes on top of them. If it reports nothing delivered yet, the earlier',
           'round never finished and you are starting the game rather than revising it.',
+          '',
+        ]
+      : []),
+    ...(brief.feedback && !brief.undelivered && channel && fastLane
+      ? [
+          '## Before you change anything',
+          '',
+          'Fetch the version the creator actually played using the MCP tools below (`start` then `get_sources`).',
+          'Do not run bash exploration commands — this execution environment is an MCP-only sandbox with no local checkout.',
+          'Read the returned files, then make the creator’s changes on top of them.',
           '',
         ]
       : []),

--- a/apps/api/src/build-prompt.ts
+++ b/apps/api/src/build-prompt.ts
@@ -86,8 +86,8 @@ export function buildPrompt(brief: BuildBrief, delivery: DeliveryContract = { ki
           '',
           'Fetch the version the creator actually played using the MCP tools below (`start` then `get_sources`).',
           'Do not run bash exploration commands — this execution environment is an MCP-only sandbox with no local checkout.',
-          'Read the returned files, then make the creator’s changes on top of them. If get_sources reports nothing',
-          'delivered yet, the earlier round never finished and you are starting the game rather than revising it.',
+          'Read the returned files, then make the creator’s changes on top of them.',
+          'If get_sources reports nothing delivered yet, the earlier round never finished and you are starting the game rather than revising it.',
           '',
         ]
       : []),

--- a/apps/api/src/build-prompt.ts
+++ b/apps/api/src/build-prompt.ts
@@ -86,7 +86,8 @@ export function buildPrompt(brief: BuildBrief, delivery: DeliveryContract = { ki
           '',
           'Fetch the version the creator actually played using the MCP tools below (`start` then `get_sources`).',
           'Do not run bash exploration commands — this execution environment is an MCP-only sandbox with no local checkout.',
-          'Read the returned files, then make the creator’s changes on top of them.',
+          'Read the returned files, then make the creator’s changes on top of them. If get_sources reports nothing',
+          'delivered yet, the earlier round never finished and you are starting the game rather than revising it.',
           '',
         ]
       : []),

--- a/apps/api/src/mcp-server.test.ts
+++ b/apps/api/src/mcp-server.test.ts
@@ -803,6 +803,33 @@ declare const GameKit: { defineGame(): unknown };
     expect(multiPatch.isError).toBe(false);
     expect((multiPatch.structured as { replacements?: number }).replacements).toBe(2);
 
+    const stagedSim = await callTool(
+      app,
+      'stage_source_file',
+      { sessionKey, path: 'game/sim.ts', content: 'export const SPEED = 4;\n' },
+      { 'mcp-session-id': sessionId },
+    );
+    expect(stagedSim.isError).toBe(false);
+
+    const multiFile = await callTool(
+      app,
+      'patch_source_file',
+      {
+        sessionKey,
+        files: [
+          { path: 'game/render.ts', old: "'hello'", new: "'hey'" },
+          { path: 'game/sim.ts', old: 'SPEED = 4', new: 'SPEED = 8' },
+        ],
+      },
+      { 'mcp-session-id': sessionId },
+    );
+    expect(multiFile.isError).toBe(false);
+    expect((multiFile.structured as { replacements?: number }).replacements).toBe(2);
+    expect((multiFile.structured as { files?: Array<{ path: string }> }).files?.map((file) => file.path)).toEqual([
+      'game/render.ts',
+      'game/sim.ts',
+    ]);
+
     // Also verify end with ackInboxIds acknowledges creator messages
     const msg = await store.appendCreatorMessage(ISSUE, 'Fix the UI font');
     const ended = await callTool(

--- a/apps/api/src/mcp-server.test.ts
+++ b/apps/api/src/mcp-server.test.ts
@@ -802,6 +802,22 @@ declare const GameKit: { defineGame(): unknown };
     );
     expect(multiPatch.isError).toBe(false);
     expect((multiPatch.structured as { replacements?: number }).replacements).toBe(2);
+
+    // Also verify end with ackInboxIds acknowledges creator messages
+    const msg = await store.appendCreatorMessage(ISSUE, 'Fix the UI font');
+    const ended = await callTool(
+      app,
+      'end',
+      {
+        sessionKey,
+        summary: 'All done and acknowledged.',
+        ackInboxIds: [msg.id],
+      },
+      { 'mcp-session-id': sessionId },
+    );
+    expect(ended.isError).toBe(false);
+    expect((ended.structured as { ok?: boolean }).ok).toBe(true);
+    expect(await store.listPendingCreatorMessages(ISSUE)).toHaveLength(0);
   });
 
   it('knowledge_query is advertised and callable, and returns the seam result', async () => {

--- a/apps/api/src/mcp-server.test.ts
+++ b/apps/api/src/mcp-server.test.ts
@@ -785,6 +785,23 @@ declare const GameKit: { defineGame(): unknown };
     expect(audioWarnings.find((w) => w.code === 'audio_catalog_hint')?.message).toMatch(
       /unknown music track "fantasy-adventure"/,
     );
+
+    // Also verify multi-patch via patch_source_file works with patches[]
+    const multiPatch = await callTool(
+      app,
+      'patch_source_file',
+      {
+        sessionKey,
+        path: 'game/render.ts',
+        patches: [
+          { old: "'hi'", new: "'hello'" },
+          { old: "textAlign: 'center'", new: "align: 'center'" },
+        ],
+      },
+      { 'mcp-session-id': sessionId },
+    );
+    expect(multiPatch.isError).toBe(false);
+    expect((multiPatch.structured as { replacements?: number }).replacements).toBe(2);
   });
 
   it('knowledge_query is advertised and callable, and returns the seam result', async () => {

--- a/apps/api/src/mcp-server.test.ts
+++ b/apps/api/src/mcp-server.test.ts
@@ -830,6 +830,32 @@ declare const GameKit: { defineGame(): unknown };
       'game/sim.ts',
     ]);
 
+    const partialOk = await callTool(
+      app,
+      'patch_source_file',
+      {
+        sessionKey,
+        path: 'game/sim.ts',
+        patches: [
+          { old: 'SPEED = 8', new: 'SPEED = 10' },
+          { old: 'does not exist', new: 'x' },
+        ],
+      },
+      { 'mcp-session-id': sessionId },
+    );
+    expect(partialOk.isError).toBe(false);
+    expect(partialOk.structured).toMatchObject({
+      ok: true,
+      incomplete: true,
+      replacements: 1,
+      failed: [{ path: 'game/sim.ts', index: 1 }],
+    });
+    const partialWarnings =
+      (partialOk.structured as { warnings?: Array<{ code: string; message: string }> }).warnings ?? [];
+    expect(partialWarnings.find((warning) => warning.code === 'patch_incomplete')?.message).toMatch(
+      /retry only failed\[\]/,
+    );
+
     // Also verify end with ackInboxIds acknowledges creator messages
     const msg = await store.appendCreatorMessage(ISSUE, 'Fix the UI font');
     const ended = await callTool(

--- a/apps/api/src/mcp-server.ts
+++ b/apps/api/src/mcp-server.ts
@@ -623,7 +623,7 @@ const BEHAVIOURAL_CONTRACT = [
   // language they did not choose, which is the whole reason the field exists.
   "Write progress in the creator's language: when get_brief.locales[0] is not 'en', send report_progress with textLocalized and locale as well as the English text.",
   'Send a screenshot as soon as the game draws anything playable via screenshot_upload_url + curl --upload-file. There is no base64 screenshot tool — PNG bytes must never enter the model.',
-  'While iterating, deliver with mode=preview (no TRACE required). Prefer stage_upload_url + curl --upload-file for new/rewritten paths when you have shell; stage_source_file is the no-shell fallback. Prefer patch_source_file for edits — prefer old+new exact replace; patch=unified diff also works (never re-emit a whole large render.ts/model.ts). To retire a path (an old game/*.ts module, or a hand-authored index.html/GAME.json field), call delete_source_file — staging empty content still delivers a live empty file, not a removal. Honour warnings.code=module_too_large by splitting before more feature work. Then submit_sources({ fromStaged:true, mode:"preview", kitEngineRef }) — fromStaged overlays onto the latest delivery/seed so only changed paths need staging. Avoid one giant files[] payload. Only mode=publish needs TRACE/PLAYTEST and can go green.',
+  'While iterating, deliver with mode=preview (no TRACE required). Prefer stage_upload_url + curl --upload-file for new/rewritten paths when you have shell; stage_source_file is the no-shell fallback. Prefer patch_source_file for edits — prefer old+new exact replace, or files: [{ path, old, new }, ...] to edit several files in one call; patch=unified diff also works (never re-emit a whole large render.ts/model.ts). To retire a path (an old game/*.ts module, or a hand-authored index.html/GAME.json field), call delete_source_file — staging empty content still delivers a live empty file, not a removal. Honour warnings.code=module_too_large by splitting before more feature work. Then submit_sources({ fromStaged:true, mode:"preview", kitEngineRef }) — fromStaged overlays onto the latest delivery/seed so only changed paths need staging. Avoid one giant files[] payload. Only mode=publish needs TRACE/PLAYTEST and can go green.',
   'If the last gate was preview_failed / red / kit_outdated (warnings.code=must_fix_gate), fix then submit_sources again — do not stop at stage/patch/show_round. Staging does not re-run the gate; the creator card stays on the refused delivery until you submit.',
   'While iterating, run only npm run typecheck -- <slug> (no browser, npm ci, capture, playtest, or agency), then stage and submit_sources({ fromStaged: true, mode: "preview", kitEngineRef }); the server verifies the preview. If a browser is available and the draft is approaching delivery, optionally run npm run check:game -- <slug> --preview (typecheck → smoke → build). Run the full gate only immediately before a mode:"publish" seal.',
   'After submit_sources, if you will not deliver more this round, call end (required — warnings.code=call_end; submit already unlocks creator handoff). Prefer end over sitting in a get_gate_verdict loop — Studio shows the gate. Do not stop after submit alone without end. If you are fixing a refused gate, ignore call_end until after the next submit_sources.',
@@ -666,7 +666,7 @@ const SESSION_WORKFLOW: readonly string[] = [
   'Capability and "how do I…" questions: check get_kit_api first for exact kit-API surface (signatures, module names). knowledge_query is for everything get_kit_api does not cover — EditorKit internals, example-game patterns, docs/process, and broader capability questions — with citations and an indexedCommit; treat its prose as a pointer to verify via get_kit_api / read_kit_file, not a source of truth for exact signatures.',
   'Build the game — continuing the seed or sources you fetched, otherwise from the kit; report_progress before and after long steps. Soft module budget: keep each game/*.ts under ~350 lines / ~12 KiB. When a file approaches that, split cohesive pieces (render→art/ui/hud/rooms; model→tables/layout/types; runtime→systems) before more feature work. Honour warnings.code=module_too_large the same way you honour call_end — act, then continue.',
   'As soon as the game draws anything playable: screenshot_upload_url then curl --upload-file <png> "$url". There is no base64 send path — PNG bytes must never enter the model. Without shell egress, skip mid-build screenshots; the gate still captures on delivery.',
-  'While iterating: run only npm run typecheck -- <slug> locally, then prefer stage_upload_url({ path }) and curl --upload-file <file> "$url" for new/rewritten paths when you have shell egress (bytes never re-enter the model). Fall back to stage_source_file({ path, content }) without shell. For edits prefer patch_source_file({ path, old, new }) — exact unique substring replace, no unified-diff arithmetic. Or patch_source_file({ path, patch }) with a unified diff (bare @@ ok). Stage only changed paths — never re-upload the whole tree. Then submit_sources({ fromStaged: true, mode: "preview", kitEngineRef }) — fromStaged overlays onto the latest delivery/seed and the server verifies it; no browser, npm ci, capture, playtest, or agency is required for this preview. If a browser is available near delivery, optionally run npm run check:game -- <slug> --preview. Run the full gate only immediately before a mode:"publish" seal. Inline files[] still works for tiny trees.',
+  'While iterating: run only npm run typecheck -- <slug> locally, then prefer stage_upload_url({ path }) and curl --upload-file <file> "$url" for new/rewritten paths when you have shell egress (bytes never re-enter the model). Fall back to stage_source_file({ path, content }) without shell. For edits prefer patch_source_file({ path, old, new }) — exact unique substring replace, no unified-diff arithmetic. Or patch_source_file({ files: [{ path, old, new }, ...] }) to edit several files in one call. Or patch_source_file({ path, patch }) with a unified diff (bare @@ ok). Stage only changed paths — never re-upload the whole tree. Then submit_sources({ fromStaged: true, mode: "preview", kitEngineRef }) — fromStaged overlays onto the latest delivery/seed and the server verifies it; no browser, npm ci, capture, playtest, or agency is required for this preview. If a browser is available near delivery, optionally run npm run check:game -- <slug> --preview. Run the full gate only immediately before a mode:"publish" seal. Inline files[] still works for tiny trees.',
   'Staging is already visible: once game.ts, GAME.json and markup are present across staging + delivery/seed, the platform assembles a live playable preview — without waiting for submit or the gate. Markup means either an index.html or a GAME.json howToPlay carrying goal and hint, from which the body is generated. style.css is optional the same way: a GAME.json theme (accent/canvasBackground/canvasBorderColor/pixelArt) generates it when none is staged. Stage a runnable tree early and keep staging/patching as you work; a buffer that does not compile simply leaves the previous preview up.',
   'After every successful submit_sources: creator handoff is already unlocked; still call end immediately if you will not deliver more (warnings.code=call_end). Prefer end over sitting in a get_gate_verdict loop — Studio shows the gate. submit alone leaves your MCP session open — end sets stop:true. ChatGPT-class agents often stop after submit; end closes the session cleanly.',
   // The thread is the creator's whole view of the round.
@@ -3844,7 +3844,7 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
 
     patch_source_file: {
       // Replaces existing staged content, and a patch can remove lines outright.
-      annotations: { title: 'Edit one staged source file', ...CONSUMES },
+      annotations: { title: 'Edit staged source files', ...CONSUMES },
       outputSchema: {
         type: 'object',
         properties: {
@@ -3853,6 +3853,19 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
           bytes: { type: 'number' },
           replacements: { type: 'number' },
           baseFrom: { type: 'string', enum: ['staged', 'delivery', 'seed'] },
+          files: {
+            type: 'array',
+            items: {
+              type: 'object',
+              properties: {
+                path: { type: 'string' },
+                bytes: { type: 'number' },
+                replacements: { type: 'number' },
+                baseFrom: { type: 'string', enum: ['staged', 'delivery', 'seed'] },
+              },
+              required: ['path', 'bytes', 'replacements', 'baseFrom'],
+            },
+          },
           hint: { type: 'string' },
           staged: {
             type: 'object',
@@ -3876,14 +3889,16 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
         required: ['ok', 'path', 'bytes', 'replacements', 'baseFrom', 'staged', 'stop', 'pendingMessages'],
       },
       description:
-        'Edit ONE existing path in the staging buffer without re-uploading the whole file. ' +
+        'Edit existing path(s) in the staging buffer without re-uploading whole files. ' +
         'Prefer this over stage_source_file whenever the file already exists (from get_sources, a prior stage, or the seed) — ' +
         'especially for large game/render.ts or game/model.ts files. ' +
-        'PREFERRED: pass old + new (exact unique substring replace), or patches: [{ old, new }, ...] for multiple replacements in one call — no @@ line numbers, no diff format. ' +
-        'With patches[], replacements apply sequentially in order; ensure earlier replacements do not make a later old snippet ambiguous. ' +
-        'ALTERNATE: pass patch as a unified diff for that single file ' +
+        'PREFERRED: pass old + new (exact unique substring replace), or patches: [{ old, new }, ...] for multiple replacements in one file, ' +
+        'or files: [{ path, old, new } | { path, patches: [{ old, new }] }, ...] to edit several files in one call — no @@ line numbers, no diff format. ' +
+        'With patches[] / files[], replacements apply sequentially per file; ensure earlier replacements do not make a later old snippet ambiguous. ' +
+        'A files[] call applies every file in memory first and writes only if all apply — one miss leaves the buffer unchanged. ' +
+        'ALTERNATE: pass path + patch as a unified diff for that single file ' +
         '("--- a/game/render.ts\\n+++ b/game/render.ts\\n@@\\n context\\n-old\\n+new\\n context\\n"; bare @@ ok). ' +
-        'old must match exactly once; widen the snippet if it is ambiguous. Do not pass patch together with old/new or patches. ' +
+        'old must match exactly once; widen the snippet if it is ambiguous. Do not mix files[] with top-level path/old/new/patches/patch. ' +
         'Then submit_sources({ fromStaged: true, mode, kitEngineRef }); fromStaged overlays onto the latest delivery/seed so you only need the patched paths staged. ' +
         BEHAVIOURAL_CONTRACT,
       inputSchema: {
@@ -3892,7 +3907,8 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
           sessionKey: SESSION_KEY_PROP,
           path: {
             type: 'string',
-            description: 'Game-relative path (e.g. game/render.ts). For unified diffs, must match the ---/+++ headers.',
+            description:
+              'Game-relative path (e.g. game/render.ts). Required for single-file edits. For unified diffs, must match the ---/+++ headers. Omit when passing files[].',
           },
           old: {
             type: 'string',
@@ -3914,36 +3930,65 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
               required: ['old', 'new'],
             },
           },
+          files: {
+            type: 'array',
+            description:
+              'Edit several files in one call. Each entry is { path, old, new } or { path, patches: [{ old, new }, ...] }. Do not pass top-level path/old/new/patches/patch with files[].',
+            items: {
+              type: 'object',
+              properties: {
+                path: { type: 'string', description: 'Game-relative path.' },
+                old: { type: 'string', description: 'Exact text to find (single replace).' },
+                new: { type: 'string', description: 'Replacement text (single replace).' },
+                patches: {
+                  type: 'array',
+                  description: 'Sequential { old, new } pairs for this file.',
+                  items: {
+                    type: 'object',
+                    properties: {
+                      old: { type: 'string' },
+                      new: { type: 'string' },
+                    },
+                    required: ['old', 'new'],
+                  },
+                },
+              },
+              required: ['path'],
+            },
+          },
           patch: {
             type: 'string',
             description:
-              'Unified diff for this one file only (alternative to old+new or patches). Bare `@@` hunks are fine when context matches.',
+              'Unified diff for this one file only (alternative to old+new, patches, or files[]). Bare `@@` hunks are fine when context matches.',
           },
           slug: { type: 'string' },
         },
-        required: ['path'],
       },
       handler: async (args, ctx) => {
         const auth = await resolveAuth(ctx, args);
         if (!('channelToken' in auth)) return auth;
         const path = typeof args.path === 'string' ? args.path.trim() : '';
-        if (!path) return toolErr('path is required');
+        const hasFiles = Array.isArray(args.files) && args.files.length > 0;
         const hasPatch = typeof args.patch === 'string' && args.patch.trim().length > 0;
         const hasOld = typeof args.old === 'string';
         const hasNew = typeof args.new === 'string';
         const hasPatches = Array.isArray(args.patches) && args.patches.length > 0;
 
+        if (hasFiles && (path || hasPatch || hasOld || hasNew || hasPatches)) {
+          return toolErr('pass files[] alone, or a single-file path with old+new / patches[] / patch');
+        }
+        if (!hasFiles && !path) return toolErr('path is required unless files[] is passed');
         const modes = [hasPatch, hasOld || hasNew, hasPatches].filter(Boolean).length;
-        if (modes > 1) {
+        if (!hasFiles && modes > 1) {
           return toolErr(
-            'pass either old+new (single exact replace), patches[] (multi-replace), or patch (unified diff)',
+            'pass either old+new (single exact replace), patches[] (multi-replace), files[], or patch (unified diff)',
           );
         }
         if (hasOld !== hasNew) {
           return toolErr('old and new must be passed together');
         }
-        if (modes === 0) {
-          return toolErr('pass old+new (preferred), patches[] (multi-replace), or patch (unified diff)');
+        if (!hasFiles && modes === 0) {
+          return toolErr('pass old+new (preferred), patches[] (multi-replace), files[], or patch (unified diff)');
         }
         const slug =
           typeof args.slug === 'string' && args.slug.trim() ? args.slug.trim() : (auth.record.slug ?? undefined);
@@ -3952,15 +3997,17 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
           'POST',
           '/api/agent/build/sources/stage/patch',
           auth.channelToken,
-          {
-            path,
-            ...(hasPatches
-              ? { patches: args.patches }
-              : hasPatch
-                ? { patch: args.patch }
-                : { old: args.old, new: args.new }),
-            ...(slug ? { slug } : {}),
-          },
+          hasFiles
+            ? { files: args.files, ...(slug ? { slug } : {}) }
+            : {
+                path,
+                ...(hasPatches
+                  ? { patches: args.patches }
+                  : hasPatch
+                    ? { patch: args.patch }
+                    : { old: args.old, new: args.new }),
+                ...(slug ? { slug } : {}),
+              },
         );
         const body = res.json() as {
           error?: string;
@@ -3970,6 +4017,12 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
           bytes?: number;
           replacements?: number;
           baseFrom?: 'staged' | 'delivery' | 'seed';
+          files?: Array<{
+            path: string;
+            bytes: number;
+            replacements: number;
+            baseFrom: 'staged' | 'delivery' | 'seed';
+          }>;
           hint?: string;
           manifestHint?: string;
           typecheckHint?: string;
@@ -3995,6 +4048,7 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
           bytes: body.bytes ?? 0,
           replacements: body.replacements ?? 0,
           baseFrom: body.baseFrom ?? 'staged',
+          ...(body.files ? { files: body.files } : {}),
           ...(hint ? { hint } : {}),
           staged: body.staged ?? { files: [], totalBytes: 0, maxBytes: 0, maxFiles: 0 },
           ...channelControlFields(body, [

--- a/apps/api/src/mcp-server.ts
+++ b/apps/api/src/mcp-server.ts
@@ -3880,6 +3880,7 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
         'Prefer this over stage_source_file whenever the file already exists (from get_sources, a prior stage, or the seed) — ' +
         'especially for large game/render.ts or game/model.ts files. ' +
         'PREFERRED: pass old + new (exact unique substring replace), or patches: [{ old, new }, ...] for multiple replacements in one call — no @@ line numbers, no diff format. ' +
+        'With patches[], replacements apply sequentially in order; ensure earlier replacements do not make a later old snippet ambiguous. ' +
         'ALTERNATE: pass patch as a unified diff for that single file ' +
         '("--- a/game/render.ts\\n+++ b/game/render.ts\\n@@\\n context\\n-old\\n+new\\n context\\n"; bare @@ ok). ' +
         'old must match exactly once; widen the snippet if it is ambiguous. Do not pass patch together with old/new or patches. ' +

--- a/apps/api/src/mcp-server.ts
+++ b/apps/api/src/mcp-server.ts
@@ -3879,10 +3879,10 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
         'Edit ONE existing path in the staging buffer without re-uploading the whole file. ' +
         'Prefer this over stage_source_file whenever the file already exists (from get_sources, a prior stage, or the seed) — ' +
         'especially for large game/render.ts or game/model.ts files. ' +
-        'PREFERRED: pass old + new (exact unique substring replace) — no @@ line numbers, no diff format. ' +
+        'PREFERRED: pass old + new (exact unique substring replace), or patches: [{ old, new }, ...] for multiple replacements in one call — no @@ line numbers, no diff format. ' +
         'ALTERNATE: pass patch as a unified diff for that single file ' +
         '("--- a/game/render.ts\\n+++ b/game/render.ts\\n@@\\n context\\n-old\\n+new\\n context\\n"; bare @@ ok). ' +
-        'old must match exactly once; widen the snippet if it is ambiguous. Do not pass patch together with old/new. ' +
+        'old must match exactly once; widen the snippet if it is ambiguous. Do not pass patch together with old/new or patches. ' +
         'Then submit_sources({ fromStaged: true, mode, kitEngineRef }); fromStaged overlays onto the latest delivery/seed so you only need the patched paths staged. ' +
         BEHAVIOURAL_CONTRACT,
       inputSchema: {
@@ -3901,10 +3901,22 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
             type: 'string',
             description: 'Replacement text for old (may be empty to delete). Pass together with old.',
           },
+          patches: {
+            type: 'array',
+            description: 'Array of { old, new } replacement pairs to apply sequentially to this file in one call.',
+            items: {
+              type: 'object',
+              properties: {
+                old: { type: 'string', description: 'Exact text to find.' },
+                new: { type: 'string', description: 'Replacement text.' },
+              },
+              required: ['old', 'new'],
+            },
+          },
           patch: {
             type: 'string',
             description:
-              'Unified diff for this one file only (alternative to old+new). Bare `@@` hunks are fine when context matches.',
+              'Unified diff for this one file only (alternative to old+new or patches). Bare `@@` hunks are fine when context matches.',
           },
           slug: { type: 'string' },
         },
@@ -3918,14 +3930,19 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
         const hasPatch = typeof args.patch === 'string' && args.patch.trim().length > 0;
         const hasOld = typeof args.old === 'string';
         const hasNew = typeof args.new === 'string';
-        if (hasPatch && (hasOld || hasNew)) {
-          return toolErr('pass either old+new (exact replace) or patch (unified diff), not both');
+        const hasPatches = Array.isArray(args.patches) && args.patches.length > 0;
+
+        const modes = [hasPatch, hasOld || hasNew, hasPatches].filter(Boolean).length;
+        if (modes > 1) {
+          return toolErr(
+            'pass either old+new (single exact replace), patches[] (multi-replace), or patch (unified diff)',
+          );
         }
         if (hasOld !== hasNew) {
           return toolErr('old and new must be passed together');
         }
-        if (!hasPatch && !hasOld) {
-          return toolErr('pass old+new (preferred) or patch (unified diff)');
+        if (modes === 0) {
+          return toolErr('pass old+new (preferred), patches[] (multi-replace), or patch (unified diff)');
         }
         const slug =
           typeof args.slug === 'string' && args.slug.trim() ? args.slug.trim() : (auth.record.slug ?? undefined);
@@ -3936,7 +3953,11 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
           auth.channelToken,
           {
             path,
-            ...(hasPatch ? { patch: args.patch } : { old: args.old, new: args.new }),
+            ...(hasPatches
+              ? { patches: args.patches }
+              : hasPatch
+                ? { patch: args.patch }
+                : { old: args.old, new: args.new }),
             ...(slug ? { slug } : {}),
           },
         );
@@ -4463,6 +4484,12 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
             description:
               "Which language summaryLocalized is written in, e.g. 'pl'. Without it summaryLocalized is ignored.",
           },
+          ackInboxIds: {
+            type: 'array',
+            description:
+              'Optional array of creator inbox message IDs to acknowledge simultaneously when ending the round.',
+            items: { type: 'string' },
+          },
         },
       },
       handler: async (args, ctx) => {
@@ -4473,6 +4500,7 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
           ...(typeof args.summary === 'string' ? { summary: args.summary } : {}),
           ...(typeof args.summaryLocalized === 'string' ? { summaryLocalized: args.summaryLocalized } : {}),
           ...(typeof args.locale === 'string' ? { locale: args.locale } : {}),
+          ...(Array.isArray(args.ackInboxIds) ? { ackInboxIds: args.ackInboxIds } : {}),
         };
         const res = await injectChannel(ctx.request, 'POST', '/api/agent/build/end', auth.channelToken, payload);
         const body = res.json() as {

--- a/apps/api/src/mcp-server.ts
+++ b/apps/api/src/mcp-server.ts
@@ -1358,7 +1358,7 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
     warnings: {
       type: 'array',
       description:
-        "Soft session nudges (progress_stale, inbox_pending, call_end, seed_unread, gate_not_started, gate_poll_backoff, module_too_large, game_manifest_invalid, typecheck_hint, audio_catalog_hint, card_unopened, must_fix_gate, must_deliver). Not errors — act on them, then continue the workflow. module_too_large means split that game/*.ts module before adding more behavior. game_manifest_invalid means the just-staged GAME.json has a shape that crashes the gate before typecheck (e.g. missing engine.modules) — fix it in the SAME stage/patch call's target, do not wait for submit_sources to find out. typecheck_hint means the file you just staged/patched would fail submit_sources' TypeScript preflight — fix it now, before staging more files on top of it. audio_catalog_hint means GAME.json names a music track id that is not in the shared catalog or a staged music.json — submit_sources will fail smoke with this same error. card_unopened means the creator has no status card yet — call show_round once. must_fix_gate means the last delivery was refused — fix and submit_sources again; staging alone does not re-run the gate.",
+        "Soft session nudges (progress_stale, inbox_pending, call_end, seed_unread, gate_not_started, gate_poll_backoff, module_too_large, game_manifest_invalid, typecheck_hint, audio_catalog_hint, card_unopened, must_fix_gate, must_deliver, patch_incomplete). Not errors — act on them, then continue the workflow. module_too_large means split that game/*.ts module before adding more behavior. game_manifest_invalid means the just-staged GAME.json has a shape that crashes the gate before typecheck (e.g. missing engine.modules) — fix it in the SAME stage/patch call's target, do not wait for submit_sources to find out. typecheck_hint means the file you just staged/patched would fail submit_sources' TypeScript preflight — fix it now, before staging more files on top of it. audio_catalog_hint means GAME.json names a music track id that is not in the shared catalog or a staged music.json — submit_sources will fail smoke with this same error. card_unopened means the creator has no status card yet — call show_round once. must_fix_gate means the last delivery was refused — fix and submit_sources again; staging alone does not re-run the gate. patch_incomplete means some edits in this patch_source_file call landed and some did not — retry only failed[] (path + index), do not resend the ones that applied.",
       items: {
         type: 'object',
         properties: {
@@ -1378,6 +1378,7 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
               'card_unopened',
               'must_fix_gate',
               'must_deliver',
+              'patch_incomplete',
             ],
           },
           message: { type: 'string' },
@@ -3866,6 +3867,19 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
               required: ['path', 'bytes', 'replacements', 'baseFrom'],
             },
           },
+          incomplete: { type: 'boolean' },
+          failed: {
+            type: 'array',
+            items: {
+              type: 'object',
+              properties: {
+                path: { type: 'string' },
+                index: { type: 'number' },
+                error: { type: 'string' },
+              },
+              required: ['path', 'index', 'error'],
+            },
+          },
           hint: { type: 'string' },
           staged: {
             type: 'object',
@@ -3895,7 +3909,7 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
         'PREFERRED: pass old + new (exact unique substring replace), or patches: [{ old, new }, ...] for multiple replacements in one file, ' +
         'or files: [{ path, old, new } | { path, patches: [{ old, new }] }, ...] to edit several files in one call — no @@ line numbers, no diff format. ' +
         'With patches[] / files[], replacements apply sequentially per file; ensure earlier replacements do not make a later old snippet ambiguous. ' +
-        'A files[] call applies every file in memory first and writes only if all apply — one miss leaves the buffer unchanged. ' +
+        'Edits that apply are kept even if later ones miss — retry only failed[] (path + index), do not resend the ones that landed. Honour warnings.code=patch_incomplete. ' +
         'ALTERNATE: pass path + patch as a unified diff for that single file ' +
         '("--- a/game/render.ts\\n+++ b/game/render.ts\\n@@\\n context\\n-old\\n+new\\n context\\n"; bare @@ ok). ' +
         'old must match exactly once; widen the snippet if it is ambiguous. Do not mix files[] with top-level path/old/new/patches/patch. ' +
@@ -4023,6 +4037,8 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
             replacements: number;
             baseFrom: 'staged' | 'delivery' | 'seed';
           }>;
+          incomplete?: boolean;
+          failed?: Array<{ path: string; index: number; error: string }>;
           hint?: string;
           manifestHint?: string;
           typecheckHint?: string;
@@ -4049,6 +4065,8 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
           replacements: body.replacements ?? 0,
           baseFrom: body.baseFrom ?? 'staged',
           ...(body.files ? { files: body.files } : {}),
+          ...(body.incomplete ? { incomplete: true } : {}),
+          ...(body.failed && body.failed.length > 0 ? { failed: body.failed } : {}),
           ...(hint ? { hint } : {}),
           staged: body.staged ?? { files: [], totalBytes: 0, maxBytes: 0, maxFiles: 0 },
           ...channelControlFields(body, [
@@ -4056,6 +4074,16 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
             ...(hint ? [{ code: 'module_too_large' as const, message: hint }] : []),
             ...(body.typecheckHint ? [{ code: 'typecheck_hint' as const, message: body.typecheckHint }] : []),
             ...(body.audioHint ? [{ code: 'audio_catalog_hint' as const, message: body.audioHint }] : []),
+            ...(body.failed && body.failed.length > 0
+              ? [
+                  {
+                    code: 'patch_incomplete' as const,
+                    message:
+                      `${body.failed.length} edit${body.failed.length === 1 ? '' : 's'} did not apply — ` +
+                      'retry only failed[] (path + index). Do not resend edits that already landed.',
+                  },
+                ]
+              : []),
           ]),
           pendingMessages: pendingMessagesFromChannel(body),
         });

--- a/apps/api/src/source-patch.test.ts
+++ b/apps/api/src/source-patch.test.ts
@@ -2,6 +2,7 @@ import { createPatch } from 'diff';
 import { describe, expect, it } from 'vitest';
 import {
   applyExactReplace,
+  applyMultipleExactReplaces,
   applySourcePatch,
   normalizePatchPath,
   normalizeUnifiedDiff,
@@ -284,5 +285,45 @@ describe('applyExactReplace', () => {
         new: 'b',
       }),
     ).toThrow(/more than once/);
+  });
+});
+
+describe('applyMultipleExactReplaces', () => {
+  const content = 'line1\nline2\nline3\nline4\n';
+
+  it('applies sequential exact replacements to a file', () => {
+    const result = applyMultipleExactReplaces({
+      content,
+      path: 'game.ts',
+      patches: [
+        { old: 'line2\n', new: 'line2_mod\n' },
+        { old: 'line4\n', new: 'line4_mod\n' },
+      ],
+    });
+    expect(result.content).toBe('line1\nline2_mod\nline3\nline4_mod\n');
+    expect(result.replacements).toBe(2);
+  });
+
+  it('refuses empty patches array', () => {
+    expect(() =>
+      applyMultipleExactReplaces({
+        content,
+        path: 'game.ts',
+        patches: [],
+      }),
+    ).toThrow(/at least one replacement/);
+  });
+
+  it('fails if any replacement in sequence is not found', () => {
+    expect(() =>
+      applyMultipleExactReplaces({
+        content,
+        path: 'game.ts',
+        patches: [
+          { old: 'line1\n', new: 'LINE1\n' },
+          { old: 'not_existing\n', new: 'x\n' },
+        ],
+      }),
+    ).toThrow(/not found in game.ts/);
   });
 });

--- a/apps/api/src/source-patch.ts
+++ b/apps/api/src/source-patch.ts
@@ -1,15 +1,4 @@
-/**
- * Unified-diff patches for game source staging (MCP / agent channel).
- *
- * Chat-thin agents (Claude Chat especially) otherwise re-emit entire `render.ts` /
- * `model.ts` files on every tweak via `stage_source_file`. A unified diff keeps the
- * tool payload proportional to the edit — the format models already know well.
- *
- * Models often emit near-unified diffs that stock parsers reject: bare `@@` (no line
- * numbers), approximate `@@ -N,M` counts, or context lines missing the leading space.
- * We normalize those before apply so agents need matching context, not exact line
- * arithmetic from a full-file re-read.
- */
+// Unified-diff patches for game source staging (MCP / agent channel).
 
 import { applyPatch, parsePatch } from 'diff';
 
@@ -22,19 +11,26 @@ export class SourcePatchError extends Error {
 
 export type ApplySourcePatchInput = {
   content: string;
-  /** Target game-relative path (e.g. game/render.ts). Must match the patch headers. */
   path: string;
-  /** Unified diff for this one path (`---/`+++` + `@@` hunks). */
   patch: string;
 };
 
 export type ApplyExactReplaceInput = {
   content: string;
   path: string;
-  /** Exact substring that must appear once in the file. */
   old: string;
-  /** Replacement text (may be empty to delete). */
   new: string;
+};
+
+export type ExactReplacePair = {
+  old: string;
+  new: string;
+};
+
+export type ApplyMultipleExactReplacesInput = {
+  content: string;
+  path: string;
+  patches: ExactReplacePair[];
 };
 
 export type ApplySourcePatchResult = {
@@ -283,6 +279,34 @@ export function applyExactReplace(input: ApplyExactReplaceInput): ApplySourcePat
 
   const content = input.content.replace(input.old, input.new);
   return { content, replacements: 1 };
+}
+
+export function applyMultipleExactReplaces(input: ApplyMultipleExactReplacesInput): ApplySourcePatchResult {
+  const path = input.path.trim();
+  if (!path) throw new SourcePatchError('path is required');
+  if (!Array.isArray(input.patches) || input.patches.length === 0) {
+    throw new SourcePatchError('patches array must contain at least one replacement');
+  }
+
+  let currentContent = input.content;
+  let totalReplacements = 0;
+
+  for (let i = 0; i < input.patches.length; i++) {
+    const p = input.patches[i]!;
+    if (typeof p.old !== 'string' || typeof p.new !== 'string') {
+      throw new SourcePatchError(`patch #${i + 1} must include old and new string properties`);
+    }
+    const res = applyExactReplace({
+      content: currentContent,
+      path,
+      old: p.old,
+      new: p.new,
+    });
+    currentContent = res.content;
+    totalReplacements += res.replacements;
+  }
+
+  return { content: currentContent, replacements: totalReplacements };
 }
 
 /** @deprecated Prefer {@link largeSourceFileHint} from `module-size.js`. Re-exported for callers. */

--- a/listings/mcp/README.md
+++ b/listings/mcp/README.md
@@ -70,7 +70,7 @@ build round; the authoritative list is whatever `tools/list` returns, and
 | `read_kit_file_fragment` | Read a Creator Kit file fragment        | read        |
 | `knowledge_query`        | Ask GameKit/EditorKit/docs a question   | read        |
 | `stage_source_file`      | Stage one source file                   | destructive |
-| `patch_source_file`      | Edit one staged source file             | destructive |
+| `patch_source_file`      | Edit one or more staged source files    | destructive |
 | `delete_source_file`     | Delete one staged source file           | destructive |
 | `clear_staged_sources`   | Clear staged source files               | destructive |
 | `list_staged_sources`    | List staged source files                | read        |

--- a/listings/mcp/chatgpt-apps-connector/tool-annotations.md
+++ b/listings/mcp/chatgpt-apps-connector/tool-annotations.md
@@ -469,7 +469,7 @@ Marked destructive because staging the same path again overwrites what was previ
 **Read Only: False**
 
 ```
-Edits a file that is already staged, so it writes state.
+Edits one or more files that are already staged, so it writes state.
 ```
 
 **Open World: False**


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary of Changes

This PR incorporates developer experience and reliability improvements observed during live self-build MCP agent sessions:

1. **Fix `must_deliver` False Warning after Preview Delivery (`agent-channel.ts`)**:
   - `control.mustDeliver` and `control.delivered` now check `record.deliveredVersion || record.previewVersion` rather than only `deliveredVersion`.
   - Prevents the channel from continuing to send false "Nothing has been delivered yet" soft warnings after a successful preview submission (`mode=preview`).

2. **Support Batch Multi-Replace in `patch_source_file` (`source-patch.ts`, `agent-channel.ts`, `mcp-server.ts`)**:
   - Added `patches: [{ old, new }, ...]` parameter to `patch_source_file` and the `/api/agent/build/sources/stage/patch` route.
   - Allows agents to apply multiple exact string substitutions to a single file in a single tool call.
   - Tool description notes that replacements apply sequentially, so an earlier pair must not make a later `old` snippet ambiguous.

3. **Multi-file patching (`files[]`)**:
   - `patch_source_file({ files: [{ path, old, new }, { path, patches: [...] }] })` edits several files in one call (up to 100 files, 50 fragments each).
   - **Best-effort apply:** every edit is tried. Ones that apply are staged. Misses are listed in `failed[]` (`path` + `index`) with `warnings.code=patch_incomplete`. The agent retries only the misses — it must not resend the ones that landed.
   - If a file write is refused after several fragments applied in memory, `failed[]` lists every applied index for that file (not just `0`).
   - If nothing in the batch applied, the call is still 400 and `failed[]` lists every miss.
   - Single-file `old`/`new` and unified diffs are unchanged.

4. **Creator Inbox Ack on `end` (`agent-channel.ts`, `mcp-server.ts`)**:
   - Added optional `ackInboxIds: string[]` to `end` tool and endpoint.
   - Allows agents to acknowledge handled creator inbox messages concurrently when ending the round instead of requiring an extra dedicated turn for `ack_inbox`.
   - **Review fix:** acks run only after the `end` is accepted (not on `stopped` or a handoff that did not start). Store failures surface instead of being swallowed.

5. **Environment Clarity in Prompt for Fast MCP Lane (`build-prompt.ts`)**:
   - Clarified in revision instructions for fast-lane MCP sessions that the execution environment is an MCP-only sandbox (instructing models to use `start` then `get_sources` and avoid running bash exploration commands).
   - **Review fix:** if `get_sources` reports nothing delivered yet, the earlier round never finished and the agent is starting the game rather than revising it.

6. **BYOCA playbook** (`.claude/skills/byoca-mcp/SKILL.md`) documents `patches[]`, `files[]`, `end({ ackInboxIds })`, and `patch_incomplete`.

## Test Coverage
- Unit tests added/updated in `source-patch.test.ts`, `agent-channel.test.ts`, `mcp-server.test.ts`, and `build-prompt.test.ts`.
- Inbox ack is covered for: successful `end`, successful builder-handoff ack, rejected `stopped` (no ack), and rejected `handoff_already_acknowledged` (no ack).
- Multi-file patch is covered for: successful multi-file + multi-fragment apply, keeping successful files when a later one misses, keeping earlier `patches[]` when a later fragment misses, 400 + `failed[]` when nothing applied, and reporting every applied index when a file write is refused.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d3a07f47-3d62-4fbe-be89-0eb6a4bb8c61?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d3a07f47-3d62-4fbe-be89-0eb6a4bb8c61&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

