### PR TITLE
Code surface: cmd/ctrl-click go-to-definition (GA-09)

### DIFF
--- a/apps/web/src/CodeMirrorEditor.tsx
+++ b/apps/web/src/CodeMirrorEditor.tsx
@@ -13,9 +13,11 @@ import { tags } from '@lezer/highlight';
 import { basicSetup } from 'codemirror';
 import { useEffect, useRef } from 'react';
 import {
+  defaultGotoHandler,
   renderDisplayParts,
   tsAutocomplete,
   tsFacet,
+  tsGoto,
   tsHover,
   tsLintSource,
   tsSync,
@@ -41,6 +43,10 @@ export type CodeMirrorEditorProps = {
   readOnly?: boolean;
   // Once set, wires tsSync/tsAutocomplete/tsHover/tsLinter; else plain CodeMirror.
   languageService?: CodeMirrorLanguageService;
+  // GA-09: cmd/ctrl-click target — path is vfs-rooted.
+  onGotoDefinition?: (path: string, from: number, to: number) => void;
+  // GA-09: mount-only selection for a cross-file jump landing.
+  initialSelection?: { anchor: number; head: number };
 };
 
 function languageExtension(language: CodeLanguage): Extension | null {
@@ -137,14 +143,35 @@ function toCmDiagnostics(view: EditorView, diagnostics: CodeMirrorDiagnostic[]):
   return out;
 }
 
+type GotoDefinitionHandler = (path: string, from: number, to: number) => void;
+
+// GA-09: same-file jumps select in place; else bubbles up.
+function makeGotoHandler(onGotoDefinitionRef: { current: GotoDefinitionHandler | undefined }) {
+  return (currentPath: string, hoverData: HoverInfo, view: EditorView) => {
+    if (defaultGotoHandler(currentPath, hoverData, view)) return true;
+    const definition = [...(hoverData.typeDef ?? []), ...(hoverData.def ?? [])].at(0);
+    if (!definition) return undefined;
+    onGotoDefinitionRef.current?.(
+      definition.fileName,
+      definition.textSpan.start,
+      definition.textSpan.start + definition.textSpan.length,
+    );
+    return true;
+  };
+}
+
 // GA-05: ts extensions, or none — worker can turn ready mid-file.
-function languageServiceExtensions(languageService: CodeMirrorLanguageService | undefined): Extension[] {
+function languageServiceExtensions(
+  languageService: CodeMirrorLanguageService | undefined,
+  onGotoDefinitionRef: { current: GotoDefinitionHandler | undefined },
+): Extension[] {
   if (!languageService) return [];
   return [
     tsFacet.of({ worker: languageService.worker, path: languageService.path }),
     tsSync(),
     autocompletion({ override: [tsAutocomplete()] }),
     tsHover({ renderTooltip: renderHoverTooltip }),
+    tsGoto({ gotoHandler: makeGotoHandler(onGotoDefinitionRef) }),
     linter(tsAdvisoryLintSource),
   ];
 }
@@ -157,6 +184,8 @@ export default function CodeMirrorEditor({
   diagnostics,
   readOnly,
   languageService,
+  onGotoDefinition,
+  initialSelection,
 }: CodeMirrorEditorProps) {
   const containerRef = useRef<HTMLDivElement | null>(null);
   const viewRef = useRef<EditorView | null>(null);
@@ -167,6 +196,8 @@ export default function CodeMirrorEditor({
   onSaveRef.current = onSave;
   const diagnosticsRef = useRef(diagnostics);
   diagnosticsRef.current = diagnostics;
+  const onGotoDefinitionRef = useRef(onGotoDefinition);
+  onGotoDefinitionRef.current = onGotoDefinition;
   // GA-05: reconfigured live below — a ready worker never remounts.
   const languageServiceCompartmentRef = useRef(new Compartment());
 
@@ -177,6 +208,7 @@ export default function CodeMirrorEditor({
       parent: containerRef.current,
       state: EditorState.create({
         doc: value,
+        selection: initialSelection,
         extensions: [
           basicSetup,
           keymap.of([
@@ -192,7 +224,7 @@ export default function CodeMirrorEditor({
           ...(langExt ? [langExt] : []),
           lintGutter(),
           linter((v) => toCmDiagnostics(v, diagnosticsRef.current)),
-          languageServiceCompartmentRef.current.of(languageServiceExtensions(languageService)),
+          languageServiceCompartmentRef.current.of(languageServiceExtensions(languageService, onGotoDefinitionRef)),
           EditorView.editable.of(!readOnly),
           EditorView.updateListener.of((update) => {
             if (update.docChanged) onChangeRef.current(update.state.doc.toString());
@@ -204,6 +236,9 @@ export default function CodeMirrorEditor({
       }),
     });
     viewRef.current = view;
+    // GA-09: a cross-file jump lands off-screen without this.
+    if (initialSelection)
+      view.dispatch({ effects: EditorView.scrollIntoView(initialSelection.anchor, { y: 'center' }) });
     return () => {
       view.destroy();
       viewRef.current = null;
@@ -219,7 +254,9 @@ export default function CodeMirrorEditor({
     const view = viewRef.current;
     if (!view) return;
     view.dispatch({
-      effects: languageServiceCompartmentRef.current.reconfigure(languageServiceExtensions(languageService)),
+      effects: languageServiceCompartmentRef.current.reconfigure(
+        languageServiceExtensions(languageService, onGotoDefinitionRef),
+      ),
     });
   }, [languageService]);
 

--- a/apps/web/src/CodeSurface.languageService.test.tsx
+++ b/apps/web/src/CodeSurface.languageService.test.tsx
@@ -11,14 +11,21 @@ import * as codeSurfaceApi from './codeSurfaceApi.js';
 import * as codeSurfaceLanguageService from './codeSurfaceLanguageService.js';
 import i18n from './i18n/index.js';
 
-type CapturedEditorProps = { languageService?: { worker: unknown; path: string } };
+type CapturedEditorProps = {
+  languageService?: { worker: unknown; path: string };
+  onGotoDefinition?: (path: string, from: number, to: number) => void;
+  initialSelection?: { anchor: number; head: number };
+};
 let lastEditorProps: CapturedEditorProps | null = null;
+// GA-09: the mock re-renders after clearing — record every value seen.
+let capturedInitialSelections: unknown[] = [];
 
 vi.mock('./CodeMirrorEditor.js', () => ({
   default: (
     props: { value: string; onChange: (value: string) => void; languageService?: unknown } & CapturedEditorProps,
   ) => {
     lastEditorProps = props;
+    capturedInitialSelections.push(props.initialSelection);
     return createElement('textarea', {
       className: 'code-surface-editor',
       value: props.value,
@@ -39,8 +46,10 @@ vi.mock('./codeSurfaceApi.js', async () => {
 
 vi.mock('./codeSurfaceLanguageService.js', () => ({
   createCodeSurfaceLanguageService: vi.fn(),
-  // Real toVfsPath, not a mock — CodeSurface.tsx calls it directly.
+  // Real toVfsPath/fromVfsPath, not mocks — CodeSurface.tsx calls them directly.
   toVfsPath: (path: string) => (path.startsWith('/') ? path : `/${path}`),
+  fromVfsPath: (path: string) => (path.startsWith('/') ? path.slice(1) : path),
+  KIT_DECLARATION_PATH: 'shared/game-kit.d.ts',
 }));
 
 const mockedApi = vi.mocked(codeSurfaceApi);
@@ -214,5 +223,98 @@ describe('CodeSurface language-service degradation (GA-06)', () => {
     root = createRoot(container);
 
     expect(destroy).toHaveBeenCalled();
+  });
+});
+
+describe('CodeSurface goto-definition (GA-09)', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(async () => {
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    await i18n.changeLanguage('en');
+    resetCodeSurfaceSessionState();
+    lastEditorProps = null;
+    capturedInitialSelections = [];
+    mockedApi.fetchCodeSurfaceSources.mockReset();
+    mockedApi.fetchCodeSurfaceKitDeclaration.mockReset();
+    mockedLanguageService.createCodeSurfaceLanguageService.mockReset();
+    mockedApi.fetchCodeSurfaceSources.mockResolvedValue(
+      sourcesFor({
+        files: [
+          { path: 'game.ts', content: 'export const boot = () => {};' },
+          { path: 'game/render.ts', content: 'export const paint = () => {};' },
+        ],
+      }),
+    );
+    mockedApi.fetchCodeSurfaceKitDeclaration.mockResolvedValue({
+      engineRef: 'v1',
+      declaration: 'interface GameKitGameContext {\n  gfx: unknown;\n}\n',
+    });
+    mockedLanguageService.createCodeSurfaceLanguageService.mockResolvedValue({
+      worker: {} as never,
+      updateFile: vi.fn(),
+      destroy: vi.fn(),
+    });
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => root.unmount());
+    container.remove();
+  });
+
+  async function render(slug = 'sky-dodge') {
+    await act(async () => {
+      root.render(createElement(CodeSurface, { slug, onBack: () => {} }));
+    });
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+  }
+
+  it('switches tabs and hands the target editor an initial selection', async () => {
+    await render();
+    expect(container.querySelector('textarea')!.value).toContain('boot');
+
+    await act(async () => {
+      lastEditorProps?.onGotoDefinition?.('/game/render.ts', 7, 12);
+      await Promise.resolve();
+    });
+
+    expect(container.querySelector('.code-surface-rail-item.is-active')?.textContent).toContain('game/render.ts');
+    expect(capturedInitialSelections).toContainEqual({ anchor: 7, head: 12 });
+  });
+
+  it('opens a read-only kit viewer for a jump into shared/game-kit.d.ts', async () => {
+    await render();
+
+    await act(async () => {
+      lastEditorProps?.onGotoDefinition?.('/shared/game-kit.d.ts', 34, 37);
+      await Promise.resolve();
+    });
+
+    const dialog = container.querySelector('.code-surface-kit-viewer');
+    expect(dialog).not.toBeNull();
+    expect(dialog?.textContent).toContain('GameKitGameContext');
+    expect(container.querySelector('.is-jump-target')).not.toBeNull();
+    // Still on game.ts — the kit hop leaves it alone.
+    expect(container.querySelector('.code-surface-rail-item.is-active')?.textContent).toContain('game.ts');
+  });
+
+  it('ignores a jump target that matches no known file (e.g. a lib .d.ts)', async () => {
+    await render();
+    const activeBefore = container.querySelector('.code-surface-rail-item.is-active')?.textContent;
+
+    await act(async () => {
+      lastEditorProps?.onGotoDefinition?.('/lib.es2022.d.ts', 0, 4);
+      await Promise.resolve();
+    });
+
+    expect(container.querySelector('.code-surface-rail-item.is-active')?.textContent).toBe(activeBefore);
+    expect(container.querySelector('.code-surface-kit-viewer')).toBeNull();
   });
 });

--- a/apps/web/src/CodeSurface.tsx
+++ b/apps/web/src/CodeSurface.tsx
@@ -27,6 +27,8 @@ import {
 import { getCodeSurfaceSessionState, setCodeSurfaceSessionState } from './codeSurfaceSessionState.js';
 import {
   createCodeSurfaceLanguageService,
+  fromVfsPath,
+  KIT_DECLARATION_PATH,
   toVfsPath,
   type CodeSurfaceLanguageService,
 } from './codeSurfaceLanguageService.js';
@@ -160,6 +162,7 @@ export function CodeSurface({ slug, onBack, editorPushRef }: CodeSurfaceProps) {
   const fileOpenedRecordedRef = useRef(new Set<string>());
   const filePickerTriggerRef = useRef<HTMLButtonElement | null>(null);
   const railRef = useRef<HTMLElement | null>(null);
+  const kitViewerBodyRef = useRef<HTMLPreElement | null>(null);
   /** One autosave timer per dirty path, not one shared timer — editing a second file
    * inside the debounce window must not cancel the first file's pending save. */
   const saveTimersRef = useRef<Map<string, number>>(new Map());
@@ -180,6 +183,10 @@ export function CodeSurface({ slug, onBack, editorPushRef }: CodeSurfaceProps) {
   const languageServiceRef = useRef<CodeSurfaceLanguageService | null>(null);
   const languageServiceInitRef = useRef(false);
   const [languageServiceReady, setLanguageServiceReady] = useState(false);
+  // GA-09: cached for the kit read-only hop.
+  const kitDeclarationRef = useRef<string | null>(null);
+  const [pendingJump, setPendingJump] = useState<{ path: string; from: number; to: number } | null>(null);
+  const [kitViewerLine, setKitViewerLine] = useState<number | null>(null);
 
   useEffect(() => {
     if (openedRecordedRef.current) return;
@@ -194,6 +201,12 @@ export function CodeSurface({ slug, onBack, editorPushRef }: CodeSurfaceProps) {
       inline: 'nearest',
     });
   }, [selected]);
+
+  // GA-09: centers the jump target the moment the kit viewer opens.
+  useEffect(() => {
+    if (kitViewerLine === null) return;
+    kitViewerBodyRef.current?.querySelector('.is-jump-target')?.scrollIntoView?.({ block: 'center' });
+  }, [kitViewerLine]);
 
   const load = useCallback(
     (isInitialLoad: boolean) => {
@@ -248,6 +261,16 @@ export function CodeSurface({ slug, onBack, editorPushRef }: CodeSurfaceProps) {
     return () => document.removeEventListener('keydown', onKeyDown);
   }, [filePickerOpen]);
 
+  // GA-09: Escape closes the kit viewer, like the file picker.
+  useEffect(() => {
+    if (kitViewerLine === null) return undefined;
+    function onKeyDown(event: KeyboardEvent) {
+      if (event.key === 'Escape') setKitViewerLine(null);
+    }
+    document.addEventListener('keydown', onKeyDown);
+    return () => document.removeEventListener('keydown', onKeyDown);
+  }, [kitViewerLine]);
+
   useEffect(
     () => () => {
       // Unmount flushes pending autosaves — direct calls, no setState after unmount.
@@ -298,6 +321,7 @@ export function CodeSurface({ slug, onBack, editorPushRef }: CodeSurfaceProps) {
     void (async () => {
       const kit = await fetchCodeSurfaceKitDeclaration(slug);
       if (cancelled) return;
+      kitDeclarationRef.current = kit?.declaration ?? null;
       const service = await createCodeSurfaceLanguageService(initialFiles, kit?.declaration ?? null);
       if (cancelled) {
         service?.destroy();
@@ -329,6 +353,17 @@ export function CodeSurface({ slug, onBack, editorPushRef }: CodeSurfaceProps) {
     if (!languageServiceReady || !languageServiceRef.current || !file || !isTsPath(file.path)) return undefined;
     return { worker: languageServiceRef.current.worker, path: toVfsPath(file.path) };
   }, [languageServiceReady, file]);
+
+  // GA-09: a cross-file jump, consumed once the target mounts.
+  const initialSelectionForEditor = useMemo(() => {
+    if (!pendingJump || pendingJump.path !== selected) return undefined;
+    return { anchor: pendingJump.from, head: pendingJump.to };
+  }, [pendingJump, selected]);
+
+  // GA-09: this render's editor already read initialSelectionForEditor above.
+  useEffect(() => {
+    if (pendingJump && pendingJump.path === selected) setPendingJump(null);
+  }, [pendingJump, selected]);
 
   /** Owner-staged paths plus local drafts that still differ — the working-copy set. */
   const changedPaths = useMemo(() => {
@@ -373,6 +408,20 @@ export function CodeSurface({ slug, onBack, editorPushRef }: CodeSurfaceProps) {
       fileOpenedRecordedRef.current.add(path);
       recordCodeStep('file_opened');
     }
+  }
+
+  // GA-09: switches tabs for a game file, opens the kit.
+  function handleGotoDefinition(vfsPath: string, from: number, to: number) {
+    const path = fromVfsPath(vfsPath);
+    if (path === KIT_DECLARATION_PATH) {
+      const declaration = kitDeclarationRef.current;
+      if (!declaration) return;
+      setKitViewerLine(declaration.slice(0, from).split('\n').length);
+      return;
+    }
+    if (!sources?.files.some((entry) => entry.path === path)) return;
+    setPendingJump({ path, from, to });
+    selectFile(path);
   }
 
   const schedulePreviewRebuild = useCallback(() => {
@@ -716,6 +765,8 @@ export function CodeSurface({ slug, onBack, editorPushRef }: CodeSurfaceProps) {
                   onSave={() => void flushPendingSaves()}
                   diagnostics={cmDiagnostics}
                   languageService={languageServiceForEditor}
+                  onGotoDefinition={handleGotoDefinition}
+                  initialSelection={initialSelectionForEditor}
                 />
               </Suspense>
             </CodeMirrorBoundary>
@@ -880,6 +931,44 @@ export function CodeSurface({ slug, onBack, editorPushRef }: CodeSurfaceProps) {
                 </div>
               ))}
             </div>
+          </section>
+        </div>
+      ) : null}
+
+      {kitViewerLine !== null && kitDeclarationRef.current ? (
+        <div className="code-surface-kit-backdrop" role="presentation" onClick={() => setKitViewerLine(null)}>
+          <section
+            className="code-surface-kit-viewer"
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="code-surface-kit-viewer-title"
+            onClick={(event) => event.stopPropagation()}
+          >
+            <header className="code-surface-kit-viewer-head">
+              <h3 id="code-surface-kit-viewer-title">{t('studioPanel.code.kitViewerTitle')}</h3>
+              <button
+                type="button"
+                className="code-surface-kit-close"
+                onClick={() => setKitViewerLine(null)}
+                aria-label={t('studioPanel.code.kitViewerClose')}
+              >
+                <PixelIcon name="close" size={13} />
+              </button>
+            </header>
+            <pre className="code-surface-readonly-view code-surface-kit-viewer-body" ref={kitViewerBodyRef}>
+              {kitDeclarationRef.current.split('\n').map((line, index) => (
+                <div key={index} className={`code-surface-line${index + 1 === kitViewerLine ? ' is-jump-target' : ''}`}>
+                  <span className="code-surface-line-number">{index + 1}</span>
+                  <span className="code-surface-line-text">
+                    {tokenizeLine(line, 'typescript').map((token, tokenIndex) => (
+                      <span key={tokenIndex} className={`code-tok code-tok-${token.kind}`}>
+                        {token.text}
+                      </span>
+                    ))}
+                  </span>
+                </div>
+              ))}
+            </pre>
           </section>
         </div>
       ) : null}

--- a/apps/web/src/codeSurfaceLanguageService.ts
+++ b/apps/web/src/codeSurfaceLanguageService.ts
@@ -15,6 +15,14 @@ export function toVfsPath(path: string): string {
   return path.startsWith('/') ? path : `/${path}`;
 }
 
+// Inverse of toVfsPath — GA-09 goto-definition targets come back vfs-rooted.
+export function fromVfsPath(path: string): string {
+  return path.startsWith('/') ? path.slice(1) : path;
+}
+
+// The kit's vfs path — shared with GA-09's hop.
+export const KIT_DECLARATION_PATH = 'shared/game-kit.d.ts';
+
 export async function createCodeSurfaceLanguageService(
   files: Record<string, string>,
   kitDeclaration: string | null,
@@ -27,7 +35,7 @@ export async function createCodeSurfaceLanguageService(
     const worker = Comlink.wrap<WorkerShape>(innerWorker);
     await worker.initialize();
     if (kitDeclaration) {
-      await worker.updateFile({ path: toVfsPath('shared/game-kit.d.ts'), code: kitDeclaration });
+      await worker.updateFile({ path: toVfsPath(KIT_DECLARATION_PATH), code: kitDeclaration });
     }
     await Promise.all(Object.entries(files).map(([path, code]) => worker.updateFile({ path: toVfsPath(path), code })));
     return {

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -321,6 +321,8 @@
       "agentRoundCompact": "Read only",
       "stagedBy": "changed · {{who}}",
       "lockedHint": "Read-only — GameKit and the tooling are shared, never edited here",
+      "kitViewerTitle": "shared/game-kit.d.ts",
+      "kitViewerClose": "Close GameKit declaration",
       "noFiles": "Nothing to show yet",
       "budget": "{{lines}}/{{maxLines}} lines",
       "livePush": "Live — running game updated, no rebuild",

--- a/apps/web/src/i18n/locales/pl.json
+++ b/apps/web/src/i18n/locales/pl.json
@@ -323,6 +323,8 @@
       "agentRoundCompact": "Tylko odczyt",
       "stagedBy": "zmienione · {{who}}",
       "lockedHint": "Tylko do odczytu — GameKit i narzędzia są wspólne, nie edytuje się ich tutaj",
+      "kitViewerTitle": "shared/game-kit.d.ts",
+      "kitViewerClose": "Zamknij deklarację GameKit",
       "noFiles": "Nie ma jeszcze nic do pokazania",
       "budget": "{{lines}}/{{maxLines}} linii",
       "livePush": "Na żywo — gra zaktualizowana, bez przebudowy",

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -11938,6 +11938,76 @@ button.builder-mode-selector:disabled {
   overflow-wrap: anywhere;
 }
 
+/* GA-09: the kit's own read-only hop — a fixed overlay, not gated to mobile like
+   .code-surface-file-backdrop, since the jump works at any viewport width. */
+.code-surface-kit-backdrop {
+  position: fixed;
+  z-index: 30;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+  background: rgba(3, 8, 13, 0.66);
+}
+
+.code-surface-kit-viewer {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  width: min(100%, 640px);
+  max-height: min(80vh, 40rem);
+  border: 1px solid var(--panel-border);
+  border-radius: 12px;
+  background: var(--panel);
+  box-shadow: 0 16px 40px rgba(0, 0, 0, 0.5);
+  overflow: hidden;
+}
+
+.code-surface-kit-viewer-head {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex: none;
+  padding: 12px 12px 10px 16px;
+  border-bottom: 1px solid var(--panel-border);
+}
+
+.code-surface-kit-viewer-head h3 {
+  flex: 1;
+  min-width: 0;
+  margin: 0;
+  font-size: 0.86rem;
+  font-family: var(--mono-font, monospace);
+  color: var(--muted);
+}
+
+.code-surface-kit-close {
+  flex: none;
+  background: none;
+  border: none;
+  color: var(--muted);
+  cursor: pointer;
+  padding: 4px;
+  border-radius: 6px;
+}
+
+.code-surface-kit-close:hover,
+.code-surface-kit-close:focus-visible {
+  color: var(--text);
+  background: rgba(148, 163, 184, 0.12);
+}
+
+.code-surface-kit-viewer-body {
+  min-height: 0;
+  overflow-y: auto;
+}
+
+.code-surface-kit-viewer-body .is-jump-target {
+  background: rgba(0, 228, 172, 0.14);
+}
+
 .code-tok-comment {
   color: var(--muted);
 }
@@ -17835,13 +17905,17 @@ body.remix-entry-open {
   background: var(--turquoise);
   color: #08241d;
   font-weight: 700;
-  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.45), 0 0 14px var(--turquoise-glow);
+  box-shadow:
+    0 4px 14px rgba(0, 0, 0, 0.45),
+    0 0 14px var(--turquoise-glow);
 }
 
 .review-play-btn.is-overlay:hover,
 .review-play-btn.is-overlay:focus-visible {
   filter: brightness(1.08);
-  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.45), 0 0 20px var(--turquoise-glow);
+  box-shadow:
+    0 4px 14px rgba(0, 0, 0, 0.45),
+    0 0 20px var(--turquoise-glow);
 }
 
 .review-play-btn.is-active {


### PR DESCRIPTION
## Summary

Follow-on to #762 (GA-02..GA-08). Wires `@valtown/codemirror-ts`'s `tsGoto` against the same worker-backed TypeScript language service, so cmd/ctrl-clicking a symbol in the Code surface jumps to where it's actually defined.

Full design/rationale in `creator-code-gamekit-autocomplete-plan.md` (GA-09) in the internal ops repo.

- **Same-file jumps** select the target in place — the library's own default handler, unchanged.
- **Cross-file jumps** (e.g. a call into `game/render.ts` from `game.ts`) switch the Code surface's rail tab to the target file and hand the freshly-mounted editor an initial selection, centered on screen, without disturbing the currently-open file's autosave state.
- **Jumps into `shared/game-kit.d.ts`** — an ambient, unimportable, read-only declaration file that never appears as a rail tab (CE-09) — open a small read-only modal instead, scrolled and highlighted to the exact declaration, reusing the same tokenized-line renderer as the surface's own read-only view. Escape or a backdrop click closes it, matching the existing mobile file-picker's interaction pattern.
- **Unresolvable targets** (a `lib.*.d.ts` internal, for instance) are a no-op — no tab switch, no dialog, nothing to show usefully.

## Test plan

- [x] `apps/web` — 157 test files / 1348 tests passing, including 3 new GA-09 cases (cross-file switch + selection, kit-file modal + highlight, unresolvable-target no-op)
- [x] `tsc --noEmit` clean
- [x] `eslint` + the repo's comment-prose gate clean
- [x] Production `vite build` succeeds; no new bundle weight outside the existing lazy CodeMirror chunk (`tsGoto`/`defaultGotoHandler` were already part of `@valtown/codemirror-ts`)
- [x] Verified against a real headless Chromium instance (local API + kit fixture): cmd-click on a cross-file call (`paintShip`, used in `game.ts`, defined in `game/render.ts`) switches tabs and highlights the function name; cmd-click on a kit member usage (`ctx.gfx.fillRect`) opens the read-only kit viewer, scrolled and highlighted exactly to `fillRect`'s declaration in `shared/game-kit.d.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y2WrkNc5Ww3LAMVMJjBT9a

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y2WrkNc5Ww3LAMVMJjBT9a)_