### PR TITLE
feat(editorkit): add layered v2 editors

### DIFF
--- a/apps/api/src/editor-contract.test.ts
+++ b/apps/api/src/editor-contract.test.ts
@@ -110,12 +110,91 @@ const V2_SCHEMA = {
   },
 };
 
+const LAYERED_V2 = {
+  version: 2,
+  layers: {
+    terrain: {
+      widget: 'tilemap',
+      label: { en: 'Terrain', pl: 'Teren' },
+      grid: { minCols: 5, maxCols: 5, minRows: 3, maxRows: 3 },
+      tiles: [
+        { key: 'floor', char: '.', label: { en: 'Floor', pl: 'Podłoże' } },
+        { key: 'start', char: '@', label: { en: 'Start', pl: 'Start' } },
+        { key: 'goal', char: '*', label: { en: 'Goal', pl: 'Meta' } },
+      ],
+      properties: {},
+      constraints: [
+        { tile: 'start', exactly: 1 },
+        { tile: 'goal', exactly: 1 },
+      ],
+    },
+    objects: {
+      widget: 'tilemap',
+      label: { en: 'Objects', pl: 'Obiekty' },
+      grid: { minCols: 5, maxCols: 5, minRows: 3, maxRows: 3 },
+      tiles: [
+        { key: 'empty', char: '.', label: { en: 'Empty', pl: 'Puste' } },
+        { key: 'wall', char: '#', label: { en: 'Wall', pl: 'Ściana' } },
+      ],
+      properties: {},
+      constraints: [],
+    },
+    triggers: {
+      widget: 'entities',
+      label: { en: 'Triggers', pl: 'Wyzwalacze' },
+      min: 0,
+      max: 4,
+      properties: { kind: { type: 'enum', values: ['exit'] } },
+      constraints: [],
+    },
+  },
+  constraints: [
+    {
+      reachable: {
+        from: { layer: 'terrain', tile: 'start' },
+        blockedBy: [{ layer: 'objects', tile: 'wall' }],
+        require: [{ layer: 'terrain', tile: 'goal' }],
+      },
+    },
+  ],
+};
+
+const LAYERED_CONTENT = {
+  layers: {
+    terrain: { properties: {}, rows: ['.....', '.@..*', '.....'] },
+    objects: { properties: {}, rows: ['.....', '.....', '.....'] },
+    triggers: [{ properties: { kind: 'exit' } }],
+  },
+};
+
 describe('editor-contract mirror', () => {
   it('accepts a schema-only v2 contract without v1 defaults', () => {
     const { definition, errors } = parseEditorDefinition(JSON.stringify(V2_SCHEMA));
     expect(errors).toEqual([]);
     expect(definition?.version).toBe(2);
     expect(definition?.params?.shipTopSpeed.default).toBeUndefined();
+  });
+
+  it('accepts and validates layered tilemap/entity content', () => {
+    const { definition, errors } = parseEditorDefinition(JSON.stringify(LAYERED_V2));
+    expect(errors).toEqual([]);
+    expect(definition?.layers?.terrain.widget).toBe('tilemap');
+    expect(definition?.layers?.triggers.widget).toBe('entities');
+    expect(validateEditorContent(definition!, LAYERED_CONTENT)).toEqual([]);
+
+    const blocked = structuredClone(LAYERED_CONTENT);
+    blocked.layers.objects.rows = ['..#..', '..#..', '..#..'];
+    expect(validateEditorContent(definition!, blocked).some((message) => message.includes('walled off'))).toBe(true);
+  });
+
+  it('generates typed layer interfaces and v2 defaults', () => {
+    const { definition } = parseEditorDefinition(JSON.stringify(LAYERED_V2));
+    const generated = generateEditorContentModule(definition!, LAYERED_CONTENT);
+    expect(generated).toContain('export interface TerrainLayer {');
+    expect(generated).toContain('export interface TriggersLayerItem {');
+    expect(generated).toContain('  layers: EditorLayers;');
+    expect(generated).toContain('"terrain": {\n      "properties": {},\n      "rows": [');
+    expect(generateEditorContentModule(definition!)).toContain('"layers": {}');
   });
 
   it('rejects v2 defaults so schema and content cannot drift', () => {

--- a/apps/api/src/editor-contract.ts
+++ b/apps/api/src/editor-contract.ts
@@ -32,8 +32,12 @@ export const MAX_GRID_ROWS = 64;
 export const MAX_PATH_POINTS = 256;
 /** Game-wide scalar tunables ("params") — same property vocabulary, one value each. */
 export const MAX_PARAMS = 16;
+export const MAX_LAYERS = 8;
+export const MAX_LAYER_ITEMS = 64;
+export const MAX_LAYER_TOTAL_CELLS = 16_384;
 /** Reserved content-document key param values ride under; illegal as a collection name. */
 export const PARAMS_KEY = 'params';
+export const LAYERS_KEY = 'layers';
 
 const KEY_PATTERN = /^[a-z][a-zA-Z0-9]{0,23}$/;
 const TILE_KEY_PATTERN = /^[a-z][a-z0-9-]{0,15}$/;
@@ -136,6 +140,24 @@ export interface CollectionSpec {
   defaults: Array<TilemapItemContent | EntityItemContent | PathItemContent>;
 }
 
+export interface TilemapLayerSpec extends TilemapItemSpec {
+  label: EditorLabel;
+}
+
+export interface EntitiesLayerSpec extends EntitiesItemSpec {
+  label: EditorLabel;
+  min: number;
+  max: number;
+}
+
+export type EditorLayerSpec = TilemapLayerSpec | EntitiesLayerSpec;
+
+export type LayerTileRef = { layer: string; tile: string };
+
+export type EditorLayerConstraint = {
+  reachable: { from: LayerTileRef; blockedBy: LayerTileRef[]; require: LayerTileRef[] };
+};
+
 export interface TilemapItemContent {
   properties: Record<string, unknown>;
   rows: string[];
@@ -155,9 +177,12 @@ export interface PathItemContent {
   points: PathPoint[];
 }
 
+export type EditorLayerContent = TilemapItemContent | EntityItemContent[];
+export type EditorLayersContent = Record<string, EditorLayerContent>;
+
 export type EditorContentDocument = Record<
   string,
-  Array<TilemapItemContent | EntityItemContent | PathItemContent> | Record<string, ParamValue>
+  Array<TilemapItemContent | EntityItemContent | PathItemContent> | Record<string, ParamValue> | EditorLayersContent
 >;
 
 export type EditorVersion = 1 | 2;
@@ -166,6 +191,8 @@ export interface EditorDefinition {
   version: EditorVersion;
   params?: Record<string, ParamSpec>;
   content: Record<string, CollectionSpec>;
+  layers?: Record<string, EditorLayerSpec>;
+  constraints?: EditorLayerConstraint[];
 }
 
 function isPlainObject(value: unknown): value is Record<string, unknown> {
@@ -547,6 +574,95 @@ function validateCollectionItemSpec(owner: string, raw: unknown, errors: string[
   return null;
 }
 
+function validateLayerSpec(key: string, raw: unknown, errors: string[]): EditorLayerSpec | null {
+  const owner = `layers.${key}`;
+  if (!isPlainObject(raw)) {
+    errors.push(`${owner}: must be an object`);
+    return null;
+  }
+  const label = raw.label === undefined ? { en: key, pl: key } : raw.label;
+  if (!isLabel(label)) {
+    errors.push(`${owner}: "label" needs non-empty "en" and "pl" values (max 32 chars)`);
+    return null;
+  }
+  if (raw.widget === 'tilemap') {
+    const item = validateTilemapSpec(owner, raw, errors);
+    return item ? { ...item, label: { en: label.en, pl: label.pl } } : null;
+  }
+  if (raw.widget === 'entities') {
+    const item = validateEntitiesSpec(owner, raw, errors);
+    if (!item) return null;
+    const min: unknown = raw.min ?? 0;
+    const max: unknown = raw.max ?? MAX_LAYER_ITEMS;
+    if (
+      typeof min !== 'number' ||
+      typeof max !== 'number' ||
+      !Number.isInteger(min) ||
+      !Number.isInteger(max) ||
+      min < 0 ||
+      max > MAX_LAYER_ITEMS ||
+      min > max
+    ) {
+      errors.push(`${owner}: entity bounds must satisfy 0 <= min <= max <= ${MAX_LAYER_ITEMS}`);
+      return null;
+    }
+    return { ...item, label: { en: label.en, pl: label.pl }, min, max };
+  }
+  errors.push(`${owner}: unknown widget "${String(raw.widget)}" (layers support tilemap or entities)`);
+  return null;
+}
+
+function validateLayerConstraints(
+  raw: unknown,
+  layers: Record<string, EditorLayerSpec>,
+  errors: string[],
+): EditorLayerConstraint[] {
+  if (raw === undefined) return [];
+  if (!Array.isArray(raw) || raw.length > MAX_CONSTRAINTS) {
+    errors.push(`layers constraints must be an array of at most ${MAX_CONSTRAINTS} rules`);
+    return [];
+  }
+  const refs = (value: unknown, owner: string): LayerTileRef[] | null => {
+    if (!Array.isArray(value) || value.length === 0) {
+      errors.push(`${owner} must be a non-empty array of layer tile references`);
+      return null;
+    }
+    const result: LayerTileRef[] = [];
+    for (const ref of value) {
+      if (!isPlainObject(ref) || typeof ref.layer !== 'string' || typeof ref.tile !== 'string') {
+        errors.push(`${owner} entries need string "layer" and "tile" keys`);
+        continue;
+      }
+      const layer = layers[ref.layer];
+      if (!layer || layer.widget !== 'tilemap') {
+        errors.push(`${owner} references unknown tilemap layer "${ref.layer}"`);
+        continue;
+      }
+      if (!layer.tiles.some((tile) => tile.key === ref.tile)) {
+        errors.push(`${owner} references unknown tile "${ref.tile}" in layer "${ref.layer}"`);
+        continue;
+      }
+      result.push({ layer: ref.layer, tile: ref.tile });
+    }
+    return result.length === value.length ? result : null;
+  };
+  const result: EditorLayerConstraint[] = [];
+  for (const [index, rule] of raw.entries()) {
+    const owner = `layers constraints[${index}]`;
+    if (!isPlainObject(rule) || !isPlainObject(rule.reachable)) {
+      errors.push(`${owner}: only "reachable" cross-layer rules are supported`);
+      continue;
+    }
+    const reachable = rule.reachable;
+    const from = refs([reachable.from], `${owner}.reachable.from`);
+    const blockedBy = refs(reachable.blockedBy, `${owner}.reachable.blockedBy`);
+    const require = refs(reachable.require, `${owner}.reachable.require`);
+    if (!from || from.length !== 1 || !blockedBy || !require) continue;
+    result.push({ reachable: { from: from[0], blockedBy, require } });
+  }
+  return result;
+}
+
 /**
  * Parse and validate an EDITOR.json source. Returns the typed definition and a
  * list of human-readable problems; a non-empty `errors` means the definition
@@ -573,7 +689,9 @@ export function parseEditorDefinition(source: string): { definition: EditorDefin
     errors.push('EDITOR.json "version" must be 1 or 2');
     return { definition: null, errors };
   }
-  const unknownKeys = Object.keys(parsed).filter((key) => key !== 'version' && key !== 'content' && key !== PARAMS_KEY);
+  const unknownKeys = Object.keys(parsed).filter(
+    (key) => !['version', 'content', PARAMS_KEY, LAYERS_KEY, 'constraints'].includes(key),
+  );
   if (unknownKeys.length > 0) {
     errors.push(`EDITOR.json has unknown top-level keys: ${unknownKeys.join(', ')}`);
   }
@@ -587,9 +705,22 @@ export function parseEditorDefinition(source: string): { definition: EditorDefin
     errors.push('EDITOR.json needs a "content" object of collections');
     return { definition: null, errors };
   }
+  if (parsed.layers !== undefined && !isPlainObject(parsed.layers)) {
+    errors.push('EDITOR.json needs a "layers" object of shared-grid layer declarations');
+    return { definition: null, errors };
+  }
   const contentKeys = isPlainObject(parsed.content) ? Object.keys(parsed.content) : [];
-  if (contentKeys.length > MAX_COLLECTIONS || (contentKeys.length === 0 && !hasParams)) {
-    errors.push(`EDITOR.json "content" needs 1-${MAX_COLLECTIONS} collections`);
+  const layerKeys = isPlainObject(parsed.layers) ? Object.keys(parsed.layers) : [];
+  if (
+    contentKeys.length > MAX_COLLECTIONS ||
+    layerKeys.length > MAX_LAYERS ||
+    (contentKeys.length === 0 && layerKeys.length === 0 && !hasParams)
+  ) {
+    errors.push(`EDITOR.json needs params, content collections, or layers`);
+    return { definition: null, errors };
+  }
+  if (parsed.version === 1 && layerKeys.length > 0) {
+    errors.push('EDITOR.json "layers" requires version 2');
     return { definition: null, errors };
   }
 
@@ -656,8 +787,43 @@ export function parseEditorDefinition(source: string): { definition: EditorDefin
     content[key] = spec;
   }
 
+  const layers: Record<string, EditorLayerSpec> = {};
+  for (const key of layerKeys) {
+    if (!KEY_PATTERN.test(key)) {
+      errors.push(`EDITOR.json layer key "${key}" must be lowerCamelCase, 1-24 characters`);
+      continue;
+    }
+    const layer = validateLayerSpec(key, (parsed.layers as Record<string, unknown>)[key], errors);
+    if (layer) layers[key] = layer;
+  }
+  const tilemapGrids = Object.values(layers)
+    .filter((layer): layer is TilemapLayerSpec => layer.widget === 'tilemap')
+    .map((layer) => JSON.stringify(layer.grid));
+  if (tilemapGrids.some((grid) => grid !== tilemapGrids[0])) {
+    errors.push('EDITOR.json tilemap layers must share the same grid bounds');
+  }
+  const layerCellBudget = Object.values(layers)
+    .filter((layer): layer is TilemapLayerSpec => layer.widget === 'tilemap')
+    .reduce((total, layer) => total + layer.grid.maxCols * layer.grid.maxRows, 0);
+  if (layerCellBudget > MAX_LAYER_TOTAL_CELLS) {
+    errors.push(`EDITOR.json tilemap layers exceed the shared ${MAX_LAYER_TOTAL_CELLS}-cell budget`);
+  }
+  const constraints = validateLayerConstraints(parsed.constraints, layers, errors);
+  if (parsed.constraints !== undefined && parsed.version !== 2) {
+    errors.push('EDITOR.json cross-layer constraints require version 2');
+  }
+
   if (errors.length > 0) return { definition: null, errors };
-  return { definition: { version: parsed.version, ...(hasParams ? { params } : {}), content }, errors };
+  return {
+    definition: {
+      version: parsed.version,
+      ...(hasParams ? { params } : {}),
+      ...(contentKeys.length > 0 ? { content } : { content: {} }),
+      ...(layerKeys.length > 0 ? { layers } : {}),
+      ...(constraints.length > 0 ? { constraints } : {}),
+    },
+    errors,
+  };
 }
 
 /**
@@ -926,6 +1092,111 @@ function validateCollectionContent(spec: CollectionSpec, items: unknown): string
   return errors;
 }
 
+function validateLayerContent(spec: EditorLayerSpec, value: unknown, where: string): string[] {
+  if (spec.widget === 'tilemap') return validateItemContent(spec, value, where);
+  return validateCollectionContent(
+    {
+      widget: 'collection',
+      label: spec.label,
+      itemLabel: spec.label,
+      min: spec.min,
+      max: spec.max,
+      item: spec,
+      defaults: [],
+    },
+    value,
+  ).map((message) => `${where}: ${message}`);
+}
+
+function layerRows(
+  layers: Record<string, EditorLayerSpec>,
+  content: Record<string, unknown>,
+  layer: string,
+): string[] | null {
+  const spec = layers[layer];
+  const value = content[layer];
+  if (!spec || spec.widget !== 'tilemap' || !isPlainObject(value) || !Array.isArray(value.rows)) return null;
+  return value.rows.every((row) => typeof row === 'string') ? (value.rows as string[]) : null;
+}
+
+function validateLayerReachable(
+  rule: EditorLayerConstraint['reachable'],
+  layers: Record<string, EditorLayerSpec>,
+  content: Record<string, unknown>,
+  where: string,
+): string[] {
+  const fromRows = layerRows(layers, content, rule.from.layer);
+  if (!fromRows) return [];
+  const tilemaps = new Map<string, string[]>();
+  for (const ref of [rule.from, ...rule.blockedBy, ...rule.require]) {
+    const rows = layerRows(layers, content, ref.layer);
+    if (rows) tilemaps.set(ref.layer, rows);
+  }
+  const height = fromRows.length;
+  const width = height > 0 ? fromRows[0].length : 0;
+  if (
+    width === 0 ||
+    [...tilemaps.values()].some((rows) => rows.length !== height || rows.some((row) => row.length !== width))
+  ) {
+    return [`${where}: all referenced layers must have the same grid dimensions`];
+  }
+  const tileChar = new Map<string, Map<string, string>>();
+  for (const ref of [rule.from, ...rule.blockedBy, ...rule.require]) {
+    const spec = layers[ref.layer];
+    if (spec?.widget !== 'tilemap') continue;
+    if (!tileChar.has(ref.layer)) tileChar.set(ref.layer, new Map(spec.tiles.map((tile) => [tile.key, tile.char])));
+  }
+  const positions = (ref: LayerTileRef): Set<number> => {
+    const rows = tilemaps.get(ref.layer);
+    const char = tileChar.get(ref.layer)?.get(ref.tile);
+    const result = new Set<number>();
+    if (!rows || !char) return result;
+    rows.forEach((row, y) => {
+      for (let x = 0; x < row.length; x += 1) if (row[x] === char) result.add(y * width + x);
+    });
+    return result;
+  };
+  const blocked = new Set<number>();
+  for (const ref of rule.blockedBy) for (const position of positions(ref)) blocked.add(position);
+  const seen = new Set<number>();
+  const queue = [...positions(rule.from)];
+  for (const position of queue) seen.add(position);
+  while (queue.length > 0) {
+    const position = queue.shift() as number;
+    const row = Math.floor(position / width);
+    const col = position % width;
+    for (const [dr, dc] of [
+      [1, 0],
+      [-1, 0],
+      [0, 1],
+      [0, -1],
+    ] as const) {
+      const nextRow = row + dr;
+      const nextCol = col + dc;
+      if (nextRow < 0 || nextCol < 0 || nextRow >= height || nextCol >= width) continue;
+      const next = nextRow * width + nextCol;
+      if (blocked.has(next) || seen.has(next)) continue;
+      seen.add(next);
+      queue.push(next);
+    }
+  }
+  const missed = rule.require.flatMap((ref) =>
+    [...positions(ref)]
+      .filter((position) => !seen.has(position))
+      .map((position) => {
+        const row = Math.floor(position / width) + 1;
+        const col = (position % width) + 1;
+        return `${ref.layer}.${ref.tile} at row ${row}, column ${col}`;
+      }),
+  );
+  return missed.length === 0
+    ? []
+    : [
+        `${where}: walled off from "${rule.from.layer}.${rule.from.tile}" — ${missed.join('; ')}. ` +
+          'Every required tile must be reachable, or the game cannot be finished.',
+      ];
+}
+
 /**
  * Validate a full content document (what a Studio draft or a publish carries)
  * against a definition. Shape: `{ <collectionKey>: EditorItemContent[] }`.
@@ -934,9 +1205,14 @@ export function validateEditorContent(definition: EditorDefinition, content: unk
   if (!isPlainObject(content)) return ['content must be an object'];
   const errors: string[] = [];
   const declared = Object.keys(definition.content);
+  const declaredLayers = Object.keys(definition.layers ?? {});
   for (const key of Object.keys(content)) {
     if (key === PARAMS_KEY) {
       if (!definition.params) errors.push(`undeclared collection "${key}"`);
+      continue;
+    }
+    if (key === LAYERS_KEY) {
+      if (!definition.layers) errors.push(`undeclared content "${key}"`);
       continue;
     }
     if (!declared.includes(key)) errors.push(`undeclared collection "${key}"`);
@@ -969,6 +1245,29 @@ export function validateEditorContent(definition: EditorDefinition, content: unk
       continue;
     }
     errors.push(...validateCollectionContent(definition.content[key], items).map((message) => `${key}: ${message}`));
+  }
+  if (definition.layers) {
+    const layers = content[LAYERS_KEY];
+    if (layers === undefined) {
+      errors.push('missing "layers" values');
+    } else if (!isPlainObject(layers)) {
+      errors.push('layers: must be an object of layer values');
+    } else {
+      for (const key of Object.keys(layers)) {
+        if (!declaredLayers.includes(key)) errors.push(`layers: undeclared layer "${key}"`);
+      }
+      for (const [key, spec] of Object.entries(definition.layers)) {
+        const value = layers[key];
+        if (value === undefined) {
+          errors.push(`layers: missing "${key}"`);
+          continue;
+        }
+        errors.push(...validateLayerContent(spec, value, `layers.${key}`));
+      }
+      for (const rule of definition.constraints ?? []) {
+        errors.push(...validateLayerReachable(rule.reachable, definition.layers, layers, 'layers'));
+      }
+    }
   }
   return errors;
 }
@@ -1021,6 +1320,36 @@ export function generateEditorContentModule(definition: EditorDefinition, conten
     lines.push('}', '');
     contentFields.push(`  ${key}: ${itemType}[];`);
   }
+  if (definition.layers && Object.keys(definition.layers).length > 0) {
+    const layerFields: string[] = [];
+    for (const [key, spec] of Object.entries(definition.layers)) {
+      const layerType = `${typeName(key)}Layer`;
+      if (spec.widget === 'tilemap') {
+        lines.push(`export interface ${layerType} {`);
+        lines.push('  properties: {');
+        for (const [name, propertySpec] of Object.entries(spec.properties)) {
+          lines.push(`    ${name}: ${propertyTsType(propertySpec)};`);
+        }
+        lines.push('  };');
+        lines.push('  rows: string[];');
+        lines.push('}', '');
+      } else {
+        lines.push(`export interface ${layerType}ItemProperties {`);
+        for (const [name, propertySpec] of Object.entries(spec.properties)) {
+          lines.push(`  ${name}: ${propertyTsType(propertySpec)};`);
+        }
+        lines.push('}', '');
+        lines.push(`export interface ${layerType}Item {`);
+        lines.push(`  properties: ${layerType}ItemProperties;`);
+        lines.push('}', '');
+      }
+      layerFields.push(`  ${key}: ${layerType}${spec.widget === 'entities' ? 'Item[]' : ''};`);
+    }
+    lines.push('export interface EditorLayers {');
+    lines.push(...layerFields);
+    lines.push('}', '');
+    contentFields.push(`  ${LAYERS_KEY}: EditorLayers;`);
+  }
   lines.push('export interface EditorContent {');
   lines.push(...contentFields);
   lines.push('}', '');
@@ -1033,6 +1362,10 @@ export function generateEditorContentModule(definition: EditorDefinition, conten
   }
   for (const [key, spec] of Object.entries(definition.content)) {
     defaults[key] = content?.[key] ?? spec.defaults;
+  }
+  if (definition.layers && Object.keys(definition.layers).length > 0) {
+    const supplied = content?.[LAYERS_KEY];
+    defaults[LAYERS_KEY] = supplied && isPlainObject(supplied) ? supplied : {};
   }
   lines.push(`export const DEFAULT_CONTENT: EditorContent = ${JSON.stringify(defaults, null, 2)};`);
   lines.push('');

--- a/apps/api/src/remix.ts
+++ b/apps/api/src/remix.ts
@@ -1,8 +1,15 @@
 import { createHash, randomBytes } from 'node:crypto';
 import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
 import { z } from 'zod';
-import { PARAMS_KEY, parseEditorDefinition, type EditorDefinition } from './editor-contract.js';
-import { EDITOR_FILE } from './editor-contract.js';
+import {
+  EDITOR_CONTENT_FILE,
+  EDITOR_FILE,
+  PARAMS_KEY,
+  parseEditorDefinition,
+  validateEditorContent,
+  type EditorContentDocument,
+  type EditorDefinition,
+} from './editor-contract.js';
 import { applyAssistPatches, assistEnabled, MAX_UTTERANCE_LENGTH, type EditorAssistant } from './editor-assist.js';
 import { rememberRemixTurn, type RemixTurn } from './remix-turns.js';
 import { codeLaneDebugEnabled, codeLaneEnabled, type VertexCodeLane } from './code-lane.js';
@@ -214,8 +221,20 @@ function ownerTag(uid: string): string {
 }
 
 /** The declaration's collections at their defaults — the base every params-only document sits on. */
-function defaultCollections(definition: EditorDefinition | null): Record<string, unknown> {
+function defaultCollections(definition: EditorDefinition | null, rawContent?: string): Record<string, unknown> {
   if (!definition) return {};
+  if (rawContent) {
+    let parsed: unknown = null;
+    try {
+      parsed = JSON.parse(rawContent);
+    } catch {
+      // Invalid JSON falls through to the defaults below.
+    }
+    if (typeof parsed === 'object' && parsed !== null && !Array.isArray(parsed)) {
+      const content = parsed as EditorContentDocument;
+      if (validateEditorContent(definition, content).length === 0) return content;
+    }
+  }
   return Object.fromEntries(Object.entries(definition.content).map(([key, spec]) => [key, spec.defaults]));
 }
 
@@ -445,12 +464,18 @@ export async function registerRemixRoutes(app: FastifyInstance, options: RemixRo
     // file is a real "no such game" rather than a swallowed error.
     const manifest = await options.githubClient.getGameFile(ref, slug, 'GAME.json');
     if (manifest === null) return null;
-    const editorJson = await options.githubClient.getGameFile(ref, slug, EDITOR_FILE);
+    const [editorJson, editorContentJson] = await Promise.all([
+      options.githubClient.getGameFile(ref, slug, EDITOR_FILE),
+      options.githubClient.getGameFile(ref, slug, EDITOR_CONTENT_FILE),
+    ]);
     // Declaration only: a repo game's code stays on the ref (the assembler reads
     // it there), so the code lane has no file list to map and says so, while the
     // params lane works on exactly the games that declare params.
+    const sources: Record<string, string> = {};
+    if (editorJson !== null) sources[EDITOR_FILE] = editorJson;
+    if (editorContentJson !== null) sources[EDITOR_CONTENT_FILE] = editorContentJson;
     return {
-      sources: editorJson === null ? {} : { [EDITOR_FILE]: editorJson },
+      sources,
       ref,
       fromStore: false,
     };
@@ -546,6 +571,9 @@ export async function registerRemixRoutes(app: FastifyInstance, options: RemixRo
         // to this server: painted content lives in the player's session and
         // reaches the game over the bridge, exactly like params.
         content: definition && Object.keys(definition.content).length > 0 ? definition.content : null,
+        layers: definition && definition.layers && Object.keys(definition.layers).length > 0 ? definition.layers : null,
+        constraints: definition?.constraints ?? null,
+        contentDefaults: defaultCollections(definition, loaded.sources[EDITOR_CONTENT_FILE]),
         canAssist,
         canCode,
         // What is worth saying here, derived from what this game can do.
@@ -588,7 +616,10 @@ export async function registerRemixRoutes(app: FastifyInstance, options: RemixRo
       // alone: `applyAssistPatches` validates the whole document, and a game
       // that declares maps would otherwise fail that validation on every
       // request — dropping perfectly good tuning patches into the code lane.
-      const content = { ...defaultCollections(session.definition), [PARAMS_KEY]: body.data.params ?? {} };
+      const content = {
+        ...defaultCollections(session.definition, session.sources[EDITOR_CONTENT_FILE]),
+        [PARAMS_KEY]: body.data.params ?? {},
+      };
       try {
         const result = await options.assistant.assist({
           definition: session.definition,
@@ -1081,7 +1112,7 @@ export async function registerRemixRoutes(app: FastifyInstance, options: RemixRo
       const { patches } = applyAssistPatches(
         session.definition!,
         {
-          ...defaultCollections(session.definition),
+          ...defaultCollections(session.definition, session.sources[EDITOR_CONTENT_FILE]),
           [PARAMS_KEY]: Object.fromEntries(Object.entries(specs).map(([key, spec]) => [key, spec.default])),
         },
         Object.entries(values).map(([key, value]) => ({ key, value })),

--- a/apps/web/src/CodeSurface.tsx
+++ b/apps/web/src/CodeSurface.tsx
@@ -711,9 +711,8 @@ export function CodeSurface({
       const base = liveContentRef.current ?? fetched;
       if (!base) return;
       const prevParams = base.params;
-      const params: Record<string, EditorParamValue> = {
-        ...(prevParams && !Array.isArray(prevParams) ? prevParams : {}),
-      };
+       const params: Record<string, EditorParamValue> =
+         prevParams && !Array.isArray(prevParams) ? { ...(prevParams as Record<string, EditorParamValue>) } : {};
       for (const change of changes) params[change.key] = change.value as EditorParamValue;
       const merged: EditorContentDoc = { ...base, params };
       liveContentRef.current = merged;

--- a/apps/web/src/EditorCollections.test.tsx
+++ b/apps/web/src/EditorCollections.test.tsx
@@ -6,6 +6,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import i18n from './i18n/index.js';
 import type {
   EditorCollectionSpec,
+  EditorContentDoc,
   EditorConstraint,
   EditorDefinition,
   EditorItemContent,
@@ -67,6 +68,61 @@ const definition: EditorDefinition = {
 };
 
 const content = { maps: [mapItem], routes: [routeItem] };
+
+const layeredDefinition: EditorDefinition = {
+  version: 2,
+  content: {},
+  layers: {
+    terrain: {
+      widget: 'tilemap',
+      label: { en: 'Terrain', pl: 'Teren' },
+      grid: { minCols: 3, maxCols: 3, minRows: 3, maxRows: 3 },
+      tiles: [
+        { key: 'floor', char: '.', label: { en: 'Floor', pl: 'Podłoga' } },
+        { key: 'start', char: '@', label: { en: 'Start', pl: 'Start' } },
+        { key: 'goal', char: '*', label: { en: 'Goal', pl: 'Meta' } },
+      ],
+      properties: {},
+      constraints: [],
+    },
+    objects: {
+      widget: 'tilemap',
+      label: { en: 'Objects', pl: 'Obiekty' },
+      grid: { minCols: 3, maxCols: 3, minRows: 3, maxRows: 3 },
+      tiles: [
+        { key: 'empty', char: '.', label: { en: 'Empty', pl: 'Puste' } },
+        { key: 'wall', char: '#', label: { en: 'Wall', pl: 'Ściana' } },
+      ],
+      properties: {},
+      constraints: [],
+    },
+    triggers: {
+      widget: 'entities',
+      label: { en: 'Triggers', pl: 'Wyzwalacze' },
+      min: 0,
+      max: 2,
+      properties: { kind: { type: 'text', max: 20 } },
+      constraints: [],
+    },
+  },
+  constraints: [
+    {
+      reachable: {
+        from: { layer: 'terrain', tile: 'start' },
+        blockedBy: [{ layer: 'objects', tile: 'wall' }],
+        require: [{ layer: 'terrain', tile: 'goal' }],
+      },
+    },
+  ],
+};
+
+const layeredContent: EditorContentDoc = {
+  layers: {
+    terrain: { properties: {}, rows: ['...', '.@*', '...'] },
+    objects: { properties: {}, rows: ['...', '...', '...'] },
+    triggers: [{ properties: { kind: 'exit' } }],
+  },
+};
 
 const game: StudioGame = {
   token: 'game-token',
@@ -164,6 +220,50 @@ describe('multi-collection editor surfaces', () => {
       root!.render(<RemixPainter content={single} doc={{ maps: [mapItem] }} onChange={vi.fn()} />);
     });
     expect(container.querySelector('.editor-collection-selector')).toBeNull();
+  });
+});
+
+describe('layered editor surfaces', () => {
+  it('renders a stacked Studio board with a declaration-driven layer rail', async () => {
+    fetchGameEditor.mockResolvedValue(editorState({ definition: layeredDefinition, content: layeredContent }));
+    await renderEditor();
+
+    expect(container.querySelectorAll('.editor-layer-board')).toHaveLength(2);
+    expect(container.querySelectorAll('.editor-layer-picker-item')).toHaveLength(3);
+    expect(container.querySelector('.editor-layer-picker-item.is-active')?.textContent).toContain('Terrain');
+    expect(container.querySelector<HTMLButtonElement>('.studio-head-action.is-primary')?.disabled).toBe(false);
+
+    const objects = Array.from(container.querySelectorAll('.editor-layer-picker-item')).find((button) =>
+      button.textContent?.includes('Objects'),
+    ) as HTMLButtonElement;
+    await act(async () => objects.click());
+    expect(container.querySelector('.editor-layer-picker-item.is-active')?.textContent).toContain('Objects');
+    expect(putEditorDraft).not.toHaveBeenCalled();
+  });
+
+  it('renders Remix layers stacked and keeps lower layers read-only', async () => {
+    const onChange = vi.fn();
+    root = createRoot(container);
+    await act(async () => {
+      root!.render(
+        <RemixPainter
+          layers={layeredDefinition.layers}
+          constraints={layeredDefinition.constraints}
+          doc={layeredContent}
+          onChange={onChange}
+        />,
+      );
+    });
+
+    expect(container.querySelectorAll('.editor-layer-board')).toHaveLength(2);
+    expect(container.querySelector('.editor-layer-picker-item.is-active')?.textContent).toContain('Triggers');
+    const terrain = Array.from(container.querySelectorAll('.editor-layer-picker-item')).find((button) =>
+      button.textContent?.includes('Terrain'),
+    ) as HTMLButtonElement;
+    await act(async () => terrain.click());
+    expect(container.textContent).toContain('Only the top layer can be edited');
+    expect(container.querySelector<HTMLButtonElement>('.editor-layer-board.is-active button')?.disabled).toBe(true);
+    expect(onChange).not.toHaveBeenCalled();
   });
 });
 
@@ -333,7 +433,10 @@ describe('the entities widget', () => {
 describe('the path widget', () => {
   const pathItem: EditorItemContent = {
     properties: { name: 'Starter' },
-    points: [{ x: 0, y: 1 }, { x: 1, y: 1 }],
+    points: [
+      { x: 0, y: 1 },
+      { x: 1, y: 1 },
+    ],
   };
   const pathDefinition: EditorDefinition = {
     version: 1,
@@ -359,9 +462,7 @@ describe('the path widget', () => {
   };
 
   it('edits a Studio path with the required keyboard controls', async () => {
-    fetchGameEditor.mockResolvedValue(
-      editorState({ definition: pathDefinition, content: { routes: [pathItem] } }),
-    );
+    fetchGameEditor.mockResolvedValue(editorState({ definition: pathDefinition, content: { routes: [pathItem] } }));
     const push = vi.fn();
     const editorPushRef = { current: push as EditorContentPush };
     root = createRoot(container);
@@ -378,12 +479,19 @@ describe('the path widget', () => {
       painter!.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }));
       painter!.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
     });
-    expect(push.mock.lastCall?.[0].routes[0].points).toEqual([{ x: 0, y: 1 }, { x: 1, y: 1 }, { x: 2, y: 1 }]);
+    expect(push.mock.lastCall?.[0].routes[0].points).toEqual([
+      { x: 0, y: 1 },
+      { x: 1, y: 1 },
+      { x: 2, y: 1 },
+    ]);
 
     act(() => {
       painter!.dispatchEvent(new KeyboardEvent('keydown', { key: 'Delete', bubbles: true }));
     });
-    expect(push.mock.lastCall?.[0].routes[0].points).toEqual([{ x: 0, y: 1 }, { x: 1, y: 1 }]);
+    expect(push.mock.lastCall?.[0].routes[0].points).toEqual([
+      { x: 0, y: 1 },
+      { x: 1, y: 1 },
+    ]);
   });
 
   it('lets Remix append by click and drag an existing point', async () => {
@@ -394,22 +502,42 @@ describe('the path widget', () => {
     });
     let painter = container.querySelector<SVGSVGElement>('.editor-path')!;
     vi.spyOn(painter, 'getBoundingClientRect').mockReturnValue({
-      x: 0, y: 0, left: 0, top: 0, right: 400, bottom: 300, width: 400, height: 300, toJSON: () => ({}),
+      x: 0,
+      y: 0,
+      left: 0,
+      top: 0,
+      right: 400,
+      bottom: 300,
+      width: 400,
+      height: 300,
+      toJSON: () => ({}),
     });
     act(() => painter.dispatchEvent(new MouseEvent('click', { bubbles: true, clientX: 250, clientY: 150 })));
     const appended = onChange.mock.lastCall?.[0] as { routes: EditorItemContent[] };
-    expect(appended.routes[0]).toMatchObject({ points: [{ x: 0, y: 1 }, { x: 1, y: 1 }, { x: 2, y: 1 }] });
+    expect(appended.routes[0]).toMatchObject({
+      points: [
+        { x: 0, y: 1 },
+        { x: 1, y: 1 },
+        { x: 2, y: 1 },
+      ],
+    });
 
     await act(async () => {
       root!.render(<RemixPainter content={pathDefinition.content} doc={appended} onChange={onChange} />);
     });
     painter = container.querySelector<SVGSVGElement>('.editor-path')!;
     vi.spyOn(painter, 'getBoundingClientRect').mockReturnValue({
-      x: 0, y: 0, left: 0, top: 0, right: 400, bottom: 300, width: 400, height: 300, toJSON: () => ({}),
+      x: 0,
+      y: 0,
+      left: 0,
+      top: 0,
+      right: 400,
+      bottom: 300,
+      width: 400,
+      height: 300,
+      toJSON: () => ({}),
     });
-    const firstHit = container.querySelector<SVGCircleElement>(
-      '[data-point-index="0"] .editor-path-point-hit',
-    )!;
+    const firstHit = container.querySelector<SVGCircleElement>('[data-point-index="0"] .editor-path-point-hit')!;
     act(() => {
       firstHit.dispatchEvent(new MouseEvent('pointerdown', { bubbles: true, clientX: 50, clientY: 150 }));
       painter.dispatchEvent(new MouseEvent('pointermove', { bubbles: true, clientX: 350, clientY: 250 }));
@@ -448,7 +576,9 @@ describe('the path widget', () => {
     };
     root = createRoot(container);
     await act(async () => {
-      root!.render(<RemixPainter content={extremeDefinition.content} doc={{ routes: [pathItem] }} onChange={vi.fn()} />);
+      root!.render(
+        <RemixPainter content={extremeDefinition.content} doc={{ routes: [pathItem] }} onChange={vi.fn()} />,
+      );
     });
 
     const viewport = container.querySelector('.editor-path-viewport');

--- a/apps/web/src/EditorPanel.tsx
+++ b/apps/web/src/EditorPanel.tsx
@@ -6,11 +6,16 @@ import {
   blankItem,
   collectionProblems,
   defaultCollectionKey,
+  defaultLayerKey,
+  defaultLayerTileKey,
   isPathItem,
   isTilemapItem,
   itemProblems,
+  layerProblems,
+  layeredProblems,
   setCell,
 } from './editorContentTools.js';
+import { LayeredBoard, LayeredSidebar } from './LayeredEditorSurface.js';
 import { recordAssistStep, recordEditorStep } from './visitTelemetry.js';
 import type { EditorContentPush, EditorSelection } from './editorBridge.js';
 import {
@@ -21,11 +26,13 @@ import {
   requestEditorAssist,
   type EditorCollectionSpec,
   type EditorContentDoc,
+  type EditorLayersDoc,
   type EditorItemContent,
   type EditorLabel,
   type EditorParamValue,
   type EditorPathSpec,
   type EditorTilemapSpec,
+  type EditorLayerSpec,
   type GameEditorState,
   type StudioApiError,
   type StudioGame,
@@ -153,6 +160,9 @@ export function EditorPanel(props: {
   const [selectedCollectionKey, setSelectedCollectionKey] = useState<string | null>(null);
   const [itemIndex, setItemIndex] = useState(0);
   const [tileKey, setTileKey] = useState<string | null>(null);
+  const [selectedLayerKey, setSelectedLayerKey] = useState<string | null>(null);
+  const [layerEntityIndex, setLayerEntityIndex] = useState(0);
+  const [layerTileKey, setLayerTileKey] = useState<string | null>(null);
   const [utterance, setUtterance] = useState('');
   const [assist, setAssist] = useState<AssistState>({ kind: 'idle' });
 
@@ -162,6 +172,14 @@ export function EditorPanel(props: {
   const spec = collectionKey ? editor!.definition.content[collectionKey] : null;
   const items = collectionKey ? ((content[collectionKey] ?? []) as EditorItemContent[]) : [];
   const item = items[itemIndex] ?? null;
+  const layerKeys = editor ? Object.keys(editor.definition.layers ?? {}) : [];
+  const layerKey =
+    editor && selectedLayerKey && editor.definition.layers?.[selectedLayerKey]
+      ? selectedLayerKey
+      : defaultLayerKey(editor?.definition.layers ?? {});
+  const layerSpec: EditorLayerSpec | null =
+    layerKey && editor?.definition.layers ? editor.definition.layers[layerKey] : null;
+  const layersContent = (content.layers ?? {}) as EditorLayersDoc;
   const paramSpecs = editor?.definition.params ?? null;
   const paramValues = (content.params ?? {}) as Record<string, EditorParamValue>;
 
@@ -177,12 +195,23 @@ export function EditorPanel(props: {
         const merged = mergeDraft(loaded);
         setContent(merged);
         const defaultKey = defaultCollectionKey(loaded.definition.content);
-        pushLive(merged, defaultKey ? { collection: defaultKey, index: 0 } : undefined);
+        const defaultLayer = defaultLayerKey(loaded.definition.layers ?? {});
+        pushLive(
+          merged,
+          defaultKey
+            ? { collection: defaultKey, index: 0 }
+            : defaultLayer
+              ? { collection: defaultLayer, index: 0 }
+              : undefined,
+        );
         setRevision(loaded.draft?.revision ?? 0);
         setSaveState('clean');
         setSelectedCollectionKey(defaultKey);
         setItemIndex(0);
         setTileKey(defaultKey ? firstTileKey(loaded.definition.content[defaultKey]) : null);
+        setSelectedLayerKey(defaultLayer);
+        setLayerEntityIndex(0);
+        setLayerTileKey(defaultLayer ? defaultLayerTileKey(loaded.definition.layers ?? {}, defaultLayer) : null);
         setState('ready');
       })
       .catch(() => {
@@ -261,6 +290,15 @@ export function EditorPanel(props: {
       list[itemIndex] = next;
       const nextContent = { ...current, [collectionKey]: list };
       pushLive(nextContent, { collection: collectionKey, index: itemIndex });
+      return nextContent;
+    });
+    scheduleSave();
+  }
+
+  function updateLayers(nextLayers: EditorLayersDoc) {
+    setContent((current) => {
+      const nextContent = { ...current, layers: nextLayers };
+      pushLive(nextContent, layerKey ? { collection: layerKey, index: 0 } : undefined);
       return nextContent;
     });
     scheduleSave();
@@ -355,11 +393,22 @@ export function EditorPanel(props: {
       const merged = mergeDraft(loaded);
       setContent(merged);
       const defaultKey = defaultCollectionKey(loaded.definition.content);
-      pushLive(merged, defaultKey ? { collection: defaultKey, index: 0 } : undefined);
+      const defaultLayer = defaultLayerKey(loaded.definition.layers ?? {});
+      pushLive(
+        merged,
+        defaultKey
+          ? { collection: defaultKey, index: 0 }
+          : defaultLayer
+            ? { collection: defaultLayer, index: 0 }
+            : undefined,
+      );
       setRevision(loaded.draft?.revision ?? 0);
       setSelectedCollectionKey(defaultKey);
       setItemIndex(0);
       setTileKey(defaultKey ? firstTileKey(loaded.definition.content[defaultKey]) : null);
+      setSelectedLayerKey(defaultLayer);
+      setLayerEntityIndex(0);
+      setLayerTileKey(defaultLayer ? defaultLayerTileKey(loaded.definition.layers ?? {}, defaultLayer) : null);
       setSaveState('clean');
     } catch {
       if (mountedRef.current) setSaveState('error');
@@ -375,6 +424,14 @@ export function EditorPanel(props: {
     pushLive(content, { collection: nextKey, index: 0 });
   }
 
+  function selectLayer(nextKey: string) {
+    if (!editor?.definition.layers?.[nextKey]) return;
+    setSelectedLayerKey(nextKey);
+    setLayerEntityIndex(0);
+    setLayerTileKey(defaultLayerTileKey(editor.definition.layers, nextKey));
+    pushLive(content, { collection: nextKey, index: 0 });
+  }
+
   async function discardDraft() {
     try {
       await deleteEditorDraft(slug);
@@ -382,9 +439,21 @@ export function EditorPanel(props: {
       if (editor) {
         setContent(editor.content);
         const defaultKey = defaultCollectionKey(editor.definition.content);
-        pushLive(editor.content, defaultKey ? { collection: defaultKey, index: 0 } : undefined);
+        const defaultLayer = defaultLayerKey(editor.definition.layers ?? {});
+        pushLive(
+          editor.content,
+          defaultKey
+            ? { collection: defaultKey, index: 0 }
+            : defaultLayer
+              ? { collection: defaultLayer, index: 0 }
+              : undefined,
+        );
         setRevision(0);
+        setSelectedCollectionKey(defaultKey);
         setItemIndex(0);
+        setSelectedLayerKey(defaultLayer);
+        setLayerEntityIndex(0);
+        setLayerTileKey(defaultLayer ? defaultLayerTileKey(editor.definition.layers ?? {}, defaultLayer) : null);
         setSaveState('clean');
       }
     } catch {
@@ -423,7 +492,7 @@ export function EditorPanel(props: {
   }
   // A definition may declare only tunables (no collections) — that renders as a
   // Tuning-only panel, not an error. Nothing at all to edit is the error case.
-  if (state === 'error' || !editor || (!spec && !paramSpecs)) {
+  if (state === 'error' || !editor || (!spec && !layerSpec && !paramSpecs)) {
     return (
       <div className="editor-panel editor-panel-note">
         {t('studioPanel.editor.loadError')}
@@ -436,17 +505,32 @@ export function EditorPanel(props: {
 
   const problems = item && spec ? itemProblems(spec.item, item, name, pathMessages) : [];
   const collectionWideProblems = spec ? collectionProblems(spec, items) : [];
+  const activeLayerProblems =
+    layerSpec && layerKey ? layerProblems(layerSpec, layersContent[layerKey], name, pathMessages) : [];
+  const layeredWideProblems = editor?.definition.layers
+    ? layeredProblems(editor.definition.layers, editor.definition.constraints, layersContent)
+    : [];
   const allProblems = editor
-    ? collectionKeys.flatMap((key) => {
-        const collection = editor.definition.content[key];
-        const collectionItems = itemsOf(content, key);
-        const perItem = collectionItems.flatMap((entry, index) => {
-          const found = itemProblems(collection.item, entry, name, pathMessages);
-          return found.length > 0 ? [`${name(collection.itemLabel)} ${index + 1}`] : [];
-        });
-        const collectionWide = collectionProblems(collection, collectionItems);
-        return collectionWide.length > 0 ? [...perItem, name(collection.itemLabel)] : perItem;
-      })
+    ? [
+        ...collectionKeys.flatMap((key) => {
+          const collection = editor.definition.content[key];
+          const collectionItems = itemsOf(content, key);
+          const perItem = collectionItems.flatMap((entry, index) => {
+            const found = itemProblems(collection.item, entry, name, pathMessages);
+            return found.length > 0 ? [`${name(collection.itemLabel)} ${index + 1}`] : [];
+          });
+          const collectionWide = collectionProblems(collection, collectionItems);
+          return collectionWide.length > 0 ? [...perItem, name(collection.itemLabel)] : perItem;
+        }),
+        ...layerKeys.flatMap((key) => {
+          const declaredLayer = editor.definition.layers?.[key];
+          if (!declaredLayer) return [];
+          return layerProblems(declaredLayer, layersContent[key], name, pathMessages).length > 0
+            ? [name(declaredLayer.label)]
+            : [];
+        }),
+        ...(layeredWideProblems.length > 0 ? ['Layers'] : []),
+      ]
     : [];
   const tilemapItem = item && isTilemapItem(item) ? item : null;
   const pathItem = item && isPathItem(item) ? item : null;
@@ -533,7 +617,18 @@ export function EditorPanel(props: {
       ) : null}
 
       <div className="editor-body">
-        {boardSpec || pathSpec ? (
+        {layerSpec && layerKey && editor.definition.layers ? (
+          <LayeredBoard
+            layers={editor.definition.layers}
+            content={layersContent}
+            activeLayerKey={layerKey}
+            name={name}
+            tileKey={layerTileKey}
+            onTileKeyChange={setLayerTileKey}
+            onLayerChange={selectLayer}
+            onChange={updateLayers}
+          />
+        ) : boardSpec || pathSpec ? (
           <div className="editor-board-col">
             {boardSpec && tilemapItem ? (
               <>
@@ -717,6 +812,19 @@ export function EditorPanel(props: {
             </div>
           ) : null}
 
+          {layerSpec && editor.definition.layers ? (
+            <LayeredSidebar
+              layers={editor.definition.layers}
+              content={layersContent}
+              activeLayerKey={layerKey}
+              name={name}
+              entityIndex={layerEntityIndex}
+              onEntityIndexChange={setLayerEntityIndex}
+              onLayerChange={selectLayer}
+              onChange={updateLayers}
+            />
+          ) : null}
+
           {spec && collectionKey ? (
             <div className="editor-side-group">
               {collectionKeys.length > 1 ? (
@@ -897,10 +1005,17 @@ export function EditorPanel(props: {
 
           <div className="editor-side-group">
             <h4>{t('studioPanel.editor.checks')}</h4>
-            {problems.length === 0 && collectionWideProblems.length === 0 ? (
+            {(
+              layerSpec
+                ? activeLayerProblems.length === 0 && layeredWideProblems.length === 0
+                : problems.length === 0 && collectionWideProblems.length === 0
+            ) ? (
               <p className="editor-check is-ok">✓ {t('studioPanel.editor.checksOk')}</p>
             ) : (
-              [...problems, ...collectionWideProblems].map((problem) => (
+              (layerSpec
+                ? [...activeLayerProblems, ...layeredWideProblems]
+                : [...problems, ...collectionWideProblems]
+              ).map((problem) => (
                 <p key={problem} className="editor-check is-bad">
                   ✕ {problem}
                 </p>

--- a/apps/web/src/LayeredEditorSurface.tsx
+++ b/apps/web/src/LayeredEditorSurface.tsx
@@ -1,0 +1,372 @@
+import type {
+  EditorEntityItemContent,
+  EditorLayerSpec,
+  EditorLayersDoc,
+  EditorLabel,
+  EditorPropertySpec,
+  EditorTilemapItemContent,
+} from './studioApi.js';
+import { blankLayerEntity } from './editorContentTools.js';
+
+type LayeredBaseProps = {
+  layers: Record<string, EditorLayerSpec>;
+  content: EditorLayersDoc;
+  activeLayerKey: string | null;
+  editableLayerKey?: string | null;
+  name: (label: EditorLabel) => string;
+  onLayerChange: (key: string) => void;
+  onChange: (next: EditorLayersDoc) => void;
+  readOnlyLabel?: string;
+};
+
+type LayeredBoardProps = LayeredBaseProps & {
+  tileKey: string | null;
+  onTileKeyChange: (key: string) => void;
+};
+
+type LayeredSidebarProps = LayeredBaseProps & {
+  entityIndex: number;
+  onEntityIndexChange: (index: number) => void;
+};
+
+function tilemapContent(value: unknown): value is EditorTilemapItemContent {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    !Array.isArray(value) &&
+    'properties' in value &&
+    'rows' in value &&
+    Array.isArray(value.rows) &&
+    value.rows.every((row) => typeof row === 'string')
+  );
+}
+
+function entityContent(value: unknown): value is EditorEntityItemContent[] {
+  return (
+    Array.isArray(value) &&
+    value.every(
+      (item) =>
+        typeof item === 'object' &&
+        item !== null &&
+        !Array.isArray(item) &&
+        'properties' in item &&
+        typeof item.properties === 'object' &&
+        item.properties !== null,
+    )
+  );
+}
+
+function canEdit(activeLayerKey: string | null, editableLayerKey: string | null | undefined): boolean {
+  return Boolean(activeLayerKey && (editableLayerKey === undefined || editableLayerKey === activeLayerKey));
+}
+
+function updateProperties(
+  content: EditorLayersDoc,
+  key: string,
+  properties: Record<string, unknown>,
+  onChange: (next: EditorLayersDoc) => void,
+) {
+  const current = content[key];
+  if (!current || typeof current !== 'object' || Array.isArray(current)) return;
+  onChange({ ...content, [key]: { ...current, properties } } as EditorLayersDoc);
+}
+
+function propertyFields(
+  properties: Record<string, EditorPropertySpec>,
+  values: Record<string, unknown>,
+  onChange: (name: string, value: unknown) => void,
+) {
+  return Object.entries(properties).map(([propertyName, propertySpec]) => {
+    const value = values[propertyName];
+    if (propertySpec.type === 'text') {
+      return (
+        <label key={propertyName} className="editor-prop">
+          <span>{propertyName}</span>
+          <input
+            type="text"
+            maxLength={propertySpec.max}
+            value={typeof value === 'string' ? value : ''}
+            onChange={(event) => onChange(propertyName, event.target.value)}
+          />
+        </label>
+      );
+    }
+    if (propertySpec.type === 'int' || propertySpec.type === 'number') {
+      return (
+        <label key={propertyName} className="editor-prop">
+          <span>
+            {propertyName}{' '}
+            <em>
+              {propertySpec.min}–{propertySpec.max}
+            </em>
+          </span>
+          <input
+            type="number"
+            min={propertySpec.min}
+            max={propertySpec.max}
+            step={propertySpec.type === 'int' ? 1 : 'any'}
+            value={typeof value === 'number' ? value : propertySpec.min}
+            onChange={(event) => {
+              const parsed = Number(event.target.value);
+              if (Number.isFinite(parsed))
+                onChange(propertyName, propertySpec.type === 'int' ? Math.round(parsed) : parsed);
+            }}
+          />
+        </label>
+      );
+    }
+    if (propertySpec.type === 'enum') {
+      return (
+        <label key={propertyName} className="editor-prop">
+          <span>{propertyName}</span>
+          <select
+            value={typeof value === 'string' ? value : propertySpec.values[0]}
+            onChange={(event) => onChange(propertyName, event.target.value)}
+          >
+            {propertySpec.values.map((option) => (
+              <option key={option} value={option}>
+                {option}
+              </option>
+            ))}
+          </select>
+        </label>
+      );
+    }
+    return (
+      <label key={propertyName} className="editor-prop">
+        <span>{propertyName}</span>
+        <input
+          type="checkbox"
+          checked={value === true}
+          onChange={(event) => onChange(propertyName, event.target.checked)}
+        />
+      </label>
+    );
+  });
+}
+
+export function LayeredBoard({
+  layers,
+  content,
+  activeLayerKey,
+  editableLayerKey,
+  name,
+  onChange,
+  tileKey,
+  onTileKeyChange,
+  readOnlyLabel = 'Layer is read-only',
+}: LayeredBoardProps) {
+  const tilemapLayers = Object.entries(layers).filter(([, spec]) => spec.widget === 'tilemap');
+  const editable = canEdit(activeLayerKey, editableLayerKey);
+  const activeSpec = activeLayerKey ? layers[activeLayerKey] : undefined;
+  const activeValue = activeLayerKey ? content[activeLayerKey] : undefined;
+  const activeTilemap = activeSpec?.widget === 'tilemap' && tilemapContent(activeValue) ? activeValue : null;
+
+  return (
+    <div className="editor-layered-board-col">
+      {tilemapLayers.length > 0 ? (
+        <div className="editor-layer-stack" aria-label="Layered board">
+          {tilemapLayers.map(([key, spec]) => {
+            const value = content[key];
+            if (spec.widget !== 'tilemap' || !tilemapContent(value)) return null;
+            const isActive = key === activeLayerKey;
+            const layerEditable = isActive && editable;
+            const layerWidth = value.rows[0]?.length ?? 0;
+            return (
+              <div
+                key={key}
+                className={`editor-layer-board${isActive ? ' is-active' : ''}${isActive ? '' : ' is-muted'}`}
+                data-layer-key={key}
+                aria-hidden={isActive ? undefined : true}
+              >
+                <div
+                  className="editor-board"
+                  role="grid"
+                  aria-label={name(spec.label)}
+                  style={{ gridTemplateColumns: `repeat(${layerWidth}, var(--editor-cell))` }}
+                >
+                  {value.rows.map((rowChars, row) =>
+                    Array.from(rowChars).map((char, col) => {
+                      const tile = spec.tiles.find((entry) => entry.char === char);
+                      return (
+                        <button
+                          key={`${key}-${row}-${col}`}
+                          type="button"
+                          role="gridcell"
+                          tabIndex={layerEditable ? 0 : -1}
+                          disabled={!layerEditable}
+                          className={`editor-cell${tile?.color ? '' : ` tile-${tile?.key ?? 'unknown'}`}`}
+                          {...(tile?.color ? { style: { background: tile.color } } : {})}
+                          aria-label={`${row + 1},${col + 1}: ${tile ? name(tile.label) : char}`}
+                          onClick={() => {
+                            const selected = spec.tiles.find((entry) => entry.key === tileKey);
+                            if (!selected || !layerEditable) return;
+                            const rows = value.rows.slice();
+                            rows[row] = rows[row].slice(0, col) + selected.char + rows[row].slice(col + 1);
+                            onChange({ ...content, [key]: { ...value, rows } });
+                          }}
+                        />
+                      );
+                    }),
+                  )}
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      ) : (
+        <div className="editor-panel-note">No tilemap layers</div>
+      )}
+
+      {activeSpec?.widget === 'tilemap' ? (
+        <div className="editor-palette" role="radiogroup" aria-label={name(activeSpec.label)}>
+          {activeSpec.tiles.map((tile) => (
+            <button
+              key={tile.key}
+              type="button"
+              role="radio"
+              aria-checked={tileKey === tile.key}
+              disabled={!editable}
+              className={`editor-tile${tileKey === tile.key ? ' is-selected' : ''}`}
+              onClick={() => onTileKeyChange(tile.key)}
+            >
+              <span
+                className={`editor-tile-swatch${tile.color ? '' : ` tile-${tile.key}`}`}
+                {...(tile.color ? { style: { background: tile.color } } : {})}
+                aria-hidden="true"
+              />
+              {name(tile.label)}
+            </button>
+          ))}
+        </div>
+      ) : null}
+
+      {activeSpec?.widget === 'entities' && !activeTilemap ? (
+        <div className="editor-panel-note">{name(activeSpec.label)}</div>
+      ) : null}
+
+      {activeLayerKey && activeSpec && !editable ? <p className="editor-layer-readonly">{readOnlyLabel}</p> : null}
+    </div>
+  );
+}
+
+export function LayeredSidebar({
+  layers,
+  content,
+  activeLayerKey,
+  editableLayerKey,
+  name,
+  onLayerChange,
+  onChange,
+  entityIndex,
+  onEntityIndexChange,
+  readOnlyLabel = 'Layer is read-only',
+}: LayeredSidebarProps) {
+  const activeSpec = activeLayerKey ? layers[activeLayerKey] : undefined;
+  const activeValue = activeLayerKey ? content[activeLayerKey] : undefined;
+  const editable = canEdit(activeLayerKey, editableLayerKey);
+  const entities = activeSpec?.widget === 'entities' && entityContent(activeValue) ? activeValue : [];
+  const activeEntityIndex = Math.min(entityIndex, Math.max(0, entities.length - 1));
+  const activeEntity = entities[activeEntityIndex];
+
+  function updateEntity(next: EditorEntityItemContent) {
+    if (!activeLayerKey || !editable || !activeEntity) return;
+    const nextEntities = entities.slice();
+    nextEntities[activeEntityIndex] = next;
+    onChange({ ...content, [activeLayerKey]: nextEntities });
+  }
+
+  return (
+    <div className="editor-layer-sidebar">
+      <div className="editor-side-group">
+        <h4>Layers</h4>
+        <div className="editor-layer-picker" role="listbox" aria-label="Layers">
+          {Object.entries(layers).map(([key, spec]) => (
+            <button
+              key={key}
+              type="button"
+              role="option"
+              aria-selected={key === activeLayerKey}
+              className={`editor-layer-picker-item${key === activeLayerKey ? ' is-active' : ''}`}
+              onClick={() => onLayerChange(key)}
+            >
+              <span>{name(spec.label)}</span>
+              <small>{spec.widget}</small>
+            </button>
+          ))}
+        </div>
+        {activeLayerKey && !editable ? <p className="editor-layer-readonly">{readOnlyLabel}</p> : null}
+      </div>
+
+      {activeSpec?.widget === 'entities' ? (
+        <div className="editor-side-group">
+          <h4>
+            {name(activeSpec.label)}{' '}
+            <span className="editor-count">
+              {entities.length} / {activeSpec.max}
+            </span>
+          </h4>
+          <ul className="editor-item-list">
+            {entities.map((_, index) => (
+              <li key={index}>
+                <button
+                  type="button"
+                  className={index === activeEntityIndex ? 'is-active' : ''}
+                  onClick={() => onEntityIndexChange(index)}
+                >
+                  {`${name(activeSpec.label)} ${index + 1}`}
+                </button>
+                {editable && entities.length > activeSpec.min ? (
+                  <button
+                    type="button"
+                    className="editor-item-remove"
+                    aria-label="Remove item"
+                    onClick={() => {
+                      onChange({ ...content, [activeLayerKey!]: entities.filter((_, item) => item !== index) });
+                      onEntityIndexChange(Math.max(0, Math.min(activeEntityIndex, entities.length - 2)));
+                    }}
+                  >
+                    ×
+                  </button>
+                ) : null}
+              </li>
+            ))}
+          </ul>
+          {editable && entities.length < activeSpec.max ? (
+            <button
+              type="button"
+              className="editor-add"
+              onClick={() => {
+                onChange({ ...content, [activeLayerKey!]: [...entities, blankLayerEntity(activeSpec)] });
+                onEntityIndexChange(entities.length);
+              }}
+            >
+              ＋ Add {name(activeSpec.label)}
+            </button>
+          ) : null}
+        </div>
+      ) : null}
+
+      {activeSpec?.widget === 'tilemap' && tilemapContent(activeValue) ? (
+        <div className="editor-side-group">
+          <h4>Properties</h4>
+          {propertyFields(activeSpec.properties, activeValue.properties, (propertyName, value) => {
+            if (editable && activeLayerKey) {
+              updateProperties(content, activeLayerKey, { ...activeValue.properties, [propertyName]: value }, onChange);
+            }
+          })}
+        </div>
+      ) : null}
+
+      {activeSpec?.widget === 'entities' && activeEntity ? (
+        <div className="editor-side-group">
+          <h4>Properties</h4>
+          {propertyFields(activeSpec.properties, activeEntity.properties, (propertyName, value) => {
+            if (editable)
+              updateEntity({ ...activeEntity, properties: { ...activeEntity.properties, [propertyName]: value } });
+          })}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/src/RemixPainter.tsx
+++ b/apps/web/src/RemixPainter.tsx
@@ -1,18 +1,25 @@
 import { useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { PathPainter } from './PathPainter.js';
+import { LayeredBoard, LayeredSidebar } from './LayeredEditorSurface.js';
 import {
   blankItem,
   collectionProblems,
   defaultCollectionKey,
+  defaultLayerTileKey,
   isPathItem,
   isTilemapItem,
   itemProblems,
+  layerProblems,
+  layeredProblems,
   setCell,
 } from './editorContentTools.js';
 import type {
   EditorCollectionSpec,
   EditorContentDoc,
+  EditorLayerConstraint,
+  EditorLayerSpec,
+  EditorLayersDoc,
   EditorItemContent,
   EditorLabel,
   EditorPathSpec,
@@ -49,14 +56,20 @@ function firstTileKey(spec: EditorCollectionSpec | null | undefined): string | n
  * reaches the server, which makes the live check the *only* check they see.
  */
 
-export function RemixPainter(props: {
-  content: Record<string, EditorCollectionSpec>;
+type RemixPainterProps = {
+  content?: Record<string, EditorCollectionSpec>;
+  layers?: Record<string, EditorLayerSpec> | null;
+  constraints?: EditorLayerConstraint[] | null;
   doc: EditorContentDoc;
   onChange: (next: EditorContentDoc) => void;
   selectedCollectionKey?: string | null;
   onCollectionChange?: (key: string) => void;
+  selectedLayerKey?: string | null;
+  onLayerChange?: (key: string) => void;
   onSelectionChange?: (selection: EditorSelection) => void;
-}) {
+};
+
+function CollectionRemixPainter(props: RemixPainterProps & { content: Record<string, EditorCollectionSpec> }) {
   const { t, i18n } = useTranslation();
   const name = (label: EditorLabel) => (i18n.language?.startsWith('pl') ? label.pl : label.en);
   const pathMessages = {
@@ -342,4 +355,88 @@ export function RemixPainter(props: {
       ) : null}
     </div>
   );
+}
+
+function LayeredRemixPainter(props: RemixPainterProps & { layers: Record<string, EditorLayerSpec> }) {
+  const { t, i18n } = useTranslation();
+  const name = (label: EditorLabel) => (i18n.language?.startsWith('pl') ? label.pl : label.en);
+  const layerKeys = Object.keys(props.layers);
+  const topLayerKey = layerKeys[layerKeys.length - 1] ?? null;
+  const [internalLayerKey, setInternalLayerKey] = useState<string | null>(null);
+  const requestedLayerKey = props.selectedLayerKey !== undefined ? props.selectedLayerKey : internalLayerKey;
+  const activeLayerKey = requestedLayerKey && props.layers[requestedLayerKey] ? requestedLayerKey : topLayerKey;
+  const [tileKey, setTileKey] = useState<string | null>(defaultLayerTileKey(props.layers, activeLayerKey));
+  const [entityIndex, setEntityIndex] = useState(0);
+  const layersContent = (props.doc.layers ?? {}) as EditorLayersDoc;
+
+  useEffect(() => {
+    setTileKey(defaultLayerTileKey(props.layers, activeLayerKey));
+    setEntityIndex(0);
+  }, [activeLayerKey, props.layers]);
+
+  const onSelectionChangeRef = useRef(props.onSelectionChange);
+  onSelectionChangeRef.current = props.onSelectionChange;
+  useEffect(() => {
+    if (activeLayerKey) onSelectionChangeRef.current?.({ collection: activeLayerKey, index: 0 });
+  }, [activeLayerKey]);
+
+  if (!activeLayerKey) return null;
+  const activeSpec = props.layers[activeLayerKey];
+  const updateLayers = (nextLayers: EditorLayersDoc) => props.onChange({ ...props.doc, layers: nextLayers });
+  const selectLayer = (nextKey: string) => {
+    if (!props.layers[nextKey]) return;
+    if (props.selectedLayerKey === undefined) setInternalLayerKey(nextKey);
+    props.onLayerChange?.(nextKey);
+    setEntityIndex(0);
+    setTileKey(defaultLayerTileKey(props.layers, nextKey));
+  };
+  const problems = layerProblems(activeSpec, layersContent[activeLayerKey], name);
+  const wideProblems = layeredProblems(props.layers, props.constraints ?? undefined, layersContent);
+
+  return (
+    <div className="remix-painter remix-layered-painter">
+      <div className="editor-layered-remix-grid">
+        <LayeredBoard
+          layers={props.layers}
+          content={layersContent}
+          activeLayerKey={activeLayerKey}
+          editableLayerKey={topLayerKey}
+          name={name}
+          tileKey={tileKey}
+          onTileKeyChange={setTileKey}
+          onLayerChange={selectLayer}
+          onChange={updateLayers}
+          readOnlyLabel={t('studioPanel.editor.readOnlyLayer')}
+        />
+        <LayeredSidebar
+          layers={props.layers}
+          content={layersContent}
+          activeLayerKey={activeLayerKey}
+          editableLayerKey={topLayerKey}
+          name={name}
+          entityIndex={entityIndex}
+          onEntityIndexChange={setEntityIndex}
+          onLayerChange={selectLayer}
+          onChange={updateLayers}
+          readOnlyLabel={t('studioPanel.editor.readOnlyLayer')}
+        />
+      </div>
+      {problems.length > 0 || wideProblems.length > 0 ? (
+        <div className="remix-painter-checks" role="status">
+          {[...problems, ...wideProblems].slice(0, 3).map((problem) => (
+            <p key={problem} className="editor-check is-bad">
+              ✕ {problem}
+            </p>
+          ))}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+export function RemixPainter(props: RemixPainterProps) {
+  if (props.layers && Object.keys(props.layers).length > 0)
+    return <LayeredRemixPainter {...props} layers={props.layers} />;
+  if (!props.content || Object.keys(props.content).length === 0) return null;
+  return <CollectionRemixPainter {...props} content={props.content} />;
 }

--- a/apps/web/src/RemixPanel.tsx
+++ b/apps/web/src/RemixPanel.tsx
@@ -26,7 +26,7 @@ import {
   type RemixSuggestion,
 } from './remixApi.js';
 import { RemixPainter } from './RemixPainter.js';
-import { defaultCollectionKey } from './editorContentTools.js';
+import { defaultCollectionKey, defaultLayerKey } from './editorContentTools.js';
 import { ProposeComposer } from './ProposeComposer.js';
 import { checkContributions } from './proposalsApi.js';
 import type {
@@ -330,6 +330,7 @@ export function RemixPanel(props: {
   contentDocRef.current = contentDoc;
   const [selectedCollectionKey, setSelectedCollectionKey] = useState<string | null>(null);
   const [selectedItemIndex, setSelectedItemIndex] = useState(0);
+  const [selectedLayerKey, setSelectedLayerKey] = useState<string | null>(null);
   const selectionRef = useRef<EditorSelection | null>(null);
   const [painterOpen, setPainterOpen] = useState(false);
   /** After the stage has opened once, Done leaves a door back on the sheet. */
@@ -505,16 +506,24 @@ export function RemixPanel(props: {
         // The painter's starting point is the declaration's own defaults. Set on
         // the ref synchronously as well, so a push scheduled in this same tick
         // (the shared-link one below) already carries the maps.
-        const contentDefaults: EditorContentDoc = started.content
-          ? Object.fromEntries(Object.entries(started.content).map(([key, spec]) => [key, spec.defaults]))
-          : {};
+        const contentDefaults: EditorContentDoc =
+          started.contentDefaults ??
+          (started.content
+            ? Object.fromEntries(Object.entries(started.content).map(([key, spec]) => [key, spec.defaults]))
+            : {});
         contentDocRef.current = contentDefaults;
         setContentDoc(contentDefaults);
         const defaultKey = started.content ? defaultCollectionKey(started.content) : null;
+        const defaultLayer = started.layers ? defaultLayerKey(started.layers) : null;
         setSelectedCollectionKey(defaultKey);
-        selectionRef.current = defaultKey ? { collection: defaultKey, index: 0 } : null;
+        setSelectedLayerKey(defaultLayer);
+        selectionRef.current = defaultKey
+          ? { collection: defaultKey, index: 0 }
+          : defaultLayer
+            ? { collection: defaultLayer, index: 0 }
+            : null;
         setSelectedItemIndex(0);
-        onCapabilities?.({ painter: Boolean(started.content) });
+        onCapabilities?.({ painter: Boolean(started.content || started.layers) });
         // A shared link's values are live the moment the game is listening.
         if (props.initialParams) window.setTimeout(() => pushToGame(merged), 300);
       })
@@ -537,12 +546,18 @@ export function RemixPanel(props: {
     setPainterOpen(true);
   }, []);
 
-  const painterStageActive = Boolean(painterOpen && session?.content && lane !== 'building');
+  const painterStageActive = Boolean(painterOpen && (session?.content || session?.layers) && lane !== 'building');
   const activeCollectionKey =
     session?.content && selectedCollectionKey && session.content[selectedCollectionKey]
       ? selectedCollectionKey
       : session?.content
         ? defaultCollectionKey(session.content)
+        : null;
+  const activeLayerKey =
+    session?.layers && selectedLayerKey && session.layers[selectedLayerKey]
+      ? selectedLayerKey
+      : session?.layers
+        ? defaultLayerKey(session.layers)
         : null;
 
   // Latest callback in a ref — parents may pass a fresh arrow each render; the
@@ -803,6 +818,7 @@ export function RemixPanel(props: {
     const previous = selectionRef.current;
     selectionRef.current = selection;
     setSelectedCollectionKey(selection.collection);
+    if (session?.layers?.[selection.collection]) setSelectedLayerKey(selection.collection);
     setSelectedItemIndex(selection.index);
     if (previous?.collection === selection.collection && previous?.index === selection.index) return;
     pushToGame(valuesRef.current);
@@ -1320,7 +1336,7 @@ export function RemixPanel(props: {
    * Done returns to the sheet (Keep/Share stay earned there). Edit ↔ Play only
    * moves focus; the painter tree and the game iframe both stay mounted.
    */
-  if (painterStageActive && session?.content) {
+  if (painterStageActive && (session?.content || session?.layers)) {
     const collectionKey = activeCollectionKey;
     const items = collectionKey ? ((contentDoc[collectionKey] as EditorItemContent[] | undefined) ?? []) : [];
     const selectedItem = items[selectedItemIndex] ?? items[0];
@@ -1392,11 +1408,15 @@ export function RemixPanel(props: {
               </span>
             ) : null}
             <RemixPainter
-              content={session.content}
+              content={session.content ?? undefined}
+              layers={session.layers ?? undefined}
+              constraints={session.constraints ?? undefined}
               doc={contentDoc}
               onChange={paintContent}
               selectedCollectionKey={activeCollectionKey}
               onCollectionChange={setSelectedCollectionKey}
+              selectedLayerKey={activeLayerKey}
+              onLayerChange={setSelectedLayerKey}
               onSelectionChange={rememberSelection}
             />
             {editorFocus === 'play' ? <span className="remix-editor-pip-cta">{t('remix.editorFocusEdit')}</span> : null}

--- a/apps/web/src/editorContentTools.ts
+++ b/apps/web/src/editorContentTools.ts
@@ -1,5 +1,10 @@
 import type {
   EditorCollectionSpec,
+  EditorEntityItemContent,
+  EditorEntitiesLayerSpec,
+  EditorLayerConstraint,
+  EditorLayerSpec,
+  EditorLayersDoc,
   EditorItemContent,
   EditorLabel,
   EditorPathItemContent,
@@ -12,12 +17,21 @@ export function defaultCollectionKey(collections: Record<string, unknown>): stri
   return Object.keys(collections).find((key) => key.length > 0) ?? null;
 }
 
-export function isTilemapItem(item: EditorItemContent): item is EditorTilemapItemContent {
-  return 'rows' in item;
+export function defaultLayerKey(layers: Record<string, unknown>): string | null {
+  return Object.keys(layers).find((key) => key.length > 0) ?? null;
 }
 
-export function isPathItem(item: EditorItemContent): item is EditorPathItemContent {
-  return 'points' in item;
+export function defaultLayerTileKey(layers: Record<string, EditorLayerSpec>, key: string | null): string | null {
+  const spec = key ? layers[key] : undefined;
+  return spec?.widget === 'tilemap' ? (spec.tiles[0]?.key ?? null) : null;
+}
+
+export function isTilemapItem(item: unknown): item is EditorTilemapItemContent {
+  return typeof item === 'object' && item !== null && !Array.isArray(item) && 'rows' in item;
+}
+
+export function isPathItem(item: unknown): item is EditorPathItemContent {
+  return typeof item === 'object' && item !== null && !Array.isArray(item) && 'points' in item;
 }
 
 export type PathProblemMessages = {
@@ -150,11 +164,7 @@ export function itemProblems(
   return problems;
 }
 
-function pathProblems(
-  spec: EditorPathSpec,
-  item: EditorPathItemContent,
-  messages?: PathProblemMessages,
-): string[] {
+function pathProblems(spec: EditorPathSpec, item: EditorPathItemContent, messages?: PathProblemMessages): string[] {
   const fallback: PathProblemMessages = {
     pointCount: (count, min, max) => `${count} points; expected ${min}-${max}`,
     outOfBounds: (index) => `Point ${index} is outside the grid`,
@@ -167,7 +177,14 @@ function pathProblems(
     problems.push(text.pointCount(item.points.length, spec.minPoints, spec.maxPoints));
   }
   item.points.forEach((point, index) => {
-    if (!Number.isInteger(point.x) || !Number.isInteger(point.y) || point.x < 0 || point.y < 0 || point.x >= spec.gridCols || point.y >= spec.gridRows) {
+    if (
+      !Number.isInteger(point.x) ||
+      !Number.isInteger(point.y) ||
+      point.x < 0 ||
+      point.y < 0 ||
+      point.x >= spec.gridCols ||
+      point.y >= spec.gridRows
+    ) {
       problems.push(text.outOfBounds(index + 1));
     }
   });
@@ -226,6 +243,135 @@ export function blankItem(spec: EditorCollectionSpec['item']): EditorItemContent
   // Smallest legal grid, all first-tile — the creator paints from there.
   const fill = spec.tiles[0]?.char ?? '.';
   return { properties, rows: Array.from({ length: spec.grid.minRows }, () => fill.repeat(spec.grid.minCols)) };
+}
+
+export function blankLayerEntity(spec: EditorEntitiesLayerSpec): EditorEntityItemContent {
+  const properties: Record<string, unknown> = {};
+  for (const [name, propertySpec] of Object.entries(spec.properties)) {
+    if (propertySpec.type === 'text') properties[name] = '';
+    else if (propertySpec.type === 'int' || propertySpec.type === 'number') properties[name] = propertySpec.min;
+    else if (propertySpec.type === 'enum') properties[name] = propertySpec.values[0];
+    else properties[name] = false;
+  }
+  return { properties };
+}
+
+function layerEntityProblems(spec: EditorEntitiesLayerSpec, items: EditorEntityItemContent[]): string[] {
+  const problems: string[] = [];
+  if (items.length < spec.min || items.length > spec.max) {
+    problems.push(`has ${items.length} items; expected ${spec.min}-${spec.max}`);
+  }
+  for (const rule of spec.constraints) {
+    if (!('uniqueBy' in rule)) continue;
+    const seen = new Map<string, number>();
+    items.forEach((item, index) => {
+      const encoded = JSON.stringify(item.properties[rule.uniqueBy]);
+      if (encoded === undefined) return;
+      const previous = seen.get(encoded);
+      if (previous !== undefined) problems.push(`${previous + 1} & ${index + 1} share the same ${rule.uniqueBy}`);
+      else seen.set(encoded, index);
+    });
+  }
+  return problems;
+}
+
+export function layerProblems(
+  spec: EditorLayerSpec,
+  value: unknown,
+  name: (label: EditorLabel) => string,
+  pathMessages?: PathProblemMessages,
+): string[] {
+  if (spec.widget === 'tilemap') {
+    return isTilemapItem(value as EditorItemContent)
+      ? itemProblems(spec, value as EditorTilemapItemContent, name, pathMessages)
+      : ['Layer needs a tilemap document'];
+  }
+  return Array.isArray(value) && value.every((item) => isPlainEntityItem(item))
+    ? layerEntityProblems(spec, value as EditorEntityItemContent[])
+    : ['Layer needs an entity list'];
+}
+
+function isPlainEntityItem(value: unknown): value is EditorEntityItemContent {
+  return typeof value === 'object' && value !== null && !Array.isArray(value) && 'properties' in value;
+}
+
+function layerRows(layers: Record<string, EditorLayerSpec>, content: EditorLayersDoc, key: string): string[] | null {
+  const spec = layers[key];
+  const value = content[key];
+  if (!spec || spec.widget !== 'tilemap' || !isTilemapItem(value as EditorItemContent)) return null;
+  return (value as EditorTilemapItemContent).rows;
+}
+
+export function layeredProblems(
+  layers: Record<string, EditorLayerSpec>,
+  constraints: EditorLayerConstraint[] | undefined,
+  content: EditorLayersDoc,
+): string[] {
+  const problems: string[] = [];
+  for (const rule of constraints ?? []) {
+    const fromRows = layerRows(layers, content, rule.reachable.from.layer);
+    if (!fromRows) continue;
+    const width = fromRows[0]?.length ?? 0;
+    const height = fromRows.length;
+    const rowsFor = (layer: string) => layerRows(layers, content, layer);
+    const referenced = [rule.reachable.from, ...rule.reachable.blockedBy, ...rule.reachable.require];
+    if (
+      referenced.some((ref) => {
+        const rows = rowsFor(ref.layer);
+        return !rows || rows.length !== height || rows.some((row) => row.length !== width);
+      })
+    ) {
+      problems.push('All layers in a reachability check must share the same grid');
+      continue;
+    }
+    const charFor = (ref: { layer: string; tile: string }) => {
+      const spec = layers[ref.layer];
+      return spec && spec.widget === 'tilemap' ? spec.tiles.find((tile) => tile.key === ref.tile)?.char : undefined;
+    };
+    const positions = (ref: { layer: string; tile: string }) => {
+      const rows = rowsFor(ref.layer);
+      const char = charFor(ref);
+      const result = new Set<number>();
+      if (!rows || !char) return result;
+      rows.forEach((row, y) => {
+        for (let x = 0; x < row.length; x += 1) if (row[x] === char) result.add(y * width + x);
+      });
+      return result;
+    };
+    const blocked = new Set<number>();
+    for (const ref of rule.reachable.blockedBy) for (const position of positions(ref)) blocked.add(position);
+    const seen = new Set<number>();
+    const queue = [...positions(rule.reachable.from)];
+    for (const position of queue) seen.add(position);
+    while (queue.length > 0) {
+      const position = queue.shift() as number;
+      const row = Math.floor(position / width);
+      const col = position % width;
+      for (const [dr, dc] of [
+        [1, 0],
+        [-1, 0],
+        [0, 1],
+        [0, -1],
+      ] as const) {
+        const nextRow = row + dr;
+        const nextCol = col + dc;
+        if (nextRow < 0 || nextCol < 0 || nextRow >= height || nextCol >= width) continue;
+        const next = nextRow * width + nextCol;
+        if (blocked.has(next) || seen.has(next)) continue;
+        seen.add(next);
+        queue.push(next);
+      }
+    }
+    const missed = rule.reachable.require.flatMap((ref) =>
+      [...positions(ref)].filter((position) => !seen.has(position)),
+    );
+    if (missed.length > 0) {
+      problems.push(
+        `${missed.length} required tile${missed.length === 1 ? '' : 's'} walled off from ${rule.reachable.from.layer}`,
+      );
+    }
+  }
+  return problems;
 }
 
 function blankPathPoints(spec: EditorPathSpec) {

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -410,6 +410,7 @@
       "pathDistinct": "A closed path needs at least 3 distinct points",
       "pathRepeatedEnd": "Do not repeat the first point; closure is automatic",
       "collection": "Collection",
+      "readOnlyLayer": "Only the top layer can be edited",
       "tiles": "Tiles",
       "properties": "Properties",
       "checks": "Checks",

--- a/apps/web/src/i18n/locales/pl.json
+++ b/apps/web/src/i18n/locales/pl.json
@@ -416,6 +416,7 @@
       "pathDistinct": "Zamknięta ścieżka wymaga co najmniej 3 różnych punktów",
       "pathRepeatedEnd": "Nie powtarzaj pierwszego punktu; zamknięcie jest automatyczne",
       "collection": "Kolekcja",
+      "readOnlyLayer": "Tylko najwyższa warstwa może być edytowana",
       "tiles": "Kafelki",
       "properties": "Właściwości",
       "checks": "Kontrole",

--- a/apps/web/src/remixApi.ts
+++ b/apps/web/src/remixApi.ts
@@ -1,6 +1,8 @@
 import type {
   EditorCollectionSpec,
   EditorContentDoc,
+  EditorLayerConstraint,
+  EditorLayerSpec,
   EditorLabel,
   EditorParamSpec,
   EditorParamValue,
@@ -37,6 +39,9 @@ export type RemixSession = {
    * it lives in this session and reaches the game over the bridge like params.
    */
   content?: Record<string, EditorCollectionSpec> | null;
+  layers?: Record<string, EditorLayerSpec> | null;
+  constraints?: EditorLayerConstraint[] | null;
+  contentDefaults?: EditorContentDoc;
   canAssist: boolean;
   canCode: boolean;
   /** Absent from an older server; an empty list is the same as none. */

--- a/apps/web/src/studioApi.ts
+++ b/apps/web/src/studioApi.ts
@@ -100,6 +100,19 @@ export type EditorCollectionSpec = {
   defaults: EditorItemContent[];
 };
 
+export type EditorTilemapLayerSpec = EditorTilemapSpec & { label: EditorLabel };
+export type EditorEntitiesLayerSpec = EditorEntitiesSpec & { label: EditorLabel; min: number; max: number };
+export type EditorLayerSpec = EditorTilemapLayerSpec | EditorEntitiesLayerSpec;
+export type EditorLayerContent = EditorTilemapItemContent | EditorEntityItemContent[];
+export type EditorLayersDoc = Record<string, EditorLayerContent>;
+export type EditorLayerConstraint = {
+  reachable: {
+    from: { layer: string; tile: string };
+    blockedBy: Array<{ layer: string; tile: string }>;
+    require: Array<{ layer: string; tile: string }>;
+  };
+};
+
 export type EditorTilemapItemContent = { properties: Record<string, unknown>; rows: string[] };
 export type EditorEntityItemContent = { properties: Record<string, unknown> };
 export type EditorPathPoint = { x: number; y: number };
@@ -112,16 +125,21 @@ export type EditorParamValue = string | number | boolean;
 export type EditorParamSpec = EditorPropertySpec & { label: EditorLabel; default: EditorParamValue };
 
 export type EditorDefinition = {
-  version: 1;
+  version: 1 | 2;
   params?: Record<string, EditorParamSpec>;
   content: Record<string, EditorCollectionSpec>;
+  layers?: Record<string, EditorLayerSpec>;
+  constraints?: EditorLayerConstraint[];
 };
 
 /**
  * A whole content document: collections keyed by name, plus param values under
  * the reserved `params` key when the game declares tunables.
  */
-export type EditorContentDoc = Record<string, EditorItemContent[] | Record<string, EditorParamValue> | undefined>;
+export type EditorContentDoc = Record<
+  string,
+  EditorItemContent[] | Record<string, EditorParamValue> | EditorLayersDoc | undefined
+>;
 
 export type GameEditorState = {
   version: string;

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -15250,6 +15250,87 @@ button.builder-mode-selector:disabled {
   gap: 14px;
 }
 
+/* Wave B layered boards share one footprint: the active layer receives input,
+   while the lower declarations stay visible as a dimmed read-through. */
+.editor-layered-board-col {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 14px;
+}
+.editor-layer-stack {
+  display: grid;
+  align-items: start;
+  justify-items: start;
+  max-width: 100%;
+  overflow: auto;
+  padding: 8px;
+  background: #0c1116;
+  border: 1px solid var(--panel-border);
+  border-radius: 12px;
+}
+.editor-layer-board {
+  grid-area: 1 / 1;
+  transition: opacity 120ms ease;
+}
+.editor-layer-board.is-active {
+  z-index: 2;
+  opacity: 1;
+}
+.editor-layer-board.is-muted {
+  z-index: 1;
+  opacity: 0.28;
+  pointer-events: none;
+}
+.editor-layer-picker {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.editor-layer-picker-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  width: 100%;
+  border: 1px solid transparent;
+  border-radius: 9px;
+  background: transparent;
+  color: var(--muted);
+  padding: 7px 10px;
+  text-align: left;
+  cursor: pointer;
+}
+.editor-layer-picker-item.is-active {
+  border-color: var(--turquoise-glow);
+  background: rgb(0 228 172 / 7%);
+  color: var(--text);
+  font-weight: 600;
+}
+.editor-layer-picker-item small {
+  font-family: ui-monospace, monospace;
+  font-size: 0.65rem;
+  opacity: 0.7;
+}
+.editor-layer-readonly {
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.74rem;
+}
+.editor-layered-remix-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(180px, 240px);
+  gap: 14px;
+  min-width: 0;
+}
+.editor-layer-sidebar {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: 14px;
+}
 .editor-board {
   display: grid;
   gap: 2px;
@@ -15668,6 +15749,10 @@ button.builder-mode-selector:disabled {
 
   .editor-side {
     width: auto;
+  }
+
+  .editor-layered-remix-grid {
+    grid-template-columns: 1fr;
   }
 }
 

--- a/apps/web/src/styles.editorSurface.test.ts
+++ b/apps/web/src/styles.editorSurface.test.ts
@@ -1,0 +1,34 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const css = readFileSync(fileURLToPath(new URL('./styles.css', import.meta.url)), 'utf8');
+
+function declarations(selector: string): string {
+  const start = css.indexOf(`${selector} {`);
+  expect(start, `missing ${selector} rule`).toBeGreaterThan(-1);
+  const end = css.indexOf('}', start);
+  expect(end, `unclosed ${selector} rule`).toBeGreaterThan(start);
+  return css.slice(start, end);
+}
+
+describe('layered editor surface CSS contract', () => {
+  it('pins the stacked board posture and active-layer interaction', () => {
+    expect(declarations('.editor-layer-stack')).toMatch(/display:\s*grid/);
+    expect(declarations('.editor-layer-board')).toMatch(/grid-area:\s*1 \/ 1/);
+    expect(declarations('.editor-layer-board.is-muted')).toMatch(/pointer-events:\s*none/);
+    expect(declarations('.editor-layer-board.is-active')).toMatch(/z-index:\s*2/);
+  });
+
+  it('keeps the picker readable beside the stacked board', () => {
+    expect(declarations('.editor-layer-picker')).toMatch(/display:\s*flex/);
+    expect(declarations('.editor-layer-picker-item.is-active')).toMatch(/border-color:/);
+    expect(declarations('.editor-layered-remix-grid')).toMatch(/grid-template-columns:/);
+  });
+
+  it('pins the edit overlay dock posture used by layered definitions', () => {
+    const dock = '.studio-edit-overlay:not(.studio-code-overlay):not(:has(.editor-board-col))';
+    expect(declarations(dock)).toMatch(/inset:\s*0 0 0 auto/);
+    expect(declarations(dock)).toMatch(/width:\s*min\(360px, 100%\)/);
+  });
+});


### PR DESCRIPTION
## Summary

- Add shared-grid layered tilemap/entity v2 declarations and typed generated content.
- Validate per-layer budgets and cross-layer reachability server-side.
- Add stacked Studio and Remix layer editing with CSS contract tests.

## Validation

- `npm run type-check`
- `npm run lint`
- `npm run build`
- Focused Wave B contract, Studio, Remix, and style tests

One real-connection integration test remains sandbox-blocked by `listen EPERM`; the focused suites otherwise pass.

Stacked on #821.