### PR TITLE
Support sourced audio catalog fallback for game sounds

### DIFF
--- a/apps/api/src/github-client.test.ts
+++ b/apps/api/src/github-client.test.ts
@@ -904,9 +904,6 @@ describe('getGameSources', () => {
   });
 
   it('falls back to the sourced-audio catalog for a sound missing from the synth catalog', async () => {
-    // shared/audio/sourced.json + shared/audio/sourced/*.mp3: vendor clips that cannot be
-    // re-rendered from parameters the way the synth catalog can. A GAME.json sound name that
-    // misses shared/audio/assets/*.wav should resolve here before being treated as missing.
     const files = new Map<string, string | Uint8Array>([
       ['games/march/index.html', '<canvas id="game"></canvas>'],
       ['games/march/game.ts', 'const game: { update(): void } = { update() {} }; GameKit.mount(game);'],
@@ -947,9 +944,6 @@ describe('getGameSources', () => {
   });
 
   it('embeds a music track drumKit sample from the sourced catalog', async () => {
-    // drumKit.kick/hat are referenced from music.json, not audio.sounds — a game never
-    // "selects" them directly — so they still need embedding or the audio module's runtime
-    // fallback silently swaps in a synthesized noise burst.
     const files = new Map<string, string | Uint8Array>([
       ['games/march/index.html', '<canvas id="game"></canvas>'],
       ['games/march/game.ts', 'const game: { update(): void } = { update() {} }; GameKit.mount(game);'],

--- a/apps/api/src/github-client.test.ts
+++ b/apps/api/src/github-client.test.ts
@@ -903,6 +903,137 @@ describe('getGameSources', () => {
     expect(() => new Function(sources?.gameJs ?? '')).not.toThrow();
   });
 
+  it('falls back to the sourced-audio catalog for a sound missing from the synth catalog', async () => {
+    // shared/audio/sourced.json + shared/audio/sourced/*.mp3: vendor clips that cannot be
+    // re-rendered from parameters the way the synth catalog can. A GAME.json sound name that
+    // misses shared/audio/assets/*.wav should resolve here before being treated as missing.
+    const files = new Map<string, string | Uint8Array>([
+      ['games/march/index.html', '<canvas id="game"></canvas>'],
+      ['games/march/game.ts', 'const game: { update(): void } = { update() {} }; GameKit.mount(game);'],
+      ['games/march/style.css', '.game { color: brass; }'],
+      ['games/march/SPEC.md', specMd({ title: 'March' })],
+      [
+        'games/march/GAME.json',
+        JSON.stringify({
+          engine: { modules: ['input', 'audio'] },
+          audio: { sounds: ['ui-toggle', 'clockwork-gear-tick'], music: 'clockwork-march' },
+        }),
+      ],
+      ['shared/game-shell.css', '.shell { display: grid; }'],
+      ['shared/modules/core.ts', 'window.GameKit = { mount() {} };'],
+      ['shared/modules/input.ts', 'GameKit.createInput = function (): void {};'],
+      ['shared/modules/audio.ts', 'GameKit.createAudio = function (): void {};'],
+      ['shared/audio/assets/ui-toggle.wav', new Uint8Array([1, 2])],
+      ['shared/audio/sourced.json', JSON.stringify({ sounds: { 'clockwork-gear-tick': { mime: 'audio/mpeg' } } })],
+      ['shared/audio/sourced/clockwork-gear-tick.mp3', new Uint8Array([5, 6])],
+      [
+        'shared/audio/music.json',
+        JSON.stringify({ tracks: { 'clockwork-march': { loop: true, data: 'data:audio/mpeg;base64,AAA=' } } }),
+      ],
+    ]);
+    const fetchImpl = vi.fn(async (input: RequestInfo | URL) => {
+      const pathname = new URL(String(input)).pathname;
+      const marker = '/contents/';
+      const path = decodeURIComponent(pathname.slice(pathname.indexOf(marker) + marker.length));
+      const value = files.get(path);
+      return value === undefined ? new Response('not found', { status: 404 }) : new Response(value, { status: 200 });
+    }) as unknown as typeof fetch;
+    const client = createGitHubClient({ token: 'test-token', repo, fetchImpl });
+
+    const sources = await client.getGameSources('main', 'march');
+
+    expect(sources?.gameJs).toContain('"ui-toggle":"data:audio/wav;base64,AQI="');
+    expect(sources?.gameJs).toContain('"clockwork-gear-tick":"data:audio/mpeg;base64,BQY="');
+  });
+
+  it('embeds a music track drumKit sample from the sourced catalog', async () => {
+    // drumKit.kick/hat are referenced from music.json, not audio.sounds — a game never
+    // "selects" them directly — so they still need embedding or the audio module's runtime
+    // fallback silently swaps in a synthesized noise burst.
+    const files = new Map<string, string | Uint8Array>([
+      ['games/march/index.html', '<canvas id="game"></canvas>'],
+      ['games/march/game.ts', 'const game: { update(): void } = { update() {} }; GameKit.mount(game);'],
+      ['games/march/style.css', '.game { color: brass; }'],
+      ['games/march/SPEC.md', specMd({ title: 'March' })],
+      [
+        'games/march/GAME.json',
+        JSON.stringify({
+          engine: { modules: ['input', 'audio'] },
+          audio: { sounds: ['ui-toggle'], music: 'clockwork-march' },
+        }),
+      ],
+      ['shared/game-shell.css', '.shell { display: grid; }'],
+      ['shared/modules/core.ts', 'window.GameKit = { mount() {} };'],
+      ['shared/modules/input.ts', 'GameKit.createInput = function (): void {};'],
+      ['shared/modules/audio.ts', 'GameKit.createAudio = function (): void {};'],
+      ['shared/audio/assets/ui-toggle.wav', new Uint8Array([1, 2])],
+      ['shared/audio/sourced.json', JSON.stringify({ sounds: { 'clockwork-kick': { mime: 'audio/mpeg' } } })],
+      ['shared/audio/sourced/clockwork-kick.mp3', new Uint8Array([7, 8])],
+      [
+        'shared/audio/music.json',
+        JSON.stringify({
+          tracks: {
+            'clockwork-march': {
+              loop: true,
+              data: 'data:audio/mpeg;base64,AAA=',
+              drumKit: { kick: 'clockwork-kick' },
+            },
+          },
+        }),
+      ],
+    ]);
+    const fetchImpl = vi.fn(async (input: RequestInfo | URL) => {
+      const pathname = new URL(String(input)).pathname;
+      const marker = '/contents/';
+      const path = decodeURIComponent(pathname.slice(pathname.indexOf(marker) + marker.length));
+      const value = files.get(path);
+      return value === undefined ? new Response('not found', { status: 404 }) : new Response(value, { status: 200 });
+    }) as unknown as typeof fetch;
+    const client = createGitHubClient({ token: 'test-token', repo, fetchImpl });
+
+    const sources = await client.getGameSources('main', 'march');
+
+    expect(sources?.gameJs).toContain('"clockwork-kick":"data:audio/mpeg;base64,Bwg="');
+  });
+
+  it('treats a sound missing from both the synth and sourced catalogs as missing sources', async () => {
+    const files = new Map<string, string | Uint8Array>([
+      ['games/march/index.html', '<canvas id="game"></canvas>'],
+      ['games/march/game.ts', 'const game: { update(): void } = { update() {} }; GameKit.mount(game);'],
+      ['games/march/style.css', '.game { color: brass; }'],
+      ['games/march/SPEC.md', specMd({ title: 'March' })],
+      [
+        'games/march/GAME.json',
+        JSON.stringify({
+          engine: { modules: ['input', 'audio'] },
+          audio: { sounds: ['ui-toggle', 'clockwork-gear-tick'], music: 'clockwork-march' },
+        }),
+      ],
+      ['shared/game-shell.css', '.shell { display: grid; }'],
+      ['shared/modules/core.ts', 'window.GameKit = { mount() {} };'],
+      ['shared/modules/input.ts', 'GameKit.createInput = function (): void {};'],
+      ['shared/modules/audio.ts', 'GameKit.createAudio = function (): void {};'],
+      ['shared/audio/assets/ui-toggle.wav', new Uint8Array([1, 2])],
+      ['shared/audio/sourced.json', JSON.stringify({ sounds: {} })],
+      [
+        'shared/audio/music.json',
+        JSON.stringify({ tracks: { 'clockwork-march': { loop: true, data: 'data:audio/mpeg;base64,AAA=' } } }),
+      ],
+    ]);
+    const fetchImpl = vi.fn(async (input: RequestInfo | URL) => {
+      const pathname = new URL(String(input)).pathname;
+      const marker = '/contents/';
+      const path = decodeURIComponent(pathname.slice(pathname.indexOf(marker) + marker.length));
+      const value = files.get(path);
+      return value === undefined ? new Response('not found', { status: 404 }) : new Response(value, { status: 200 });
+    }) as unknown as typeof fetch;
+    const client = createGitHubClient({ token: 'test-token', repo, fetchImpl });
+
+    const sources = await client.getGameSources('main', 'march');
+
+    expect(sources).toBeNull();
+  });
+
   it('generates style.css from GAME.json theme when the games repo ships none', async () => {
     // Mirrors how index.html already falls back to howToPlay.
     const files = new Map<string, string | Uint8Array>([

--- a/apps/api/src/github-client.test.ts
+++ b/apps/api/src/github-client.test.ts
@@ -913,7 +913,10 @@ describe('getGameSources', () => {
         'games/march/GAME.json',
         JSON.stringify({
           engine: { modules: ['input', 'audio'] },
-          audio: { sounds: ['ui-toggle', 'clockwork-gear-tick'], music: 'clockwork-march' },
+          audio: {
+            sounds: ['ui-toggle', 'clockwork-gear-tick', 'wood-bridge-creak'],
+            music: 'clockwork-march',
+          },
         }),
       ],
       ['shared/game-shell.css', '.shell { display: grid; }'],
@@ -921,8 +924,17 @@ describe('getGameSources', () => {
       ['shared/modules/input.ts', 'GameKit.createInput = function (): void {};'],
       ['shared/modules/audio.ts', 'GameKit.createAudio = function (): void {};'],
       ['shared/audio/assets/ui-toggle.wav', new Uint8Array([1, 2])],
-      ['shared/audio/sourced.json', JSON.stringify({ sounds: { 'clockwork-gear-tick': { mime: 'audio/mpeg' } } })],
+      [
+        'shared/audio/sourced.json',
+        JSON.stringify({
+          sounds: {
+            'clockwork-gear-tick': { mime: 'audio/mpeg' },
+            'wood-bridge-creak': { mime: 'audio/mpeg' },
+          },
+        }),
+      ],
       ['shared/audio/sourced/clockwork-gear-tick.mp3', new Uint8Array([5, 6])],
+      ['shared/audio/sourced/wood-bridge-creak.mp3', new Uint8Array([9, 10])],
       [
         'shared/audio/music.json',
         JSON.stringify({ tracks: { 'clockwork-march': { loop: true, data: 'data:audio/mpeg;base64,AAA=' } } }),
@@ -941,6 +953,12 @@ describe('getGameSources', () => {
 
     expect(sources?.gameJs).toContain('"ui-toggle":"data:audio/wav;base64,AQI="');
     expect(sources?.gameJs).toContain('"clockwork-gear-tick":"data:audio/mpeg;base64,BQY="');
+    expect(sources?.gameJs).toContain('"wood-bridge-creak":"data:audio/mpeg;base64,CQo="');
+    // Concurrent misses must fetch the sourced catalog once.
+    const sourcedCatalogCalls = fetchImpl.mock.calls.filter(([input]) =>
+      String(input).includes('/shared/audio/sourced.json'),
+    );
+    expect(sourcedCatalogCalls).toHaveLength(1);
   });
 
   it('embeds a music track drumKit sample from the sourced catalog', async () => {

--- a/apps/api/src/github-client.ts
+++ b/apps/api/src/github-client.ts
@@ -167,12 +167,6 @@ interface GameManifest {
   audio?: { sounds?: unknown; music?: unknown; musicTracks?: unknown };
 }
 
-/**
- * `shared/audio/sourced.json` — vendor-generated clips that cannot be re-rendered from
- * parameters the way the synth catalog (`shared/audio/assets/*.wav`) can. A `GAME.json`
- * sound name that misses the synth catalog is looked up here before it is treated as
- * missing. Mirrors games-repo `tools/lib/sourced-audio.ts` / `tools/lib/assemble.ts`.
- */
 interface SourcedAudioCatalog {
   sounds?: Record<string, { mime?: unknown }>;
 }
@@ -1443,10 +1437,7 @@ export function createGitHubClient(options: GitHubClientOptions): GitHubClient {
       }
       const availableModuleSources = moduleSources.filter((source): source is string => source !== null);
 
-      // A sound is either in the synth catalog (rendered on demand, `shared/audio/assets/*.wav`)
-      // or the sourced one (vendor clips that cannot be re-rendered, `shared/audio/sourced/*.mp3`
-      // + `shared/audio/sourced.json` for the mime). Checked in that order and cached so a game
-      // whose whole selection is one or the other only pays for the catalog fetch it needs.
+      // Synth `.wav` first, then the sourced `.mp3` catalog as a fallback.
       let sourcedCatalog: Record<string, { mime?: unknown }> | null = null;
       const loadSourcedCatalog = async (): Promise<Record<string, { mime?: unknown }>> => {
         if (sourcedCatalog === null) {
@@ -1510,10 +1501,7 @@ export function createGitHubClient(options: GitHubClientOptions): GitHubClient {
           selected[name] = tracks[name];
         }
 
-        // A drumKit sample is referenced from a track's `drumKit`, not `audio.sounds` — a
-        // game never "selects" it directly — so without embedding it here the engine's
-        // runtime fallback silently masks the miss as a synthesized noise burst instead of
-        // the sample nobody shipped. Mirrors games-repo assemble.ts.
+        // drumKit samples aren't in audio.sounds, so embed them here too.
         for (const track of Object.values(selected) as Array<{ drumKit?: { kick?: unknown; hat?: unknown } }>) {
           for (const soundName of [track.drumKit?.kick, track.drumKit?.hat]) {
             if (typeof soundName !== 'string' || Object.hasOwn(assets, soundName)) {

--- a/apps/api/src/github-client.ts
+++ b/apps/api/src/github-client.ts
@@ -167,6 +167,16 @@ interface GameManifest {
   audio?: { sounds?: unknown; music?: unknown; musicTracks?: unknown };
 }
 
+/**
+ * `shared/audio/sourced.json` — vendor-generated clips that cannot be re-rendered from
+ * parameters the way the synth catalog (`shared/audio/assets/*.wav`) can. A `GAME.json`
+ * sound name that misses the synth catalog is looked up here before it is treated as
+ * missing. Mirrors games-repo `tools/lib/sourced-audio.ts` / `tools/lib/assemble.ts`.
+ */
+interface SourcedAudioCatalog {
+  sounds?: Record<string, { mime?: unknown }>;
+}
+
 interface ParsedGameManifest {
   modules: GameKitModuleName[];
   sounds: string[];
@@ -1433,23 +1443,44 @@ export function createGitHubClient(options: GitHubClientOptions): GitHubClient {
       }
       const availableModuleSources = moduleSources.filter((source): source is string => source !== null);
 
-      const audioAssets = await Promise.all(
-        manifest.sounds.map(async (soundName) => {
-          const bytes = await readRawBytes(`shared/audio/assets/${soundName}.wav`, ref);
-          return bytes ? [soundName, `data:audio/wav;base64,${Buffer.from(bytes).toString('base64')}`] : null;
-        }),
-      );
+      // A sound is either in the synth catalog (rendered on demand, `shared/audio/assets/*.wav`)
+      // or the sourced one (vendor clips that cannot be re-rendered, `shared/audio/sourced/*.mp3`
+      // + `shared/audio/sourced.json` for the mime). Checked in that order and cached so a game
+      // whose whole selection is one or the other only pays for the catalog fetch it needs.
+      let sourcedCatalog: Record<string, { mime?: unknown }> | null = null;
+      const loadSourcedCatalog = async (): Promise<Record<string, { mime?: unknown }>> => {
+        if (sourcedCatalog === null) {
+          const source = await readRawFile('shared/audio/sourced.json', ref);
+          sourcedCatalog = source ? ((JSON.parse(source) as SourcedAudioCatalog).sounds ?? {}) : {};
+        }
+        return sourcedCatalog;
+      };
+      const resolveSoundAsset = async (soundName: string): Promise<[string, string] | null> => {
+        const wavBytes = await readRawBytes(`shared/audio/assets/${soundName}.wav`, ref);
+        if (wavBytes) {
+          return [soundName, `data:audio/wav;base64,${Buffer.from(wavBytes).toString('base64')}`];
+        }
+        const sourced = await loadSourcedCatalog();
+        if (!Object.hasOwn(sourced, soundName)) {
+          return null;
+        }
+        const mp3Bytes = await readRawBytes(`shared/audio/sourced/${soundName}.mp3`, ref);
+        if (!mp3Bytes) {
+          return null;
+        }
+        const mime = typeof sourced[soundName].mime === 'string' ? (sourced[soundName].mime as string) : 'audio/mpeg';
+        return [soundName, `data:${mime};base64,${Buffer.from(mp3Bytes).toString('base64')}`];
+      };
+
+      const audioAssets = await Promise.all(manifest.sounds.map(resolveSoundAsset));
       if (audioAssets.some((asset) => asset === null)) {
         return null;
       }
 
-      const assetEntries = audioAssets.filter((asset): asset is [string, string] => asset !== null);
+      const assets: Record<string, string> = Object.fromEntries(
+        audioAssets.filter((asset): asset is [string, string] => asset !== null),
+      );
       const assetChunks: string[] = [];
-      if (assetEntries.length > 0) {
-        assetChunks.push(
-          `window.__GAME_AUDIO_ASSETS__ = Object.freeze(${JSON.stringify(Object.fromEntries(assetEntries))});`,
-        );
-      }
 
       // Music: shared catalog plus optional per-game music.json, then inject the
       // autoplay name plus every track this game can reach — not the whole catalog.
@@ -1478,8 +1509,30 @@ export function createGitHubClient(options: GitHubClientOptions): GitHubClient {
           }
           selected[name] = tracks[name];
         }
+
+        // A drumKit sample is referenced from a track's `drumKit`, not `audio.sounds` — a
+        // game never "selects" it directly — so without embedding it here the engine's
+        // runtime fallback silently masks the miss as a synthesized noise burst instead of
+        // the sample nobody shipped. Mirrors games-repo assemble.ts.
+        for (const track of Object.values(selected) as Array<{ drumKit?: { kick?: unknown; hat?: unknown } }>) {
+          for (const soundName of [track.drumKit?.kick, track.drumKit?.hat]) {
+            if (typeof soundName !== 'string' || Object.hasOwn(assets, soundName)) {
+              continue;
+            }
+            const resolved = await resolveSoundAsset(soundName);
+            if (resolved === null) {
+              return null;
+            }
+            assets[resolved[0]] = resolved[1];
+          }
+        }
+
         assetChunks.push(`window.__GAME_AUDIO_MUSIC__ = ${JSON.stringify(manifest.music)};`);
         assetChunks.push(`window.__GAME_MUSIC_TRACKS__ = Object.freeze(${JSON.stringify(selected)});`);
+      }
+
+      if (Object.keys(assets).length > 0) {
+        assetChunks.unshift(`window.__GAME_AUDIO_ASSETS__ = Object.freeze(${JSON.stringify(assets)});`);
       }
 
       const assetsJs = assetChunks.length > 0 ? `${assetChunks.join('\n')}\n` : '';

--- a/apps/api/src/github-client.ts
+++ b/apps/api/src/github-client.ts
@@ -1438,13 +1438,14 @@ export function createGitHubClient(options: GitHubClientOptions): GitHubClient {
       const availableModuleSources = moduleSources.filter((source): source is string => source !== null);
 
       // Synth `.wav` first, then the sourced `.mp3` catalog as a fallback.
-      let sourcedCatalog: Record<string, { mime?: unknown }> | null = null;
-      const loadSourcedCatalog = async (): Promise<Record<string, { mime?: unknown }>> => {
-        if (sourcedCatalog === null) {
-          const source = await readRawFile('shared/audio/sourced.json', ref);
-          sourcedCatalog = source ? ((JSON.parse(source) as SourcedAudioCatalog).sounds ?? {}) : {};
+      let sourcedCatalogPromise: Promise<Record<string, { mime?: unknown }>> | null = null;
+      const loadSourcedCatalog = (): Promise<Record<string, { mime?: unknown }>> => {
+        if (sourcedCatalogPromise === null) {
+          sourcedCatalogPromise = readRawFile('shared/audio/sourced.json', ref).then((source) =>
+            source ? ((JSON.parse(source) as SourcedAudioCatalog).sounds ?? {}) : {},
+          );
         }
-        return sourcedCatalog;
+        return sourcedCatalogPromise;
       };
       const resolveSoundAsset = async (soundName: string): Promise<[string, string] | null> => {
         const wavBytes = await readRawBytes(`shared/audio/assets/${soundName}.wav`, ref);


### PR DESCRIPTION
## Summary
Add support for falling back to the sourced audio catalog (`shared/audio/sourced.json` + `shared/audio/sourced/*.mp3`) when a game references sounds that aren't available in the synth catalog (`shared/audio/assets/*.wav`). This allows games to use vendor-generated audio clips that cannot be re-rendered from parameters.

## Key Changes
- **Sound resolution logic**: Implemented a two-tier lookup system that checks the synth catalog first, then falls back to the sourced catalog before treating a sound as missing
- **Sourced catalog interface**: Added `SourcedAudioCatalog` interface to parse `shared/audio/sourced.json` and extract MIME type information
- **Lazy catalog loading**: Sourced catalog is only loaded once and cached if needed, avoiding unnecessary fetches when all sounds are in the synth catalog
- **DrumKit sample embedding**: Extended audio asset resolution to include drumKit samples (kick/hat) referenced from music tracks, which are not directly selected by games but need embedding to avoid silent fallbacks
- **Unified asset handling**: Consolidated audio asset management into a single `assets` object that includes both direct game sounds and indirect drumKit samples

## Notable Implementation Details
- The `resolveSoundAsset` function encapsulates the fallback logic and is reused for both game sounds and drumKit samples
- If any sound is missing from both catalogs, the entire source generation fails (returns null) rather than silently degrading
- MIME type defaults to `audio/mpeg` if not specified in the sourced catalog
- Asset chunks are reordered to ensure the assets declaration comes first in the generated JavaScript

https://claude.ai/code/session_011AAR4UoEUM63b8aJgnxrVp