### PR TITLE
fix(api): cancel Copilot MCP rounds on the repo that actually holds them

### DIFF
--- a/apps/api/src/managed-provider-copilot.test.ts
+++ b/apps/api/src/managed-provider-copilot.test.ts
@@ -38,6 +38,14 @@ function run(overrides: Partial<WorkflowRun> = {}): WorkflowRun {
   return { id: 1, path: COPILOT_AGENT_WORKFLOW_PATH, status: 'in_progress', ...overrides };
 }
 
+function emptyTasks() {
+  const getTask = vi.fn(async () => null);
+  return {
+    client: { startTask: vi.fn(), getTask, listTasks: vi.fn(async () => []) } as unknown as AgentTasksClient,
+    getTask,
+  };
+}
+
 function tasks(result: AgentTask = task()) {
   const startTask = vi.fn(async (_input: AgentTaskInput) => result);
   const getTask = vi.fn(async () => result);
@@ -243,6 +251,70 @@ describe('Copilot managed provider', () => {
 
     expect(listWorkflowRuns).toHaveBeenCalledWith({ branch: 'copilot/tv-tycoon' });
     expect(cancelWorkflowRun.mock.calls.map(([id]) => id)).toEqual([12, 13]);
+  });
+
+  // Agent Tasks are per repo: the games-repo client cannot see this.
+  it('cancels an MCP-lane session on the scratch repo, not the games repo', async () => {
+    const harness = emptyTasks();
+    const harnessGithub = githubStub();
+    const mcpStub = tasks(task({ id: 'mcp-task-1', state: 'in_progress', branch: { headRef: 'copilot/mcp-round' } }));
+    const listWorkflowRuns = vi.fn(async () => [run({ id: 21 })]);
+    const cancelWorkflowRun = vi.fn(async () => undefined);
+    const provider = createCopilotManagedProvider(
+      {
+        apiKey: apiKey(),
+        model: 'gpt-5.4',
+        repo: 'gamedevpl/www.gamedev.pl-games',
+        mcpRepo: 'gamedevpl/scratchpad',
+      },
+      {
+        tasks: harness.client,
+        github: harnessGithub,
+        mcpTasks: mcpStub.client,
+        mcpGithub: githubStub({ listWorkflowRuns, cancelWorkflowRun }),
+      },
+    );
+
+    await provider.startSession({
+      correlationId: '42',
+      prompt: buildPrompt(BRIEF, { kind: 'channel', fast: true }),
+      model: 'gpt-5.4',
+      outputPath: 'outputs',
+      promptLane: 'mcp',
+      tools: { mcpEndpoints: [{ url: 'https://www.gamedev.pl/api/mcp', name: 'gamedevpl' }] },
+    });
+
+    await expect(provider.cancelSession('mcp-task-1')).resolves.toEqual({ enforced: true });
+
+    expect(listWorkflowRuns).toHaveBeenCalledWith({ branch: 'copilot/mcp-round' });
+    expect(cancelWorkflowRun).toHaveBeenCalledWith(21);
+    expect(harnessGithub.listWorkflowRuns).not.toHaveBeenCalled();
+  });
+
+  // A restart loses the session map; cancel must still find it.
+  it('cancels an untracked MCP session after a provider restart', async () => {
+    const harness = emptyTasks();
+    const mcpStub = tasks(task({ id: 'mcp-task-1', state: 'in_progress', branch: { headRef: 'copilot/mcp-round' } }));
+    const cancelWorkflowRun = vi.fn(async () => undefined);
+    const provider = createCopilotManagedProvider(
+      {
+        apiKey: apiKey(),
+        model: 'gpt-5.4',
+        repo: 'gamedevpl/www.gamedev.pl-games',
+        mcpRepo: 'gamedevpl/scratchpad',
+      },
+      {
+        tasks: harness.client,
+        github: githubStub(),
+        mcpTasks: mcpStub.client,
+        mcpGithub: githubStub({ listWorkflowRuns: vi.fn(async () => [run({ id: 21 })]), cancelWorkflowRun }),
+      },
+    );
+
+    await expect(provider.cancelSession('mcp-task-1')).resolves.toEqual({ enforced: true });
+
+    expect(harness.getTask).toHaveBeenCalledWith('mcp-task-1');
+    expect(cancelWorkflowRun).toHaveBeenCalledWith(21);
   });
 
   it('reports an unenforced cancel rather than throwing when GitHub refuses', async () => {

--- a/apps/api/src/managed-provider-copilot.ts
+++ b/apps/api/src/managed-provider-copilot.ts
@@ -37,6 +37,7 @@ export interface CopilotManagedProviderDeps {
   github?: CopilotGitHubClient;
   // MCP-lane rounds; GitHub scopes Agent Tasks per repo, not per call.
   mcpTasks?: AgentTasksClient;
+  mcpGithub?: CopilotGitHubClient;
 }
 
 function seedSlug(files: ManagedSessionRequest['workspaceFiles']): string | undefined {
@@ -123,10 +124,25 @@ export function createCopilotManagedProvider(
           ...(config.timeoutMs ? { timeoutMs: config.timeoutMs } : {}),
         })
       : undefined);
-  const mcpGithub = mcpRepo ? createGitHubClient({ token: config.apiKey, repo: mcpRepo }) : undefined;
+  const mcpGithub =
+    deps.mcpGithub ?? (mcpRepo ? createGitHubClient({ token: config.apiKey, repo: mcpRepo }) : undefined);
   // In-process session-repo tracking, same lifetime as credentialRef bookkeeping.
   const mcpSessionIds = new Set<string>();
   const mcpWorkspaces = new Set<string>();
+
+  interface SessionLane {
+    tasks: AgentTasksClient;
+    github: CopilotGitHubClient;
+  }
+
+  // Agent Tasks are scoped per repo, so one lane's client cannot see the other's
+  // session. Ask the tracked lane first, then probe, exactly as getSession does.
+  function sessionLanes(sessionId: string): SessionLane[] {
+    const harness: SessionLane = { tasks, github };
+    if (!mcpTasks || !mcpGithub) return [harness];
+    const mcp: SessionLane = { tasks: mcpTasks, github: mcpGithub };
+    return mcpSessionIds.has(sessionId) ? [mcp] : [harness, mcp];
+  }
 
   return {
     vendor: COPILOT_VENDOR,
@@ -197,30 +213,33 @@ export function createCopilotManagedProvider(
 
     // No stop endpoint in agent tasks — cancel the Actions run instead.
     async cancelSession(sessionId: string): Promise<{ enforced: boolean }> {
-      const branch = await tasks
-        .getTask(sessionId)
-        .then((task) => (task ? resolveTaskBranch(task) : null))
-        .catch(() => null);
-      // No branch yet means no run to stop; the next poll retries.
-      if (!branch) return { enforced: false };
+      for (const lane of sessionLanes(sessionId)) {
+        const branch = await lane.tasks
+          .getTask(sessionId)
+          .then((task) => (task ? resolveTaskBranch(task) : null))
+          .catch(() => null);
+        // Not this lane's session, or no branch yet; the next poll retries.
+        if (!branch) continue;
 
-      const runs = await github.listWorkflowRuns({ branch }).catch(() => []);
-      // Validation CI shares the branch, so match the agent workflow path.
-      const inFlight = runs.filter(
-        (run) => run.path === COPILOT_AGENT_WORKFLOW_PATH && IN_FLIGHT_RUN_STATUSES.includes(run.status),
-      );
+        const runs = await lane.github.listWorkflowRuns({ branch }).catch(() => []);
+        // Validation CI shares the branch, so match the agent workflow path.
+        const inFlight = runs.filter(
+          (run) => run.path === COPILOT_AGENT_WORKFLOW_PATH && IN_FLIGHT_RUN_STATUSES.includes(run.status),
+        );
 
-      // One left running is one still spending, so every match must cancel.
-      let allCancelled = true;
-      for (const run of inFlight) {
-        // Best effort: a token without `actions: write` reports unenforced.
-        const cancelled = await github
-          .cancelWorkflowRun(run.id)
-          .then(() => true)
-          .catch(() => false);
-        allCancelled = allCancelled && cancelled;
+        // One left running is one still spending, so every match must cancel.
+        let allCancelled = true;
+        for (const run of inFlight) {
+          // Best effort: a token without `actions: write` reports unenforced.
+          const cancelled = await lane.github
+            .cancelWorkflowRun(run.id)
+            .then(() => true)
+            .catch(() => false);
+          allCancelled = allCancelled && cancelled;
+        }
+        return { enforced: inFlight.length > 0 && allCancelled };
       }
-      return { enforced: inFlight.length > 0 && allCancelled };
+      return { enforced: false };
     },
 
     async deleteWorkspace(workspace: string): Promise<void> {


### PR DESCRIPTION
## The bug

GitHub scopes Agent Tasks per repo *in the URL*, so a session started on one lane is invisible to the other lane's client. `cancelSession` only ever asked the games-repo client:

```ts
const branch = await tasks.getTask(sessionId)   // games repo — an MCP round isn't here
  .then((task) => (task ? resolveTaskBranch(task) : null))
  .catch(() => null);
if (!branch) return { enforced: false };        // reads as "nothing to stop"
```

For an MCP round `getTask` returns null, the method reports `{ enforced: false }`, and nothing is stopped. #798 fixed exactly this for *polling* — `getSession` falls back to `mcpTasks` — but left cancel behind.

**This is live.** Since production cut over to the MCP lane this morning, both ceilings the managed backend enforces on observation have been silent no-ops:

- `managed-backend.ts:417` — the credit budget stop
- `managed-backend.ts:447` — the wall-clock expiry

Each calls `cancelSession`, each believed the `{ enforced: false }`, and a round that blew its ceiling kept running and kept spending. This is the failure mode the "no ceiling, no dispatch" guard in `agent-backend-env.ts` exists to prevent, arriving through the back door.

## The fix

`cancelSession` now resolves the owning lane the same way `getSession` already does — the tracked lane when the session id is known, otherwise probe both — and cancels workflow runs through *that* lane's GitHub client. Adds `deps.mcpGithub` so the scratch-repo client is injectable, which is what makes this testable at all.

## Validation

Both new tests fail against the previous implementation and pass against this one (verified by reverting the lane resolution and re-running — 2 failed / 15 passed):

- `cancels an MCP-lane session on the scratch repo, not the games repo`
- `cancels an untracked MCP session after a provider restart`

Full gate:

- `npm run test -w @gamedevpl/api` — 3194 tests, 198 files, all pass
- `npm run type-check` — clean
- `npx eslint` on changed files, `--max-warnings 0` — clean
- `npm run comment-prose` — clean

## Context

Found while mapping the harness lane for removal. That refactor collapses these two clients into one and makes this class of bug structurally impossible — but it is a larger change, and this ceiling should not stay broken while it lands.

---
_Generated by [Claude Code](https://claude.ai/code/session_01N56phUDE38ZDGRa7PanE5P)_