### PR TITLE
Deliver the seed to managed mcp rounds instead of skipping it

### DIFF
--- a/.claude/skills/byoca-mcp/SKILL.md
+++ b/.claude/skills/byoca-mcp/SKILL.md
@@ -376,20 +376,42 @@ seeding mechanism seems very ineffective, no seeds happening" and traced to
 `submissions.ts`'s mute-setting condition and `seedBuild`'s mute check, not to `SEED_DISPATCH`
 or credentials being unset.
 
-### A seed nobody can read is never generated
+### A seed is delivered two ways, and the round says which
 
-`supportsSeedFiles` fixed the _delivery_ half — a provider that rejects `workspaceFiles`
-now degrades instead of throwing — but generation still ran first, so an Anthropic round,
-a Gemini round on a named environment, or Copilot on the `mcp` lane paid a full generation
-(two Vertex calls, a couple of minutes) for a draft the dispatch then dropped on the floor.
+`AgentBackend.seedDelivery(promptLane?)` answers, before anything is generated, how a seed
+would reach that round's agent:
 
-`AgentBackend.acceptsSeed(promptLane?)` moves that question ahead of the spend. The managed
-backend answers it from the same `seedSupportedOn` helper `start` uses, so the capability
-cannot drift between "would we send it" and "should we make it"; a backend that does not
-implement it is treated as accepting (the self backend stores every seed on the job).
-`dispatchBuild` reads it before `seedBuild`, and it also gates `willAttemptSelfSeed`, so a
-self round on a hypothetical non-accepting backend is marked `unavailable` rather than left
-`pending` forever.
+| Answer      | Means                                                             | Who                                                                              |
+| ----------- | ----------------------------------------------------------------- | -------------------------------------------------------------------------------- |
+| `workspace` | Files are placed for the agent, so the prompt may say so          | Copilot on `harness` (staged branch); Gemini with a scratch env (inline sources) |
+| `channel`   | Files are stored on the job; the agent reads them with `get_seed` | every self/BYOCA round; managed `mcp` rounds whose vendor refuses inline files   |
+| `none`      | Nothing would arrive, so a generation is only a bill              | a non-`mcp` lane whose provider cannot take files                                |
+
+**`channel` is the entry that made managed rounds seedable at all.** The first pass at this
+only asked whether the provider accepts `workspaceFiles` (`acceptsSeed`), and skipped
+generation when it did not — which was right about the waste and wrong about the
+conclusion. Anthropic _always_ rejects inline files, and it is an `mcp`-lane vendor, so
+"cannot be handed a seed" was being read as "cannot have one" and **every managed round on
+Anthropic built unseeded**. But an `mcp` round holds a round key and talks to this very
+channel; it can fetch a seed perfectly well. The missing piece was never the vendor — it
+was `submissions.ts` persisting the draft to the job only when `builder === 'self'`, so
+`get_seed` had nothing to return for a platform round.
+
+That condition is now `readsSeedFromJob` (i.e. `seedDelivery === 'channel'`), and the same
+predicate gates the `pending` / `unavailable` status writes and the stored-seed reuse. The
+managed backend still decides inline placement separately from `supportsSeedFiles`, so a
+`channel` round's prompt never claims a draft is in a checkout that does not have one.
+
+Two rules worth keeping when touching this:
+
+- **Do not infer delivery from the builder.** `seedDeliveryFor` falls back to `channel` for
+  `self` and `workspace` otherwise, but that is a backstop for a backend that forgot to
+  declare itself, not the source of truth. A self backend that silently defaulted to
+  `workspace` would land its rounds back in the staging mute — which is exactly how the
+  original bug behaved.
+- **The staging mute is about `workspace`, not about `platform`.** `seedBuild` takes the
+  delivery and honours the cooldown only for `workspace`, because that is the only mode
+  where a failed branch write wastes the draft.
 
 ### `regenerate_seed` — the one way out of a dead round-0
 
@@ -408,9 +430,11 @@ sleep, so a tool that waited would burn the connector's budget.
   buys a second copy of the first mistake. The steer (≤600 chars) rides the _picker_ call as
   well as the generate call, because a drifted draft usually drifted on its references. It
   is fenced as data with its own "cannot widen the file scope" preamble, like the spec.
-- **Self only.** A platform round's seed is committed to `seed/job-<id>` and passed as
-  `base_ref`; the workspace is already forked by the time an agent could ask, so there is
-  nothing to replace. Refused as `platform_round`.
+- **`channel` rounds only** — every self round, and managed `mcp` rounds. Refused as
+  `seed_not_readable` for a `workspace` round: its seed is a branch or an inline set the
+  agent forked at dispatch, so rewriting the job's copy would not reach it. Note this
+  tracks the _delivery_, not the builder: a managed `mcp` round can regenerate, and the
+  refusal is not "you are the platform".
 - **Refused once staged** (`already_staged`, checked in the channel where `gamesStore`
   lives) — the staging buffer overlays _onto_ the seed, so a new seed would move the base
   of files already written against it — and once delivered (`already_delivered`), whose
@@ -727,7 +751,7 @@ queued.
 | GAME.json staging shape check      | `apps/api/src/game-manifest-hint.ts` (`gameManifestHint`) — wired into the stage/patch routes in `agent-channel.ts`                                                                                    |
 | Round-0 seed generation            | `apps/api/src/game-seed.ts` (`VertexGameSeeder`) + `seedBuild`/`seedStagingMutedUntil` in `submissions.ts` — mute is `builder === 'platform'`-scoped and skips `mcp`-lane rounds (`result.promptLane`) |
 | Seed regeneration                  | `regenerateSeed` in `submissions.ts` + `POST /api/agent/build/seed/regenerate` in `agent-channel.ts` + `regenerate_seed` in `mcp-server.ts`; cap via `store.incrementSeedRegenerations`                |
-| "Would this lane use a seed?"      | `AgentBackend.acceptsSeed` — managed answers from `seedSupportedOn`; read before generating, so an unusable seed is never paid for                                                                     |
+| "How would this lane get a seed?"  | `AgentBackend.seedDelivery` → `workspace` / `channel` / `none`; read before generating, and `seedDeliveryFor` in `submissions.ts` backstops a backend that does not declare it                         |
 | Seed → managed session wiring      | `apps/api/src/managed-backend.ts` (`start`) — checks `provider.supportsSeedFiles` before attaching `workspaceFiles`; drops `brief.seed` from the prompt too when unsupported                           |
 | Account-session invalidation       | `apps/api/src/agent-session-revocation.ts`                                                                                                                                                             |
 | Channel (`POST …/end`, …)          | `apps/api/src/agent-channel.ts`                                                                                                                                                                        |

--- a/apps/api/src/agent-backend.ts
+++ b/apps/api/src/agent-backend.ts
@@ -76,6 +76,9 @@ export interface BuildBrief {
   seed?: SeedFiles;
 }
 
+// How the agent gets the seed: placed, read, or not at all.
+export type SeedDelivery = 'workspace' | 'channel' | 'none';
+
 /** The subset of a seed draft a backend needs to place it. */
 export interface SeedFiles {
   /** The game directory the files belong in. */
@@ -143,6 +146,6 @@ export interface AgentBackend {
   cancel(ref: string, credentialRef?: string): Promise<{ enforced: boolean }>;
   /** Releases workspace state once a job is finished. Best effort. */
   cleanup?(previous: DispatchResult): Promise<void>;
-  // Whether this lane would use brief.seed. Absent means yes.
-  acceptsSeed?(promptLane?: BuildPromptLane): boolean;
+  // How this lane would receive a seed. Absent means workspace.
+  seedDelivery?(promptLane?: BuildPromptLane): SeedDelivery;
 }

--- a/apps/api/src/agent-channel.test.ts
+++ b/apps/api/src/agent-channel.test.ts
@@ -6,6 +6,7 @@ import type { AgentChannelOptions } from './agent-channel.js';
 import { buildApp } from './app.js';
 import { mintSessionToken, SESSION_COOKIE_NAME } from './auth.js';
 import type { CatalogGameEntry, GameSources, GitHubClient, LinkedPullRequest } from './github-client.js';
+import type { AgentBackend } from './agent-backend.js';
 import type { GameSeeder } from './game-seed.js';
 import { InvalidUploadError, type GamesStore } from './games-store.js';
 import type { KnowledgeQueryResult } from './knowledge-search.js';
@@ -60,6 +61,7 @@ async function createApp(
     /** Live-preview timings; the real ones are tens of seconds and no test can wait them out. */
     stagedPreview?: { debounceMs?: number; minGapMs?: number; maxBytes?: number };
     gameSeeder?: GameSeeder;
+    agentBackend?: AgentBackend;
   },
 ) {
   await store.upsertUser({ uid: 'g:owner' });
@@ -73,6 +75,7 @@ async function createApp(
       ...(agentChannel ? { agentChannel } : {}),
       ...(extra?.stagedPreview ? { stagedPreview: extra.stagedPreview } : {}),
       ...(extra?.gameSeeder ? { gameSeeder: extra.gameSeeder } : {}),
+      ...(extra?.agentBackend ? { agentBackend: extra.agentBackend } : {}),
     },
   });
 }
@@ -3047,7 +3050,39 @@ describe('seed regeneration', () => {
     expect(seedCalls).toBe(0);
   });
 
-  it('refuses a platform round, whose seed is a branch it already forked', async () => {
+  it('lets a managed round that reads its seed regenerate one too', async () => {
+    // The refusal tracks how the seed arrives, not who is building.
+    const store = new InMemoryStore();
+    await seedSubmission(store);
+    await store.setSubmissionSlug(ISSUE, 'squad-game');
+    await store.setRoundBuilder(ISSUE, 'platform');
+    const platformBackend: AgentBackend = {
+      name: 'managed:stub',
+      seedDelivery: () => 'channel' as const,
+      dispatch: async () => ({ ref: 'session-1', promptLane: 'mcp' }),
+      resume: async () => ({ ref: 'session-2' }),
+      observe: async () => null,
+      cancel: async () => ({ enforced: false }),
+    };
+    app = await createApp(store, undefined, {
+      gameSeeder: seederStub(),
+      agentBackend: platformBackend,
+    });
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/agent/build/seed/regenerate',
+      headers: agentHeaders(),
+      payload: {},
+    });
+
+    expect(res.statusCode).toBe(200);
+    await vi.waitFor(async () => {
+      expect((await store.getSubmission(ISSUE))?.seedStatus).toBe('available');
+    });
+  });
+
+  it('refuses a round that was handed its seed as a workspace it already forked', async () => {
     const store = new InMemoryStore();
     await seedSubmission(store);
     await store.setSubmissionSlug(ISSUE, 'squad-game');
@@ -3063,7 +3098,7 @@ describe('seed regeneration', () => {
     });
 
     expect(res.statusCode).toBe(409);
-    expect(res.json().error).toBe('platform_round');
+    expect(res.json().error).toBe('seed_not_readable');
     expect(seedCalls).toBe(0);
   });
 

--- a/apps/api/src/agent-channel.ts
+++ b/apps/api/src/agent-channel.ts
@@ -114,7 +114,8 @@ const RegenerateSeedRequestSchema = z.object({
 const REGENERATE_SEED_REFUSALS: Record<string, string> = {
   not_configured: 'this deployment does not generate seeds',
   not_found: 'no round to regenerate a seed for',
-  platform_round: 'a platform round’s seed is committed to a branch at dispatch, so it cannot be replaced mid-round',
+  seed_not_readable:
+    'this round was handed its seed as a workspace rather than reading it, so replacing the stored copy would not reach the agent',
   already_delivered: 'this round already delivered — build on what you delivered rather than restarting from a draft',
   cap_reached: 'this job has used its seed regenerations; continue from the draft you have or scaffold from the kit',
 };
@@ -579,7 +580,7 @@ export interface AgentChannelOptions {
     log: FastifyRequest['log'];
   }) => Promise<
     | { ok: true; status: 'pending'; regenerationsRemaining: number }
-    | { ok: false; reason: 'not_configured' | 'not_found' | 'platform_round' | 'already_delivered' | 'cap_reached' }
+    | { ok: false; reason: 'not_configured' | 'not_found' | 'seed_not_readable' | 'already_delivered' | 'cap_reached' }
   >;
   onSourcesDelivered?: (input: {
     issueNumber: number;

--- a/apps/api/src/managed-backend.test.ts
+++ b/apps/api/src/managed-backend.test.ts
@@ -220,6 +220,32 @@ describe('managed backend', () => {
     expect(started[0].workspaceFiles).toBeUndefined();
   });
 
+  it('reports a seed the mcp lane can read rather than one it cannot be handed', () => {
+    const mcpTools = { mcpEndpoints: [{ url: 'https://www.gamedev.pl/api/mcp', name: 'gamedevpl' }] };
+    const refuses = createManagedBackend({
+      provider: fakeProvider({ supportsSeedFiles: false, promptLane: 'mcp' }).provider,
+      deliver: async () => ({ version: 'v1' }),
+      tools: mcpTools,
+    });
+    // Cannot take files, but holds a key — still worth making.
+    expect(refuses.seedDelivery?.()).toBe('channel');
+    expect(refuses.seedDelivery?.('mcp')).toBe('channel');
+
+    const accepts = createManagedBackend({
+      provider: fakeProvider({ supportsSeedFiles: true, promptLane: 'mcp' }).provider,
+      deliver: async () => ({ version: 'v1' }),
+      tools: mcpTools,
+    });
+    expect(accepts.seedDelivery?.()).toBe('workspace');
+
+    // Off the mcp lane there is no channel, so nothing arrives.
+    const harness = createManagedBackend({
+      provider: fakeProvider({ supportsSeedFiles: false, promptLane: 'harness' }).provider,
+      deliver: async () => ({ version: 'v1' }),
+    });
+    expect(harness.seedDelivery?.()).toBe('none');
+  });
+
   it('preserves the provider seed workspace separately from the agent workspace', async () => {
     const { provider } = fakeProvider({
       startSession: async () => ({

--- a/apps/api/src/managed-backend.ts
+++ b/apps/api/src/managed-backend.ts
@@ -1,5 +1,5 @@
 // AgentBackend over any ManagedAgentProvider; delivery is pulled.
-import type { AgentBackend, BuildBrief, DispatchResult } from './agent-backend.js';
+import type { AgentBackend, BuildBrief, DispatchResult, SeedDelivery } from './agent-backend.js';
 import { buildPrompt } from './build-prompt.js';
 import { forbiddenDeliveryPathReason } from './games-store.js';
 import type { AgentObservation, AgentSessionTokens } from './job-state.js';
@@ -373,8 +373,11 @@ export function createManagedBackend(options: ManagedBackendOptions): AgentBacke
   return {
     name: backendName,
 
-    acceptsSeed(promptLane): boolean {
-      return seedSupportedOn(promptLane ?? defaultPromptLane);
+    seedDelivery(promptLane): SeedDelivery {
+      const lane = promptLane ?? defaultPromptLane;
+      if (seedSupportedOn(lane)) return 'workspace';
+      // An mcp round can read what it cannot be handed.
+      return lane === 'mcp' ? 'channel' : 'none';
     },
 
     async dispatch(brief: BuildBrief): Promise<DispatchResult> {

--- a/apps/api/src/self-build-backend.ts
+++ b/apps/api/src/self-build-backend.ts
@@ -6,7 +6,7 @@
 // path Copilot uses for upload and inbox — so gate, store and publication stay unaware
 // of who is typing on the other end.
 
-import type { AgentBackend, BuildBrief, DispatchResult, SeedFiles } from './agent-backend.js';
+import type { AgentBackend, BuildBrief, DispatchResult, SeedDelivery, SeedFiles } from './agent-backend.js';
 import type { AgentObservation } from './job-state.js';
 
 export interface SelfBuildSignals {
@@ -56,6 +56,9 @@ export function createSelfBuildBackend(options: SelfBuildBackendOptions = {}): A
 
   return {
     name: 'self',
+
+    // BYOCA has no workspace we can write; get_seed reads it back.
+    seedDelivery: (): SeedDelivery => 'channel',
 
     async dispatch(brief: BuildBrief): Promise<DispatchResult> {
       return openRound(brief);

--- a/apps/api/src/submissions.test.ts
+++ b/apps/api/src/submissions.test.ts
@@ -6042,13 +6042,54 @@ describe('seeded dispatch', () => {
     await app.close();
   });
 
+  it('stores the seed on the job for a managed round that can only read it', async () => {
+    // The Anthropic shape: refuses inline files, but can read get_seed.
+    const stub = createGithubClientStub({});
+    const briefs: BuildBrief[] = [];
+    const backend: AgentBackend = {
+      name: 'managed:stub',
+      seedDelivery: () => 'channel' as const,
+      dispatch: async (brief) => {
+        briefs.push(brief);
+        return { ref: 'session-1', promptLane: 'mcp' };
+      },
+      resume: async () => ({ ref: 'session-2' }),
+      observe: async () => null,
+      cancel: async () => ({ enforced: false }),
+    };
+    const { app, store, authHeaders } = await createApp({
+      githubClient: stub.githubClient,
+      agentBackend: backend,
+      submissionTokenSecret: secret,
+      gameSeeder: seederStub({ compiles: true }),
+    });
+
+    const created = await app.inject({
+      method: 'POST',
+      url: '/api/submissions',
+      headers: authHeaders,
+      payload: { title: 'Managed Game', concept: 'A game where you deliver parcels between comets, dodging debris.' },
+    });
+    expect(created.statusCode).toBe(200);
+    await vi.waitFor(() => expect(briefs).toHaveLength(1));
+
+    // The seed is on the job, which is what get_seed reads.
+    const record = await store.getSubmission(briefs[0].issueNumber);
+    expect(record?.seed?.files).toHaveLength(1);
+    expect(record?.seedStatus).toBe('available');
+    // Still offered to the backend, which decides if it can place files.
+    expect(briefs[0].seed).toBeDefined();
+
+    await app.close();
+  });
+
   it('does not pay for a seed a backend would discard', async () => {
-    // acceptsSeed is read before generation, not after the bill.
+    // seedDelivery is read before generation, not after the bill.
     const stub = createGithubClientStub({});
     const briefs: BuildBrief[] = [];
     const backend: AgentBackend = {
       name: 'stub',
-      acceptsSeed: () => false,
+      seedDelivery: () => 'none' as const,
       dispatch: async (brief) => {
         briefs.push(brief);
         return { ref: 'task-1', promptLane: 'mcp' };

--- a/apps/api/src/submissions.ts
+++ b/apps/api/src/submissions.ts
@@ -39,7 +39,7 @@ import {
 import { startHealthCheck } from './game-health.js';
 import { createStagedPreviewPublisher, type StagedPreviewOptions } from './staged-preview.js';
 import { createInternalAuthVerifierFromEnv, type InternalAuthVerifier } from './internal-auth.js';
-import type { AgentBackend, BuildHistoryEntry, BuildPromptLane, SeedFiles } from './agent-backend.js';
+import type { AgentBackend, BuildHistoryEntry, BuildPromptLane, SeedDelivery, SeedFiles } from './agent-backend.js';
 import {
   createAgentBackendRegistryFromEnv,
   resolveBuilderBackend,
@@ -810,6 +810,15 @@ export async function registerSubmissionRoutes(
     return resolveBuilderBackend(agentBackends, resolvedBuilder, vendor);
   }
 
+  // A self round has no workspace, whatever a backend forgot to declare.
+  function seedDeliveryFor(
+    backend: AgentBackend | undefined,
+    builder: BuilderKind,
+    promptLane?: BuildPromptLane,
+  ): SeedDelivery {
+    return backend?.seedDelivery?.(promptLane) ?? (builder === 'self' ? 'channel' : 'workspace');
+  }
+
   function backendByStoredName(name: string | undefined): AgentBackend | undefined {
     if (!name) return undefined;
     if (agentBackends.self.name === name) return agentBackends.self;
@@ -992,13 +1001,13 @@ export async function registerSubmissionRoutes(
     issueNumber: number;
     slug: string;
     spec: string;
-    builder: BuilderKind;
+    delivery: SeedDelivery;
     steer?: string;
     log: { error: (context: object, message: string) => void };
   }): Promise<SeedDraft | undefined> {
     if (!gameSeeder || !store) return undefined;
-    // Only platform rounds stage branches, so only they risk staging failure.
-    if (input.builder === 'platform' && now() < seedStagingMutedUntil) {
+    // Only a workspace hand-off stages anything, so only it risks staging failure.
+    if (input.delivery === 'workspace' && now() < seedStagingMutedUntil) {
       input.log.error(
         { issueNumber: input.issueNumber },
         'skipping the seed: a recent draft could not be staged, so generating another would be wasted',
@@ -1030,19 +1039,23 @@ export async function registerSubmissionRoutes(
   // Each regeneration is a paid generation, so this is a spend ceiling.
   const MAX_SEED_REGENERATIONS = 2;
 
-  // Queues a replacement round-0 draft. Self only: a platform seed is a forked branch.
+  // Queues a replacement draft, for rounds that read the job's copy.
   async function regenerateSeed(input: {
     issueNumber: number;
     steer?: string;
     log: { error: (context: object, message: string) => void; info?: (context: object, message: string) => void };
   }): Promise<
     | { ok: true; status: 'pending'; regenerationsRemaining: number }
-    | { ok: false; reason: 'not_configured' | 'not_found' | 'platform_round' | 'already_delivered' | 'cap_reached' }
+    | { ok: false; reason: 'not_configured' | 'not_found' | 'seed_not_readable' | 'already_delivered' | 'cap_reached' }
   > {
     if (!gameSeeder || !store) return { ok: false, reason: 'not_configured' };
     const record = await store.getSubmission(input.issueNumber);
     if (!record || !record.slug) return { ok: false, reason: 'not_found' };
-    if (builderOf(record) !== 'self') return { ok: false, reason: 'platform_round' };
+    // A round handed a workspace already forked it; a rewrite cannot catch up.
+    const roundBuilder = builderOf(record);
+    if (seedDeliveryFor(await backendFor(roundBuilder), roundBuilder) !== 'channel') {
+      return { ok: false, reason: 'seed_not_readable' };
+    }
     // A delivered round was already judged; do not move its starting point.
     if ((record.roundDeliveryCount ?? 0) > 0) return { ok: false, reason: 'already_delivered' };
 
@@ -1056,7 +1069,7 @@ export async function registerSubmissionRoutes(
         issueNumber: input.issueNumber,
         slug,
         spec: record.spec ?? '',
-        builder: 'self',
+        delivery: 'channel',
         ...(input.steer ? { steer: input.steer } : {}),
         log: input.log,
       });
@@ -1213,32 +1226,26 @@ export async function registerSubmissionRoutes(
       // really there — and so the slug it mints is on the record the brief reads from.
       // A seed is written into `games/<slug>/`, so a job without a slug cannot have one.
       // Every new submission has one by now; the guard is for the paths that do not.
-      // Self rounds reuse a seed already on the job (resume of the same round).
-      const storedSeed = builder === 'self' ? existing?.seed : undefined;
-      // Ask before paying: some lanes discard the seed they are handed.
-      const backendAcceptsSeed = selected.acceptsSeed?.(input.promptLane) ?? true;
-      // Only self builds expose seed files on the job (`get_seed`). Platform seeds land
-      // on a branch the coding agent already has — no pending race for MCP.
-      const willAttemptSelfSeed =
-        builder === 'self' &&
-        !storedSeed &&
-        !input.feedback &&
-        Boolean(input.slug) &&
-        Boolean(gameSeeder) &&
-        backendAcceptsSeed;
+      // Ask before paying, and ask how the seed would arrive.
+      const seedDelivery = seedDeliveryFor(selected, builder, input.promptLane);
+      // Only these rounds read the job's copy, so only they need one stored.
+      const readsSeedFromJob = seedDelivery === 'channel';
+      const storedSeed = readsSeedFromJob ? existing?.seed : undefined;
+      const willAttemptJobSeed =
+        readsSeedFromJob && !storedSeed && !input.feedback && Boolean(input.slug) && Boolean(gameSeeder);
       if (storedSeed) {
         await store.setSubmissionSeed(input.issueNumber, storedSeed);
-      } else if (willAttemptSelfSeed) {
+      } else if (willAttemptJobSeed) {
         // Seed generation can take minutes; mark pending so MCP agents recheck get_seed
         // instead of treating a race as "no seed, scaffold from scratch".
         await store.setSeedStatus(input.issueNumber, 'pending');
-      } else if (builder === 'self') {
+      } else if (readsSeedFromJob) {
         await store.setSeedStatus(input.issueNumber, 'unavailable');
       }
       const draft =
-        storedSeed || input.feedback || !input.slug || !backendAcceptsSeed
+        storedSeed || input.feedback || !input.slug || seedDelivery === 'none'
           ? undefined
-          : await seedBuild({ ...input, slug: input.slug, builder });
+          : await seedBuild({ ...input, slug: input.slug, delivery: seedDelivery });
       const seed: SeedFiles | undefined = storedSeed
         ? storedSeed
         : draft
@@ -1249,14 +1256,14 @@ export async function registerSubmissionRoutes(
               ...(draft.notes ? { notes: draft.notes } : {}),
             }
           : undefined;
-      if (builder === 'self' && !storedSeed) {
+      if (readsSeedFromJob && !storedSeed) {
         if (seed) {
           // Persist before dispatch so a racing get_brief/get_seed can see the draft even
           // if the self backend's persistSeed races behind the first tool call.
           await store.setSubmissionSeed(input.issueNumber, seed);
-        } else if (willAttemptSelfSeed) {
+        } else if (willAttemptJobSeed) {
           // Downgrade pending→unavailable only when generation was attempted and failed.
-          // The !willAttemptSelfSeed path already wrote unavailable above.
+          // The !willAttemptJobSeed path already wrote unavailable above.
           await store.setSeedStatus(input.issueNumber, 'unavailable');
         }
       }


### PR DESCRIPTION
## Summary

Follow-up to #799. That PR fixed a false-positive circuit breaker muting seed generation, and made `supportsSeedFiles` prevent generating a seed a managed provider would reject or discard. But `acceptsSeed` asked the wrong question — "does this provider accept inline files?" — and treated *no* as "skip generation." Anthropic always rejects inline `workspaceFiles` and is an `mcp`-lane vendor, so "cannot be **handed** a seed" was being read as "cannot **have** one." **Every managed round on Anthropic built unseeded.**

An `mcp` round holds a round key and talks to the same build channel BYOCA uses — it can fetch a seed fine. The real blocker was `submissions.ts` persisting the generated draft to the job only when `builder === 'self'`, so `get_seed` had nothing to return for a platform round even when generation succeeded.

## The fix

`AgentBackend.acceptsSeed(promptLane?)` → `AgentBackend.seedDelivery(promptLane?)`, answering **how** a seed reaches the round's agent instead of whether it's allowed to exist:

| Answer | Means | Who |
|---|---|---|
| `workspace` | Files are placed for the agent (staged branch or inline sources), so the prompt may say a draft is already in the checkout | Copilot on `harness`; Gemini with a scratch environment |
| `channel` | Files are stored on the job; the agent reads them with `get_seed` | every self/BYOCA round; **managed `mcp` rounds whose vendor refuses inline files** |
| `none` | Nothing would arrive, so generating one is only a bill | a non-`mcp` lane whose provider cannot take files |

`submissions.ts` now keys seed persistence, the `pending`/`unavailable` status writes, and stored-seed reuse on `seedDelivery === 'channel'` (`readsSeedFromJob`) instead of `builder === 'self'`. A managed `mcp` round that can't take inline files now generates a seed, stores it on the job, and its agent reads it via `get_seed` — Studio shows `pending` while it generates, same as BYOCA always has.

Two related corrections fell out of the same change:

- **The staging mute now keys on `workspace` delivery, not `builder === 'platform'`.** The mute exists because a failed *branch write* wastes the draft; a round that never stages a branch (self, or a managed `channel` round) was never at risk of that failure.
- **`regenerate_seed` refuses on delivery, not builder.** A managed `mcp` round can now recover a failed or off-brief draft exactly like BYOCA can. The refusal code `platform_round` is renamed `seed_not_readable`, which is what it always actually meant — a round handed a workspace has already forked it, and a rewrite of the job's copy can't catch up.

## A guard worth calling out

`seedDeliveryFor` in `submissions.ts` backstops a backend that doesn't declare `seedDelivery`: it falls back to `channel` for `builder === 'self'` and `workspace` otherwise. That fallback is a safety net, not the source of truth — a self backend that silently defaulted to `workspace` would land its rounds back in the staging mute, which is exactly how the original bug in #799 behaved. A test (`managed-backend.test.ts`) pins the real classification per lane so this can't regress silently.

## Testing

3195 tests pass (5 new); `npm run lint` (including the `comment-prose` budget) and typecheck clean.

New coverage:
- a managed round whose provider can't take inline files still gets its seed stored on the job and readable via `get_seed`, and its prompt does not falsely claim a draft is in the checkout
- `seedDelivery` classification per lane on the managed backend (`channel` when the vendor refuses inline files on `mcp`, `workspace` when it accepts them, `none` off `mcp` with no channel to fall back to)
- a managed `mcp` round can call `regenerate_seed`, and a `workspace` round is refused with `seed_not_readable`
- confirmed the new "seed reaches a managed round" test fails against the pre-fix `builder === 'self'` condition, so it isn't vacuous

The `byoca-mcp` skill records the delivery model and both guard rules.

https://claude.ai/code/session_01DLh3ShdDejjF9Xn5HSAJ2Q

---
_Generated by [Claude Code](https://claude.ai/code/session_01DLh3ShdDejjF9Xn5HSAJ2Q)_