### PR TITLE
fix(contract): add platformer module ahead of games-repo #690

### DIFF
--- a/apps/api/fixtures/games-repo/shared/assemble-contract.json
+++ b/apps/api/fixtures/games-repo/shared/assemble-contract.json
@@ -20,6 +20,7 @@
     "gfx3d",
     "racing",
     "football",
+    "platformer",
     "effects",
     "audio",
     "party",

--- a/apps/api/src/games-repo-contract-check.ts
+++ b/apps/api/src/games-repo-contract-check.ts
@@ -327,9 +327,7 @@ export async function runGamesRepoContractCheck(options: ContractCheckOptions): 
     ['vehicles', Date.parse('2026-09-01T00:00:00.000Z')],
     ['urban', Date.parse('2026-08-11T00:00:00.000Z')],
     ['cards', Date.parse('2026-08-15T00:00:00.000Z')],
-    // games-repo #690 (platformer vertical). Website-first: this side adds the module
-    // ahead of the games tip so contract:games-repo does not 502 play/draft the moment
-    // #690 merges. Remove once #690 lands.
+    // games-repo #690 (platformer vertical). Remove once it lands.
     ['platformer', Date.parse('2026-08-29T00:00:00.000Z')],
   ]);
   const websiteExtras = localModules.filter((m) => !remoteModules.includes(m));

--- a/apps/api/src/games-repo-contract-check.ts
+++ b/apps/api/src/games-repo-contract-check.ts
@@ -327,6 +327,10 @@ export async function runGamesRepoContractCheck(options: ContractCheckOptions): 
     ['vehicles', Date.parse('2026-09-01T00:00:00.000Z')],
     ['urban', Date.parse('2026-08-11T00:00:00.000Z')],
     ['cards', Date.parse('2026-08-15T00:00:00.000Z')],
+    // games-repo #690 (platformer vertical). Website-first: this side adds the module
+    // ahead of the games tip so contract:games-repo does not 502 play/draft the moment
+    // #690 merges. Remove once #690 lands.
+    ['platformer', Date.parse('2026-08-29T00:00:00.000Z')],
   ]);
   const websiteExtras = localModules.filter((m) => !remoteModules.includes(m));
   const now = options.now?.() ?? Date.now();

--- a/apps/api/src/games-repo-contract.test.ts
+++ b/apps/api/src/games-repo-contract.test.ts
@@ -109,6 +109,7 @@ describe('games-repo-contract (website half)', () => {
       'gfx3d',
       'racing',
       'football',
+      'platformer',
       'effects',
       'audio',
       'party',
@@ -232,7 +233,7 @@ describe('games-repo source extractors', () => {
       // Canonical order
       export const GAME_KIT_MODULES = [
         'input', 'collision', 'world', 'grid', 'path', 'ai', 'gameplay', 'rng', 'cards', 'vehicles', 'urban',
-        'drawing', 'actors', 'gfx', 'ui', 'gfx3d', 'racing', 'football', 'effects', 'audio', 'party', 'save', 'commons', 'presence', 'mascot', 'zone',
+        'drawing', 'actors', 'gfx', 'ui', 'gfx3d', 'racing', 'football', 'platformer', 'effects', 'audio', 'party', 'save', 'commons', 'presence', 'mascot', 'zone',
         'sensing', 'voice', 'editor',
       ] as const;
     `;
@@ -246,6 +247,7 @@ describe('games-repo source extractors', () => {
         urban: 'shared/verticals/urban/index.ts',
         racing: 'shared/verticals/racing/index.ts',
         football: 'shared/verticals/football/index.ts',
+        platformer: 'shared/verticals/platformer/index.ts',
       });
     `;
     expect(extractGameKitVerticals(source)).toEqual(GAME_KIT_VERTICAL_ENTRIES);

--- a/apps/api/src/games-repo-contract.ts
+++ b/apps/api/src/games-repo-contract.ts
@@ -62,9 +62,7 @@ export const GAME_KIT_MODULES = [
   // Genre verticals: the GitHub client bundles their private shared/verticals graphs.
   'racing',
   'football',
-  // Genre vertical: platformer physics + pluggable level sources + recipe vocabulary
-  // (games-repo #690). Website-first — see WEBSITE_AHEAD_EXPIRY in
-  // games-repo-contract-check.ts.
+  // Genre vertical: platformer physics/levels/recipes (games-repo #690, website-first).
   'platformer',
   'effects',
   'audio',

--- a/apps/api/src/games-repo-contract.ts
+++ b/apps/api/src/games-repo-contract.ts
@@ -62,6 +62,10 @@ export const GAME_KIT_MODULES = [
   // Genre verticals: the GitHub client bundles their private shared/verticals graphs.
   'racing',
   'football',
+  // Genre vertical: platformer physics + pluggable level sources + recipe vocabulary
+  // (games-repo #690). Website-first — see WEBSITE_AHEAD_EXPIRY in
+  // games-repo-contract-check.ts.
+  'platformer',
   'effects',
   'audio',
   'party',
@@ -191,6 +195,7 @@ export const GAME_KIT_VERTICAL_ENTRIES: Partial<Record<GameKitModuleName, string
   urban: 'shared/verticals/urban/index.ts',
   racing: 'shared/verticals/racing/index.ts',
   football: 'shared/verticals/football/index.ts',
+  platformer: 'shared/verticals/platformer/index.ts',
 };
 
 /** Pull the `GAME_KIT_VERTICALS = { ... }` object literal out of games-repo assemble source. */


### PR DESCRIPTION
## Why

[games-repo#690](https://github.com/gamedevpl/www.gamedev.pl-games/pull/690) adds a `platformer` GameKit vertical (physics core, pluggable level sources, a recipe vocabulary compiling to `defineGame`) but is blocked on this side: `contract:games-repo` fails the moment games-repo introduces a module this side doesn't recognize, and play/draft would 502 for any game selecting `platformer`. Merge order is website-first, same rule as a budget raise — this PR is that half.

Confirmed against games-repo branch `claude/gamekit-recipe-framework` (`4642bbc`) directly: `platformer` is inserted right after `football`, before `effects`, as a `GAME_KIT_VERTICALS` entry pointing at `shared/verticals/platformer/index.ts` — matching `vehicles`/`urban`/`racing`/`football`.

## What changed

Same shape as #717 (`cards`):

- `apps/api/src/games-repo-contract.ts` — `platformer` added to `GAME_KIT_MODULES` and `GAME_KIT_VERTICAL_ENTRIES`.
- `apps/api/fixtures/games-repo/shared/assemble-contract.json` — mirrored, so the local-dev fixture snapshot test stays in lockstep.
- `apps/api/src/games-repo-contract.test.ts` — expected module/vertical lists updated to match.
- `apps/api/src/games-repo-contract-check.ts` — a short-lived `WEBSITE_AHEAD_EXPIRY` entry for `platformer` (expires 2026-08-29), so this exception fails closed if games-repo#690 doesn't land in time rather than staying a silent permanent allowance.

## Verification

- `npx vitest run` in `apps/api` — 197 files, 3141 tests passing (after `npm run build:packages` for the workspace-linked packages).
- `npx tsc --noEmit` clean.
- `npx eslint` clean on the touched files.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JYJqkH9wbBpWBwLPYDL7kf)_