### PR TITLE
fix(api): fail closed when Copilot's MCP lane has no scratch repo

### DIFF
--- a/apps/api/src/agent-backend-env.test.ts
+++ b/apps/api/src/agent-backend-env.test.ts
@@ -119,7 +119,8 @@ describe('createAgentBackendRegistryFromEnv', () => {
     );
   });
 
-  it('can select the Copilot MCP lane without changing backend selection', () => {
+  // Half-configured is worse than off: the MCP round would hit games.
+  it('fails closed when the Copilot MCP lane has no scratch repo', () => {
     setEnv({
       MANAGED_AGENT_VENDOR: 'copilot',
       AGENT_TASKS_TOKEN: randomBytes(32).toString('hex'),
@@ -127,11 +128,16 @@ describe('createAgentBackendRegistryFromEnv', () => {
       MANAGED_AGENT_MAX_SECONDS: '900',
       MANAGED_AGENT_PROMPT_LANE: 'mcp',
     });
-    const registry = createAgentBackendRegistryFromEnv({ info: vi.fn(), warn: vi.fn() }, undefined, {
+    const warn = vi.fn();
+    const registry = createAgentBackendRegistryFromEnv({ info: vi.fn(), warn }, undefined, {
       deliver: async () => ({ version: 'v1' }),
     });
 
-    expect(registry.platformByVendor.get('copilot')?.name).toBe('managed:copilot');
+    expect(registry.platformByVendor.get('copilot')).toBeUndefined();
+    expect(warn).toHaveBeenCalledWith(
+      expect.objectContaining({ vendor: 'copilot' }),
+      'copilot MCP lane is enabled but MANAGED_AGENT_COPILOT_MCP_REPO is missing',
+    );
   });
 
   it('accepts a separate MCP-lane repo for Copilot without changing backend selection', () => {

--- a/apps/api/src/agent-backend-env.ts
+++ b/apps/api/src/agent-backend-env.ts
@@ -77,8 +77,7 @@ function buildManagedBackendForVendor(
     isCopilot
       ? process.env.AGENT_TASKS_TOKEN
       : isGemini
-        ? (process.env.GEMINI_API_KEY ??
-          (allowGenericApiKeyFallback ? process.env.MANAGED_AGENT_API_KEY : undefined))
+        ? (process.env.GEMINI_API_KEY ?? (allowGenericApiKeyFallback ? process.env.MANAGED_AGENT_API_KEY : undefined))
         : process.env.MANAGED_AGENT_API_KEY
   )?.trim();
   const model = (
@@ -148,6 +147,11 @@ function buildManagedBackendForVendor(
   const needsMcpEndpoint = effectivePromptLane === 'mcp';
   if (needsMcpEndpoint && !mcpUrl) {
     log?.warn({ vendor }, 'managed agent MCP lane is enabled but MANAGED_AGENT_MCP_URL is missing');
+    return undefined;
+  }
+  // Without the scratch repo an MCP round lands in the games repo.
+  if (isCopilot && needsMcpEndpoint && !process.env.MANAGED_AGENT_COPILOT_MCP_REPO?.trim()) {
+    log?.warn({ vendor }, 'copilot MCP lane is enabled but MANAGED_AGENT_COPILOT_MCP_REPO is missing');
     return undefined;
   }
 

--- a/apps/api/src/managed-provider-copilot.test.ts
+++ b/apps/api/src/managed-provider-copilot.test.ts
@@ -73,7 +73,8 @@ describe('Copilot managed provider', () => {
     });
   });
 
-  it('accepts a per-round MCP lane without staging a harness seed branch', async () => {
+  // The old fallback was silent: MCP rounds landed in the games repo.
+  it('refuses a per-round MCP lane when no scratch repo is configured', async () => {
     const stub = tasks();
     const createBranchWithFiles = vi.fn(async () => undefined);
     const provider = createCopilotManagedProvider(
@@ -81,18 +82,20 @@ describe('Copilot managed provider', () => {
       { tasks: stub.client, github: githubStub({ createBranchWithFiles }) },
     );
 
-    await provider.startSession({
-      correlationId: '42',
-      prompt: buildPrompt(BRIEF, { kind: 'channel', fast: true }),
-      model: 'gpt-5.4',
-      outputPath: 'outputs',
-      promptLane: 'mcp',
-      tools: { mcpEndpoints: [{ url: 'https://www.gamedev.pl/api/mcp', name: 'gamedevpl' }] },
-      workspaceFiles: [{ path: 'games/comet-courier/game.ts', content: 'x' }],
-    });
+    await expect(
+      provider.startSession({
+        correlationId: '42',
+        prompt: buildPrompt(BRIEF, { kind: 'channel', fast: true }),
+        model: 'gpt-5.4',
+        outputPath: 'outputs',
+        promptLane: 'mcp',
+        tools: { mcpEndpoints: [{ url: 'https://www.gamedev.pl/api/mcp', name: 'gamedevpl' }] },
+        workspaceFiles: [{ path: 'games/comet-courier/game.ts', content: 'x' }],
+      }),
+    ).rejects.toThrow(/MANAGED_AGENT_COPILOT_MCP_REPO/);
 
+    expect(stub.startTask).not.toHaveBeenCalled();
     expect(createBranchWithFiles).not.toHaveBeenCalled();
-    expect(stub.startTask.mock.calls[0]?.[0].prompt).toContain('"key": "tok_abc"');
   });
 
   it('declares seed files unsupported on the mcp lane, supported off it', () => {

--- a/apps/api/src/managed-provider-copilot.ts
+++ b/apps/api/src/managed-provider-copilot.ts
@@ -140,7 +140,11 @@ export function createCopilotManagedProvider(
       if (promptLane !== 'mcp' && request.tools?.mcpEndpoints?.length) {
         throw new ManagedAgentError('copilot managed provider uses the harness prompt lane, not MCP');
       }
-      if (promptLane === 'mcp' && mcpTasks) {
+      if (promptLane === 'mcp') {
+        // Falling back would put an MCP round in the games repo, no MCP.
+        if (!mcpTasks) {
+          throw new ManagedAgentError('copilot MCP lane requires a separate repo; set MANAGED_AGENT_COPILOT_MCP_REPO');
+        }
         const task = await mcpTasks.startTask({
           prompt: withoutSeedPrompt(request.prompt),
           baseRef: mcpBaseRef,
@@ -151,7 +155,7 @@ export function createCopilotManagedProvider(
         mcpSessionIds.add(task.id);
         return taskSession(task, request.model);
       }
-      const seedBranch = promptLane === 'mcp' ? null : await stageSeed(request, baseRef, github);
+      const seedBranch = await stageSeed(request, baseRef, github);
       const task = await tasks.startTask({
         prompt: seedBranch ? request.prompt : withoutSeedPrompt(request.prompt),
         baseRef: seedBranch ?? baseRef,

--- a/docs/managed-agent-backend.md
+++ b/docs/managed-agent-backend.md
@@ -469,29 +469,39 @@ With `MANAGED_AGENT_DELIVERY_MODE=preview` (the default), a successful delivery 
 
 ## Configuration
 
-| Variable                            | Meaning                                                               |
-| ----------------------------------- | --------------------------------------------------------------------- |
-| `MANAGED_AGENT_VENDOR`              | Registered adapter id; required configuration must also be valid      |
-| `MANAGED_AGENT_API_KEY`             | Anthropic or Gemini credential. Never logged, never persisted         |
-| `GEMINI_API_KEY`                    | Optional Gemini-specific credential fallback                          |
-| `MANAGED_AGENT_MODEL`               | Anthropic or Gemini model label                                       |
-| `AGENT_TASKS_TOKEN`                 | Copilot Agent Tasks credential — needs `actions: write` to interrupt  |
-| `AGENT_TASKS_MODEL`                 | Copilot model label; defaults to the existing Copilot model           |
-| `GAMES_REPO`                        | Games repository targeted by Copilot                                  |
-| `GAMES_PUBLISHED_REF`               | Copilot harness base ref                                              |
-| `AGENT_CUSTOM_AGENT`                | Copilot custom agent name                                             |
-| `MANAGED_AGENT_ID`                  | Anthropic Managed Agent resource id                                   |
-| `MANAGED_AGENT_ENVIRONMENT_ID`      | Anthropic Managed Environment resource id                             |
-| `MANAGED_AGENT_MCP_URL`             | MCP endpoint; triggers per-round vault + `overrideTools`              |
-| `MANAGED_AGENT_VAULT_IDS`           | Optional static vault ids for probe-only MCP integrations             |
-| `MANAGED_AGENT_EFFORT`              | `low` / `medium` / `high`                                             |
-| `MANAGED_AGENT_MAX_SECONDS`         | Hard ceiling on one session's wall clock — **required, every vendor** |
-| `MANAGED_AGENT_MAX_LIST_COST_CENTS` | Anthropic session budget, in whole cents                              |
-| `MANAGED_AGENT_COPILOT_MAX_CREDITS` | Optional Copilot per-round credit ceiling                             |
-| `MANAGED_AGENT_PROMPT_LANE`         | Optional default lane: `mcp`, `harness`, or `outputs`                 |
-| `MANAGED_AGENT_MAX_TOTAL_TOKENS`    | Optional Gemini per-round token ceiling                               |
-| `MANAGED_AGENT_DELIVERY_MODE`       | `preview` (default) or `publish`                                      |
-| `MANAGED_AGENT_BASE_URL`            | Override the API origin — gateways, tests                             |
+| Variable                                 | Meaning                                                               |
+| ---------------------------------------- | --------------------------------------------------------------------- |
+| `MANAGED_AGENT_VENDOR`                   | Registered adapter id; required configuration must also be valid      |
+| `MANAGED_AGENT_API_KEY`                  | Anthropic or Gemini credential. Never logged, never persisted         |
+| `GEMINI_API_KEY`                         | Optional Gemini-specific credential fallback                          |
+| `MANAGED_AGENT_MODEL`                    | Anthropic or Gemini model label                                       |
+| `AGENT_TASKS_TOKEN`                      | Copilot Agent Tasks credential — needs `actions: write` to interrupt  |
+| `AGENT_TASKS_MODEL`                      | Copilot model label; defaults to the existing Copilot model           |
+| `GAMES_REPO`                             | Games repository targeted by Copilot                                  |
+| `GAMES_PUBLISHED_REF`                    | Copilot harness base ref                                              |
+| `AGENT_CUSTOM_AGENT`                     | Copilot custom agent name                                             |
+| `MANAGED_AGENT_ID`                       | Anthropic Managed Agent resource id                                   |
+| `MANAGED_AGENT_ENVIRONMENT_ID`           | Anthropic Managed Environment resource id                             |
+| `MANAGED_AGENT_MCP_URL`                  | MCP endpoint; triggers per-round vault + `overrideTools`              |
+| `MANAGED_AGENT_VAULT_IDS`                | Optional static vault ids for probe-only MCP integrations             |
+| `MANAGED_AGENT_EFFORT`                   | `low` / `medium` / `high`                                             |
+| `MANAGED_AGENT_MAX_SECONDS`              | Hard ceiling on one session's wall clock — **required, every vendor** |
+| `MANAGED_AGENT_MAX_LIST_COST_CENTS`      | Anthropic session budget, in whole cents                              |
+| `MANAGED_AGENT_COPILOT_MAX_CREDITS`      | Optional Copilot per-round credit ceiling                             |
+| `MANAGED_AGENT_PROMPT_LANE`              | Optional default lane: `mcp`, `harness`, or `outputs`                 |
+| `MANAGED_AGENT_COPILOT_MCP_REPO`         | Scratch repo for Copilot MCP-lane rounds — **required for that lane** |
+| `MANAGED_AGENT_COPILOT_MCP_BASE_REF`     | Base ref in the scratch repo; defaults to `main`                      |
+| `MANAGED_AGENT_COPILOT_MCP_CUSTOM_AGENT` | Custom agent there; defaults to `game-builder-mcp`                    |
+| `MANAGED_AGENT_MAX_TOTAL_TOKENS`         | Optional Gemini per-round token ceiling                               |
+| `MANAGED_AGENT_DELIVERY_MODE`            | `preview` (default) or `publish`                                      |
+| `MANAGED_AGENT_BASE_URL`                 | Override the API origin — gateways, tests                             |
+
+Copilot defaults to the `harness` lane, which dispatches into `GAMES_REPO`. Its `mcp` lane
+dispatches somewhere else entirely — a separate, content-free scratch repo holding nothing
+but an MCP-only custom agent doc, so a prompt-injectable session never shares a checkout
+with real source. Turning that lane on therefore takes two variables, not one:
+`MANAGED_AGENT_PROMPT_LANE=mcp` **and** `MANAGED_AGENT_COPILOT_MCP_REPO`. Setting only the
+first is refused at startup rather than quietly served from the games repo.
 
 Selection replaces the _platform_ backend. Builder routing, the job state machine, the
 gate, Studio and self builds are untouched: a managed round is a platform round whose


### PR DESCRIPTION
## What happened

A managed round dispatched to Copilot was supposed to run in `gamedevpl/scratchpad` over MCP. It did neither — the task landed in `gamedevpl/www.gamedev.pl-games` on the `game-builder` harness agent, with no MCP and no warning anywhere. The only tell was the task URL.

The cause is a silent fallback in `managed-provider-copilot.ts`:

```ts
if (promptLane === 'mcp' && mcpTasks) { ... }   // scratchpad, game-builder-mcp
// falls through to the harness dispatch when mcpTasks is undefined
```

`mcpTasks` exists only when `MANAGED_AGENT_COPILOT_MCP_REPO` is set. Unset, an MCP-lane round quietly became a harness round in the private games repo — which is precisely the exposure #798 added the separate repo to remove: a prompt-injectable session sharing a checkout with real proprietary source.

## Changes

- `startSession` throws when the lane is `mcp` and no scratch repo is configured, instead of falling through. The dead `promptLane === 'mcp' ? null : …` seed-staging ternary below it goes away with it.
- `agent-backend-env.ts` refuses to build a copilot backend at all when the lane is `mcp` and `MANAGED_AGENT_COPILOT_MCP_REPO` is missing — the same fail-closed shape every usage ceiling in that file already uses. A half-configured lane is worse than a disabled one.
- Documents all three `MANAGED_AGENT_COPILOT_MCP_*` variables. The code comment already pointed at `docs/managed-agent-backend.md` for them, but the env table never listed them. Adds a note that enabling the lane takes two variables (`MANAGED_AGENT_PROMPT_LANE=mcp` **and** the repo), not one.

Two existing tests encoded the old fallback and now assert the refusal instead.

## Not in scope

This is the guardrail, not the rollout. The operator steps from #798 are still outstanding and are what actually enables the lane: setting the repo variables, granting `AGENT_TASKS_TOKEN` access to `gamedevpl/scratchpad`, and creating the `copilot-mcp-connector` secret there. After this change a deploy missing the repo variable disables copilot dispatch loudly rather than serving it from the games repo.

## Validation

- `npm run test -w @gamedevpl/api` — 3171 tests, 198 files, all pass
- `npm run type-check` — clean
- `npx eslint` on changed files, `--max-warnings 0` — clean
- `npm run comment-prose` — clean

---
_Generated by [Claude Code](https://claude.ai/code/session_01N56phUDE38ZDGRa7PanE5P)_