### PR TITLE
Document scripted feedback loop path in desk review skill

### DIFF
--- a/.claude/skills/ingest-desk-reviews/SKILL.md
+++ b/.claude/skills/ingest-desk-reviews/SKILL.md
@@ -56,6 +56,13 @@ From the pasted JSON:
 - Product plan: [`docs/game-assessment-plan.md`](../../docs/game-assessment-plan.md)
 - Catalog agents still use games-repo `game-assessment` tickets for the **automated
   floor** (SPEC/media/agency) — that is separate from desk keep/cut judgment.
+- **Scripted / unsupervised path.** This skill covers a one-off "paste JSON, get a
+  synthesis" pass. For running the whole fetch -> plan -> synthesize -> dispatch loop
+  unattended from a laptop CLI — including handing tier 1/2 fixes to a local coding
+  agent, gated by `check:game` before anything is committed — see
+  [`catalog-feedback-loop`](https://github.com/gamedevpl/www.gamedev.pl-games/blob/main/.github/skills/catalog-feedback-loop/SKILL.md)
+  in the games repo (`tools/assess/`). It implements the same priority heuristic and the
+  same untrusted-notes posture as this skill, just scripted.
 
 Self-improvement clause: if this skill is wrong, stale, or missing something that cost
 you time, update it in the same session.


### PR DESCRIPTION
## Summary
Added documentation to the desk review skill clarifying the distinction between the interactive "paste JSON" workflow covered by this skill and the automated scripted feedback loop for unattended catalog processing.

## Changes
- Added a new section documenting the **scripted/unsupervised path** for running the full fetch → plan → synthesize → dispatch loop
- Clarified that this skill covers only the one-off interactive synthesis pass
- Referenced the `catalog-feedback-loop` skill in the games repo for the automated workflow
- Noted that both paths implement the same priority heuristic and untrusted-notes posture, with the scripted version adding local coding agent integration gated by `check:game` validation

## Details
This documentation update helps users understand when to use this skill versus the scripted feedback loop tool, and establishes that both approaches share the same underlying assessment logic and safety constraints.

https://claude.ai/code/session_01GKwsiFyE6hssB1o9RmLs5m