### PR TITLE
TA-01/TA-02: ghost-text autocomplete (API + web)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -226,6 +226,13 @@ jobs:
             ENV_VARS="${ENV_VARS}|CODE_LANE=${CODE_LANE_VAL}"
           fi
 
+          # TA-01's ghost-text completion route: off unless set, same reasoning as
+          # EDITOR_ASSIST above — a hand-set value would vanish on the next deploy.
+          TAB_COMPLETE_VAL="${{ vars.TAB_COMPLETE }}"
+          if [ -n "$TAB_COMPLETE_VAL" ]; then
+            ENV_VARS="${ENV_VARS}|TAB_COMPLETE=${TAB_COMPLETE_VAL}"
+          fi
+
           # The Code surface (creator-code-editing-execution-plan.md CE-02): manual
           # editing of a game's own sources in the Studio. A kill switch, not a cohort
           # gate — the owner decision is all-creators, so it ships on by default and this

--- a/apps/api/src/admin.test.ts
+++ b/apps/api/src/admin.test.ts
@@ -536,6 +536,8 @@ describe('/api/admin/creation-limits', () => {
         configuredVendors: [],
         defaultVendor: null,
       },
+      tabCompletePaused: false,
+      globalDailyTabCompleteTokenCap: 2_000_000,
     });
     // A pause left on by accident is this feature's own failure mode, so the record of
     // who set it is part of the deliverable.
@@ -570,6 +572,30 @@ describe('/api/admin/creation-limits', () => {
         configuredVendors: [],
         defaultVendor: null,
       },
+      tabCompletePaused: false,
+      globalDailyTabCompleteTokenCap: 2_000_000,
+    });
+    await app.close();
+  });
+
+  it('sets the tab-complete pause and cap, independent of the other lanes', async () => {
+    const app = await appWith(store);
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/admin/creation-limits',
+      headers: authHeaders('g:boss'),
+      payload: { tabCompletePaused: true, globalDailyTabCompleteTokenCap: 500_000 },
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json() as CreationLimitsResponse;
+    expect(body.effective.tabCompletePaused).toBe(true);
+    expect(body.effective.globalDailyTabCompleteTokenCap).toBe(500_000);
+    expect(body.effective.paused).toBe(false);
+    expect(await store.getCreationLimits()).toMatchObject({
+      tabCompletePaused: true,
+      globalDailyTabCompleteTokenCap: 500_000,
     });
     await app.close();
   });

--- a/apps/api/src/admin.ts
+++ b/apps/api/src/admin.ts
@@ -167,6 +167,9 @@ const CreationLimitsPatchSchema = z
     // The studio chat breaker rides the same document too.
     chatPaused: z.boolean().optional(),
     globalDailyChatCap: z.number().int().min(0).max(100_000).nullable().optional(),
+    // TA-01's own breaker, denominated in tokens rather than calls.
+    tabCompletePaused: z.boolean().optional(),
+    globalDailyTabCompleteTokenCap: z.number().int().min(0).max(50_000_000).nullable().optional(),
     // Same document: whether the platform builder is offered. See managed-availability.ts.
     managedBuilderMode: z.enum(['auto', 'off', 'coming_soon']).optional(),
     // null clears the override, same as globalDailySubmissionCap above.
@@ -182,11 +185,13 @@ const CreationLimitsPatchSchema = z
       patch.globalDailyEditCap !== undefined ||
       patch.chatPaused !== undefined ||
       patch.globalDailyChatCap !== undefined ||
+      patch.tabCompletePaused !== undefined ||
+      patch.globalDailyTabCompleteTokenCap !== undefined ||
       patch.managedBuilderMode !== undefined ||
       patch.managedAgentVendorOverride !== undefined ||
       patch.managedDailyCap !== undefined ||
       patch.managedDailyUserCap !== undefined,
-    'nothing to change: send paused, globalDailySubmissionCap, editingPaused, globalDailyEditCap, chatPaused, globalDailyChatCap, managedBuilderMode, managedAgentVendorOverride, managedDailyCap and/or managedDailyUserCap',
+    'nothing to change: send paused, globalDailySubmissionCap, editingPaused, globalDailyEditCap, chatPaused, globalDailyChatCap, tabCompletePaused, globalDailyTabCompleteTokenCap, managedBuilderMode, managedAgentVendorOverride, managedDailyCap and/or managedDailyUserCap',
   );
 
 const PublicPlayPatchSchema = z.object({

--- a/apps/api/src/admin.ts
+++ b/apps/api/src/admin.ts
@@ -28,7 +28,11 @@ import {
   type DailyRetentionPoint,
   type TelemetryTrends,
 } from './telemetry-trends.js';
-import { DEFAULT_CREATION_LIMITS_TTL_MS, resolveDefaultGlobalDailyCap } from './creation-limits.js';
+import {
+  DEFAULT_CREATION_LIMITS_TTL_MS,
+  resolveDefaultGlobalDailyCap,
+  resolveDefaultGlobalDailyTabCompleteTokenCap,
+} from './creation-limits.js';
 import {
   BOT_UID_PREFIX,
   type BetaInvite,
@@ -143,8 +147,11 @@ export interface CreationLimitsResponse {
       // MANAGED_AGENT_VENDOR, shown next to the override control.
       defaultVendor: string | null;
     };
+    // TA-01's own breaker (creator-code-tab-autocomplete-research.md).
+    tabCompletePaused: boolean;
+    globalDailyTabCompleteTokenCap: number;
   };
-  today: { dateStr: string; submissions: number; managedBuilds: number };
+  today: { dateStr: string; submissions: number; managedBuilds: number; tabCompleteTokens: number };
   /** Upper bound, in ms, on how long a change takes to reach every instance. */
   propagationMs: number;
 }
@@ -386,10 +393,11 @@ export async function registerAdminRoutes(app: FastifyInstance, options: AdminRo
   /** Reads the stored breaker plus today's spend, uncached — an operator wants truth. */
   async function readCreationLimits(): Promise<CreationLimitsResponse> {
     const dateStr = new Date(now()).toISOString().slice(0, 10);
-    const [stored, submissions, managedBuilds] = await Promise.all([
+    const [stored, submissions, managedBuilds, tabCompleteTokens] = await Promise.all([
       store.getCreationLimits(),
       store.getGlobalSubmissionCount(dateStr),
       store.getGlobalManagedBuildCount(dateStr),
+      store.getGlobalTabCompleteTokenCount(dateStr),
     ]);
     const storedVendor = stored?.managedAgentVendorOverride ?? null;
     // An invalid default must not report as effective when nothing overrode it.
@@ -411,8 +419,11 @@ export async function registerAdminRoutes(app: FastifyInstance, options: AdminRo
           configuredVendors: [...configuredVendors],
           defaultVendor,
         },
+        tabCompletePaused: stored?.tabCompletePaused === true,
+        globalDailyTabCompleteTokenCap:
+          stored?.globalDailyTabCompleteTokenCap ?? resolveDefaultGlobalDailyTabCompleteTokenCap(),
       },
-      today: { dateStr, submissions, managedBuilds },
+      today: { dateStr, submissions, managedBuilds, tabCompleteTokens },
       propagationMs: creationLimitsTtlMs,
     };
   }

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -33,8 +33,9 @@ import { registerCreatorStudioRoutes } from './creator-studio.js';
 import { registerEditorRoutes } from './editor-drafts.js';
 import { VertexEditorAssistant, type EditorAssistant } from './editor-assist.js';
 import { VertexCodeLane } from './code-lane.js';
+import { VertexTabCompleter, type TabCompleter } from './tab-complete.js';
 import { registerRemixRoutes, MAX_REMIX_ID_LENGTH } from './remix.js';
-import { createEditingGate, createCreationGate } from './creation-limits.js';
+import { createEditingGate, createCreationGate, createTabCompleteGate } from './creation-limits.js';
 import { createGenerator } from './generator.js';
 import { createDefaultContentChecker, type ContentChecker } from './moderation.js';
 import { registerContactRoutes, type ContactRoutesOptions } from './contact.js';
@@ -146,6 +147,8 @@ export interface BuildAppOptions {
   specRefiner?: SpecRefiner;
   /** The editor's NL tuning router. Defaults to the Vertex one; stubbed in tests. */
   editorAssistant?: EditorAssistant;
+  // Ghost-text completer (TA-01). Defaults to Vertex; stubbed in tests.
+  tabCompleter?: TabCompleter;
   multiplayerRoutes?: MultiplayerRoutesOptions;
   /** Seams for play-session telemetry; defaults to a live catalog-backed slug gate. */
   telemetryRoutes?: Omit<TelemetryRoutesOptions, 'store'>;
@@ -757,6 +760,9 @@ export async function buildApp(options: BuildAppOptions = {}): Promise<FastifyIn
     scheduleStagedPreview: submissionSeams.scheduleStagedPreview ?? undefined,
     onSourcesDelivered: gateTrigger,
     log: app.log,
+    // TA-01: built unconditionally (the Vertex client is lazy); TAB_COMPLETE gates it.
+    tabCompleter: options.tabCompleter ?? new VertexTabCompleter(),
+    tabCompleteGate: createTabCompleteGate({ store, logWarn: (payload, msg) => app.log.warn(payload, msg) }),
   });
 
   // The Creator Studio content editor (EditorKit): drafts in Firestore, publish

--- a/apps/api/src/creation-limits.test.ts
+++ b/apps/api/src/creation-limits.test.ts
@@ -281,24 +281,35 @@ describe('tab-complete gate (the ghost-text token breaker)', () => {
     const store = new InMemoryStore();
     // Room for exactly one reservation, not two.
     const gate = createTabCompleteGate({ store, ttlMs: 0, defaultGlobalDailyCap: TAB_COMPLETE_TOKEN_RESERVATION });
-    expect(await gate.peek('g:alice', '2026-08-02')).toEqual({ allowed: true });
+    expect(await gate.peek('g:alice', '2026-08-02')).toEqual({ allowed: true, reserved: true });
     expect(await gate.peek('g:bob', '2026-08-02')).toEqual({ allowed: false, reason: 'over_capacity' });
+  });
+
+  it('refuses a reservation that would itself cross a cap smaller than one reservation', async () => {
+    const store = new InMemoryStore();
+    // A cap below one reservation must still refuse.
+    const gate = createTabCompleteGate({ store, ttlMs: 0, defaultGlobalDailyCap: 100 });
+    expect(await gate.peek('g:alice', '2026-08-02')).toEqual({ allowed: false, reason: 'over_capacity' });
+    expect(await store.getGlobalTabCompleteTokenCount('2026-08-02')).toBe(0);
   });
 
   it('gives back the unused reservation once real usage is known', async () => {
     const store = new InMemoryStore();
-    const gate = createTabCompleteGate({ store, ttlMs: 0, defaultGlobalDailyCap: TAB_COMPLETE_TOKEN_RESERVATION });
-    expect(await gate.peek('g:alice', '2026-08-02')).toEqual({ allowed: true });
-    await gate.spend('g:alice', '2026-08-02', 100);
-    // Reservation released; a second request has room again.
-    expect(await gate.peek('g:bob', '2026-08-02')).toEqual({ allowed: true });
+    // Room for one reservation plus headroom for the next.
+    const cap = TAB_COMPLETE_TOKEN_RESERVATION + 500;
+    const gate = createTabCompleteGate({ store, ttlMs: 0, defaultGlobalDailyCap: cap });
+    const peeked = await gate.peek('g:alice', '2026-08-02');
+    expect(peeked).toEqual({ allowed: true, reserved: true });
+    await gate.spend('g:alice', '2026-08-02', 100, peeked.allowed && peeked.reserved);
+    // Reservation released down to real usage; a second request has room again.
+    expect(await gate.peek('g:bob', '2026-08-02')).toEqual({ allowed: true, reserved: true });
   });
 
   it('tops up the counter when real usage exceeds the reservation', async () => {
     const store = new InMemoryStore();
     const gate = createTabCompleteGate({ store, ttlMs: 0, defaultGlobalDailyCap: TAB_COMPLETE_TOKEN_RESERVATION + 10 });
-    expect(await gate.peek('g:alice', '2026-08-02')).toEqual({ allowed: true });
-    await gate.spend('g:alice', '2026-08-02', TAB_COMPLETE_TOKEN_RESERVATION + 10);
+    expect(await gate.peek('g:alice', '2026-08-02')).toEqual({ allowed: true, reserved: true });
+    await gate.spend('g:alice', '2026-08-02', TAB_COMPLETE_TOKEN_RESERVATION + 10, true);
     expect(await gate.peek('g:bob', '2026-08-02')).toEqual({ allowed: false, reason: 'over_capacity' });
   });
 
@@ -306,8 +317,29 @@ describe('tab-complete gate (the ghost-text token breaker)', () => {
     const store = new InMemoryStore();
     const gate = createTabCompleteGate({ store, ttlMs: 0, defaultGlobalDailyCap: 5_000 });
     // spend() with no prior peek must not underflow the day's counter.
-    await gate.spend('g:alice', '2026-08-02', 0);
+    await gate.spend('g:alice', '2026-08-02', 0, false);
     expect(await store.getGlobalTabCompleteTokenCount('2026-08-02')).toBe(0);
+  });
+
+  it('does not release a reservation that was never actually recorded', async () => {
+    const store = new InMemoryStore();
+    let failNextIncrement = true;
+    const originalIncrement = store.checkAndIncrementGlobalTabCompleteTokens.bind(store);
+    store.checkAndIncrementGlobalTabCompleteTokens = async (dateStr, tokens, limit) => {
+      if (failNextIncrement) {
+        failNextIncrement = false;
+        throw new Error('firestore unavailable');
+      }
+      return originalIncrement(dateStr, tokens, limit);
+    };
+    const gate = createTabCompleteGate({ store, ttlMs: 0, defaultGlobalDailyCap: 500, logWarn: () => {} });
+
+    // The reservation write failed, so peek() admits without reserving.
+    const peeked = await gate.peek('g:alice', '2026-08-02');
+    expect(peeked).toEqual({ allowed: true, reserved: false });
+    // A naive spend() would underflow to 0 instead of keeping usage.
+    await gate.spend('g:alice', '2026-08-02', 200, peeked.allowed && peeked.reserved);
+    expect(await store.getGlobalTabCompleteTokenCount('2026-08-02')).toBe(200);
   });
 
   it('honours the stored tabCompletePaused switch without touching other lanes', async () => {
@@ -323,10 +355,10 @@ describe('tab-complete gate (the ghost-text token breaker)', () => {
     const store = new InMemoryStore();
     await store.setCreationLimits({ globalDailyTabCompleteTokenCap: TAB_COMPLETE_TOKEN_RESERVATION }, 'operator');
     const gate = createTabCompleteGate({ store, ttlMs: 0 });
-    expect(await gate.peek('bot:e2e', '2026-08-02')).toEqual({ allowed: true });
-    await gate.spend('bot:e2e', '2026-08-02', 999_999);
+    expect(await gate.peek('bot:e2e', '2026-08-02')).toEqual({ allowed: true, reserved: false });
+    await gate.spend('bot:e2e', '2026-08-02', 999_999, false);
     expect(await store.getGlobalTabCompleteTokenCount('2026-08-02')).toBe(0);
     // The real cap stays untouched, so a creator still gets a turn.
-    expect(await gate.peek('g:alice', '2026-08-02')).toEqual({ allowed: true });
+    expect(await gate.peek('g:alice', '2026-08-02')).toEqual({ allowed: true, reserved: true });
   });
 });

--- a/apps/api/src/creation-limits.test.ts
+++ b/apps/api/src/creation-limits.test.ts
@@ -3,8 +3,10 @@ import {
   createChatGate,
   createCreationGate,
   createEditingGate,
+  createTabCompleteGate,
   DEFAULT_GLOBAL_DAILY_SUBMISSION_CAP,
   resolveDefaultGlobalDailyCap,
+  TAB_COMPLETE_TOKEN_RESERVATION,
   type CreationGateOptions,
 } from './creation-limits.js';
 import { InMemoryStore, type CreationLimits, type Store } from './store.js';
@@ -271,5 +273,60 @@ describe('chat gate (the studio mini chat agent spend breaker)', () => {
     expect(await gate.checkAndSpend('bot:e2e', '2026-08-02')).toEqual({ allowed: true });
     expect(await gate.checkAndSpend('g:alice', '2026-08-02')).toEqual({ allowed: true });
     expect(await gate.checkAndSpend('g:bob', '2026-08-02')).toEqual({ allowed: false, reason: 'over_capacity' });
+  });
+});
+
+describe('tab-complete gate (the ghost-text token breaker)', () => {
+  it('reserves a worst-case slot on peek, so a burst cannot all pass free', async () => {
+    const store = new InMemoryStore();
+    // Room for exactly one reservation, not two.
+    const gate = createTabCompleteGate({ store, ttlMs: 0, defaultGlobalDailyCap: TAB_COMPLETE_TOKEN_RESERVATION });
+    expect(await gate.peek('g:alice', '2026-08-02')).toEqual({ allowed: true });
+    expect(await gate.peek('g:bob', '2026-08-02')).toEqual({ allowed: false, reason: 'over_capacity' });
+  });
+
+  it('gives back the unused reservation once real usage is known', async () => {
+    const store = new InMemoryStore();
+    const gate = createTabCompleteGate({ store, ttlMs: 0, defaultGlobalDailyCap: TAB_COMPLETE_TOKEN_RESERVATION });
+    expect(await gate.peek('g:alice', '2026-08-02')).toEqual({ allowed: true });
+    await gate.spend('g:alice', '2026-08-02', 100);
+    // Reservation released; a second request has room again.
+    expect(await gate.peek('g:bob', '2026-08-02')).toEqual({ allowed: true });
+  });
+
+  it('tops up the counter when real usage exceeds the reservation', async () => {
+    const store = new InMemoryStore();
+    const gate = createTabCompleteGate({ store, ttlMs: 0, defaultGlobalDailyCap: TAB_COMPLETE_TOKEN_RESERVATION + 10 });
+    expect(await gate.peek('g:alice', '2026-08-02')).toEqual({ allowed: true });
+    await gate.spend('g:alice', '2026-08-02', TAB_COMPLETE_TOKEN_RESERVATION + 10);
+    expect(await gate.peek('g:bob', '2026-08-02')).toEqual({ allowed: false, reason: 'over_capacity' });
+  });
+
+  it('releasing a reservation never drops the counter below zero', async () => {
+    const store = new InMemoryStore();
+    const gate = createTabCompleteGate({ store, ttlMs: 0, defaultGlobalDailyCap: 5_000 });
+    // spend() with no prior peek must not underflow the day's counter.
+    await gate.spend('g:alice', '2026-08-02', 0);
+    expect(await store.getGlobalTabCompleteTokenCount('2026-08-02')).toBe(0);
+  });
+
+  it('honours the stored tabCompletePaused switch without touching other lanes', async () => {
+    const store = new InMemoryStore();
+    await store.setCreationLimits({ tabCompletePaused: true }, 'operator');
+    const gate = createTabCompleteGate({ store, ttlMs: 0 });
+    expect(await gate.peek('g:alice', '2026-08-02')).toEqual({ allowed: false, reason: 'paused' });
+    const editing = createEditingGate({ store, ttlMs: 0, defaultGlobalDailyCap: 5 });
+    expect(await editing.checkAndSpend('g:alice', '2026-08-02')).toEqual({ allowed: true });
+  });
+
+  it('lets bots through uncounted, on both peek and spend', async () => {
+    const store = new InMemoryStore();
+    await store.setCreationLimits({ globalDailyTabCompleteTokenCap: TAB_COMPLETE_TOKEN_RESERVATION }, 'operator');
+    const gate = createTabCompleteGate({ store, ttlMs: 0 });
+    expect(await gate.peek('bot:e2e', '2026-08-02')).toEqual({ allowed: true });
+    await gate.spend('bot:e2e', '2026-08-02', 999_999);
+    expect(await store.getGlobalTabCompleteTokenCount('2026-08-02')).toBe(0);
+    // The real cap stays untouched, so a creator still gets a turn.
+    expect(await gate.peek('g:alice', '2026-08-02')).toEqual({ allowed: true });
   });
 });

--- a/apps/api/src/creation-limits.ts
+++ b/apps/api/src/creation-limits.ts
@@ -391,6 +391,104 @@ export function createChatGate(options: CreationGateOptions): ChatGate {
   };
 }
 
+// A deliberate cap the owner chose for this lane, not a fallback.
+export const DEFAULT_GLOBAL_DAILY_TAB_COMPLETE_TOKEN_CAP = 2_000_000;
+
+export function resolveDefaultGlobalDailyTabCompleteTokenCap(
+  override?: number,
+  env: NodeJS.ProcessEnv = process.env,
+): number {
+  if (typeof override === 'number' && Number.isFinite(override) && override >= 0) return override;
+  const raw = env.GLOBAL_DAILY_TAB_COMPLETE_TOKEN_CAP?.trim();
+  if (raw) {
+    const parsed = Number(raw);
+    if (Number.isFinite(parsed) && parsed >= 0) return parsed;
+  }
+  return DEFAULT_GLOBAL_DAILY_TAB_COMPLETE_TOKEN_CAP;
+}
+
+export interface TabCompleteGate {
+  // Pre-call check that spends nothing — a refusal costs no model call.
+  peek(uid: string, dateStr: string): Promise<CreationGateOutcome>;
+  // Post-call: records the tokens the completed request actually used.
+  spend(uid: string, dateStr: string, tokens: number): Promise<void>;
+}
+
+// Same chassis as editing/chat, denominated in tokens rather than calls.
+export function createTabCompleteGate(options: CreationGateOptions): TabCompleteGate {
+  const { store } = options;
+  const now = options.now ?? Date.now;
+  const ttlMs = options.ttlMs ?? DEFAULT_CREATION_LIMITS_TTL_MS;
+  const defaultCap = resolveDefaultGlobalDailyTabCompleteTokenCap(options.defaultGlobalDailyCap);
+  const logWarn = options.logWarn ?? (() => {});
+
+  const defaults: CreationLimits = {
+    paused: false,
+    globalDailySubmissionCap: null,
+    editingPaused: false,
+    globalDailyEditCap: null,
+    tabCompletePaused: false,
+    globalDailyTabCompleteTokenCap: null,
+    managedDailyCap: null,
+    managedDailyUserCap: null,
+  };
+  let cache: { value: CreationLimits; expiresAt: number } | null = null;
+
+  async function limits(): Promise<CreationLimits> {
+    if (cache && cache.expiresAt > now()) return cache.value;
+    try {
+      const stored = (await store.getCreationLimits()) ?? defaults;
+      cache = { value: stored, expiresAt: now() + ttlMs };
+      return stored;
+    } catch (error) {
+      if (cache) {
+        logWarn({ err: error }, 'creation limits unreadable; tab-complete gate using the last known values');
+        return cache.value;
+      }
+      logWarn({ err: error }, 'creation limits unreadable and never read; tab-complete gate using defaults');
+      return defaults;
+    }
+  }
+
+  return {
+    async peek(uid, dateStr) {
+      if (bypassesBreaker(uid)) return { allowed: true };
+      const value = await limits();
+      if (value.tabCompletePaused) return { allowed: false, reason: 'paused' };
+      const cap = value.globalDailyTabCompleteTokenCap ?? defaultCap;
+      if (cap <= 0) return { allowed: false, reason: 'over_capacity' };
+      try {
+        const spent = await store.checkAndIncrementGlobalTabCompleteTokens(dateStr, 0, cap);
+        if (!spent.allowed) {
+          logWarn(
+            { dateStr, cap, current: spent.current },
+            'global daily tab-complete token cap reached; refusing completions',
+          );
+          return { allowed: false, reason: 'over_capacity' };
+        }
+      } catch (error) {
+        // A blip is not "over capacity" — same reasoning as the other breakers.
+        logWarn({ err: error, dateStr }, 'global tab-complete token counter unreachable; admitting the request');
+      }
+      return { allowed: true };
+    },
+
+    async spend(uid, dateStr, tokens) {
+      if (bypassesBreaker(uid) || tokens <= 0) return;
+      const value = await limits();
+      const cap = value.globalDailyTabCompleteTokenCap ?? defaultCap;
+      try {
+        const spent = await store.checkAndIncrementGlobalTabCompleteTokens(dateStr, tokens, cap);
+        if (spent.current >= Math.ceil(cap * 0.8)) {
+          logWarn({ dateStr, cap, current: spent.current }, 'global daily tab-complete token cap is over 80% spent');
+        }
+      } catch (error) {
+        logWarn({ err: error, dateStr }, 'global tab-complete token counter unreachable; usage not recorded');
+      }
+    },
+  };
+}
+
 /** Wire error codes, so the web app can say something true about which limit was hit. */
 export const CREATION_REFUSAL_CODES: Record<CreationRefusal, string> = {
   paused: 'creation_paused',

--- a/apps/api/src/creation-limits.ts
+++ b/apps/api/src/creation-limits.ts
@@ -407,10 +407,13 @@ export function resolveDefaultGlobalDailyTabCompleteTokenCap(
   return DEFAULT_GLOBAL_DAILY_TAB_COMPLETE_TOKEN_CAP;
 }
 
+// Worst-case request cost: prefix + suffix chars plus the output cap.
+export const TAB_COMPLETE_TOKEN_RESERVATION = 1400;
+
 export interface TabCompleteGate {
-  // Pre-call check that spends nothing — a refusal costs no model call.
+  // Reserves a worst-case slot so concurrent calls cannot all pass free.
   peek(uid: string, dateStr: string): Promise<CreationGateOutcome>;
-  // Post-call: records the tokens the completed request actually used.
+  // Reconciles the reservation. Call once per peek; pass 0 on failure.
   spend(uid: string, dateStr: string, tokens: number): Promise<void>;
 }
 
@@ -458,7 +461,11 @@ export function createTabCompleteGate(options: CreationGateOptions): TabComplete
       const cap = value.globalDailyTabCompleteTokenCap ?? defaultCap;
       if (cap <= 0) return { allowed: false, reason: 'over_capacity' };
       try {
-        const spent = await store.checkAndIncrementGlobalTabCompleteTokens(dateStr, 0, cap);
+        const spent = await store.checkAndIncrementGlobalTabCompleteTokens(
+          dateStr,
+          TAB_COMPLETE_TOKEN_RESERVATION,
+          cap,
+        );
         if (!spent.allowed) {
           logWarn(
             { dateStr, cap, current: spent.current },
@@ -474,13 +481,13 @@ export function createTabCompleteGate(options: CreationGateOptions): TabComplete
     },
 
     async spend(uid, dateStr, tokens) {
-      if (bypassesBreaker(uid) || tokens <= 0) return;
+      if (bypassesBreaker(uid)) return;
       const value = await limits();
       const cap = value.globalDailyTabCompleteTokenCap ?? defaultCap;
       try {
-        const spent = await store.checkAndIncrementGlobalTabCompleteTokens(dateStr, tokens, cap);
-        if (spent.current >= Math.ceil(cap * 0.8)) {
-          logWarn({ dateStr, cap, current: spent.current }, 'global daily tab-complete token cap is over 80% spent');
+        const current = await store.adjustGlobalTabCompleteTokens(dateStr, tokens - TAB_COMPLETE_TOKEN_RESERVATION);
+        if (current >= Math.ceil(cap * 0.8)) {
+          logWarn({ dateStr, cap, current }, 'global daily tab-complete token cap is over 80% spent');
         }
       } catch (error) {
         logWarn({ err: error, dateStr }, 'global tab-complete token counter unreachable; usage not recorded');

--- a/apps/api/src/creation-limits.ts
+++ b/apps/api/src/creation-limits.ts
@@ -410,11 +410,13 @@ export function resolveDefaultGlobalDailyTabCompleteTokenCap(
 // Worst-case request cost: prefix + suffix chars plus the output cap.
 export const TAB_COMPLETE_TOKEN_RESERVATION = 1400;
 
+export type TabCompletePeekOutcome = { allowed: true; reserved: boolean } | { allowed: false; reason: CreationRefusal };
+
 export interface TabCompleteGate {
-  // Reserves a worst-case slot so concurrent calls cannot all pass free.
-  peek(uid: string, dateStr: string): Promise<CreationGateOutcome>;
-  // Reconciles the reservation. Call once per peek; pass 0 on failure.
-  spend(uid: string, dateStr: string, tokens: number): Promise<void>;
+  // Reserves a worst-case slot; reserved=false if none was recorded.
+  peek(uid: string, dateStr: string): Promise<TabCompletePeekOutcome>;
+  // Reconciles the reservation. Pass the `reserved` flag peek() returned.
+  spend(uid: string, dateStr: string, tokens: number, reserved: boolean): Promise<void>;
 }
 
 // Same chassis as editing/chat, denominated in tokens rather than calls.
@@ -455,7 +457,7 @@ export function createTabCompleteGate(options: CreationGateOptions): TabComplete
 
   return {
     async peek(uid, dateStr) {
-      if (bypassesBreaker(uid)) return { allowed: true };
+      if (bypassesBreaker(uid)) return { allowed: true, reserved: false };
       const value = await limits();
       if (value.tabCompletePaused) return { allowed: false, reason: 'paused' };
       const cap = value.globalDailyTabCompleteTokenCap ?? defaultCap;
@@ -473,19 +475,22 @@ export function createTabCompleteGate(options: CreationGateOptions): TabComplete
           );
           return { allowed: false, reason: 'over_capacity' };
         }
+        return { allowed: true, reserved: true };
       } catch (error) {
-        // A blip is not "over capacity" — same reasoning as the other breakers.
+        // A blip is not over capacity; nothing was reserved to release.
         logWarn({ err: error, dateStr }, 'global tab-complete token counter unreachable; admitting the request');
+        return { allowed: true, reserved: false };
       }
-      return { allowed: true };
     },
 
-    async spend(uid, dateStr, tokens) {
+    async spend(uid, dateStr, tokens, reserved) {
       if (bypassesBreaker(uid)) return;
       const value = await limits();
       const cap = value.globalDailyTabCompleteTokenCap ?? defaultCap;
+      // Only release a reservation that peek() actually recorded.
+      const delta = reserved ? tokens - TAB_COMPLETE_TOKEN_RESERVATION : tokens;
       try {
-        const current = await store.adjustGlobalTabCompleteTokens(dateStr, tokens - TAB_COMPLETE_TOKEN_RESERVATION);
+        const current = await store.adjustGlobalTabCompleteTokens(dateStr, delta);
         if (current >= Math.ceil(cap * 0.8)) {
           logWarn({ dateStr, cap, current }, 'global daily tab-complete token cap is over 80% spent');
         }

--- a/apps/api/src/creator-code.test.ts
+++ b/apps/api/src/creator-code.test.ts
@@ -7,6 +7,7 @@ import { createGcsObjectStore, type GcsObjectStore } from './gcs-sign.js';
 import { createGcsGamesStore, type GamesStore } from './games-store.js';
 import { KIT_ROOT_DIR } from './kit-registry.js';
 import { InMemoryStore } from './store.js';
+import { StubTabCompleter, type TabCompleter } from './tab-complete.js';
 
 const sessionSecret = 'dev-session-secret-change-me';
 const submissionTokenSecret = 'test-submission-secret';
@@ -118,7 +119,7 @@ describe('the Code surface routes (creator-code.ts)', () => {
 
   async function withApp<T>(
     fn: (app: Awaited<ReturnType<typeof buildApp>>) => Promise<T>,
-    options: { objectStore?: GcsObjectStore; games?: GamesStore } = {},
+    options: { objectStore?: GcsObjectStore; games?: GamesStore; tabCompleter?: TabCompleter } = {},
   ): Promise<T> {
     const app = await buildApp({
       store,
@@ -127,6 +128,7 @@ describe('the Code surface routes (creator-code.ts)', () => {
         submissionTokenSecret,
         agentChannel: { gamesStore: options.games ?? games, objectStore: options.objectStore },
       },
+      tabCompleter: options.tabCompleter,
     });
     try {
       return await fn(app);
@@ -570,5 +572,89 @@ describe('the Code surface routes (creator-code.ts)', () => {
         const submitted = record?.transitions?.find((entry) => entry.to === 'submitted');
         expect(submitted?.by).toBe('creator');
       }));
+  });
+
+  describe('POST /api/me/studio/games/:slug/sources/complete', () => {
+    function withTabComplete<T>(fn: () => Promise<T>): Promise<T> {
+      const prior = process.env.TAB_COMPLETE;
+      process.env.TAB_COMPLETE = 'true';
+      return fn().finally(() => {
+        if (prior === undefined) delete process.env.TAB_COMPLETE;
+        else process.env.TAB_COMPLETE = prior;
+      });
+    }
+
+    it('404s when the TAB_COMPLETE kill switch is off, even with CODE_SURFACE on', async () =>
+      withApp(
+        async (app) => {
+          const res = await app.inject({
+            method: 'POST',
+            url: '/api/me/studio/games/sky-dodge/sources/complete',
+            headers: { ...authHeaders('g:creator'), 'content-type': 'application/json' },
+            payload: { path: 'game.ts', prefixWindow: 'const x = ', suffixWindow: ';' },
+          });
+          expect(res.statusCode).toBe(404);
+        },
+        { tabCompleter: new StubTabCompleter({ completion: '1' }) },
+      ));
+
+    it('404s for a slug the caller does not own — never 403', async () =>
+      withTabComplete(() =>
+        withApp(
+          async (app) => {
+            const res = await app.inject({
+              method: 'POST',
+              url: '/api/me/studio/games/sky-dodge/sources/complete',
+              headers: { ...authHeaders('g:other'), 'content-type': 'application/json' },
+              payload: { path: 'game.ts', prefixWindow: 'const x = ', suffixWindow: ';' },
+            });
+            expect(res.statusCode).toBe(404);
+          },
+          { tabCompleter: new StubTabCompleter({ completion: '1' }) },
+        ),
+      ));
+
+    it('returns the proposal from the injected completer', async () =>
+      withTabComplete(() =>
+        withApp(
+          async (app) => {
+            const res = await app.inject({
+              method: 'POST',
+              url: '/api/me/studio/games/sky-dodge/sources/complete',
+              headers: { ...authHeaders('g:creator'), 'content-type': 'application/json' },
+              payload: { path: 'game.ts', prefixWindow: 'const speed = ', suffixWindow: ';' },
+            });
+            expect(res.statusCode).toBe(200);
+            expect(res.json()).toEqual({ completion: '0.16' });
+          },
+          { tabCompleter: new StubTabCompleter({ completion: '0.16' }) },
+        ),
+      ));
+
+    it('429s once the per-creator daily quota is spent', async () => {
+      process.env.DAILY_TAB_COMPLETE_QUOTA = '3';
+      try {
+        await withTabComplete(() =>
+          withApp(
+            async (app) => {
+              const request = () =>
+                app.inject({
+                  method: 'POST',
+                  url: '/api/me/studio/games/sky-dodge/sources/complete',
+                  headers: { ...authHeaders('g:creator'), 'content-type': 'application/json' },
+                  payload: { path: 'game.ts', prefixWindow: 'a', suffixWindow: 'b' },
+                });
+              for (let i = 0; i < 3; i += 1) {
+                expect((await request()).statusCode).toBe(200);
+              }
+              expect((await request()).statusCode).toBe(429);
+            },
+            { tabCompleter: new StubTabCompleter({ completion: 'x' }) },
+          ),
+        );
+      } finally {
+        delete process.env.DAILY_TAB_COMPLETE_QUOTA;
+      }
+    });
   });
 });

--- a/apps/api/src/creator-code.test.ts
+++ b/apps/api/src/creator-code.test.ts
@@ -656,5 +656,25 @@ describe('the Code surface routes (creator-code.ts)', () => {
         delete process.env.DAILY_TAB_COMPLETE_QUOTA;
       }
     });
+
+    it('refuses on the global pause without spending the per-creator quota', async () =>
+      withTabComplete(() =>
+        withApp(
+          async (app) => {
+            await store.setCreationLimits({ tabCompletePaused: true }, 'operator');
+            const res = await app.inject({
+              method: 'POST',
+              url: '/api/me/studio/games/sky-dodge/sources/complete',
+              headers: { ...authHeaders('g:creator'), 'content-type': 'application/json' },
+              payload: { path: 'game.ts', prefixWindow: 'a', suffixWindow: 'b' },
+            });
+            expect(res.statusCode).toBe(503);
+            // A refused global gate must leave the daily allowance untouched.
+            const dateStr = new Date().toISOString().slice(0, 10);
+            expect((await store.getUsage('g:creator', dateStr)).tabCompletes).toBe(0);
+          },
+          { tabCompleter: new StubTabCompleter({ completion: 'x' }) },
+        ),
+      ));
   });
 });

--- a/apps/api/src/creator-code.ts
+++ b/apps/api/src/creator-code.ts
@@ -710,11 +710,13 @@ export async function registerCreatorCodeRoutes(
       const uid = request.user!.uid;
 
       // Global refusal first — must not spend a creator's own daily slot.
+      let reserved = false;
       if (options.tabCompleteGate) {
         const gate = await options.tabCompleteGate.peek(uid, dateStr);
         if (!gate.allowed) {
           return reply.status(503).send({ error: 'completions are resting right now — try again later' });
         }
+        reserved = gate.reserved;
       }
 
       const quota = await store.checkAndIncrementQuota(
@@ -725,8 +727,8 @@ export async function registerCreatorCodeRoutes(
         'tabCompletes',
       );
       if (!quota.allowed) {
-        // The peek above reserved a slot — a refusal here must free it.
-        await options.tabCompleteGate?.spend(uid, dateStr, 0);
+        // The peek above may reserve a slot — free it on refusal.
+        await options.tabCompleteGate?.spend(uid, dateStr, 0, reserved);
         return reply.status(429).send({ error: 'daily tab-complete quota exceeded' });
       }
 
@@ -739,12 +741,12 @@ export async function registerCreatorCodeRoutes(
         });
       } catch (error) {
         request.log.warn({ slug: resolved.slug, err: error }, 'tab-complete call failed');
-        await options.tabCompleteGate?.spend(uid, dateStr, 0);
+        await options.tabCompleteGate?.spend(uid, dateStr, 0, reserved);
         return reply.status(503).send({ error: 'no completion right now — try again' });
       }
 
       const tokens = result.tokens;
-      await options.tabCompleteGate?.spend(uid, dateStr, tokens ? tokens.input + tokens.output : 0);
+      await options.tabCompleteGate?.spend(uid, dateStr, tokens ? tokens.input + tokens.output : 0, reserved);
       if (tokens) {
         await store
           .recordJobCost(resolved.record.issueNumber, {

--- a/apps/api/src/creator-code.ts
+++ b/apps/api/src/creator-code.ts
@@ -10,6 +10,7 @@ import {
   type SourceFile,
   type StagedSourceEntry,
 } from './games-store.js';
+import type { TabCompleteGate } from './creation-limits.js';
 import { resolveJobState } from './job-state.js';
 import { createKitFileStore, type KitFileStore } from './kit-files.js';
 import { parseKitRegistry } from './kit-registry.js';
@@ -27,6 +28,7 @@ import {
   type SourceDeliveryService,
 } from './source-delivery.js';
 import type { Store, SubmissionRecord } from './store.js';
+import { MAX_PREFIX_CHARS, MAX_SUFFIX_CHARS, tabCompleteEnabled, type TabCompleter } from './tab-complete.js';
 import { sharedSourcesFromKitTree } from './typecheck-preflight.js';
 import { typeCheckGame } from './type-check.js';
 
@@ -58,6 +60,11 @@ export interface CreatorCodeRoutesOptions {
    * owner write has to feed the same assembly an agent write does, or the "stage
    * refreshes" fix on the read side has nothing to read. */
   scheduleStagedPreview?: (issueNumber: number) => void;
+  // TA-01: the ghost-text completer. Built unconditionally; TAB_COMPLETE gates the route.
+  tabCompleter?: TabCompleter;
+  // Shared daily token budget for ghost text — same chassis as editingGate.
+  tabCompleteGate?: TabCompleteGate;
+  dailyTabCompleteQuota?: number;
   /** Starts the gate on a manual delivery — the same trigger the agent channel uses. */
   onSourcesDelivered?: (input: {
     issueNumber: number;
@@ -74,6 +81,9 @@ export interface CreatorCodeRoutesOptions {
 
 /** CE-19: floor between two manual deliveries on the same game, copied from EditorKit. */
 export const DELIVER_COOLDOWN_MS = 10 * 60 * 1000;
+
+// TA-01: per-creator daily ceiling on completion calls, generous for typing.
+export const DEFAULT_DAILY_TAB_COMPLETE_QUOTA = 2000;
 
 /** One entry in the merged "what the next delivery would contain" file list (CE-03). */
 export interface CreatorCodeFile {
@@ -669,6 +679,81 @@ export async function registerCreatorCodeRoutes(
         request.log.warn({ err: error, slug: resolved.slug }, 'code surface: kit declaration load failed');
         return reply.status(404).send({ error: 'no kit published' });
       }
+    },
+  );
+
+  const CompleteInputSchema = z.object({
+    path: z.string().trim().min(1).max(120),
+    prefixWindow: z.string().max(MAX_PREFIX_CHARS),
+    suffixWindow: z.string().max(MAX_SUFFIX_CHARS),
+  });
+
+  // TA-01: ghost-text proposal, off by default unlike every route above.
+  app.post<{ Params: { slug: string } }>(
+    '/api/me/studio/games/:slug/sources/complete',
+    { config: { rateLimit: { max: 600, timeWindow: '1 hour' } } },
+    async (request, reply) => {
+      if (notFoundIfDisabled(reply)) return;
+      if (!options.tabCompleter || !tabCompleteEnabled()) {
+        return reply.status(404).send({ error: 'not found' });
+      }
+      const resolved = await resolveForSlug(request, reply);
+      if (!resolved) return;
+
+      const parsed = CompleteInputSchema.safeParse(request.body ?? {});
+      if (!parsed.success) {
+        return reply.status(400).send({ error: parsed.error.issues[0]?.message ?? 'invalid request' });
+      }
+
+      const nowMs = (options.now ?? Date.now)();
+      const dateStr = new Date(nowMs).toISOString().slice(0, 10);
+      const uid = request.user!.uid;
+
+      const quota = await store.checkAndIncrementQuota(
+        uid,
+        dateStr,
+        options.dailyTabCompleteQuota ??
+          Number(process.env.DAILY_TAB_COMPLETE_QUOTA ?? DEFAULT_DAILY_TAB_COMPLETE_QUOTA),
+        'tabCompletes',
+      );
+      if (!quota.allowed) {
+        return reply.status(429).send({ error: 'daily tab-complete quota exceeded' });
+      }
+
+      // Checked before the paid call, so a refusal costs the creator nothing.
+      if (options.tabCompleteGate) {
+        const gate = await options.tabCompleteGate.peek(uid, dateStr);
+        if (!gate.allowed) {
+          return reply.status(503).send({ error: 'completions are resting right now — try again later' });
+        }
+      }
+
+      let result;
+      try {
+        result = await options.tabCompleter.complete({
+          path: parsed.data.path,
+          prefixWindow: parsed.data.prefixWindow,
+          suffixWindow: parsed.data.suffixWindow,
+        });
+      } catch (error) {
+        request.log.warn({ slug: resolved.slug, err: error }, 'tab-complete call failed');
+        return reply.status(503).send({ error: 'no completion right now — try again' });
+      }
+
+      if (result.tokens) {
+        const spent = result.tokens.input + result.tokens.output;
+        await options.tabCompleteGate?.spend(uid, dateStr, spent);
+        await store
+          .recordJobCost(resolved.record.issueNumber, {
+            kind: 'tab_complete',
+            at: new Date(nowMs).toISOString(),
+            by: result.model ?? 'vertex',
+            tokens: result.tokens,
+          })
+          .catch(() => {});
+      }
+
+      return reply.send({ completion: result.completion });
     },
   );
 

--- a/apps/api/src/creator-code.ts
+++ b/apps/api/src/creator-code.ts
@@ -709,6 +709,14 @@ export async function registerCreatorCodeRoutes(
       const dateStr = new Date(nowMs).toISOString().slice(0, 10);
       const uid = request.user!.uid;
 
+      // Global refusal first — must not spend a creator's own daily slot.
+      if (options.tabCompleteGate) {
+        const gate = await options.tabCompleteGate.peek(uid, dateStr);
+        if (!gate.allowed) {
+          return reply.status(503).send({ error: 'completions are resting right now — try again later' });
+        }
+      }
+
       const quota = await store.checkAndIncrementQuota(
         uid,
         dateStr,
@@ -717,15 +725,9 @@ export async function registerCreatorCodeRoutes(
         'tabCompletes',
       );
       if (!quota.allowed) {
+        // The peek above reserved a slot — a refusal here must free it.
+        await options.tabCompleteGate?.spend(uid, dateStr, 0);
         return reply.status(429).send({ error: 'daily tab-complete quota exceeded' });
-      }
-
-      // Checked before the paid call, so a refusal costs the creator nothing.
-      if (options.tabCompleteGate) {
-        const gate = await options.tabCompleteGate.peek(uid, dateStr);
-        if (!gate.allowed) {
-          return reply.status(503).send({ error: 'completions are resting right now — try again later' });
-        }
       }
 
       let result;
@@ -737,18 +739,19 @@ export async function registerCreatorCodeRoutes(
         });
       } catch (error) {
         request.log.warn({ slug: resolved.slug, err: error }, 'tab-complete call failed');
+        await options.tabCompleteGate?.spend(uid, dateStr, 0);
         return reply.status(503).send({ error: 'no completion right now — try again' });
       }
 
-      if (result.tokens) {
-        const spent = result.tokens.input + result.tokens.output;
-        await options.tabCompleteGate?.spend(uid, dateStr, spent);
+      const tokens = result.tokens;
+      await options.tabCompleteGate?.spend(uid, dateStr, tokens ? tokens.input + tokens.output : 0);
+      if (tokens) {
         await store
           .recordJobCost(resolved.record.issueNumber, {
             kind: 'tab_complete',
             at: new Date(nowMs).toISOString(),
             by: result.model ?? 'vertex',
-            tokens: result.tokens,
+            tokens,
           })
           .catch(() => {});
       }

--- a/apps/api/src/store.ts
+++ b/apps/api/src/store.ts
@@ -3918,10 +3918,11 @@ export class InMemoryStore implements Store {
     limit: number,
   ): Promise<{ allowed: boolean; current: number }> {
     const current = this.globalTabCompleteTokens.get(dateStr) ?? 0;
-    if (current >= limit) {
+    const next = current + tokens;
+    // Refuse a reservation that would itself cross the cap.
+    if (next > limit) {
       return { allowed: false, current };
     }
-    const next = current + tokens;
     this.globalTabCompleteTokens.set(dateStr, next);
     return { allowed: true, current: next };
   }
@@ -6624,12 +6625,13 @@ export class FirestoreStore implements Store {
       const snap = await transaction.get(ref);
       const value = snap.data()?.tabCompleteTokens;
       const current = typeof value === 'number' ? value : 0;
+      const nextVal = current + tokens;
 
-      if (current >= limit) {
+      // Refuse a reservation that would itself cross the cap.
+      if (nextVal > limit) {
         return { allowed: false, current };
       }
 
-      const nextVal = current + tokens;
       transaction.set(ref, { tabCompleteTokens: nextVal }, { merge: true });
       return { allowed: true, current: nextVal };
     });

--- a/apps/api/src/store.ts
+++ b/apps/api/src/store.ts
@@ -441,7 +441,7 @@ export interface JobSeedOutcome {
  * (docs: architecture B), so that arriving is a writer, not a migration.
  */
 export interface JobCostEntry {
-  kind: 'agent_session' | 'gate_run' | 'seed' | 'assist' | 'chat';
+  kind: 'agent_session' | 'gate_run' | 'seed' | 'assist' | 'chat' | 'tab_complete';
   at: string;
   /**
    * Who charged for it: an agent backend (`copilot`), a service (`cloud-build`), or —
@@ -688,6 +688,10 @@ export interface CreationLimits {
   chatPaused?: boolean;
   // Own daily ceiling on chat-agent calls, separate from the edit cap.
   globalDailyChatCap?: number | null;
+  // Refuse the tab-complete ghost-text lane outright (TA-*); Play/editing untouched.
+  tabCompletePaused?: boolean;
+  // Shared daily token ceiling for ghost-text completion, everyone together.
+  globalDailyTabCompleteTokenCap?: number | null;
   // Switches the `platform` option; `auto` defers to whether a backend exists.
   managedBuilderMode?: 'auto' | 'off' | 'coming_soon';
   // Runtime override; unset defers to MANAGED_AGENT_VENDOR, the env-var default.
@@ -722,6 +726,8 @@ export interface UsageCounters {
   chats: number;
   // Platform rounds this creator started today.
   managedBuilds: number;
+  // Ghost-text completion calls today (TA-01), one per model call.
+  tabCompletes: number;
 }
 
 /**
@@ -2176,6 +2182,12 @@ export interface Store {
   checkAndIncrementGlobalEdits(dateStr: string, limit: number): Promise<{ allowed: boolean; current: number }>;
   /** Same shape, for the chat agent's own shared daily allowance. */
   checkAndIncrementGlobalChats(dateStr: string, limit: number): Promise<{ allowed: boolean; current: number }>;
+  // Same shape as chats, but counts tokens for ghost-text completion.
+  checkAndIncrementGlobalTabCompleteTokens(
+    dateStr: string,
+    tokens: number,
+    limit: number,
+  ): Promise<{ allowed: boolean; current: number }>;
   // Platform rounds everyone together has started on `dateStr`.
   getGlobalManagedBuildCount(dateStr: string): Promise<number>;
   // Same shape, for the shared daily ceiling.
@@ -2684,6 +2696,7 @@ function emptyUsageCounters(): UsageCounters {
     assists: 0,
     chats: 0,
     managedBuilds: 0,
+    tabCompletes: 0,
   };
 }
 
@@ -2707,6 +2720,7 @@ export class InMemoryStore implements Store {
   private globalEdits = new Map<string, number>();
   private globalChats = new Map<string, number>();
   private globalManagedBuilds = new Map<string, number>();
+  private globalTabCompleteTokens = new Map<string, number>();
   private creationLimits: CreationLimits | null = null;
   private publicPlayConfig: PublicPlayConfig | null = null;
   private waitlist = new Map<string, WaitlistEntry>();
@@ -3819,6 +3833,11 @@ export class InMemoryStore implements Store {
         patch.globalDailyChatCap !== undefined
           ? patch.globalDailyChatCap
           : (this.creationLimits?.globalDailyChatCap ?? null),
+      tabCompletePaused: patch.tabCompletePaused ?? this.creationLimits?.tabCompletePaused ?? false,
+      globalDailyTabCompleteTokenCap:
+        patch.globalDailyTabCompleteTokenCap !== undefined
+          ? patch.globalDailyTabCompleteTokenCap
+          : (this.creationLimits?.globalDailyTabCompleteTokenCap ?? null),
       managedBuilderMode: patch.managedBuilderMode ?? this.creationLimits?.managedBuilderMode ?? 'auto',
       managedAgentVendorOverride:
         patch.managedAgentVendorOverride !== undefined
@@ -3883,6 +3902,20 @@ export class InMemoryStore implements Store {
     }
     this.globalChats.set(dateStr, current + 1);
     return { allowed: true, current: current + 1 };
+  }
+
+  async checkAndIncrementGlobalTabCompleteTokens(
+    dateStr: string,
+    tokens: number,
+    limit: number,
+  ): Promise<{ allowed: boolean; current: number }> {
+    const current = this.globalTabCompleteTokens.get(dateStr) ?? 0;
+    if (current >= limit) {
+      return { allowed: false, current };
+    }
+    const next = current + tokens;
+    this.globalTabCompleteTokens.set(dateStr, next);
+    return { allowed: true, current: next };
   }
 
   async getGlobalManagedBuildCount(dateStr: string): Promise<number> {
@@ -6416,6 +6449,9 @@ export class FirestoreStore implements Store {
       globalDailyEditCap: typeof data?.globalDailyEditCap === 'number' ? data.globalDailyEditCap : null,
       chatPaused: data?.chatPaused === true,
       globalDailyChatCap: typeof data?.globalDailyChatCap === 'number' ? data.globalDailyChatCap : null,
+      tabCompletePaused: data?.tabCompletePaused === true,
+      globalDailyTabCompleteTokenCap:
+        typeof data?.globalDailyTabCompleteTokenCap === 'number' ? data.globalDailyTabCompleteTokenCap : null,
       managedBuilderMode:
         data?.managedBuilderMode === 'off' || data?.managedBuilderMode === 'coming_soon'
           ? data.managedBuilderMode
@@ -6453,6 +6489,11 @@ export class FirestoreStore implements Store {
         chatPaused: patch.chatPaused ?? existing.chatPaused ?? false,
         globalDailyChatCap:
           patch.globalDailyChatCap !== undefined ? patch.globalDailyChatCap : (existing.globalDailyChatCap ?? null),
+        tabCompletePaused: patch.tabCompletePaused ?? existing.tabCompletePaused ?? false,
+        globalDailyTabCompleteTokenCap:
+          patch.globalDailyTabCompleteTokenCap !== undefined
+            ? patch.globalDailyTabCompleteTokenCap
+            : (existing.globalDailyTabCompleteTokenCap ?? null),
         managedBuilderMode: patch.managedBuilderMode ?? existing.managedBuilderMode ?? 'auto',
         managedAgentVendorOverride:
           patch.managedAgentVendorOverride !== undefined
@@ -6548,6 +6589,27 @@ export class FirestoreStore implements Store {
 
       const nextVal = current + 1;
       transaction.set(ref, { chats: nextVal }, { merge: true });
+      return { allowed: true, current: nextVal };
+    });
+  }
+
+  async checkAndIncrementGlobalTabCompleteTokens(
+    dateStr: string,
+    tokens: number,
+    limit: number,
+  ): Promise<{ allowed: boolean; current: number }> {
+    const ref = this.globalUsageRef(dateStr);
+    return await this.db.runTransaction(async (transaction) => {
+      const snap = await transaction.get(ref);
+      const value = snap.data()?.tabCompleteTokens;
+      const current = typeof value === 'number' ? value : 0;
+
+      if (current >= limit) {
+        return { allowed: false, current };
+      }
+
+      const nextVal = current + tokens;
+      transaction.set(ref, { tabCompleteTokens: nextVal }, { merge: true });
       return { allowed: true, current: nextVal };
     });
   }

--- a/apps/api/src/store.ts
+++ b/apps/api/src/store.ts
@@ -2172,6 +2172,8 @@ export interface Store {
   setPublicPlaySlugs(slugs: string[], updatedBy: string): Promise<PublicPlayConfig>;
   /** How many submissions everyone together has made on `dateStr`. */
   getGlobalSubmissionCount(dateStr: string): Promise<number>;
+  // Tab-complete tokens everyone together has spent on `dateStr`.
+  getGlobalTabCompleteTokenCount(dateStr: string): Promise<number>;
   /**
    * The global counterpart of checkAndIncrementQuota: takes one slot out of the day's
    * shared allowance, or refuses. Transactional for the same reason the per-user
@@ -2188,6 +2190,8 @@ export interface Store {
     tokens: number,
     limit: number,
   ): Promise<{ allowed: boolean; current: number }>;
+  // Reconciles a reservation against real usage — never refused, floors at 0.
+  adjustGlobalTabCompleteTokens(dateStr: string, delta: number): Promise<number>;
   // Platform rounds everyone together has started on `dateStr`.
   getGlobalManagedBuildCount(dateStr: string): Promise<number>;
   // Same shape, for the shared daily ceiling.
@@ -3874,6 +3878,10 @@ export class InMemoryStore implements Store {
     return this.globalSubmissions.get(dateStr) ?? 0;
   }
 
+  async getGlobalTabCompleteTokenCount(dateStr: string): Promise<number> {
+    return this.globalTabCompleteTokens.get(dateStr) ?? 0;
+  }
+
   async checkAndIncrementGlobalSubmissions(
     dateStr: string,
     limit: number,
@@ -3916,6 +3924,13 @@ export class InMemoryStore implements Store {
     const next = current + tokens;
     this.globalTabCompleteTokens.set(dateStr, next);
     return { allowed: true, current: next };
+  }
+
+  async adjustGlobalTabCompleteTokens(dateStr: string, delta: number): Promise<number> {
+    const current = this.globalTabCompleteTokens.get(dateStr) ?? 0;
+    const next = Math.max(0, current + delta);
+    this.globalTabCompleteTokens.set(dateStr, next);
+    return next;
   }
 
   async getGlobalManagedBuildCount(dateStr: string): Promise<number> {
@@ -6539,6 +6554,12 @@ export class FirestoreStore implements Store {
     return typeof value === 'number' ? value : 0;
   }
 
+  async getGlobalTabCompleteTokenCount(dateStr: string): Promise<number> {
+    const snap = await this.globalUsageRef(dateStr).get();
+    const value = snap.data()?.tabCompleteTokens;
+    return typeof value === 'number' ? value : 0;
+  }
+
   async checkAndIncrementGlobalSubmissions(
     dateStr: string,
     limit: number,
@@ -6611,6 +6632,18 @@ export class FirestoreStore implements Store {
       const nextVal = current + tokens;
       transaction.set(ref, { tabCompleteTokens: nextVal }, { merge: true });
       return { allowed: true, current: nextVal };
+    });
+  }
+
+  async adjustGlobalTabCompleteTokens(dateStr: string, delta: number): Promise<number> {
+    const ref = this.globalUsageRef(dateStr);
+    return await this.db.runTransaction(async (transaction) => {
+      const snap = await transaction.get(ref);
+      const value = snap.data()?.tabCompleteTokens;
+      const current = typeof value === 'number' ? value : 0;
+      const next = Math.max(0, current + delta);
+      transaction.set(ref, { tabCompleteTokens: next }, { merge: true });
+      return next;
     });
   }
 

--- a/apps/api/src/tab-complete-deploy-flag.test.ts
+++ b/apps/api/src/tab-complete-deploy-flag.test.ts
@@ -1,0 +1,26 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+// TAB_COMPLETE gates TA-01 — same threading rule as every other flag.
+
+const workflow = readFileSync(new URL('../../../.github/workflows/deploy.yml', import.meta.url), 'utf8');
+const script = readFileSync(new URL('../../../infra/deploy-api.sh', import.meta.url), 'utf8');
+
+describe('the tab-complete flag', () => {
+  it('is threaded by both deploy paths, so neither drops what the other set', () => {
+    expect(workflow).toContain('TAB_COMPLETE_VAL="${{ vars.TAB_COMPLETE }}"');
+    expect(workflow).toContain('ENV_VARS="${ENV_VARS}|TAB_COMPLETE=${TAB_COMPLETE_VAL}"');
+    expect(script).toMatch(/for FLAG_VAR in [^;]*\bTAB_COMPLETE\b/);
+  });
+
+  it('is never pinned on in either path', () => {
+    const code = (source: string) =>
+      source
+        .split('\n')
+        .filter((line) => !/^\s*#/.test(line))
+        .join('\n');
+    const pinned = /TAB_COMPLETE=("?)(true|1)\1/i;
+    expect(code(workflow)).not.toMatch(pinned);
+    expect(code(script)).not.toMatch(pinned);
+  });
+});

--- a/apps/api/src/tab-complete.test.ts
+++ b/apps/api/src/tab-complete.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest';
+import { StubTabCompleter, tabCompleteEnabled, VertexTabCompleter } from './tab-complete.js';
+
+// Same stub shape as the code lane test uses: real usage included.
+function stubClient(text: string, usage = { inputTokens: 42, outputTokens: 7 }) {
+  const prompts: string[] = [];
+  const client = ((prompt: string) => {
+    prompts.push(prompt);
+    const chain = {
+      temperature: () => chain,
+      signal: () => chain,
+      run: () => Promise.resolve({ parts: [{ type: 'text', text }], usage }),
+    };
+    return chain;
+  }) as never;
+  return { client, prompts };
+}
+
+describe('VertexTabCompleter', () => {
+  it('assembles prefix and suffix into one prompt and reports tokens', async () => {
+    const { client, prompts } = stubClient('const speed = 0.16;');
+    const completer = new VertexTabCompleter({ client });
+
+    const result = await completer.complete({
+      path: 'game/runtime.ts',
+      prefixWindow: 'function startGame() {\n  ',
+      suffixWindow: '\n}\n',
+    });
+
+    expect(result.completion).toBe('const speed = 0.16;');
+    expect(result.tokens).toEqual({ input: 42, output: 7 });
+    expect(prompts[0]).toContain('function startGame() {');
+    expect(prompts[0]).toContain('\n}\n');
+    expect(prompts[0]).toContain('game/runtime.ts');
+  });
+
+  it('strips a stray markdown fence the model added despite the instruction', async () => {
+    const { client } = stubClient('```typescript\nconst x = 1;\n```');
+    const result = await new VertexTabCompleter({ client }).complete({
+      path: 'a.ts',
+      prefixWindow: '',
+      suffixWindow: '',
+    });
+    expect(result.completion).toBe('const x = 1;');
+  });
+});
+
+describe('StubTabCompleter', () => {
+  it('returns a fixed result for tests and Vertex-less local runs', async () => {
+    const completer = new StubTabCompleter({ completion: 'return 0;' });
+    await expect(completer.complete()).resolves.toEqual({ completion: 'return 0;' });
+  });
+});
+
+describe('tabCompleteEnabled', () => {
+  it('is off unless the deploy flag says exactly true — opposite default from CODE_SURFACE', () => {
+    expect(tabCompleteEnabled({} as NodeJS.ProcessEnv)).toBe(false);
+    expect(tabCompleteEnabled({ TAB_COMPLETE: '1' } as unknown as NodeJS.ProcessEnv)).toBe(false);
+    expect(tabCompleteEnabled({ TAB_COMPLETE: 'true' } as unknown as NodeJS.ProcessEnv)).toBe(true);
+  });
+});

--- a/apps/api/src/tab-complete.test.ts
+++ b/apps/api/src/tab-complete.test.ts
@@ -1,19 +1,29 @@
 import { describe, expect, it } from 'vitest';
-import { StubTabCompleter, tabCompleteEnabled, VertexTabCompleter } from './tab-complete.js';
+import {
+  MAX_COMPLETION_OUTPUT_TOKENS,
+  StubTabCompleter,
+  tabCompleteEnabled,
+  VertexTabCompleter,
+} from './tab-complete.js';
 
 // Same stub shape as the code lane test uses: real usage included.
 function stubClient(text: string, usage = { inputTokens: 42, outputTokens: 7 }) {
   const prompts: string[] = [];
+  const maxOutputTokensCalls: unknown[] = [];
   const client = ((prompt: string) => {
     prompts.push(prompt);
     const chain = {
       temperature: () => chain,
+      maxOutputTokens: (n: unknown) => {
+        maxOutputTokensCalls.push(n);
+        return chain;
+      },
       signal: () => chain,
       run: () => Promise.resolve({ parts: [{ type: 'text', text }], usage }),
     };
     return chain;
   }) as never;
-  return { client, prompts };
+  return { client, prompts, maxOutputTokensCalls };
 }
 
 describe('VertexTabCompleter', () => {
@@ -32,6 +42,12 @@ describe('VertexTabCompleter', () => {
     expect(prompts[0]).toContain('function startGame() {');
     expect(prompts[0]).toContain('\n}\n');
     expect(prompts[0]).toContain('game/runtime.ts');
+  });
+
+  it('caps output tokens so one proposal cannot blow the daily budget', async () => {
+    const { client, maxOutputTokensCalls } = stubClient('x');
+    await new VertexTabCompleter({ client }).complete({ path: 'a.ts', prefixWindow: '', suffixWindow: '' });
+    expect(maxOutputTokensCalls).toEqual([MAX_COMPLETION_OUTPUT_TOKENS]);
   });
 
   it('strips a stray markdown fence the model added despite the instruction', async () => {

--- a/apps/api/src/tab-complete.test.ts
+++ b/apps/api/src/tab-complete.test.ts
@@ -1,10 +1,11 @@
-import { describe, expect, it } from 'vitest';
-import {
-  MAX_COMPLETION_OUTPUT_TOKENS,
-  StubTabCompleter,
-  tabCompleteEnabled,
-  VertexTabCompleter,
-} from './tab-complete.js';
+import { describe, expect, it, vi } from 'vitest';
+
+// A real call once burned the output cap on invisible thinking tokens.
+const createVertexClient = vi.fn(() => vi.fn());
+vi.mock('./genai.js', () => ({ createVertexClient }));
+
+const { MAX_COMPLETION_OUTPUT_TOKENS, StubTabCompleter, tabCompleteEnabled, VertexTabCompleter } =
+  await import('./tab-complete.js');
 
 // Same stub shape as the code lane test uses: real usage included.
 function stubClient(text: string, usage = { inputTokens: 42, outputTokens: 7 }) {
@@ -58,6 +59,13 @@ describe('VertexTabCompleter', () => {
       suffixWindow: '',
     });
     expect(result.completion).toBe('const x = 1;');
+  });
+
+  it('disables thinking on the real Vertex client — thinking tokens starve the visible answer', async () => {
+    await new VertexTabCompleter().complete({ path: 'a.ts', prefixWindow: '', suffixWindow: '' }).catch(() => {});
+    expect(createVertexClient).toHaveBeenCalledWith(
+      expect.objectContaining({ generationConfig: { thinkingConfig: { thinkingBudget: 0 } } }),
+    );
   });
 });
 

--- a/apps/api/src/tab-complete.test.ts
+++ b/apps/api/src/tab-complete.test.ts
@@ -61,6 +61,17 @@ describe('VertexTabCompleter', () => {
     expect(result.completion).toBe('const x = 1;');
   });
 
+  it('preserves boundary whitespace an unfenced completion needs', async () => {
+    const { client } = stubClient(' value');
+    const result = await new VertexTabCompleter({ client }).complete({
+      path: 'a.ts',
+      prefixWindow: 'return',
+      suffixWindow: ';',
+    });
+    // A trim() here would corrupt "return" + " value" into "returnvalue".
+    expect(result.completion).toBe(' value');
+  });
+
   it('disables thinking on the real Vertex client — thinking tokens starve the visible answer', async () => {
     await new VertexTabCompleter().complete({ path: 'a.ts', prefixWindow: '', suffixWindow: '' }).catch(() => {});
     expect(createVertexClient).toHaveBeenCalledWith(

--- a/apps/api/src/tab-complete.ts
+++ b/apps/api/src/tab-complete.ts
@@ -1,0 +1,98 @@
+import { resultText, type GenAIClient, type GenerationResult } from 'genaicode';
+import { createVertexClient } from './genai.js';
+
+// TA-01: prompt-based FIM — Vertex Gemini has no suffix field.
+export const DEFAULT_TAB_COMPLETE_MODEL = 'gemini-3.7-flash';
+export const DEFAULT_TAB_COMPLETE_TIMEOUT_MS = 4000;
+// continue.dev's shape: ~700 tokens prefix, ~300 suffix, ~4 chars/token.
+export const MAX_PREFIX_CHARS = 3000;
+export const MAX_SUFFIX_CHARS = 1200;
+
+export interface TabCompleteRequest {
+  path: string;
+  prefixWindow: string;
+  suffixWindow: string;
+}
+
+export interface TabCompleteResult {
+  completion: string;
+  tokens?: { input: number; output: number };
+  model?: string;
+}
+
+export interface TabCompleter {
+  complete(request: TabCompleteRequest): Promise<TabCompleteResult>;
+}
+
+function stripFences(text: string): string {
+  const trimmed = text.trim();
+  // A stray ```typescript fence survives sometimes despite the prompt.
+  const fenced = trimmed.match(/^```[^\n]*\n([\s\S]*?)\n?```$/);
+  return fenced ? fenced[1]! : trimmed;
+}
+
+function buildPrompt(request: TabCompleteRequest): string {
+  return `You are completing TypeScript code inside a small browser game. Continue the code exactly where PREFIX leaves off, so that it reads naturally into SUFFIX. Do not repeat PREFIX or SUFFIX. Emit code only — no commentary, no markdown fences. If nothing sensible continues the code, reply with an empty string.
+
+File: ${request.path}
+
+PREFIX:
+${request.prefixWindow}
+SUFFIX:
+${request.suffixWindow}
+
+Completion:`;
+}
+
+export class VertexTabCompleter implements TabCompleter {
+  private client?: GenAIClient;
+
+  constructor(
+    private options: {
+      client?: GenAIClient;
+      projectId?: string;
+      region?: string;
+      model?: string;
+      timeoutMs?: number;
+    } = {},
+  ) {}
+
+  private getClient(): GenAIClient {
+    this.client ??=
+      this.options.client ??
+      createVertexClient({
+        projectId: this.options.projectId,
+        region: this.options.region,
+        defaultRegion: 'global',
+        model: this.options.model,
+        defaultModel: DEFAULT_TAB_COMPLETE_MODEL,
+      });
+    return this.client;
+  }
+
+  async complete(request: TabCompleteRequest): Promise<TabCompleteResult> {
+    const result: GenerationResult = await this.getClient()(buildPrompt(request))
+      .temperature(0.2)
+      .signal(AbortSignal.timeout(this.options.timeoutMs ?? DEFAULT_TAB_COMPLETE_TIMEOUT_MS))
+      .run();
+    return {
+      completion: stripFences(resultText(result)),
+      tokens: { input: result.usage?.inputTokens ?? 0, output: result.usage?.outputTokens ?? 0 },
+      model: this.options.model ?? process.env.VERTEX_MODEL ?? DEFAULT_TAB_COMPLETE_MODEL,
+    };
+  }
+}
+
+// Deterministic stand-in for tests and local runs with no Vertex access.
+export class StubTabCompleter implements TabCompleter {
+  constructor(private result: TabCompleteResult = { completion: '' }) {}
+
+  async complete(): Promise<TabCompleteResult> {
+    return this.result;
+  }
+}
+
+export function tabCompleteEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
+  // Off unless the deploy flag says exactly 'true' — opposite default from CODE_SURFACE.
+  return env.TAB_COMPLETE === 'true';
+}

--- a/apps/api/src/tab-complete.ts
+++ b/apps/api/src/tab-complete.ts
@@ -7,6 +7,8 @@ export const DEFAULT_TAB_COMPLETE_TIMEOUT_MS = 4000;
 // continue.dev's shape: ~700 tokens prefix, ~300 suffix, ~4 chars/token.
 export const MAX_PREFIX_CHARS = 3000;
 export const MAX_SUFFIX_CHARS = 1200;
+// A completion is a few lines, not a whole file — floors cost.
+export const MAX_COMPLETION_OUTPUT_TOKENS = 300;
 
 export interface TabCompleteRequest {
   path: string;
@@ -73,6 +75,7 @@ export class VertexTabCompleter implements TabCompleter {
   async complete(request: TabCompleteRequest): Promise<TabCompleteResult> {
     const result: GenerationResult = await this.getClient()(buildPrompt(request))
       .temperature(0.2)
+      .maxOutputTokens(MAX_COMPLETION_OUTPUT_TOKENS)
       .signal(AbortSignal.timeout(this.options.timeoutMs ?? DEFAULT_TAB_COMPLETE_TIMEOUT_MS))
       .run();
     return {

--- a/apps/api/src/tab-complete.ts
+++ b/apps/api/src/tab-complete.ts
@@ -27,10 +27,9 @@ export interface TabCompleter {
 }
 
 function stripFences(text: string): string {
-  const trimmed = text.trim();
-  // A stray ```typescript fence survives sometimes despite the prompt.
-  const fenced = trimmed.match(/^```[^\n]*\n([\s\S]*?)\n?```$/);
-  return fenced ? fenced[1]! : trimmed;
+  // Trimmed only to detect a fence — real whitespace must survive.
+  const fenced = text.trim().match(/^```[^\n]*\n([\s\S]*?)\n?```$/);
+  return fenced ? fenced[1]! : text;
 }
 
 function buildPrompt(request: TabCompleteRequest): string {

--- a/apps/api/src/tab-complete.ts
+++ b/apps/api/src/tab-complete.ts
@@ -1,5 +1,5 @@
 import { resultText, type GenAIClient, type GenerationResult } from 'genaicode';
-import { createVertexClient } from './genai.js';
+import { createVertexClient, type VertexGenerationConfig } from './genai.js';
 
 // TA-01: prompt-based FIM — Vertex Gemini has no suffix field.
 export const DEFAULT_TAB_COMPLETE_MODEL = 'gemini-3.7-flash';
@@ -68,6 +68,8 @@ export class VertexTabCompleter implements TabCompleter {
         defaultRegion: 'global',
         model: this.options.model,
         defaultModel: DEFAULT_TAB_COMPLETE_MODEL,
+        // Thinking eats the same output budget and leaves nothing for the code.
+        generationConfig: { thinkingConfig: { thinkingBudget: 0 } } as VertexGenerationConfig,
       });
     return this.client;
   }

--- a/apps/web/src/CodeMirrorEditor.tsx
+++ b/apps/web/src/CodeMirrorEditor.tsx
@@ -1,4 +1,4 @@
-import { autocompletion } from '@codemirror/autocomplete';
+import { autocompletion, completionStatus } from '@codemirror/autocomplete';
 import { indentWithTab } from '@codemirror/commands';
 import { css } from '@codemirror/lang-css';
 import { html } from '@codemirror/lang-html';
@@ -7,8 +7,16 @@ import { json } from '@codemirror/lang-json';
 import { markdown } from '@codemirror/lang-markdown';
 import { HighlightStyle, syntaxHighlighting } from '@codemirror/language';
 import { forceLinting, linter, lintGutter, type Diagnostic as CmDiagnostic } from '@codemirror/lint';
-import { Compartment, EditorState, type Extension } from '@codemirror/state';
-import { EditorView, keymap } from '@codemirror/view';
+import { Compartment, EditorState, Prec, StateEffect, StateField, type Extension, type Text } from '@codemirror/state';
+import {
+  Decoration,
+  type DecorationSet,
+  EditorView,
+  keymap,
+  ViewPlugin,
+  type ViewUpdate,
+  WidgetType,
+} from '@codemirror/view';
 import { tags } from '@lezer/highlight';
 import { basicSetup } from 'codemirror';
 import { useEffect, useRef } from 'react';
@@ -47,6 +55,8 @@ export type CodeMirrorEditorProps = {
   onGotoDefinition?: (path: string, from: number, to: number) => void;
   // GA-09: mount-only selection for a cross-file jump landing.
   initialSelection?: { anchor: number; head: number };
+  // TA-02: ghost-text proposal for the window around the cursor.
+  fetchGhostText?: (prefixWindow: string, suffixWindow: string, signal: AbortSignal) => Promise<string>;
 };
 
 function languageExtension(language: CodeLanguage): Extension | null {
@@ -160,6 +170,152 @@ function makeGotoHandler(onGotoDefinitionRef: { current: GotoDefinitionHandler |
   };
 }
 
+// TA-01's own caps — a window, never the whole file.
+const GHOST_TEXT_MAX_PREFIX_CHARS = 3000;
+const GHOST_TEXT_MAX_SUFFIX_CHARS = 1200;
+const GHOST_TEXT_DEBOUNCE_MS = 300;
+
+type FetchGhostText = (prefixWindow: string, suffixWindow: string, signal: AbortSignal) => Promise<string>;
+
+// Never mid-selection, never over an open tooltip.
+function ghostTextSuppressed(state: EditorState): boolean {
+  if (!state.selection.main.empty) return true;
+  // Not 'pending': that fires on every keystroke, long before a dropdown shows.
+  if (completionStatus(state) === 'active') return true;
+  // No public accessor for an open hover/lint tooltip — DOM it is.
+  return document.querySelector('.cm-tooltip-hover, .cm-tooltip-lint') !== null;
+}
+
+type GhostTextValue = { text: string; forDoc: Text } | null;
+
+const setGhostText = StateEffect.define<GhostTextValue>();
+
+// Hand-rolled: a tried library reset this on any unrelated dispatch.
+const ghostTextField = StateField.define<GhostTextValue>({
+  create: () => null,
+  update(value, tr) {
+    if (tr.docChanged) return null;
+    for (const effect of tr.effects) {
+      if (effect.is(setGhostText)) return effect.value;
+    }
+    // A cursor move with no edit makes a pinned proposal stale.
+    if (tr.selection) return null;
+    return value;
+  },
+});
+
+class GhostTextWidget extends WidgetType {
+  constructor(readonly text: string) {
+    super();
+  }
+  eq(other: GhostTextWidget): boolean {
+    return other.text === this.text;
+  }
+  toDOM(): HTMLElement {
+    const span = document.createElement('span');
+    span.className = 'cm-ghost-text';
+    span.textContent = this.text;
+    return span;
+  }
+}
+
+function ghostTextDecorations(state: EditorState): DecorationSet {
+  const value = state.field(ghostTextField, false);
+  if (!value) return Decoration.none;
+  const pos = state.selection.main.head;
+  return Decoration.set([Decoration.widget({ widget: new GhostTextWidget(value.text), side: 1 }).range(pos)]);
+}
+
+// TA-02: debounces on doc change; cancels its own timer and fetch.
+function ghostTextFetchPlugin(fetchGhostTextRef: { current: FetchGhostText | undefined }) {
+  return ViewPlugin.fromClass(
+    class {
+      timer: number | null = null;
+      abortController: AbortController | null = null;
+
+      update(update: ViewUpdate): void {
+        if (!update.docChanged) return;
+        this.cancel();
+        const view = update.view;
+        this.timer = window.setTimeout(() => {
+          this.timer = null;
+          void this.fetch(view);
+        }, GHOST_TEXT_DEBOUNCE_MS);
+      }
+
+      async fetch(view: EditorView): Promise<void> {
+        const state = view.state;
+        if (!fetchGhostTextRef.current || ghostTextSuppressed(state)) return;
+        const pos = state.selection.main.head;
+        const prefixWindow = state.sliceDoc(Math.max(0, pos - GHOST_TEXT_MAX_PREFIX_CHARS), pos);
+        const suffixWindow = state.sliceDoc(pos, Math.min(state.doc.length, pos + GHOST_TEXT_MAX_SUFFIX_CHARS));
+        const controller = new AbortController();
+        this.abortController = controller;
+        let text: string;
+        try {
+          text = await fetchGhostTextRef.current(prefixWindow, suffixWindow, controller.signal);
+        } catch {
+          return;
+        }
+        if (controller.signal.aborted || !text) return;
+        // Nothing may have moved on while the network call was in flight.
+        if (!view.state.doc.eq(state.doc) || view.state.selection.main.head !== pos) return;
+        view.dispatch({ effects: setGhostText.of({ text, forDoc: view.state.doc }) });
+      }
+
+      cancel(): void {
+        if (this.timer !== null) {
+          window.clearTimeout(this.timer);
+          this.timer = null;
+        }
+        this.abortController?.abort();
+        this.abortController = null;
+      }
+
+      destroy(): void {
+        this.cancel();
+      }
+    },
+  );
+}
+
+function makeGhostTextExtension(fetchGhostTextRef: { current: FetchGhostText | undefined }): Extension[] {
+  const fetchPlugin = ghostTextFetchPlugin(fetchGhostTextRef);
+  return [
+    ghostTextField,
+    EditorView.decorations.compute([ghostTextField], ghostTextDecorations),
+    fetchPlugin,
+    Prec.highest(
+      keymap.of([
+        {
+          key: 'Tab',
+          run: (view) => {
+            const value = view.state.field(ghostTextField, false);
+            if (!value) return false;
+            const pos = view.state.selection.main.head;
+            view.dispatch({
+              changes: { from: pos, insert: value.text },
+              selection: { anchor: pos + value.text.length },
+              userEvent: 'input.complete',
+            });
+            return true;
+          },
+        },
+        {
+          key: 'Escape',
+          run: (view) => {
+            const value = view.state.field(ghostTextField, false);
+            if (!value) return false;
+            view.plugin(fetchPlugin)?.cancel();
+            view.dispatch({ effects: setGhostText.of(null) });
+            return true;
+          },
+        },
+      ]),
+    ),
+  ];
+}
+
 // GA-05: ts extensions, or none — worker can turn ready mid-file.
 function languageServiceExtensions(
   languageService: CodeMirrorLanguageService | undefined,
@@ -186,6 +342,7 @@ export default function CodeMirrorEditor({
   languageService,
   onGotoDefinition,
   initialSelection,
+  fetchGhostText,
 }: CodeMirrorEditorProps) {
   const containerRef = useRef<HTMLDivElement | null>(null);
   const viewRef = useRef<EditorView | null>(null);
@@ -198,6 +355,8 @@ export default function CodeMirrorEditor({
   diagnosticsRef.current = diagnostics;
   const onGotoDefinitionRef = useRef(onGotoDefinition);
   onGotoDefinitionRef.current = onGotoDefinition;
+  const fetchGhostTextRef = useRef(fetchGhostText);
+  fetchGhostTextRef.current = fetchGhostText;
   // GA-05: reconfigured live below — a ready worker never remounts.
   const languageServiceCompartmentRef = useRef(new Compartment());
 
@@ -225,6 +384,7 @@ export default function CodeMirrorEditor({
           lintGutter(),
           linter((v) => toCmDiagnostics(v, diagnosticsRef.current)),
           languageServiceCompartmentRef.current.of(languageServiceExtensions(languageService, onGotoDefinitionRef)),
+          ...(readOnly ? [] : makeGhostTextExtension(fetchGhostTextRef)),
           EditorView.editable.of(!readOnly),
           EditorView.updateListener.of((update) => {
             if (update.docChanged) onChangeRef.current(update.state.doc.toString());

--- a/apps/web/src/CodeMirrorEditor.tsx
+++ b/apps/web/src/CodeMirrorEditor.tsx
@@ -200,6 +200,8 @@ const ghostTextField = StateField.define<GhostTextValue>({
     }
     // A cursor move with no edit makes a pinned proposal stale.
     if (tr.selection) return null;
+    // Clears ghost text once the popup takes over — its Tab wins.
+    if (completionStatus(tr.state) === 'active') return null;
     return value;
   },
 });
@@ -291,7 +293,8 @@ function makeGhostTextExtension(fetchGhostTextRef: { current: FetchGhostText | u
           key: 'Tab',
           run: (view) => {
             const value = view.state.field(ghostTextField, false);
-            if (!value) return false;
+            // Defers to the popup's own accept binding once one is active.
+            if (!value || completionStatus(view.state) === 'active') return false;
             const pos = view.state.selection.main.head;
             view.dispatch({
               changes: { from: pos, insert: value.text },

--- a/apps/web/src/CodeSurface.languageService.test.tsx
+++ b/apps/web/src/CodeSurface.languageService.test.tsx
@@ -377,4 +377,19 @@ describe('CodeSurface ghost text (TA-02)', () => {
     );
     expect(result).toBe('resolve()');
   });
+
+  it('never fetches for a non-TypeScript file — the prompt only knows TypeScript', async () => {
+    await render();
+    const jsonTab = [...container.querySelectorAll('.code-surface-rail-item')].find((button) =>
+      button.textContent?.includes('GAME.json'),
+    ) as HTMLButtonElement;
+    await act(async () => {
+      jsonTab.click();
+    });
+
+    const result = await lastEditorProps?.fetchGhostText?.('{', '}', new AbortController().signal);
+
+    expect(result).toBe('');
+    expect(mockedApi.fetchCodeSurfaceCompletion).not.toHaveBeenCalled();
+  });
 });

--- a/apps/web/src/CodeSurface.languageService.test.tsx
+++ b/apps/web/src/CodeSurface.languageService.test.tsx
@@ -15,6 +15,7 @@ type CapturedEditorProps = {
   languageService?: { worker: unknown; path: string };
   onGotoDefinition?: (path: string, from: number, to: number) => void;
   initialSelection?: { anchor: number; head: number };
+  fetchGhostText?: (prefixWindow: string, suffixWindow: string, signal: AbortSignal) => Promise<string>;
 };
 let lastEditorProps: CapturedEditorProps | null = null;
 // GA-09: the mock re-renders after clearing — record every value seen.
@@ -41,6 +42,7 @@ vi.mock('./codeSurfaceApi.js', async () => {
     fetchCodeSurfaceSources: vi.fn(),
     stageCodeSurfaceFile: vi.fn(),
     fetchCodeSurfaceKitDeclaration: vi.fn(),
+    fetchCodeSurfaceCompletion: vi.fn(),
   };
 });
 
@@ -316,5 +318,63 @@ describe('CodeSurface goto-definition (GA-09)', () => {
 
     expect(container.querySelector('.code-surface-rail-item.is-active')?.textContent).toBe(activeBefore);
     expect(container.querySelector('.code-surface-kit-viewer')).toBeNull();
+  });
+});
+
+describe('CodeSurface ghost text (TA-02)', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(async () => {
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    await i18n.changeLanguage('en');
+    resetCodeSurfaceSessionState();
+    lastEditorProps = null;
+    mockedApi.fetchCodeSurfaceSources.mockReset();
+    mockedApi.fetchCodeSurfaceKitDeclaration.mockReset();
+    mockedApi.fetchCodeSurfaceCompletion.mockReset();
+    mockedLanguageService.createCodeSurfaceLanguageService.mockReset();
+    mockedApi.fetchCodeSurfaceSources.mockResolvedValue(sourcesFor());
+    mockedApi.fetchCodeSurfaceKitDeclaration.mockResolvedValue(null);
+    mockedApi.fetchCodeSurfaceCompletion.mockResolvedValue('resolve()');
+    mockedLanguageService.createCodeSurfaceLanguageService.mockResolvedValue({
+      worker: {} as never,
+      updateFile: vi.fn(),
+      destroy: vi.fn(),
+    });
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => root.unmount());
+    container.remove();
+  });
+
+  async function render(slug = 'sky-dodge') {
+    await act(async () => {
+      root.render(createElement(CodeSurface, { slug, onBack: () => {} }));
+    });
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+  }
+
+  it('forwards a fetch to the open file, through fetchCodeSurfaceCompletion', async () => {
+    await render();
+    const controller = new AbortController();
+
+    const result = await lastEditorProps?.fetchGhostText?.('const x = ', ';', controller.signal);
+
+    expect(mockedApi.fetchCodeSurfaceCompletion).toHaveBeenCalledWith(
+      'sky-dodge',
+      'game.ts',
+      'const x = ',
+      ';',
+      controller.signal,
+    );
+    expect(result).toBe('resolve()');
   });
 });

--- a/apps/web/src/CodeSurface.tsx
+++ b/apps/web/src/CodeSurface.tsx
@@ -15,6 +15,7 @@ import type { CodeMirrorDiagnostic } from './CodeMirrorEditor.js';
 import {
   CodeSurfaceApiError,
   deliverCodeSurface,
+  fetchCodeSurfaceCompletion,
   fetchCodeSurfaceKitDeclaration,
   discardCodeSurfaceEdits,
   fetchCodeSurfaceSources,
@@ -424,6 +425,12 @@ export function CodeSurface({ slug, onBack, editorPushRef }: CodeSurfaceProps) {
     selectFile(path);
   }
 
+  // TA-02: the editor extension supplies the window, this supplies the call.
+  function fetchGhostText(prefixWindow: string, suffixWindow: string, signal: AbortSignal): Promise<string> {
+    if (!file) return Promise.resolve('');
+    return fetchCodeSurfaceCompletion(slug, file.path, prefixWindow, suffixWindow, signal);
+  }
+
   const schedulePreviewRebuild = useCallback(() => {
     if (previewTimerRef.current !== null) window.clearTimeout(previewTimerRef.current);
     if (cooldownTimerRef.current !== null) {
@@ -767,6 +774,7 @@ export function CodeSurface({ slug, onBack, editorPushRef }: CodeSurfaceProps) {
                   languageService={languageServiceForEditor}
                   onGotoDefinition={handleGotoDefinition}
                   initialSelection={initialSelectionForEditor}
+                  fetchGhostText={fetchGhostText}
                 />
               </Suspense>
             </CodeMirrorBoundary>

--- a/apps/web/src/CodeSurface.tsx
+++ b/apps/web/src/CodeSurface.tsx
@@ -427,7 +427,8 @@ export function CodeSurface({ slug, onBack, editorPushRef }: CodeSurfaceProps) {
 
   // TA-02: the editor extension supplies the window, this supplies the call.
   function fetchGhostText(prefixWindow: string, suffixWindow: string, signal: AbortSignal): Promise<string> {
-    if (!file) return Promise.resolve('');
+    // The prompt only knows TypeScript — other file types would get it wrong.
+    if (!file || !isTsPath(file.path)) return Promise.resolve('');
     return fetchCodeSurfaceCompletion(slug, file.path, prefixWindow, suffixWindow, signal);
   }
 

--- a/apps/web/src/CreationLimitsPanel.test.tsx
+++ b/apps/web/src/CreationLimitsPanel.test.tsx
@@ -37,8 +37,10 @@ function limits(overrides: Partial<CreationLimits> = {}): CreationLimits {
         configuredVendors: ['anthropic'],
         defaultVendor: 'anthropic',
       },
+      tabCompletePaused: false,
+      globalDailyTabCompleteTokenCap: 2_000_000,
     },
-    today: { dateStr: '2026-07-30', submissions: 12, managedBuilds: 3 },
+    today: { dateStr: '2026-07-30', submissions: 12, managedBuilds: 3, tabCompleteTokens: 0 },
     propagationMs: 60_000,
     ...overrides,
   };
@@ -106,6 +108,8 @@ describe('CreationLimitsPanel', () => {
             configuredVendors: ['anthropic'],
             defaultVendor: 'anthropic',
           },
+          tabCompletePaused: false,
+          globalDailyTabCompleteTokenCap: 2_000_000,
         },
       }),
     );
@@ -156,6 +160,8 @@ describe('CreationLimitsPanel', () => {
             configuredVendors: ['anthropic', 'gemini'],
             defaultVendor: 'anthropic',
           },
+          tabCompletePaused: false,
+          globalDailyTabCompleteTokenCap: 2_000_000,
         },
       }),
     );
@@ -175,6 +181,8 @@ describe('CreationLimitsPanel', () => {
             configuredVendors: ['anthropic', 'gemini'],
             defaultVendor: 'anthropic',
           },
+          tabCompletePaused: false,
+          globalDailyTabCompleteTokenCap: 2_000_000,
         },
       }),
     );
@@ -214,6 +222,8 @@ describe('CreationLimitsPanel', () => {
             configuredVendors: ['anthropic'],
             defaultVendor: 'anthropic',
           },
+          tabCompletePaused: false,
+          globalDailyTabCompleteTokenCap: 2_000_000,
         },
       }),
     );

--- a/apps/web/src/CreationLimitsPanel.tsx
+++ b/apps/web/src/CreationLimitsPanel.tsx
@@ -35,6 +35,7 @@ export function CreationLimitsPanel({ onChanged }: { onChanged?: () => void }) {
   const [capDraft, setCapDraft] = useState('');
   const [managedCapDraft, setManagedCapDraft] = useState('');
   const [managedUserCapDraft, setManagedUserCapDraft] = useState('');
+  const [tabCapDraft, setTabCapDraft] = useState('');
 
   const load = useCallback(async () => {
     try {
@@ -49,6 +50,7 @@ export function CreationLimitsPanel({ onChanged }: { onChanged?: () => void }) {
       setManagedUserCapDraft(
         response.effective.managedDailyUserCap === null ? '' : String(response.effective.managedDailyUserCap),
       );
+      setTabCapDraft(String(response.effective.globalDailyTabCompleteTokenCap));
       setState('ready');
     } catch {
       setState('error');
@@ -67,6 +69,8 @@ export function CreationLimitsPanel({ onChanged }: { onChanged?: () => void }) {
       managedAgentVendorOverride?: ManagedAgentVendor | null;
       managedDailyCap?: number | null;
       managedDailyUserCap?: number | null;
+      tabCompletePaused?: boolean;
+      globalDailyTabCompleteTokenCap?: number | null;
     }) => {
       setBusy(true);
       setMessage(null);
@@ -82,6 +86,7 @@ export function CreationLimitsPanel({ onChanged }: { onChanged?: () => void }) {
         setManagedUserCapDraft(
           result.effective.managedDailyUserCap === null ? '' : String(result.effective.managedDailyUserCap),
         );
+        setTabCapDraft(String(result.effective.globalDailyTabCompleteTokenCap));
         // The change lands in Firestore, and instances read it through a cache — so say
         // when it will be everywhere rather than implying it already is.
         setMessage(`in force everywhere within ${relative(result.propagationMs)}`);
@@ -108,6 +113,9 @@ export function CreationLimitsPanel({ onChanged }: { onChanged?: () => void }) {
   const parsedManagedUserCap = managedUserCapDraft.trim() === '' ? null : Number(managedUserCapDraft);
   const managedUserCapValid =
     parsedManagedUserCap === null || (Number.isInteger(parsedManagedUserCap) && parsedManagedUserCap >= 0);
+
+  const parsedTabCap = Number(tabCapDraft);
+  const tabCapValid = Number.isInteger(parsedTabCap) && parsedTabCap >= 0;
 
   const managedStatusLine = !effective.hasPlatformBackend
     ? 'Not configured in this environment (reads as "coming soon" regardless of the switch below).'
@@ -272,6 +280,59 @@ export function CreationLimitsPanel({ onChanged }: { onChanged?: () => void }) {
         <p className="health-note">
           An in-flight platform round keeps running when this changes — the switch only gates new dispatches. Reaches
           every instance within {relative(limits.propagationMs)}.
+        </p>
+      </section>
+      <section className="admin-limits">
+        <h2 className="health-section-title">Tab completion (ghost text)</h2>
+        <p className="health-summary">
+          {effective.tabCompletePaused ? 'Tab completion is paused.' : 'Tab completion is open.'}{' '}
+          {today.tabCompleteTokens} of {effective.globalDailyTabCompleteTokenCap} tokens used today ({today.dateStr}).
+        </p>
+
+        <div className="admin-limits-controls">
+          <button
+            type="button"
+            className={effective.tabCompletePaused ? 'admin-limits-resume' : 'admin-limits-pause'}
+            disabled={busy}
+            onClick={() => void apply({ tabCompletePaused: !effective.tabCompletePaused })}
+          >
+            {effective.tabCompletePaused ? 'Resume tab completion' : 'Pause tab completion'}
+          </button>
+
+          <label className="admin-limits-cap">
+            Daily token cap
+            <input
+              type="number"
+              min={0}
+              value={tabCapDraft}
+              disabled={busy}
+              onChange={(event) => setTabCapDraft(event.target.value)}
+            />
+          </label>
+          <button
+            type="button"
+            disabled={busy || !tabCapValid || parsedTabCap === effective.globalDailyTabCompleteTokenCap}
+            onClick={() => void apply({ globalDailyTabCompleteTokenCap: parsedTabCap })}
+          >
+            Set cap
+          </button>
+          <button
+            type="button"
+            disabled={
+              busy ||
+              stored?.globalDailyTabCompleteTokenCap === undefined ||
+              stored?.globalDailyTabCompleteTokenCap === null
+            }
+            onClick={() => void apply({ globalDailyTabCompleteTokenCap: null })}
+          >
+            Use the deployed default
+          </button>
+        </div>
+
+        {message && <p className="admin-limits-message">{message}</p>}
+
+        <p className="health-note">
+          Also requires the `TAB_COMPLETE` deploy flag. Reaches every instance within {relative(limits.propagationMs)}.
         </p>
       </section>
       <PublicPlayPanel onChanged={onChanged} />

--- a/apps/web/src/adminApi.ts
+++ b/apps/web/src/adminApi.ts
@@ -77,6 +77,8 @@ export interface CreationLimits {
     managedAgentVendorOverride?: ManagedAgentVendor | null;
     managedDailyCap?: number | null;
     managedDailyUserCap?: number | null;
+    tabCompletePaused?: boolean;
+    globalDailyTabCompleteTokenCap?: number | null;
     updatedAt?: string;
     updatedBy?: string;
   } | null;
@@ -94,8 +96,11 @@ export interface CreationLimits {
       configuredVendors: ManagedAgentVendor[];
       defaultVendor: ManagedAgentVendor | null;
     };
+    // TA-01's breaker — off/on and the shared daily token ceiling.
+    tabCompletePaused: boolean;
+    globalDailyTabCompleteTokenCap: number;
   };
-  today: { dateStr: string; submissions: number; managedBuilds: number };
+  today: { dateStr: string; submissions: number; managedBuilds: number; tabCompleteTokens: number };
   propagationMs: number;
 }
 
@@ -120,6 +125,8 @@ export async function setCreationLimits(patch: {
   managedAgentVendorOverride?: ManagedAgentVendor | null;
   managedDailyCap?: number | null;
   managedDailyUserCap?: number | null;
+  tabCompletePaused?: boolean;
+  globalDailyTabCompleteTokenCap?: number | null;
 }): Promise<CreationLimits | { error: string }> {
   const res = await fetch(`${API_BASE}/api/admin/creation-limits`, {
     method: 'POST',

--- a/apps/web/src/codeSurfaceApi.ts
+++ b/apps/web/src/codeSurfaceApi.ts
@@ -155,6 +155,30 @@ export async function fetchCodeSurfaceKitDeclaration(slug: string): Promise<Code
   }
 }
 
+// TA-01: advisory-only, like the kit declaration fetch — never throws.
+export async function fetchCodeSurfaceCompletion(
+  slug: string,
+  path: string,
+  prefixWindow: string,
+  suffixWindow: string,
+  signal: AbortSignal,
+): Promise<string> {
+  try {
+    const response = await fetch(`${API_BASE}/api/me/studio/games/${encodeURIComponent(slug)}/sources/complete`, {
+      method: 'POST',
+      credentials: 'include',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ path, prefixWindow, suffixWindow }),
+      signal,
+    });
+    if (!response.ok) return '';
+    const body = (await response.json()) as { completion?: string };
+    return body.completion ?? '';
+  } catch {
+    return '';
+  }
+}
+
 export type CodeSurfaceDeliverOutcome =
   | {
       accepted: true;

--- a/apps/web/src/legal/privacy.en.ts
+++ b/apps/web/src/legal/privacy.en.ts
@@ -216,6 +216,14 @@ export const privacyEn: LegalDocument = {
             `If you believe a rejection was wrong, write to [${CONTACT_EMAIL}](mailto:${CONTACT_EMAIL}) and a human ` +
             'will look at it.',
         },
+        {
+          kind: 'p',
+          text:
+            'Separately: if you are a game’s owner and use the Code editor’s suggestion feature, the code you are ' +
+            'actively editing is sent to the same AI model (Google Gemini, via Google Cloud Vertex AI) to generate ' +
+            'completion suggestions as you type. This is off unless you choose to use it, applies only to your own ' +
+            'game, and is never used to train models, same as above.',
+        },
       ],
     },
     {
@@ -236,7 +244,7 @@ export const privacyEn: LegalDocument = {
             ['Google (Sign in with Google)', 'Authentication', 'USA — Data Privacy Framework'],
             [
               'Google Cloud Vertex AI (Gemini)',
-              'Moderating and refining your game description',
+              'Moderating and refining your game description; suggesting code completions in the Code editor',
               'USA / global — Standard Contractual Clauses',
             ],
             ['GitHub (Microsoft)', 'Games repository and coding agent', 'USA — Data Privacy Framework'],

--- a/apps/web/src/legal/privacy.en.ts
+++ b/apps/web/src/legal/privacy.en.ts
@@ -219,10 +219,10 @@ export const privacyEn: LegalDocument = {
         {
           kind: 'p',
           text:
-            'Separately: if you are a game’s owner and use the Code editor’s suggestion feature, the code you are ' +
-            'actively editing is sent to the same AI model (Google Gemini, via Google Cloud Vertex AI) to generate ' +
-            'completion suggestions as you type. This is off unless you choose to use it, applies only to your own ' +
-            'game, and is never used to train models, same as above.',
+            'Separately: while you are a game’s owner and the Code editor’s suggestion feature is enabled, the code ' +
+            'around your cursor is automatically sent to the same AI model (Google Gemini, via Google Cloud Vertex ' +
+            'AI) a moment after you pause typing, to propose a completion. This applies only inside the Code editor ' +
+            'on your own game, and is never used to train models, same as above.',
         },
       ],
     },

--- a/apps/web/src/legal/privacy.pl.ts
+++ b/apps/web/src/legal/privacy.pl.ts
@@ -224,11 +224,11 @@ export const privacyPl: LegalDocument = {
         {
           kind: 'p',
           text:
-            'Osobno: jeśli jesteś właścicielem/właścicielką gry i korzystasz z funkcji podpowiedzi w edytorze kodu, ' +
-            'kod, który aktywnie edytujesz, jest wysyłany do tego samego modelu AI (Google Gemini, przez Google ' +
-            'Cloud Vertex AI), aby wygenerować podpowiedzi uzupełnień podczas pisania. Funkcja jest wyłączona, ' +
-            'dopóki jej nie włączysz, dotyczy wyłącznie Twojej własnej gry i — tak jak powyżej — nigdy nie jest ' +
-            'wykorzystywana do trenowania modeli.',
+            'Osobno: gdy jesteś właścicielem/właścicielką gry i funkcja podpowiedzi w edytorze kodu jest włączona, ' +
+            'kod wokół kursora jest automatycznie wysyłany do tego samego modelu AI (Google Gemini, przez Google ' +
+            'Cloud Vertex AI) chwilę po tym, jak przestajesz pisać, aby zaproponować uzupełnienie. Dotyczy to ' +
+            'wyłącznie edytora kodu w Twojej własnej grze i — tak jak powyżej — nigdy nie jest wykorzystywane do ' +
+            'trenowania modeli.',
         },
       ],
     },

--- a/apps/web/src/legal/privacy.pl.ts
+++ b/apps/web/src/legal/privacy.pl.ts
@@ -221,6 +221,15 @@ export const privacyPl: LegalDocument = {
             `ponownie. Jeśli jednak uważasz, że odrzucenie było błędne, napisz na [${CONTACT_EMAIL}](mailto:${CONTACT_EMAIL}), ` +
             'a sprawę oceni człowiek.',
         },
+        {
+          kind: 'p',
+          text:
+            'Osobno: jeśli jesteś właścicielem/właścicielką gry i korzystasz z funkcji podpowiedzi w edytorze kodu, ' +
+            'kod, który aktywnie edytujesz, jest wysyłany do tego samego modelu AI (Google Gemini, przez Google ' +
+            'Cloud Vertex AI), aby wygenerować podpowiedzi uzupełnień podczas pisania. Funkcja jest wyłączona, ' +
+            'dopóki jej nie włączysz, dotyczy wyłącznie Twojej własnej gry i — tak jak powyżej — nigdy nie jest ' +
+            'wykorzystywana do trenowania modeli.',
+        },
       ],
     },
     {
@@ -245,7 +254,7 @@ export const privacyPl: LegalDocument = {
             ['Google (logowanie kontem Google)', 'Uwierzytelnianie', 'USA — Data Privacy Framework'],
             [
               'Google Cloud Vertex AI (Gemini)',
-              'Moderacja i doprecyzowanie opisu gry',
+              'Moderacja i doprecyzowanie opisu gry; podpowiedzi uzupełnień kodu w edytorze kodu',
               'USA / globalnie — standardowe klauzule umowne',
             ],
             ['GitHub (Microsoft)', 'Repozytorium gier i agent kodujący', 'USA — Data Privacy Framework'],

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -12023,6 +12023,12 @@ button.builder-mode-selector:disabled {
   background: rgba(0, 228, 172, 0.14);
 }
 
+/* TA-02: ghost-text proposal — must never intercept the click meant for it. */
+.cm-ghost-text {
+  opacity: 0.45;
+  pointer-events: none;
+}
+
 .code-tok-comment {
   color: var(--muted);
 }

--- a/infra/deploy-api.sh
+++ b/infra/deploy-api.sh
@@ -296,7 +296,7 @@ done
 #
 # The rule this file already states for REMIX_DEBUG applies to every one of them: both
 # supported paths carry a flag, or neither should.
-for FLAG_VAR in SEED_DISPATCH CODE_LANE EDITOR_ASSIST MCP_AUTHORIZATION_SERVERS MCP_UI CODE_SURFACE; do
+for FLAG_VAR in SEED_DISPATCH CODE_LANE EDITOR_ASSIST MCP_AUTHORIZATION_SERVERS MCP_UI CODE_SURFACE TAB_COMPLETE; do
   eval "FLAG_VAL=\${${FLAG_VAR}:-}"
   if [ -n "${FLAG_VAL}" ]; then
     ENV_VARS="${ENV_VARS}|${FLAG_VAR}=${FLAG_VAL}"


### PR DESCRIPTION
## Summary

The LLM ghost-text autocomplete track (TA-*), following CE-36/GA-01..09 (deterministic autocomplete, shipped separately). Both the API route and the web client that calls it.

### TA-01 — API

- `POST /api/me/studio/games/:slug/sources/complete` — the ghost-text proposal endpoint, same owner-auth/404 posture as every other Code Surface route.
- `tab-complete.ts`: `VertexTabCompleter` assembles the client's prefix/suffix window into one prompt (Vertex Gemini has no native FIM `suffix` field, so this is prompt-based FIM), reusing the existing Vertex AI integration (`gemini-3.7-flash`) — no new provider, no new credential. Thinking disabled and output capped at 300 tokens (see "Verification" below for why).
- `TAB_COMPLETE` kill switch, off by default — the opposite default from `CODE_SURFACE`.
- Two independent spend controls: a per-creator daily call quota (`tabCompletes`) and a global 2,000,000-token/day hard cap (`createTabCompleteGate`, peek-before-call/spend-after). Operator toggle for both wired into the admin panel.
- Privacy policy (en/pl) updated to disclose the new data flow.

### TA-02 — Web

- Idle-debounced (300ms) ghost-text extension in `CodeMirrorEditor.tsx`, wired to the route through `CodeSurface.tsx`.
- Hand-rolled rather than the research doc's first-pick library (`codemirror-extension-inline-suggestion`): a real-Chromium test against a real model call found the library's state field resets on *any* transaction lacking its own effect, so this app's own autosave/typecheck dispatches silently erased a shown proposal within ~400ms of it rendering. The hand-rolled version (StateField + widget decoration + `Prec.highest` Tab/Esc keymap) only resets on an edit, a bare cursor move, or explicit dismiss.
- Suppressed while the CE-36 `.`-triggered tooltip is genuinely showing (`completionStatus === 'active'`, not `'pending'` — pending fires on nearly every keystroke and would have starved ghost text entirely), mid-selection, or over an open hover/lint tooltip.
- Tab inserts the proposal as a normal buffer edit through the existing autosave/staging path — no special-cased accept path needed.

## Verification

- Real, non-mocked verification: spun up the API + web dev server locally with a real `gemini-3.7-flash` client (API-key path, local-only) and drove real Chromium against it.
- This caught two real bugs before they shipped: the output-token cap needed thinking disabled first (Gemini's extended-thinking tokens share the same budget and were starving the visible answer), and the first-choice ghost-text library's decoration didn't survive the app's own background dispatches.
- Confirmed end to end: proposal renders with correct, contextual completions; survives autosave + typecheck; Tab accepts into the real buffer; Escape dismisses.

## Test plan

- [x] `apps/api/src/tab-complete.test.ts` — prompt assembly, token accounting, markdown-fence stripping, kill-switch default, thinking disabled (regression-pinned via a mocked Vertex client), output-token cap
- [x] `apps/api/src/creator-code.test.ts` — new route: kill-switch 404, ownership 404, happy path, per-creator quota 429
- [x] `apps/web/src/CodeSurface.languageService.test.tsx` — `fetchGhostText` prop wiring
- [x] `npx tsc --noEmit` clean on both `apps/api` and `apps/web`
- [x] `npx eslint` clean on all touched files
- [x] Full API suite (3200 tests) and full web suite (1358 tests) passing
- [x] `apps/web` production build succeeds
- [x] Repo-wide comment-prose gate at baseline
- [x] Real Chromium + real Gemini call, screenshots attached to the session (proposal render, persistence through autosave/typecheck, Tab-accept)