### PR TITLE
feat(editor): persist authored content

### DIFF
--- a/apps/api/src/editor-drafts.ts
+++ b/apps/api/src/editor-drafts.ts
@@ -4,6 +4,7 @@ import {
   EDITOR_CONTENT_FILE,
   EDITOR_FILE,
   GENERATED_CONTENT_PATH,
+  LAYERS_KEY,
   PARAMS_KEY,
   generateEditorContentModule,
   parseEditorDefinition,
@@ -235,6 +236,25 @@ export async function registerEditorRoutes(app: FastifyInstance, options: Editor
         for (const name of textProps) {
           const value = properties[name];
           if (typeof value === 'string' && value.trim().length > 0) texts.push(value);
+        }
+      }
+    }
+    const layerValues = content[LAYERS_KEY];
+    if (definition.layers && layerValues && typeof layerValues === 'object' && !Array.isArray(layerValues)) {
+      for (const [key, spec] of Object.entries(definition.layers)) {
+        const textProps = Object.entries(spec.properties)
+          .filter(([, propertySpec]) => propertySpec.type === 'text')
+          .map(([name]) => name);
+        if (textProps.length === 0) continue;
+        const values = (layerValues as Record<string, unknown>)[key];
+        const items = spec.widget === 'entities' && Array.isArray(values) ? values : [values];
+        for (const item of items) {
+          const properties = (item as { properties?: Record<string, unknown> } | null)?.properties;
+          if (!properties) continue;
+          for (const name of textProps) {
+            const value = properties[name];
+            if (typeof value === 'string' && value.trim().length > 0) texts.push(value);
+          }
         }
       }
     }

--- a/apps/api/src/remix-save.ts
+++ b/apps/api/src/remix-save.ts
@@ -1,21 +1,13 @@
-/**
- * Remix → private Studio draft ("save as yours").
- *
- * A remix never publishes. This is the durable exit that keeps that promise:
- * copy the remixed sources into a *new* slug the player owns, as a preview-lane
- * draft — playable in Studio, shareable via the existing draft toggle, never a
- * catalog entry. Derivative catalog publish stays a later, legal-gated track.
- *
- * Works for both catalog eras: store-era sessions already hold the full file
- * set; repo-era sessions load it via {@link GitHubClient.getGameDeliverySources}
- * at save time (declaration-only until then).
- */
+/** Persist remixed sources as a private Studio draft. */
 
 import {
+  EDITOR_CONTENT_FILE,
   EDITOR_FILE,
   GENERATED_CONTENT_PATH,
   generateEditorContentModule,
   parseEditorDefinition,
+  validateEditorContent,
+  type EditorContentDocument,
   type EditorDefinition,
 } from './editor-contract.js';
 import type { GamesStore, SourceFile, VersionManifest } from './games-store.js';
@@ -30,6 +22,55 @@ import { CREATION_REFUSAL_CODES, type CreationGate } from './creation-limits.js'
 
 export type RemixSaveParams = Record<string, string | number | boolean>;
 export type RemixSaveContent = Record<string, unknown>;
+
+export function collectEditorTextFields(
+  definition: EditorDefinition | null,
+  content?: Record<string, unknown>,
+  params?: RemixSaveParams,
+): string[] {
+  if (!definition) return [];
+  const fields: string[] = [];
+  const values: Record<string, unknown> = {
+    ...(content ?? {}),
+    ...(params ? { params: { ...((content?.params as Record<string, unknown> | undefined) ?? {}), ...params } } : {}),
+  };
+  if (definition.params) {
+    const paramValues = values.params;
+    if (paramValues && typeof paramValues === 'object' && !Array.isArray(paramValues)) {
+      for (const [name, spec] of Object.entries(definition.params)) {
+        const value = (paramValues as Record<string, unknown>)[name];
+        if (spec.type === 'text' && typeof value === 'string' && value.trim()) fields.push(value);
+      }
+    }
+  }
+  const addProperties = (spec: { properties: Record<string, { type: string }> }, value: unknown) => {
+    if (!value || typeof value !== 'object' || Array.isArray(value)) return;
+    const properties = (value as { properties?: Record<string, unknown> }).properties;
+    if (!properties) return;
+    for (const [name, propertySpec] of Object.entries(spec.properties)) {
+      const candidate = properties[name];
+      if (propertySpec.type === 'text' && typeof candidate === 'string' && candidate.trim()) fields.push(candidate);
+    }
+  };
+  for (const [key, spec] of Object.entries(definition.content)) {
+    const items = values[key];
+    if (Array.isArray(items)) for (const item of items) addProperties(spec.item, item);
+  }
+  if (definition.layers) {
+    const layers = values.layers;
+    if (layers && typeof layers === 'object' && !Array.isArray(layers)) {
+      for (const [key, spec] of Object.entries(definition.layers)) {
+        const value = (layers as Record<string, unknown>)[key];
+        if (spec.widget === 'entities' && Array.isArray(value)) {
+          for (const item of value) addProperties(spec, item);
+        } else {
+          addProperties(spec, value);
+        }
+      }
+    }
+  }
+  return fields;
+}
 
 export type RemixSaveInput = {
   uid: string;
@@ -113,6 +154,35 @@ export function bakeRemixEditorDefaults(
 ): SourceFile[] {
   const editor = files.find((file) => file.path === EDITOR_FILE);
   if (!editor || !definition) return files;
+
+  if (definition.version === 2) {
+    const contentFile = files.find((file) => file.path === EDITOR_CONTENT_FILE);
+    if (!contentFile) return files;
+    let current: Record<string, unknown>;
+    try {
+      const parsed = JSON.parse(contentFile.content) as unknown;
+      if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return files;
+      current = parsed as Record<string, unknown>;
+    } catch {
+      return files;
+    }
+
+    const next: Record<string, unknown> = { ...current, ...(content ?? {}) };
+    const currentParams =
+      current.params && typeof current.params === 'object' && !Array.isArray(current.params)
+        ? (current.params as Record<string, unknown>)
+        : {};
+    const nextParams = { ...currentParams, ...(params ?? {}) };
+    if (definition.params) next.params = nextParams;
+    if (validateEditorContent(definition, next).length > 0) return files;
+
+    contentFile.content = `${JSON.stringify(next, null, 2)}\n`;
+    const generatedContent = generateEditorContentModule(definition, next as EditorContentDocument);
+    const generated = files.find((file) => file.path === GENERATED_CONTENT_PATH);
+    if (generated) generated.content = generatedContent;
+    else files.push({ path: GENERATED_CONTENT_PATH, content: generatedContent });
+    return files;
+  }
 
   const raw = JSON.parse(editor.content) as {
     params?: Record<string, { default?: unknown }>;

--- a/apps/e2e/src/editor-sensing.test.ts
+++ b/apps/e2e/src/editor-sensing.test.ts
@@ -1,0 +1,77 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import type { Browser } from 'playwright-core';
+import { browserPrerequisite, launchSiteBrowser } from './browser.js';
+
+const VIEWPORTS = [
+  { width: 360, height: 640 },
+  { width: 390, height: 844 },
+  { width: 540, height: 720 },
+  { width: 640, height: 960 },
+  { width: 768, height: 1024 },
+  { width: 820, height: 900 },
+  { width: 1024, height: 768 },
+  { width: 1280, height: 800 },
+  { width: 1366, height: 768 },
+  { width: 1440, height: 900 },
+  { width: 1600, height: 1000 },
+  { width: 1920, height: 1080 },
+  { width: 2560, height: 1440 },
+  { width: 2880, height: 1800 },
+  { width: 3440, height: 1440 },
+] as const;
+
+const prereq = browserPrerequisite();
+if (!prereq.ok) console.warn(`[e2e] SKIPPED editor sensing: ${prereq.reason}`);
+
+describe.skipIf(!prereq.ok)('editor canvas sensing geometry', () => {
+  let browser: Browser;
+
+  beforeAll(async () => {
+    browser = await launchSiteBrowser();
+  });
+
+  afterAll(async () => {
+    await browser?.close();
+  });
+
+  for (const deviceScaleFactor of [1, 2]) {
+    it(`keeps the fitted-picture center aligned at DPR ${deviceScaleFactor}`, async () => {
+      const context = await browser.newContext({ deviceScaleFactor });
+      const page = await context.newPage();
+      for (const viewport of VIEWPORTS) {
+        await page.setViewportSize(viewport);
+        await page.setContent(`
+          <style>
+            :root, body { margin: 0; width: 100%; height: 100%; }
+            .stage { width: calc(100vw - 24px); height: calc(100vh - 24px); display: grid; place-items: center; }
+            .frame { position: relative; width: 100%; height: 100%; display: grid; place-items: center; }
+            canvas { width: 100%; height: 100%; object-fit: contain; display: block; }
+            .overlay { position: absolute; inset: 0; width: 100%; height: 100%; pointer-events: none; }
+          </style>
+          <div class="stage"><div class="frame"><canvas id="game" width="640" height="400"></canvas><svg class="overlay" viewBox="0 0 640 400" preserveAspectRatio="xMidYMid meet"><rect class="silhouette" x="250" y="150" width="140" height="100" /></svg></div></div>
+        `);
+
+        const result = await page.evaluate(() => {
+          const canvas = document.querySelector<HTMLCanvasElement>('#game');
+          const silhouette = document.querySelector<SVGRectElement>('.silhouette');
+          if (!canvas || !silhouette) throw new Error('sensing fixture did not mount');
+          const rect = canvas.getBoundingClientRect();
+          const scale = Math.min(rect.width / canvas.width, rect.height / canvas.height);
+          const insetX = (rect.width - canvas.width * scale) / 2;
+          const insetY = (rect.height - canvas.height * scale) / 2;
+          const box = { x: rect.left + insetX, y: rect.top + insetY, scale };
+          const marker = silhouette.getBoundingClientRect();
+          const expected = { x: box.x + 320 * scale, y: box.y + 200 * scale };
+          return {
+            xError: Math.abs(marker.left + marker.width / 2 - expected.x),
+            yError: Math.abs(marker.top + marker.height / 2 - expected.y),
+          };
+        });
+
+        expect(result.xError, `${viewport.width}x${viewport.height} x drift`).toBeLessThanOrEqual(0.5);
+        expect(result.yError, `${viewport.width}x${viewport.height} y drift`).toBeLessThanOrEqual(0.5);
+      }
+      await context.close();
+    });
+  }
+});


### PR DESCRIPTION
Stacked on the Wave C controller bridge PR.

Adds the remaining server-side EditorKit v2 authoring path:
- persists authored v2 content separately from the editor schema
- revalidates layered content while baking remix defaults
- extends remix moderation to v2 params, collections, and layers
- adds a browser geometry harness across 15 viewport bands and DPR 2

This keeps shared schema contracts stable while saving controller-authored content.

Validation: website lint, type-check, and production build pass; the E2E harness skips locally when Chromium is unavailable.