### PR TITLE
fix(studio): restore mobile chat and editor navigation

### DIFF
--- a/apps/web/src/CreatorStudioView.test.tsx
+++ b/apps/web/src/CreatorStudioView.test.tsx
@@ -477,14 +477,13 @@ describe('CreatorStudioView', () => {
       shelfOpen!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
     });
     expect(container.querySelector('.studio-layout')?.classList.contains('is-shelf-open')).toBe(true);
-    // The drawer has its own edge toggle/backdrop. A second escape chip must not
-    // float over the first shelf row and steal its tap target.
+    // Drawer controls own dismissal; no extra escape chip should steal taps.
     expect(container.querySelector('.studio-fullbleed')).toBeNull();
     expect(container.querySelector('.studio-chat-rail')?.classList.contains('is-collapsed')).toBe(true);
     await act(async () => {
-      container.querySelector<HTMLElement>('.studio-shelf-backdrop')!.dispatchEvent(
-        new MouseEvent('click', { bubbles: true }),
-      );
+      container
+        .querySelector<HTMLElement>('.studio-shelf-backdrop')!
+        .dispatchEvent(new MouseEvent('click', { bubbles: true }));
     });
     expect(container.querySelector('.studio-layout')?.classList.contains('is-shelf-open')).toBe(false);
     expect(container.querySelector('.studio-stage')).not.toBeNull();

--- a/apps/web/src/CreatorStudioView.test.tsx
+++ b/apps/web/src/CreatorStudioView.test.tsx
@@ -480,6 +480,7 @@ describe('CreatorStudioView', () => {
     // The drawer has its own edge toggle/backdrop. A second escape chip must not
     // float over the first shelf row and steal its tap target.
     expect(container.querySelector('.studio-fullbleed')).toBeNull();
+    expect(container.querySelector('.studio-chat-rail')?.classList.contains('is-collapsed')).toBe(true);
     await act(async () => {
       container.querySelector<HTMLElement>('.studio-shelf-backdrop')!.dispatchEvent(
         new MouseEvent('click', { bubbles: true }),

--- a/apps/web/src/CreatorStudioView.test.tsx
+++ b/apps/web/src/CreatorStudioView.test.tsx
@@ -477,11 +477,13 @@ describe('CreatorStudioView', () => {
       shelfOpen!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
     });
     expect(container.querySelector('.studio-layout')?.classList.contains('is-shelf-open')).toBe(true);
-    expect(container.querySelector('.studio-fullbleed')).not.toBeNull();
+    // The drawer has its own edge toggle/backdrop. A second escape chip must not
+    // float over the first shelf row and steal its tap target.
+    expect(container.querySelector('.studio-fullbleed')).toBeNull();
     await act(async () => {
-      container
-        .querySelector<HTMLButtonElement>('.studio-fullbleed')!
-        .dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      container.querySelector<HTMLElement>('.studio-shelf-backdrop')!.dispatchEvent(
+        new MouseEvent('click', { bubbles: true }),
+      );
     });
     expect(container.querySelector('.studio-layout')?.classList.contains('is-shelf-open')).toBe(false);
     expect(container.querySelector('.studio-stage')).not.toBeNull();

--- a/apps/web/src/CreatorStudioView.tsx
+++ b/apps/web/src/CreatorStudioView.tsx
@@ -800,8 +800,7 @@ export function CreatorStudioView({
               <div className="studio-detail">
                 {(() => {
                   const covered = shelfOpen || tab === 'details' || tab === 'edit' || tab === 'code';
-                  // The shelf drawer owns the screen while it is open. Keeping the
-                  // chat backdrop mounted here blocks the drawer opener and its rows.
+                  // Drawer covers chat; keep its opener and rows clickable.
                   const chatCovered = shelfOpen || tab === 'details' || tab === 'edit';
                   const chatVisible = railOpen && !chatCovered;
                   const canClaim = Boolean(

--- a/apps/web/src/CreatorStudioView.tsx
+++ b/apps/web/src/CreatorStudioView.tsx
@@ -800,7 +800,9 @@ export function CreatorStudioView({
               <div className="studio-detail">
                 {(() => {
                   const covered = shelfOpen || tab === 'details' || tab === 'edit' || tab === 'code';
-                  const chatCovered = tab === 'details' || tab === 'edit';
+                  // The shelf drawer owns the screen while it is open. Keeping the
+                  // chat backdrop mounted here blocks the drawer opener and its rows.
+                  const chatCovered = shelfOpen || tab === 'details' || tab === 'edit';
                   const chatVisible = railOpen && !chatCovered;
                   const canClaim = Boolean(
                     !user?.handle &&
@@ -1120,7 +1122,7 @@ export function CreatorStudioView({
                           </>
                         ) : null}
 
-                        <StudioFullBleed visible={covered} onClick={backToFullBleed} />
+                        <StudioFullBleed visible={covered && !shelfOpen} onClick={backToFullBleed} />
                       </div>
                     </>
                   );

--- a/apps/web/src/StudioChatRail.test.tsx
+++ b/apps/web/src/StudioChatRail.test.tsx
@@ -53,6 +53,41 @@ describe('StudioChatRail', () => {
     await act(async () => root.unmount());
   });
 
+  it('measures the site header so chat does not cover navigation', async () => {
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    mockSheetMedia(true);
+    const header = document.createElement('header');
+    header.className = 'app-header';
+    vi.spyOn(header, 'getBoundingClientRect').mockReturnValue({
+      height: 71,
+      width: 390,
+      top: 0,
+      left: 0,
+      bottom: 71,
+      right: 390,
+      x: 0,
+      y: 0,
+      toJSON: () => ({}),
+    });
+    document.body.appendChild(header);
+
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    const root = createRoot(host);
+    await act(async () => {
+      root.render(
+        <StudioChatRail title="Sky Dodge" open onOpenChange={vi.fn()} unreadCount={0}>
+          <p>Thread</p>
+        </StudioChatRail>,
+      );
+    });
+
+    expect(document.documentElement.style.getPropertyValue('--studio-chat-rail-top-inset')).toBe('71px');
+
+    await act(async () => root.unmount());
+    header.remove();
+  });
+
   it('keeps a phone peek detent while another pane temporarily covers chat', async () => {
     (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
     mockSheetMedia(true);
@@ -103,6 +138,7 @@ describe('StudioChatRail', () => {
     const expand = host.querySelector<HTMLButtonElement>('.studio-chat-rail-expand');
     expect(rail?.classList.contains('is-half')).toBe(true);
     expect(expand?.getAttribute('aria-label')).toBe('Full screen');
+    expect(expand?.getAttribute('aria-pressed')).toBe('false');
     expect(host.querySelector('.studio-chat-rail-popout')).toBeNull();
 
     await act(async () => {
@@ -110,6 +146,7 @@ describe('StudioChatRail', () => {
     });
     expect(rail?.classList.contains('is-full')).toBe(true);
     expect(expand?.getAttribute('aria-label')).toBe('Exit full screen');
+    expect(expand?.getAttribute('aria-pressed')).toBe('true');
 
     await act(async () => {
       expand?.click();
@@ -155,13 +192,57 @@ describe('StudioChatRail', () => {
 
     await act(async () => {
       grab?.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true, pointerId: 1, clientY: 500, button: 0 }));
-      grab?.dispatchEvent(new PointerEvent('pointermove', { bubbles: true, pointerId: 1, clientY: 180 }));
-      grab?.dispatchEvent(new PointerEvent('pointerup', { bubbles: true, pointerId: 1, clientY: 180 }));
+      window.dispatchEvent(new PointerEvent('pointermove', { bubbles: true, pointerId: 1, clientY: 180 }));
+      window.dispatchEvent(new PointerEvent('pointerup', { bubbles: true, pointerId: 1, clientY: 180 }));
     });
     expect(rail.classList.contains('is-dragging')).toBe(false);
     expect(rail.classList.contains('is-full')).toBe(true);
     expect(rail.style.getPropertyValue('--studio-chat-rail-peek-height')).toBe('124px');
 
+    await act(async () => root.unmount());
+  });
+
+  it('finishes a drag when pointer capture is unavailable', async () => {
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    mockSheetMedia(true);
+    Object.defineProperty(window, 'innerHeight', { configurable: true, value: 800 });
+    HTMLElement.prototype.setPointerCapture = vi.fn(() => {
+      throw new Error('capture unavailable');
+    });
+
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    const root = createRoot(host);
+
+    await act(async () => {
+      root.render(
+        <StudioChatRail title="Sky Dodge" open onOpenChange={vi.fn()} unreadCount={0}>
+          <p>Thread</p>
+        </StudioChatRail>,
+      );
+    });
+
+    const rail = host.querySelector('.studio-chat-rail') as HTMLElement;
+    const grab = host.querySelector<HTMLButtonElement>('.studio-chat-rail-grab');
+    vi.spyOn(rail, 'getBoundingClientRect').mockReturnValue({
+      height: 384,
+      width: 390,
+      top: 416,
+      left: 0,
+      bottom: 800,
+      right: 390,
+      x: 0,
+      y: 416,
+      toJSON: () => ({}),
+    });
+
+    await act(async () => {
+      grab?.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true, pointerId: 2, clientY: 500, button: 0 }));
+      window.dispatchEvent(new PointerEvent('pointermove', { bubbles: true, pointerId: 2, clientY: 180 }));
+      window.dispatchEvent(new PointerEvent('pointerup', { bubbles: true, pointerId: 2, clientY: 180 }));
+    });
+
+    expect(rail.classList.contains('is-full')).toBe(true);
     await act(async () => root.unmount());
   });
 });

--- a/apps/web/src/StudioChatRail.tsx
+++ b/apps/web/src/StudioChatRail.tsx
@@ -247,6 +247,7 @@ export function StudioChatRail({
                 type="button"
                 className="studio-chat-rail-head-action studio-chat-rail-expand"
                 onClick={() => setDetent(detent === 'full' ? 'half' : 'full')}
+                aria-pressed={detent === 'full'}
                 aria-label={detent === 'full' ? exitFullLabel : expandLabel}
                 data-tooltip={detent === 'full' ? exitFullLabel : expandLabel}
               >

--- a/apps/web/src/StudioChatRail.tsx
+++ b/apps/web/src/StudioChatRail.tsx
@@ -95,9 +95,15 @@ export function StudioChatRail({
   // — without this, the viewport-fixed sheet paints over its dismiss/reload controls
   // instead of sitting above them.
   useEffect(() => {
-    if (typeof ResizeObserver === 'undefined') return;
     const root = document.documentElement;
     const measure = () => {
+      const header = document.querySelector('.app-header') as HTMLElement | null;
+      if (header) {
+        const headerBottom = Math.max(0, Math.ceil(header.getBoundingClientRect().bottom));
+        root.style.setProperty('--studio-chat-rail-top-inset', `${headerBottom}px`);
+      } else {
+        root.style.removeProperty('--studio-chat-rail-top-inset');
+      }
       const overlay = document.querySelector('.install-prompt, .app-update') as HTMLElement | null;
       if (!overlay) {
         root.style.removeProperty('--studio-chat-rail-overlay-lift');
@@ -108,21 +114,28 @@ export function StudioChatRail({
       root.style.setProperty('--studio-chat-rail-overlay-lift', `${lift}px`);
     };
     measure();
-    const resizeObserver = new ResizeObserver(measure);
+    let resizeObserver: ResizeObserver | null = null;
     const watchOverlays = () => {
-      resizeObserver.disconnect();
-      document.querySelectorAll('.install-prompt, .app-update').forEach((node) => resizeObserver.observe(node));
+      resizeObserver?.disconnect();
+      document.querySelectorAll('.install-prompt, .app-update, .app-header').forEach((node) => {
+        resizeObserver?.observe(node);
+      });
       measure();
     };
-    watchOverlays();
-    const mutationObserver = new MutationObserver(watchOverlays);
-    mutationObserver.observe(document.body, { childList: true, subtree: true });
+    if (typeof ResizeObserver !== 'undefined') {
+      resizeObserver = new ResizeObserver(measure);
+      watchOverlays();
+    }
+    const mutationObserver =
+      typeof MutationObserver === 'undefined' ? null : new MutationObserver(watchOverlays);
+    mutationObserver?.observe(document.body, { childList: true, subtree: true });
     window.addEventListener('resize', measure);
     return () => {
-      resizeObserver.disconnect();
-      mutationObserver.disconnect();
+      resizeObserver?.disconnect();
+      mutationObserver?.disconnect();
       window.removeEventListener('resize', measure);
       root.style.removeProperty('--studio-chat-rail-overlay-lift');
+      root.style.removeProperty('--studio-chat-rail-top-inset');
     };
   }, []);
 
@@ -130,7 +143,11 @@ export function StudioChatRail({
     if (!isSheet || event.button !== 0) return;
     const rail = asideRef.current;
     if (!rail) return;
-    event.currentTarget.setPointerCapture(event.pointerId);
+    try {
+      event.currentTarget.setPointerCapture(event.pointerId);
+    } catch {
+      // Some iOS webviews do not implement element pointer capture.
+    }
     dragRef.current = {
       pointerId: event.pointerId,
       startY: event.clientY,
@@ -139,28 +156,36 @@ export function StudioChatRail({
     };
   };
 
-  const onGrabPointerMove = (event: PointerEvent<HTMLButtonElement>) => {
-    const drag = dragRef.current;
-    if (!drag || drag.pointerId !== event.pointerId) return;
-    const dy = drag.startY - event.clientY;
-    if (!drag.moved && Math.abs(dy) < SHEET_DRAG_CLICK_SLOP_PX) return;
-    drag.moved = true;
-    setDragHeight(clampSheetDragHeight(drag.startH + dy, window.innerHeight));
-  };
-
-  const endGrab = (event: PointerEvent<HTMLButtonElement>) => {
-    const drag = dragRef.current;
-    if (!drag || drag.pointerId !== event.pointerId) return;
-    dragRef.current = null;
-    if (event.currentTarget.hasPointerCapture(event.pointerId)) {
-      event.currentTarget.releasePointerCapture(event.pointerId);
-    }
-    if (!drag.moved) return;
-    ignoreGrabClickRef.current = true;
-    const height = clampSheetDragHeight(drag.startH + drag.startY - event.clientY, window.innerHeight);
-    setDetent(snapSheetDetent(height, window.innerHeight));
-    setDragHeight(null);
-  };
+  useEffect(() => {
+    if (!isSheet) return;
+    const onMove = (event: globalThis.PointerEvent) => {
+      const drag = dragRef.current;
+      if (!drag || drag.pointerId !== event.pointerId) return;
+      const dy = drag.startY - event.clientY;
+      if (!drag.moved && Math.abs(dy) < SHEET_DRAG_CLICK_SLOP_PX) return;
+      drag.moved = true;
+      setDragHeight(clampSheetDragHeight(drag.startH + dy, window.innerHeight));
+    };
+    const onEnd = (event: globalThis.PointerEvent) => {
+      const drag = dragRef.current;
+      if (!drag || drag.pointerId !== event.pointerId) return;
+      dragRef.current = null;
+      if (!drag.moved) return;
+      ignoreGrabClickRef.current = true;
+      const height = clampSheetDragHeight(drag.startH + drag.startY - event.clientY, window.innerHeight);
+      setDetent(snapSheetDetent(height, window.innerHeight));
+      setDragHeight(null);
+    };
+    window.addEventListener('pointermove', onMove);
+    window.addEventListener('pointerup', onEnd);
+    window.addEventListener('pointercancel', onEnd);
+    return () => {
+      window.removeEventListener('pointermove', onMove);
+      window.removeEventListener('pointerup', onEnd);
+      window.removeEventListener('pointercancel', onEnd);
+      dragRef.current = null;
+    };
+  }, [isSheet]);
 
   const onGrabClick = () => {
     if (ignoreGrabClickRef.current) {

--- a/apps/web/src/StudioChatRail.tsx
+++ b/apps/web/src/StudioChatRail.tsx
@@ -229,9 +229,6 @@ export function StudioChatRail({
             type="button"
             className="studio-chat-rail-grab"
             onPointerDown={onGrabPointerDown}
-            onPointerMove={onGrabPointerMove}
-            onPointerUp={endGrab}
-            onPointerCancel={endGrab}
             onClick={onGrabClick}
             aria-label={
               detent === 'full'

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -12570,6 +12570,27 @@ button.builder-mode-selector:disabled {
   }
 }
 
+@media (max-width: 800px) {
+  /* The mobile sheet rules above are more specific than the shared collapsed
+     clip. Repeat the clip after them or a covered rail remains painted over a
+     drawer even though it is inert. */
+  .studio-chat-rail.is-sheet.is-collapsed {
+    position: absolute;
+    inset: auto;
+    width: 1px;
+    height: 1px;
+    max-width: 1px;
+    max-height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    visibility: hidden;
+    pointer-events: none;
+    border: 0;
+  }
+}
+
 .studio-detail-head {
   display: flex;
   flex-direction: column;

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -11677,7 +11677,10 @@ button.builder-mode-selector:disabled {
   display: flex;
   flex-direction: column;
   background: var(--panel);
-  overflow: hidden;
+  min-height: 0;
+  overflow: auto;
+  overscroll-behavior: contain;
+  -webkit-overflow-scrolling: touch;
 }
 
 /* Edit definitions without a board dock beside the running game. */
@@ -12463,6 +12466,12 @@ button.builder-mode-selector:disabled {
 
 .studio-chat-rail-backdrop {
   z-index: 1090;
+  top: var(--studio-chat-rail-top-inset, 0px);
+}
+
+/* The sheet is modal over the stage, not over the site's navigation. */
+.app:has(.studio-chat-rail.is-sheet:not(.is-collapsed)) .app-header {
+  z-index: 1200;
 }
 
 /* Collapsed to the pill: the thread stays mounted (its poll, and any unsent composer
@@ -12538,14 +12547,26 @@ button.builder-mode-selector:disabled {
   }
 
   .studio-chat-rail.is-full {
-    height: 88vh;
+    top: var(--studio-chat-rail-top-inset, 0px);
+    height: auto;
     max-height: none;
+    border-radius: 0;
   }
 
   .studio-chat-rail.is-sheet.is-dragging {
     height: var(--studio-chat-rail-drag-height);
     max-height: none;
     transition: none;
+  }
+}
+
+@media (max-width: 800px) {
+  /* Keep the Studio strip usable while the sheet is half-open. Full chat still
+     leaves the global header as its escape hatch. */
+  .app:has(.studio-chat-rail.is-sheet.is-peek:not(.is-collapsed)) .studio-strip,
+  .app:has(.studio-chat-rail.is-sheet.is-half:not(.is-collapsed)) .studio-strip {
+    position: relative;
+    z-index: 1200;
   }
 }
 
@@ -14590,10 +14611,14 @@ button.builder-mode-selector:disabled {
   --editor-cell: clamp(20px, 4.2vw, 40px);
   flex: 1;
   min-width: 0;
+  min-height: 0;
   display: flex;
   flex-direction: column;
   gap: 14px;
   padding: 10px 4px 18px;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  -webkit-overflow-scrolling: touch;
 }
 
 .editor-panel-note {
@@ -14609,6 +14634,11 @@ button.builder-mode-selector:disabled {
   align-items: center;
   gap: 10px;
   flex-wrap: wrap;
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  padding: 4px 0 6px;
+  background: var(--panel);
 }
 
 .editor-save-state {
@@ -14657,6 +14687,7 @@ button.builder-mode-selector:disabled {
   gap: 18px;
   align-items: flex-start;
   min-width: 0;
+  min-height: 0;
 }
 
 .editor-board-col {

--- a/apps/web/src/styles.studioChatRail.test.ts
+++ b/apps/web/src/styles.studioChatRail.test.ts
@@ -59,6 +59,12 @@ describe('Studio chat rail header', () => {
     );
   });
 
+  it('keeps a covered sheet from painting over the games drawer', () => {
+    expect(css).toMatch(
+      /\.studio-chat-rail\.is-sheet\.is-collapsed\s*\{[\s\S]*?visibility:\s*hidden[\s\S]*?pointer-events:\s*none/s,
+    );
+  });
+
   it('makes chat full screen fill the work area below the header', () => {
     expect(declarations('.studio-chat-rail.is-full')).toMatch(
       /top:\s*var\(--studio-chat-rail-top-inset,\s*0px\)/,

--- a/apps/web/src/styles.studioChatRail.test.ts
+++ b/apps/web/src/styles.studioChatRail.test.ts
@@ -44,6 +44,29 @@ describe('Studio chat rail header', () => {
     expect(css).toMatch(/\.studio-chat-rail\.is-sheet\s*\{[^}]*z-index:\s*1100/s);
   });
 
+  it('keeps navigation above the phone sheet and its backdrop', () => {
+    expect(declarations('.studio-chat-rail-backdrop')).toMatch(
+      /top:\s*var\(--studio-chat-rail-top-inset,\s*0px\)/,
+    );
+    expect(css).toMatch(
+      /\.app:has\(\.studio-chat-rail\.is-sheet:not\(\.is-collapsed\)\) \.app-header\s*\{[^}]*z-index:\s*1200/s,
+    );
+  });
+
+  it('keeps the half-open Studio controls reachable', () => {
+    expect(css).toMatch(
+      /\.app:has\(\.studio-chat-rail\.is-sheet\.is-half:not\(\.is-collapsed\)\) \.studio-strip\s*\{[^}]*z-index:\s*1200/s,
+    );
+  });
+
+  it('makes chat full screen fill the work area below the header', () => {
+    expect(declarations('.studio-chat-rail.is-full')).toMatch(
+      /top:\s*var\(--studio-chat-rail-top-inset,\s*0px\)/,
+    );
+    expect(declarations('.studio-chat-rail.is-full')).toMatch(/height:\s*auto/);
+    expect(declarations('.studio-chat-rail.is-full')).toMatch(/border-radius:\s*0/);
+  });
+
   it('lets the transcript take vertical pans inside the sheet', () => {
     expect(declarations('.studio-chat-rail-body')).toMatch(/touch-action:\s*pan-y/);
     expect(declarations('.studio-chat-rail-body .studio-thread-scroll')).toMatch(/touch-action:\s*pan-y/);

--- a/apps/web/src/styles.studioEditor.test.ts
+++ b/apps/web/src/styles.studioEditor.test.ts
@@ -1,0 +1,27 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const css = readFileSync(fileURLToPath(new URL('./styles.css', import.meta.url)), 'utf8');
+
+function declarations(selector: string): string {
+  const start = css.indexOf(`${selector} {`);
+  expect(start, `missing ${selector} rule`).toBeGreaterThan(-1);
+  const end = css.indexOf('}', start);
+  expect(end, `unclosed ${selector} rule`).toBeGreaterThan(start);
+  return css.slice(start, end);
+}
+
+describe('Studio editor layout', () => {
+  it('keeps the editor overlay independently scrollable', () => {
+    expect(declarations('.studio-edit-overlay')).toMatch(/min-height:\s*0/);
+    expect(declarations('.studio-edit-overlay')).toMatch(/overflow:\s*auto/);
+    expect(declarations('.studio-edit-overlay')).toMatch(/overscroll-behavior:\s*contain/);
+  });
+
+  it('keeps long editor content scrollable without losing its toolbar', () => {
+    expect(declarations('.editor-panel')).toMatch(/min-height:\s*0/);
+    expect(declarations('.editor-panel')).toMatch(/overflow-y:\s*auto/);
+    expect(declarations('.editor-panel-head')).toMatch(/position:\s*sticky/);
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- keep the mobile Studio header and half-open controls above the chat backdrop
- make chat fullscreen fill the work area below the header and make drag release-safe on iOS webviews
- prevent the return-to-game chip from covering the games drawer
- make the Edit surface independently scrollable with a sticky toolbar

## Validation
- Reproduced locally at 390×844: before the fix, the chat backdrop intercepted Back, hamburger, and the shelf opener.
- Focused Studio tests pass.
- Full gate passes: `npm install`, type-check, lint, all tests, and build.
- Manual headed-browser walkthrough passed: hamburger, chat drag/fullscreen, Edit, editor scroll, return-to-game, and games drawer.

[studio_mobile_chat_navigation_editor_walkthrough.mp4](https://cursor.com/agents/bc-019fff09-b8f6-77e6-b7ef-969b4add3eb2/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fstudio_mobile_chat_navigation_editor_walkthrough.mp4)

## Instrumentation
This is a layout/navigation correction; it does not change the measured creator or visit funnel. Existing `studio` route and editor `code_step` / `studio_step` events remain unchanged.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fff09-b8f6-77e6-b7ef-969b4add3eb2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fff09-b8f6-77e6-b7ef-969b4add3eb2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

