### PR TITLE
KC-09: spike a dev-only gamepad relay

### DIFF
--- a/apps/web/src/GameTheater.tsx
+++ b/apps/web/src/GameTheater.tsx
@@ -11,6 +11,7 @@ import { ReportGameButton } from './ReportGameButton.js';
 import { ShareGameButton } from './ShareGameButton.js';
 import { VoteWidget } from './VoteWidget.js';
 import { useGamePlayer } from './gamePlayer.js';
+import { useGamepadSpike } from './gamepadSpike.js';
 import { recordRemixStep, recordVisitEvent } from './visitTelemetry.js';
 import { useGameSaveBridge } from './gameSave.js';
 import { usePresenceBridge } from './presence.js';
@@ -311,6 +312,8 @@ export function GameTheater({
   // orientation readings into the frame, and the readings never leave the browser. On
   // iOS the sensor needs a real gesture on our own chrome, hence the bar control below.
   const sensing = useSensingBridge(frameRef);
+
+  useGamepadSpike(frameRef);
 
   // The game reports its own (localized) title over the bridge. Prefer it: on a
   // direct `/play/<slug>` link there's no catalog entry to take a title from, so

--- a/apps/web/src/gamepadSpike.test.ts
+++ b/apps/web/src/gamepadSpike.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  gamepadSpikeEnabled,
+  normalizeGamepad,
+  startGamepadSpikeRelay,
+  type GamepadSpikeFrame,
+} from './gamepadSpike.js';
+
+function button(pressed: boolean, value = pressed ? 1 : 0): GamepadButton {
+  return { pressed, touched: pressed, value };
+}
+
+function gamepad(overrides: Partial<Gamepad> = {}): Gamepad {
+  return {
+    axes: [0, 0],
+    buttons: Array.from({ length: 16 }, () => button(false)),
+    connected: true,
+    hapticActuators: [],
+    id: 'Test pad',
+    index: 0,
+    mapping: 'standard',
+    timestamp: 25,
+    vibrationActuator: null,
+    ...overrides,
+  } as Gamepad;
+}
+
+describe('gamepad spike flag', () => {
+  it('requires both development mode and the explicit query flag', () => {
+    expect(gamepadSpikeEnabled('?gamepad-spike=1', true)).toBe(true);
+    expect(gamepadSpikeEnabled('?gamepad-spike=0', true)).toBe(false);
+    expect(gamepadSpikeEnabled('?gamepad-spike=1', false)).toBe(false);
+  });
+});
+
+describe('gamepad normalization', () => {
+  it('maps standard buttons and stick axes to the party vocabulary', () => {
+    const buttons = Array.from({ length: 16 }, () => button(false));
+    buttons[0] = button(true);
+    buttons[12] = button(true);
+    const normalized = normalizeGamepad(gamepad({ axes: [-0.75, 0.8], buttons }), 1_000);
+
+    expect(normalized.party).toEqual({ up: true, down: true, left: true, right: false, a: true });
+    expect(normalized.gamepad).toMatchObject({
+      index: 0,
+      mapping: 'standard',
+      axes: [-0.75, 0.8],
+      sourceTimestamp: 1_025,
+    });
+  });
+
+  it('clamps malformed values and represents a disconnected state', () => {
+    expect(normalizeGamepad(null, 0)).toEqual({
+      party: { up: false, down: false, left: false, right: false, a: false },
+      gamepad: null,
+    });
+
+    const normalized = normalizeGamepad(gamepad({ axes: [Infinity, -4], timestamp: 0 }), 100);
+    expect(normalized.gamepad?.axes).toEqual([0, -1]);
+    expect(normalized.gamepad?.sourceTimestamp).toBeNull();
+  });
+});
+
+describe('gamepad relay', () => {
+  it('polls once per animation frame and stops cleanly', () => {
+    const frames: FrameRequestCallback[] = [];
+    const sent: GamepadSpikeFrame[] = [];
+    const cancelFrame = vi.fn();
+    const pad = gamepad();
+    let nextHandle = 0;
+    const stop = startGamepadSpikeRelay({
+      getGamepads: () => [pad],
+      requestFrame: (callback) => {
+        frames.push(callback);
+        nextHandle += 1;
+        return nextHandle;
+      },
+      cancelFrame,
+      now: () => 10,
+      timeOrigin: 1_000,
+      post: (frame) => sent.push(frame),
+    });
+
+    expect(sent).toHaveLength(0);
+    frames.shift()?.(10);
+    expect(sent[0]).toMatchObject({ t: 'gamepad:state', sequence: 0, sampledAt: 1_010 });
+
+    stop();
+    expect(cancelFrame).toHaveBeenCalledWith(2);
+    frames.shift()?.(20);
+    expect(sent).toHaveLength(1);
+  });
+
+  it('emits party input edges using the existing controller vocabulary', () => {
+    const frames: FrameRequestCallback[] = [];
+    const sent: GamepadSpikeFrame[] = [];
+    const buttons = Array.from({ length: 16 }, () => button(false));
+    const pad = gamepad({ buttons });
+    const stop = startGamepadSpikeRelay({
+      getGamepads: () => [pad],
+      requestFrame: (callback) => {
+        frames.push(callback);
+        return frames.length;
+      },
+      cancelFrame: vi.fn(),
+      now: () => 10,
+      timeOrigin: 1_000,
+      post: (frame) => sent.push(frame),
+    });
+
+    frames.shift()?.(10);
+    buttons[0] = button(true);
+    frames.shift()?.(20);
+    buttons[0] = button(false);
+    frames.shift()?.(30);
+    stop();
+
+    const partyFrames = sent.filter((frame) => frame.t === 'input');
+    expect(partyFrames).toEqual([
+      { ns: 'gdp', v: 1, t: 'input', slot: 1, k: 'a', d: 1 },
+      { ns: 'gdp', v: 1, t: 'input', slot: 1, k: 'a', d: 0 },
+    ]);
+  });
+
+  it('reports a disconnected state when browser polling throws', () => {
+    const frames: FrameRequestCallback[] = [];
+    const sent: GamepadSpikeFrame[] = [];
+    const stop = startGamepadSpikeRelay({
+      getGamepads: () => {
+        throw new DOMException('blocked', 'SecurityError');
+      },
+      requestFrame: (callback) => {
+        frames.push(callback);
+        return frames.length;
+      },
+      cancelFrame: vi.fn(),
+      now: () => 10,
+      timeOrigin: 1_000,
+      post: (frame) => sent.push(frame),
+    });
+
+    frames.shift()?.(10);
+    stop();
+
+    expect(sent).toHaveLength(1);
+    expect(sent[0]).toMatchObject({ t: 'gamepad:state', gamepad: null });
+  });
+});

--- a/apps/web/src/gamepadSpike.test.ts
+++ b/apps/web/src/gamepadSpike.test.ts
@@ -78,7 +78,10 @@ describe('gamepad relay', () => {
       cancelFrame,
       now: () => 10,
       timeOrigin: 1_000,
-      post: (frame) => sent.push(frame),
+      post: (frame) => {
+        sent.push(frame);
+        return true;
+      },
     });
 
     expect(sent).toHaveLength(0);
@@ -105,7 +108,10 @@ describe('gamepad relay', () => {
       cancelFrame: vi.fn(),
       now: () => 10,
       timeOrigin: 1_000,
-      post: (frame) => sent.push(frame),
+      post: (frame) => {
+        sent.push(frame);
+        return true;
+      },
     });
 
     frames.shift()?.(10);
@@ -136,7 +142,10 @@ describe('gamepad relay', () => {
       cancelFrame: vi.fn(),
       now: () => 10,
       timeOrigin: 1_000,
-      post: (frame) => sent.push(frame),
+      post: (frame) => {
+        sent.push(frame);
+        return true;
+      },
     });
 
     frames.shift()?.(10);
@@ -144,5 +153,39 @@ describe('gamepad relay', () => {
 
     expect(sent).toHaveLength(1);
     expect(sent[0]).toMatchObject({ t: 'gamepad:state', gamepad: null });
+  });
+
+  it('replays a held input edge when the iframe becomes ready', () => {
+    const frames: FrameRequestCallback[] = [];
+    const sent: GamepadSpikeFrame[] = [];
+    const buttons = Array.from({ length: 16 }, () => button(false));
+    buttons[0] = button(true);
+    let ready = false;
+    const stop = startGamepadSpikeRelay({
+      getGamepads: () => [gamepad({ buttons })],
+      requestFrame: (callback) => {
+        frames.push(callback);
+        return frames.length;
+      },
+      cancelFrame: vi.fn(),
+      now: () => 10,
+      timeOrigin: 1_000,
+      post: (frame) => {
+        if (!ready) return false;
+        sent.push(frame);
+        return true;
+      },
+    });
+
+    frames.shift()?.(10);
+    expect(sent).toHaveLength(0);
+
+    ready = true;
+    frames.shift()?.(20);
+    stop();
+
+    expect(sent.filter((frame) => frame.t === 'input')).toEqual([
+      { ns: 'gdp', v: 1, t: 'input', slot: 1, k: 'a', d: 1 },
+    ]);
   });
 });

--- a/apps/web/src/gamepadSpike.ts
+++ b/apps/web/src/gamepadSpike.ts
@@ -110,7 +110,7 @@ export function startGamepadSpikeRelay(dependencies: RelayDependencies): () => v
 
   const poll = () => {
     if (!active) return;
-    let gamepad: Gamepad | null = null;
+    let gamepad: Gamepad | null;
     try {
       gamepad = Array.from(dependencies.getGamepads()).find((candidate) => candidate?.connected) ?? null;
     } catch {

--- a/apps/web/src/gamepadSpike.ts
+++ b/apps/web/src/gamepadSpike.ts
@@ -46,7 +46,7 @@ type RelayDependencies = {
   cancelFrame: (handle: number) => void;
   now: () => number;
   timeOrigin: number;
-  post: (frame: GamepadSpikeFrame) => void;
+  post: (frame: GamepadSpikeFrame) => boolean;
 };
 
 function clamp(value: number, min: number, max: number): number {
@@ -118,9 +118,10 @@ export function startGamepadSpikeRelay(dependencies: RelayDependencies): () => v
     }
     const sampledAt = dependencies.timeOrigin + dependencies.now();
     const normalized = normalizeGamepad(gamepad, dependencies.timeOrigin);
+    const deliveredParty = { ...previousParty };
     for (const key of INPUT_KEYS) {
       if (normalized.party[key] === previousParty[key]) continue;
-      dependencies.post({
+      const delivered = dependencies.post({
         ns: BRIDGE_NAMESPACE,
         v: PROTOCOL_VERSION,
         t: 'input',
@@ -128,8 +129,9 @@ export function startGamepadSpikeRelay(dependencies: RelayDependencies): () => v
         k: key,
         d: normalized.party[key] ? 1 : 0,
       });
+      if (delivered) deliveredParty[key] = normalized.party[key];
     }
-    previousParty = normalized.party;
+    previousParty = deliveredParty;
     dependencies.post({
       ns: BRIDGE_NAMESPACE,
       v: PROTOCOL_VERSION,
@@ -160,7 +162,12 @@ export function useGamepadSpike(frameRef: MutableRefObject<HTMLIFrameElement | n
       cancelFrame: (handle) => cancelAnimationFrame(handle),
       now: () => performance.now(),
       timeOrigin: Number.isFinite(performance.timeOrigin) ? performance.timeOrigin : Date.now() - performance.now(),
-      post: (frame) => frameRef.current?.contentWindow?.postMessage(frame, '*'),
+      post: (frame) => {
+        const target = frameRef.current?.contentWindow;
+        if (!target) return false;
+        target.postMessage(frame, '*');
+        return true;
+      },
     });
   }, [frameRef]);
 }

--- a/apps/web/src/gamepadSpike.ts
+++ b/apps/web/src/gamepadSpike.ts
@@ -1,0 +1,166 @@
+import { useEffect, type MutableRefObject } from 'react';
+import { BRIDGE_NAMESPACE, INPUT_KEYS, PROTOCOL_VERSION, type InputKey } from './mp/protocol.js';
+
+const AXIS_THRESHOLD = 0.5;
+
+export type GamepadPartyState = Record<InputKey, boolean>;
+
+export type GamepadButtonState = {
+  pressed: boolean;
+  touched: boolean;
+  value: number;
+};
+
+export type GamepadState = {
+  index: number;
+  mapping: string;
+  axes: number[];
+  buttons: GamepadButtonState[];
+  sourceTimestamp: number | null;
+};
+
+export type GamepadRelayFrame = {
+  ns: typeof BRIDGE_NAMESPACE;
+  v: typeof PROTOCOL_VERSION;
+  t: 'gamepad:state';
+  sequence: number;
+  sampledAt: number;
+  party: GamepadPartyState;
+  gamepad: GamepadState | null;
+};
+
+export type GamepadPartyFrame = {
+  ns: typeof BRIDGE_NAMESPACE;
+  v: typeof PROTOCOL_VERSION;
+  t: 'input';
+  slot: 1;
+  k: InputKey;
+  d: 0 | 1;
+};
+
+export type GamepadSpikeFrame = GamepadRelayFrame | GamepadPartyFrame;
+
+type RelayDependencies = {
+  getGamepads: () => readonly (Gamepad | null)[];
+  requestFrame: (callback: FrameRequestCallback) => number;
+  cancelFrame: (handle: number) => void;
+  now: () => number;
+  timeOrigin: number;
+  post: (frame: GamepadSpikeFrame) => void;
+};
+
+function clamp(value: number, min: number, max: number): number {
+  if (!Number.isFinite(value)) return 0;
+  return Math.max(min, Math.min(max, value));
+}
+
+function pressed(gamepad: Gamepad, index: number): boolean {
+  return gamepad.buttons[index]?.pressed === true;
+}
+
+function axis(gamepad: Gamepad, index: number): number {
+  return clamp(gamepad.axes[index] ?? 0, -1, 1);
+}
+
+function partyState(gamepad: Gamepad | null): GamepadPartyState {
+  const state = Object.fromEntries(INPUT_KEYS.map((key) => [key, false])) as GamepadPartyState;
+  if (!gamepad) return state;
+
+  const horizontal = axis(gamepad, 0);
+  const vertical = axis(gamepad, 1);
+  state.up = pressed(gamepad, 12) || vertical <= -AXIS_THRESHOLD;
+  state.down = pressed(gamepad, 13) || vertical >= AXIS_THRESHOLD;
+  state.left = pressed(gamepad, 14) || horizontal <= -AXIS_THRESHOLD;
+  state.right = pressed(gamepad, 15) || horizontal >= AXIS_THRESHOLD;
+  state.a = pressed(gamepad, 0);
+  return state;
+}
+
+export function normalizeGamepad(
+  gamepad: Gamepad | null,
+  timeOrigin: number,
+): Pick<GamepadRelayFrame, 'party' | 'gamepad'> {
+  if (!gamepad) return { party: partyState(null), gamepad: null };
+
+  return {
+    party: partyState(gamepad),
+    gamepad: {
+      index: gamepad.index,
+      mapping: gamepad.mapping,
+      axes: Array.from(gamepad.axes, (value) => clamp(value, -1, 1)),
+      buttons: Array.from(gamepad.buttons, (button) => ({
+        pressed: button.pressed,
+        touched: button.touched === true,
+        value: clamp(button.value, 0, 1),
+      })),
+      sourceTimestamp: gamepad.timestamp > 0 ? timeOrigin + gamepad.timestamp : null,
+    },
+  };
+}
+
+export function gamepadSpikeEnabled(search: string, development: boolean): boolean {
+  return development && new URLSearchParams(search).get('gamepad-spike') === '1';
+}
+
+export function startGamepadSpikeRelay(dependencies: RelayDependencies): () => void {
+  let active = true;
+  let handle = 0;
+  let sequence = 0;
+  let previousParty = partyState(null);
+
+  const poll = () => {
+    if (!active) return;
+    let gamepad: Gamepad | null = null;
+    try {
+      gamepad = Array.from(dependencies.getGamepads()).find((candidate) => candidate?.connected) ?? null;
+    } catch {
+      gamepad = null;
+    }
+    const sampledAt = dependencies.timeOrigin + dependencies.now();
+    const normalized = normalizeGamepad(gamepad, dependencies.timeOrigin);
+    for (const key of INPUT_KEYS) {
+      if (normalized.party[key] === previousParty[key]) continue;
+      dependencies.post({
+        ns: BRIDGE_NAMESPACE,
+        v: PROTOCOL_VERSION,
+        t: 'input',
+        slot: 1,
+        k: key,
+        d: normalized.party[key] ? 1 : 0,
+      });
+    }
+    previousParty = normalized.party;
+    dependencies.post({
+      ns: BRIDGE_NAMESPACE,
+      v: PROTOCOL_VERSION,
+      t: 'gamepad:state',
+      sequence,
+      sampledAt,
+      ...normalized,
+    });
+    sequence += 1;
+    handle = dependencies.requestFrame(poll);
+  };
+
+  handle = dependencies.requestFrame(poll);
+  return () => {
+    active = false;
+    dependencies.cancelFrame(handle);
+  };
+}
+
+export function useGamepadSpike(frameRef: MutableRefObject<HTMLIFrameElement | null>): void {
+  useEffect(() => {
+    if (!gamepadSpikeEnabled(window.location.search, import.meta.env.DEV)) return;
+    if (typeof navigator.getGamepads !== 'function') return;
+
+    return startGamepadSpikeRelay({
+      getGamepads: () => navigator.getGamepads(),
+      requestFrame: (callback) => requestAnimationFrame(callback),
+      cancelFrame: (handle) => cancelAnimationFrame(handle),
+      now: () => performance.now(),
+      timeOrigin: Number.isFinite(performance.timeOrigin) ? performance.timeOrigin : Date.now() - performance.now(),
+      post: (frame) => frameRef.current?.contentWindow?.postMessage(frame, '*'),
+    });
+  }, [frameRef]);
+}

--- a/docs/gamepad-findings.md
+++ b/docs/gamepad-findings.md
@@ -1,0 +1,105 @@
+# Gamepad findings
+
+Status: KC-09 research spike. The checked-in prototype is development-only and does not ship gamepad support.
+
+## Recommendation
+
+Use a shell relay. The trusted page should poll `navigator.getGamepads()`, normalize the active controller, and send versioned state to the sandboxed game over the existing `postMessage` bridge.
+
+The Gamepad specification currently gives the `gamepad` Permissions Policy feature a default allowlist of `*`, and Chrome exposed the API in the current sandbox without an iframe `allow="gamepad"` attribute. Direct access is technically possible there. It is still the wrong platform boundary:
+
+- Games-repo Check 17 deliberately forbids `navigator.*` in untrusted game code.
+- Shell ownership matches the existing sensing and voice bridges.
+- The shell can centralize deadzones, remapping, privacy, visibility, reconnects, and controller-to-player assignment.
+- The iframe sandbox and its `allow` attribute remain unchanged.
+
+The shared `input` module should own the normalized controller as another local input source. `party` should consume that source for local player slots rather than own browser polling. This keeps single-player gamepad support possible and prevents a second normalization contract from growing inside multiplayer.
+
+References:
+
+- [W3C Gamepad Working Draft](https://www.w3.org/TR/gamepad/), especially sections 3, 4.1, 12.1, and 20.
+- [WebKit Safari 10.1 Gamepad announcement](https://webkit.org/blog/7477/new-web-features-in-safari-10-1/).
+- [WebKit Safari 18.0 notes](https://webkit.org/blog/15865/webkit-features-in-safari-18-0/), including the WKWebView Gamepad fix.
+
+## Prototype
+
+The prototype lives in `apps/web/src/gamepadSpike.ts` and is mounted beside the sensing and voice shell bridges in `GameTheater.tsx`.
+
+It activates only when both conditions are true:
+
+1. Vite compiled the app in development mode.
+2. The page URL contains `?gamepad-spike=1`.
+
+Production builds fold the development condition to false. The prototype adds no control, iframe permission, catalog field, API, or game behavior.
+
+While active, it polls once per animation frame and sends two representations:
+
+1. Party-compatible edges using the existing `{ ns: 'gdp', v: 1, t: 'input', slot: 1, k, d }` vocabulary. Standard buttons 12–15 and axes 0–1 map to the d-pad; standard button 0 maps to `a`.
+2. A richer `{ ns: 'gdp', v: 1, t: 'gamepad:state', ... }` frame containing:
+
+```ts
+{
+  sequence: number;
+  sampledAt: number;
+  party: { up: boolean; down: boolean; left: boolean; right: boolean; a: boolean };
+  gamepad: null | {
+    index: number;
+    mapping: string;
+    axes: number[];
+    buttons: Array<{ pressed: boolean; touched: boolean; value: number }>;
+    sourceTimestamp: number | null;
+  };
+}
+```
+
+The device identifier is intentionally omitted. It is unnecessary for gameplay and increases fingerprinting surface. `sourceTimestamp` and `sampledAt` make end-to-end latency measurable without adding a second clock protocol.
+
+The prototype is intentionally incomplete: it chooses the first connected controller, maps it to party slot 1, and has no player-facing discovery or remapping UI.
+
+## Browser experiment
+
+Test harness: a localhost page with two `srcdoc` iframes using `sandbox="allow-scripts"`. One had no `allow` attribute; the other had `allow="gamepad"`. Each frame and the top-level page recorded API exposure, effective policy, whether `getGamepads()` threw, returned slot count, and connected count.
+
+Environment: macOS 26.5.2 build 25F84, Apple Silicon. Test date: 2026-08-14.
+
+| Browser                          | Version          | Top level                                                        | Sandboxed, no `allow`                                 | Sandboxed, `allow="gamepad"`                          | Hardware state                                           |
+| -------------------------------- | ---------------- | ---------------------------------------------------------------- | ----------------------------------------------------- | ----------------------------------------------------- | -------------------------------------------------------- |
+| Chrome-compatible in-app browser | 150.0.0.0        | API exposed; policy allowed; call returned four slots            | API exposed; policy allowed; call returned four slots | API exposed; policy allowed; call returned four slots | No controller was connected, so all four slots were null |
+| Safari                           | 26.5.2 installed | Not run: this environment exposes no controllable Safari session | Not run                                               | Not run                                               | Not run                                                  |
+| Firefox                          | Not installed    | Not run                                                          | Not run                                               | Not run                                               | Not run                                                  |
+
+Chrome therefore did not require a permissions-policy attribute for this sandbox. That matches the specification's current default allowlist of `*`. This is an API/policy result, not a claim that hardware input was exercised.
+
+Safari and Firefox remain a manual verification gap. The spike must not be promoted until the same harness is run in both with a physical standard-layout controller, including a button press to satisfy browsers that expose a connected pad only after user interaction.
+
+## Latency
+
+The Chrome harness sent 240 animation-frame-paced messages from the shell into the sandbox and measured receipt using absolute high-resolution timestamps. It also delivered 30 real keyboard presses into the same iframe and measured event dispatch at the listener.
+
+| Path                                  | Samples |    Mean |     p50 |     p95 |
+| ------------------------------------- | ------: | ------: | ------: | ------: |
+| Keyboard event dispatch inside iframe |      30 | 0.15 ms | 0.10 ms | 0.20 ms |
+| Shell `postMessage` into iframe       |     240 | 0.78 ms | 0.80 ms | 1.10 ms |
+
+The measured relay overhead over keyboard dispatch was about 0.63 ms on average. A frame-paced poll adds 0–16.7 ms at 60 Hz, 8.3 ms on average, before the measured bridge cost. The expected added latency is therefore about 8.9 ms on average and under 18 ms near p95.
+
+That final estimate is modeled because no physical controller was connected. A hardware run should calculate `receivedAt - sourceTimestamp` for each changed sample and compare it with the keyboard measurement above.
+
+## Production follow-ups
+
+1. Complete the physical-controller matrix on current Chrome, Firefox, and Safari desktop releases; repeat on Android Chrome and iOS Safari.
+2. Add an explicit game-to-shell hello before polling, matching sensing and voice. Silent games must cost nothing.
+3. Define the normalized state in a shared bridge contract, including deadzone rules, edge semantics, visibility resets, and disconnect releases.
+4. Add the controller source to GameKit `input`; let games use existing logical actions before exposing raw axes or buttons.
+5. Let `party` assign controller indices to local slots, preserve keyboard hot-seat fallback, and avoid claiming a slot on an all-released frame.
+6. Add remapping and deadzone settings with keyboard, pointer, touch, and accessibility parity.
+7. Treat haptics as a separate capability review; never relay arbitrary device identifiers.
+8. Add browser integration tests once WebDriver implementations can inject gamepad input consistently.
+
+## Exit state
+
+- Prototype retained behind the development-only flag.
+- No iframe sandbox or permissions-policy change.
+- No GameKit module added.
+- No game changed.
+- No production behavior change.

--- a/docs/gamepad-findings.md
+++ b/docs/gamepad-findings.md
@@ -54,11 +54,13 @@ While active, it polls once per animation frame and sends two representations:
 
 The device identifier is intentionally omitted. It is unnecessary for gameplay and increases fingerprinting surface. `sourceTimestamp` and `sampledAt` make end-to-end latency measurable without adding a second clock protocol.
 
-The prototype is intentionally incomplete: it chooses the first connected controller, maps it to party slot 1, and has no player-facing discovery or remapping UI.
+The prototype is intentionally incomplete: it chooses the first connected controller, maps it to party slot 1, and has no player-facing discovery or remapping UI. Slot assignment remains an unsolved ownership decision for the production design, not a recommendation that every pad should drive player 1.
 
 ## Browser experiment
 
-Test harness: a localhost page with two `srcdoc` iframes using `sandbox="allow-scripts"`. One had no `allow` attribute; the other had `allow="gamepad"`. Each frame and the top-level page recorded API exposure, effective policy, whether `getGamepads()` threw, returned slot count, and connected count.
+Test harness: [`gamepad-harness.html`](./gamepad-harness.html), served from localhost, with two `srcdoc` iframes using `sandbox="allow-scripts"`. One had no `allow` attribute; the other had `allow="gamepad"`. Each frame and the top-level page recorded API exposure, whether `document.permissionsPolicy.allowsFeature('gamepad')` (with the legacy `featurePolicy` fallback) returned true, whether `getGamepads()` threw, returned slot count, and connected count.
+
+To repeat it, serve `docs/` over localhost, open `gamepad-harness.html`, connect a controller, press a button, and reload. Focus the no-allow iframe and press ordinary keys to add keyboard samples to the latency result.
 
 Environment: macOS 26.5.2 build 25F84, Apple Silicon. Test date: 2026-08-14.
 
@@ -68,7 +70,7 @@ Environment: macOS 26.5.2 build 25F84, Apple Silicon. Test date: 2026-08-14.
 | Safari                           | 26.5.2 installed | Not run: this environment exposes no controllable Safari session | Not run                                               | Not run                                               | Not run                                                  |
 | Firefox                          | Not installed    | Not run                                                          | Not run                                               | Not run                                               | Not run                                                  |
 
-Chrome therefore did not require a permissions-policy attribute for this sandbox. That matches the specification's current default allowlist of `*`. This is an API/policy result, not a claim that hardware input was exercised.
+Chrome therefore did not require a permissions-policy attribute for this sandbox: `document.permissionsPolicy.allowsFeature('gamepad')` returned true both with and without the iframe `allow` attribute. That matches the specification's current default allowlist of `*`. This is an API/policy result, not a claim that hardware input was exercised.
 
 Safari and Firefox remain a manual verification gap. The spike must not be promoted until the same harness is run in both with a physical standard-layout controller, including a button press to satisfy browsers that expose a connected pad only after user interaction.
 
@@ -95,6 +97,8 @@ That final estimate is modeled because no physical controller was connected. A h
 6. Add remapping and deadzone settings with keyboard, pointer, touch, and accessibility parity.
 7. Treat haptics as a separate capability review; never relay arbitrary device identifiers.
 8. Add browser integration tests once WebDriver implementations can inject gamepad input consistently.
+
+The spike currently emits one disconnected `gamepad:state` frame per animation frame while enabled, roughly 60 null frames per second at 60 Hz. The production edge-semantics work in item 3 should suppress unchanged disconnected state as well as unchanged connected samples.
 
 ## Exit state
 

--- a/docs/gamepad-findings.md
+++ b/docs/gamepad-findings.md
@@ -6,7 +6,7 @@ Status: KC-09 research spike. The checked-in prototype is development-only and d
 
 Use a shell relay. The trusted page should poll `navigator.getGamepads()`, normalize the active controller, and send versioned state to the sandboxed game over the existing `postMessage` bridge.
 
-The Gamepad specification currently gives the `gamepad` Permissions Policy feature a default allowlist of `*`, and Chrome exposed the API in the current sandbox without an iframe `allow="gamepad"` attribute. Direct access is technically possible there. It is still the wrong platform boundary:
+The W3C Gamepad Working Draft published 10 July 2025 and its current editor's draft both give the `gamepad` Permissions Policy feature a default allowlist of `*`. Chrome exposed the API in the current sandbox without an iframe `allow="gamepad"` attribute. Direct access is technically possible there. It is still the wrong platform boundary:
 
 - Games-repo Check 17 deliberately forbids `navigator.*` in untrusted game code.
 - Shell ownership matches the existing sensing and voice bridges.
@@ -17,7 +17,7 @@ The shared `input` module should own the normalized controller as another local 
 
 References:
 
-- [W3C Gamepad Working Draft](https://www.w3.org/TR/gamepad/), especially sections 3, 4.1, 12.1, and 20.
+- [W3C Gamepad Working Draft](https://www.w3.org/TR/gamepad/#permissions-policy), especially sections 3, 4.1, 12.1, and 20, and the [current editor's draft](https://w3c.github.io/gamepad/#permissions-policy).
 - [WebKit Safari 10.1 Gamepad announcement](https://webkit.org/blog/7477/new-web-features-in-safari-10-1/).
 - [WebKit Safari 18.0 notes](https://webkit.org/blog/15865/webkit-features-in-safari-18-0/), including the WKWebView Gamepad fix.
 

--- a/docs/gamepad-harness.html
+++ b/docs/gamepad-harness.html
@@ -1,0 +1,171 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>KC-09 Gamepad Sandbox Probe</title>
+    <style>
+      body {
+        margin: 24px;
+        font: 16px system-ui;
+      }
+
+      iframe {
+        width: 420px;
+        height: 120px;
+        border: 1px solid #888;
+      }
+
+      pre {
+        padding: 12px;
+        background: #eee;
+        white-space: pre-wrap;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>KC-09 Gamepad Sandbox Probe</h1>
+    <p>Connect a controller and press a button, then reload.</p>
+    <div id="frames"></div>
+    <pre id="results">Waiting…</pre>
+    <script>
+      const results = [];
+      const latency = { relay: [], keyboard: [] };
+      const output = document.getElementById('results');
+      const child = (label) => `<!doctype html><meta charset="utf-8"><body>${label}<script>
+        const policy = document.permissionsPolicy || document.featurePolicy;
+        let call = 'missing';
+        let slots = null;
+        let connected = null;
+        try {
+          if (typeof navigator.getGamepads === 'function') {
+            const pads = navigator.getGamepads();
+            call = 'ok';
+            slots = pads.length;
+            connected = Array.from(pads).filter(Boolean).length;
+          }
+        } catch (error) {
+          call = error.name + ': ' + error.message;
+        }
+        parent.postMessage({
+          probe: 'kc09',
+          label: '${label}',
+          userAgent: navigator.userAgent,
+          api: typeof navigator.getGamepads === 'function',
+          policy: policy && typeof policy.allowsFeature === 'function' ? policy.allowsFeature('gamepad') : null,
+          call,
+          slots,
+          connected
+        }, '*');
+        addEventListener('message', (event) => {
+          if (!event.data || event.data.probe !== 'kc09-latency') return;
+          parent.postMessage({ probe: 'kc09-latency-ack', label: '${label}', sentAt: event.data.sentAt, receivedAt: performance.timeOrigin + performance.now() }, '*');
+        });
+        addEventListener('keydown', (event) => {
+          parent.postMessage({ probe: 'kc09-keyboard-ack', label: '${label}', eventAt: performance.timeOrigin + event.timeStamp, receivedAt: performance.timeOrigin + performance.now() }, '*');
+        });
+        document.body.tabIndex = 0;
+        document.body.focus();
+      <\/script>`;
+
+      function percentile(values, fraction) {
+        if (!values.length) return null;
+        const sorted = [...values].sort((a, b) => a - b);
+        return sorted[Math.min(sorted.length - 1, Math.floor(sorted.length * fraction))];
+      }
+
+      function summary(values) {
+        if (!values.length) return { count: 0 };
+        return {
+          count: values.length,
+          meanMs: values.reduce((sum, value) => sum + value, 0) / values.length,
+          p50Ms: percentile(values, 0.5),
+          p95Ms: percentile(values, 0.95),
+        };
+      }
+
+      function render() {
+        output.textContent = JSON.stringify(
+          {
+            probes: results,
+            latency: {
+              relay: summary(latency.relay),
+              keyboard: summary(latency.keyboard),
+            },
+          },
+          null,
+          2,
+        );
+      }
+
+      function addFrame(label, allow) {
+        const frame = document.createElement('iframe');
+        frame.sandbox = 'allow-scripts';
+        frame.title = label;
+        if (allow) frame.allow = allow;
+        frame.srcdoc = child(label);
+        document.getElementById('frames').append(frame);
+      }
+
+      window.addEventListener('message', (event) => {
+        if (!event.data) return;
+        if (event.data.probe === 'kc09') {
+          results.push(event.data);
+          render();
+          if (event.data.label === 'sandbox-no-allow') {
+            let count = 0;
+            const relay = () => {
+              event.source.postMessage(
+                { probe: 'kc09-latency', sentAt: performance.timeOrigin + performance.now() },
+                '*',
+              );
+              count += 1;
+              if (count < 240) requestAnimationFrame(relay);
+            };
+            requestAnimationFrame(relay);
+          }
+          return;
+        }
+        if (event.data.probe === 'kc09-latency-ack') {
+          latency.relay.push(event.data.receivedAt - event.data.sentAt);
+          render();
+          return;
+        }
+        if (event.data.probe === 'kc09-keyboard-ack') {
+          latency.keyboard.push(event.data.receivedAt - event.data.eventAt);
+          render();
+        }
+      });
+
+      const topPolicy = document.permissionsPolicy || document.featurePolicy;
+      let topCall = 'missing';
+      let topSlots = null;
+      let topConnected = null;
+      try {
+        if (typeof navigator.getGamepads === 'function') {
+          const pads = navigator.getGamepads();
+          topCall = 'ok';
+          topSlots = pads.length;
+          topConnected = Array.from(pads).filter(Boolean).length;
+        }
+      } catch (error) {
+        topCall = error.name + ': ' + error.message;
+      }
+      results.push({
+        probe: 'kc09',
+        label: 'top-level',
+        userAgent: navigator.userAgent,
+        api: typeof navigator.getGamepads === 'function',
+        policy:
+          topPolicy && typeof topPolicy.allowsFeature === 'function'
+            ? topPolicy.allowsFeature('gamepad')
+            : null,
+        call: topCall,
+        slots: topSlots,
+        connected: topConnected,
+      });
+      render();
+      addFrame('sandbox-no-allow', '');
+      addFrame('sandbox-gamepad-allow', 'gamepad');
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## What

Implements the KC-09 gamepad research spike without shipping gamepad support:

- adds a development-only, query-gated shell relay (`?gamepad-spike=1`)
- maps the standard D-pad / left stick and button A to the existing party input vocabulary
- emits a richer normalized axes/buttons frame for architectural evaluation
- records browser-policy, latency, privacy, ownership, and follow-up findings
- adds focused normalization, relay, disconnect, and production-gate tests

## Why

The roadmap asks us to determine whether gamepad input belongs in the trusted website shell, GameKit input, or party. The evidence supports shell polling with normalized input owned by the shared input layer; party should consume it only for local-player assignment.

No game, GameKit module, iframe sandbox, permissions policy, or production behavior changes in this spike. A production build inspection confirms the relay code is tree-shaken from the app bundle.

## Evidence

Chrome-compatible browser 150 on macOS 26.5.2:

- top level: API exposed, policy allowed, four empty slots
- sandboxed iframe without `allow="gamepad"`: same result
- sandboxed iframe with `allow="gamepad"`: same result
- shell-to-iframe relay: 0.78 ms mean, 1.10 ms p95 over 240 samples
- keyboard dispatch baseline: 0.15 ms mean, 0.20 ms p95 over 30 samples

No physical controller was connected. Safari is installed but unavailable to this automation environment; Firefox is not installed. The findings explicitly retain both browsers plus real hardware as a manual gate before production work.

## Validation

- `npm run type-check`
- `npm run lint`
- `npm run test -w @gamedevpl/web` — 157 files, 1,343 tests passed
- `npm run build`
- production bundle search: no `gamepad:state` or `gamepad-spike` runtime strings; `getGamepads` appears only in TypeScript editor declarations

The exact concurrent `npm run test` command is not green locally: it overloaded this machine and produced 28 unrelated five-second timeouts across API and web. The affected web workspace passes in isolation; no broad timeout changes are included.

## Cross-repo note

KC-09's exit criteria explicitly require no game or GameKit changes. This PR therefore does not manufacture an empty games-repo code change; games-side roadmap tracking will link here instead.