### PR TITLE
Add "Fix it" button to crash card that seeds chat with error

### DIFF
--- a/apps/web/src/CreatorStudioView.tsx
+++ b/apps/web/src/CreatorStudioView.tsx
@@ -435,6 +435,7 @@ export function CreatorStudioView({
     setChecklistUnread(0);
     setRailManualOpen(null);
     setTheaterOpen(false);
+    setChatDraft(null);
     seenActivityRef.current = 0;
     latestActivityRef.current = null;
   }, [stageToken]);

--- a/apps/web/src/CreatorStudioView.tsx
+++ b/apps/web/src/CreatorStudioView.tsx
@@ -390,9 +390,7 @@ export function CreatorStudioView({
   const studioStatus = useStudioStatusPoll(stageToken);
   const stageSource = useStageSource(stageToken ?? '', studioStatus);
   const [stageStatus, setStageStatus] = useState<StageStatus>({ kind: 'empty' });
-  // The crash card's "Fix it" button seeds this with a prompt describing the failure and
-  // opens the rail; the composer consumes it once and clears it back to null so a later
-  // re-render (or reopening the rail by hand) doesn't repopulate a stale draft.
+  // "Fix it" seeds this; the composer consumes it once, then clears it.
   const [chatDraft, setChatDraft] = useState<{ text: string; seq: number } | null>(null);
   // What the ribbon should describe — the *displayed* document's origin, reported back
   // by the stage. Distinct from `stageSource.origin` (the latest fetched one) while a

--- a/apps/web/src/CreatorStudioView.tsx
+++ b/apps/web/src/CreatorStudioView.tsx
@@ -390,6 +390,10 @@ export function CreatorStudioView({
   const studioStatus = useStudioStatusPoll(stageToken);
   const stageSource = useStageSource(stageToken ?? '', studioStatus);
   const [stageStatus, setStageStatus] = useState<StageStatus>({ kind: 'empty' });
+  // The crash card's "Fix it" button seeds this with a prompt describing the failure and
+  // opens the rail; the composer consumes it once and clears it back to null so a later
+  // re-render (or reopening the rail by hand) doesn't repopulate a stale draft.
+  const [chatDraft, setChatDraft] = useState<{ text: string; seq: number } | null>(null);
   // What the ribbon should describe — the *displayed* document's origin, reported back
   // by the stage. Distinct from `stageSource.origin` (the latest fetched one) while a
   // swap is held during play: the ribbon must not claim a not-yet-applied build's
@@ -929,6 +933,10 @@ export function CreatorStudioView({
                           onPostureChange={setPosture}
                           covered={covered}
                           onStatusChange={setStageStatus}
+                          onFixIt={(message) => {
+                            setChatDraft({ text: t('studioPanel.stage.fixItPrompt', { message }), seq: Date.now() });
+                            setRailManualOpen(true);
+                          }}
                           onNewerStageWaiting={setNewerStageWaiting}
                           onImproved={(newToken) => setHandoffToken(newToken)}
                           onDisplayedOriginChange={setDisplayedOrigin}
@@ -983,6 +991,8 @@ export function CreatorStudioView({
                             key={threadToken ?? activeGame.token}
                             token={threadToken ?? activeGame.token}
                             embedded
+                            draft={chatDraft}
+                            onDraftConsumed={() => setChatDraft(null)}
                             justHandedOff={handoffToken != null}
                             onImproved={(newToken) => setHandoffToken(newToken)}
                             onPlaytest={() => changePosture('play')}

--- a/apps/web/src/StudioStage.test.tsx
+++ b/apps/web/src/StudioStage.test.tsx
@@ -269,8 +269,7 @@ describe('StudioStage', () => {
     const onFixIt = vi.fn();
     const props = baseProps({ posture: 'watch', onFixIt });
     const { host, rerender, unmount } = await mount(props);
-    // The initial document never runs through `watchSwappedDocument` (it's already
-    // `shownHtml` on mount) — swap to a new source so the crash listener attaches.
+    // Swap sources so the crash listener attaches (mount alone skips it).
     await rerender({
       ...props,
       source: { html: GAME_B, rawHtml: GAME_B, origin: { kind: 'staged', at: Date.now(), versionLabel: null } },

--- a/apps/web/src/StudioStage.test.tsx
+++ b/apps/web/src/StudioStage.test.tsx
@@ -264,6 +264,63 @@ describe('StudioStage', () => {
     unmount();
   });
 
+  it('crash card surfaces a Fix it button that reports the crash message', async () => {
+    vi.useFakeTimers();
+    const onFixIt = vi.fn();
+    const props = baseProps({ posture: 'watch', onFixIt });
+    const { host, rerender, unmount } = await mount(props);
+    // The initial document never runs through `watchSwappedDocument` (it's already
+    // `shownHtml` on mount) — swap to a new source so the crash listener attaches.
+    await rerender({
+      ...props,
+      source: { html: GAME_B, rawHtml: GAME_B, origin: { kind: 'staged', at: Date.now(), versionLabel: null } },
+    });
+
+    const iframe = host.querySelector('iframe')!;
+    await act(async () => {
+      const event = new MessageEvent('message', {
+        data: { source: 'gdpl-player', type: 'error', message: 'Bastion requires gfx3d' },
+      });
+      Object.defineProperty(event, 'source', { value: iframe.contentWindow });
+      Object.defineProperty(event, 'origin', { value: 'null' });
+      window.dispatchEvent(event);
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    const fixItBtn = Array.from(host.querySelectorAll('button')).find((btn) => /fix it/i.test(btn.textContent ?? ''));
+    expect(fixItBtn).not.toBeUndefined();
+    await act(async () => {
+      fixItBtn!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    expect(onFixIt).toHaveBeenCalledWith('Bastion requires gfx3d');
+    unmount();
+  });
+
+  it('omits the Fix it button when no handler is wired', async () => {
+    vi.useFakeTimers();
+    const props = baseProps({ posture: 'watch' });
+    const { host, rerender, unmount } = await mount(props);
+    await rerender({
+      ...props,
+      source: { html: GAME_B, rawHtml: GAME_B, origin: { kind: 'staged', at: Date.now(), versionLabel: null } },
+    });
+
+    const iframe = host.querySelector('iframe')!;
+    await act(async () => {
+      const event = new MessageEvent('message', {
+        data: { source: 'gdpl-player', type: 'error', message: 'boom' },
+      });
+      Object.defineProperty(event, 'source', { value: iframe.contentWindow });
+      Object.defineProperty(event, 'origin', { value: 'null' });
+      window.dispatchEvent(event);
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    const fixItBtn = Array.from(host.querySelectorAll('button')).find((btn) => /fix it/i.test(btn.textContent ?? ''));
+    expect(fixItBtn).toBeUndefined();
+    unmount();
+  });
+
   it('unmutes and resumes the frame on entering play — watching must not leave a game silent forever', async () => {
     vi.useFakeTimers();
     const props = baseProps({ posture: 'watch' });

--- a/apps/web/src/StudioStage.tsx
+++ b/apps/web/src/StudioStage.tsx
@@ -69,8 +69,6 @@ export type StudioStageProps = {
   /** True whenever a surface (rail/details/edit/shelf) covers the stage. */
   covered: boolean;
   onStatusChange?: (status: StageStatus) => void;
-  /** The crash card's "Fix it" button — called with the crash message so the parent can
-   * open the chat rail with a prefilled prompt describing the failure. */
   onFixIt?: (message: string) => void;
   /** A staged swap is being held for the ribbon's "newer stage waiting" exception. */
   onNewerStageWaiting?: (waiting: boolean) => void;

--- a/apps/web/src/StudioStage.tsx
+++ b/apps/web/src/StudioStage.tsx
@@ -69,6 +69,9 @@ export type StudioStageProps = {
   /** True whenever a surface (rail/details/edit/shelf) covers the stage. */
   covered: boolean;
   onStatusChange?: (status: StageStatus) => void;
+  /** The crash card's "Fix it" button — called with the crash message so the parent can
+   * open the chat rail with a prefilled prompt describing the failure. */
+  onFixIt?: (message: string) => void;
   /** A staged swap is being held for the ribbon's "newer stage waiting" exception. */
   onNewerStageWaiting?: (waiting: boolean) => void;
   /** A published-game improvement opened a new job; the parent moves the thread onto it. */
@@ -92,6 +95,7 @@ export function StudioStage({
   onPostureChange,
   covered,
   onStatusChange,
+  onFixIt,
   onNewerStageWaiting,
   onImproved,
   onDisplayedOriginChange,
@@ -434,7 +438,17 @@ export function StudioStage({
           </p>
           {status.kind === 'crashed' ? <code className="studio-stage-card-detail">{status.message}</code> : null}
           <div className="studio-stage-card-actions">
-            <button type="button" className="primary-btn" onClick={recoverToLastGood} disabled={!lastGoodRef.current}>
+            {status.kind === 'crashed' && onFixIt ? (
+              <button type="button" className="primary-btn" onClick={() => onFixIt(status.message)}>
+                <PixelIcon name="wrench" size={12} /> {t('studioPanel.stage.fixIt')}
+              </button>
+            ) : null}
+            <button
+              type="button"
+              className={status.kind === 'crashed' && onFixIt ? 'secondary-btn' : 'primary-btn'}
+              onClick={recoverToLastGood}
+              disabled={!lastGoodRef.current}
+            >
               <PixelIcon name="undo" size={12} />{' '}
               {t('studioPanel.stage.backTo', { time: formatClock(lastGoodAtRef.current ?? Date.now()) })}
             </button>

--- a/apps/web/src/SubmissionStatusView.test.ts
+++ b/apps/web/src/SubmissionStatusView.test.ts
@@ -1619,9 +1619,6 @@ describe('SubmissionStatusView', () => {
   });
 
   it('seeds a parent-supplied draft into the compact composer and reports it consumed', async () => {
-    // The stage crash card's "Fix it" button hands the composer a prompt describing the
-    // crash — the composer must show it immediately and tell the parent it took it, so
-    // the parent's own copy clears instead of repopulating the box on a later render.
     (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
     mockedGetSubmissionStatus.mockResolvedValue({
       status: 'needs_changes',

--- a/apps/web/src/SubmissionStatusView.test.ts
+++ b/apps/web/src/SubmissionStatusView.test.ts
@@ -1618,6 +1618,51 @@ describe('SubmissionStatusView', () => {
     });
   });
 
+  it('seeds a parent-supplied draft into the compact composer and reports it consumed', async () => {
+    // The stage crash card's "Fix it" button hands the composer a prompt describing the
+    // crash — the composer must show it immediately and tell the parent it took it, so
+    // the parent's own copy clears instead of repopulating the box on a later render.
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    mockedGetSubmissionStatus.mockResolvedValue({
+      status: 'needs_changes',
+      preview: { slug: 'space-runner' },
+      progress: { headSha: 'sha-1', commits: [], checklist: [] },
+    });
+    mockedGetSubmissionPreview.mockResolvedValue({
+      slug: 'space-runner',
+      title: 'Space Runner',
+      html: '<canvas></canvas>',
+    });
+    await i18n.changeLanguage('en');
+    window.history.pushState(null, '', '/studio/draft-token/thread');
+
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    const onDraftConsumed = vi.fn();
+
+    await act(async () => {
+      root.render(
+        createElement(SubmissionStatusView, {
+          token: 'draft-token',
+          embedded: true,
+          draft: { text: 'The game crashed with: Bastion requires gfx3d', seq: 1 },
+          onDraftConsumed,
+        }),
+      );
+      await flushEffects();
+      await flushEffects();
+    });
+
+    const textarea = container.querySelector<HTMLTextAreaElement>('.status-feedback-input');
+    expect(textarea?.value).toBe('The game crashed with: Bastion requires gfx3d');
+    expect(onDraftConsumed).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
+
   it('shows a sending indicator on the compact composer while the request is in flight', async () => {
     // The compact send is icon-only. Disabling it without a spinner or "Sending…" left
     // creators staring at a grey arrow with no idea whether anything was happening —

--- a/apps/web/src/SubmissionStatusView.tsx
+++ b/apps/web/src/SubmissionStatusView.tsx
@@ -1455,14 +1455,17 @@ function FeedbackPanel({
     if (!draft) return;
     setText(draft.text);
     onDraftConsumed?.();
-    const input = inputRef.current;
-    if (input) {
-      input.focus();
-      input.style.height = 'auto';
-      input.style.height = `${Math.min(input.scrollHeight, 220)}px`;
-    }
+    inputRef.current?.focus();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [draft?.seq]);
+
+  // Runs after `text` commits, so a seeded draft measures its real height.
+  useEffect(() => {
+    const input = inputRef.current;
+    if (!input) return;
+    input.style.height = 'auto';
+    input.style.height = `${Math.min(input.scrollHeight, 220)}px`;
+  }, [text]);
 
   useEffect(() => {
     setStopRequested(handoffPending === 'self');

--- a/apps/web/src/SubmissionStatusView.tsx
+++ b/apps/web/src/SubmissionStatusView.tsx
@@ -341,6 +341,15 @@ type SubmissionStatusViewProps = {
    * text — render it escaped, same as every other transcript row.
    */
   onActivityCount?: (count: number, latest: string | null) => void;
+  /**
+   * Embedded only: a prompt the parent wants sitting in the composer, e.g. the stage
+   * crash card's "Fix it" button. `seq` distinguishes two drafts with identical text so
+   * clicking "Fix it" again after editing the box still overwrites it. `onDraftConsumed`
+   * fires once the composer has applied it, so the parent can clear its own copy and a
+   * later render (or the rail reopening by hand) doesn't repopulate a stale draft.
+   */
+  draft?: { text: string; seq: number } | null;
+  onDraftConsumed?: () => void;
 };
 
 export function SubmissionStatusView({
@@ -355,6 +364,8 @@ export function SubmissionStatusView({
   onImproved,
   justHandedOff = false,
   onActivityCount,
+  draft,
+  onDraftConsumed,
 }: SubmissionStatusViewProps) {
   const { t, i18n } = useTranslation();
   const [status, setStatus] = useState<SubmissionStatus | null>(null);
@@ -944,6 +955,8 @@ export function SubmissionStatusView({
                     phase={status.phase}
                     handoffPending={status.builderHandoff?.target}
                     agentWorking={agentWorking}
+                    draft={draft}
+                    onDraftConsumed={onDraftConsumed}
                     onSwitchToPlatform={
                       status.builder === 'self' && (agentWorking || status.builderHandoff?.target === 'platform')
                         ? handoffToPlatformFromUi
@@ -1387,6 +1400,8 @@ function FeedbackPanel({
   platformUnavailable,
   onSent,
   onPublishedImprove,
+  draft,
+  onDraftConsumed,
 }: {
   token: string;
   /** Routes the message: an improvement on the live game, or a change on the build. */
@@ -1421,6 +1436,9 @@ function FeedbackPanel({
    * path — a draft revision continues the current round and stays on this thread.
    */
   onPublishedImprove?: (token: string) => void;
+  /** A prompt the parent wants seeded into the box — see `SubmissionStatusView`'s doc. */
+  draft?: { text: string; seq: number } | null;
+  onDraftConsumed?: () => void;
 }) {
   const { t } = useTranslation();
   const [text, setText] = useState('');
@@ -1440,6 +1458,23 @@ function FeedbackPanel({
   useEffect(() => {
     setBuilder(initialBuilder);
   }, [initialBuilder, token]);
+
+  // Applies a draft the parent seeded (e.g. the stage crash card's "Fix it" button),
+  // keyed on `seq` so a second click after the box was edited still overwrites it.
+  // Consuming clears the parent's copy so reopening the rail by hand later doesn't
+  // repopulate a stale prompt.
+  useEffect(() => {
+    if (!draft) return;
+    setText(draft.text);
+    onDraftConsumed?.();
+    const input = inputRef.current;
+    if (input) {
+      input.focus();
+      input.style.height = 'auto';
+      input.style.height = `${Math.min(input.scrollHeight, 220)}px`;
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [draft?.seq]);
 
   useEffect(() => {
     setStopRequested(handoffPending === 'self');

--- a/apps/web/src/SubmissionStatusView.tsx
+++ b/apps/web/src/SubmissionStatusView.tsx
@@ -341,13 +341,6 @@ type SubmissionStatusViewProps = {
    * text — render it escaped, same as every other transcript row.
    */
   onActivityCount?: (count: number, latest: string | null) => void;
-  /**
-   * Embedded only: a prompt the parent wants sitting in the composer, e.g. the stage
-   * crash card's "Fix it" button. `seq` distinguishes two drafts with identical text so
-   * clicking "Fix it" again after editing the box still overwrites it. `onDraftConsumed`
-   * fires once the composer has applied it, so the parent can clear its own copy and a
-   * later render (or the rail reopening by hand) doesn't repopulate a stale draft.
-   */
   draft?: { text: string; seq: number } | null;
   onDraftConsumed?: () => void;
 };
@@ -1436,7 +1429,6 @@ function FeedbackPanel({
    * path — a draft revision continues the current round and stays on this thread.
    */
   onPublishedImprove?: (token: string) => void;
-  /** A prompt the parent wants seeded into the box — see `SubmissionStatusView`'s doc. */
   draft?: { text: string; seq: number } | null;
   onDraftConsumed?: () => void;
 }) {
@@ -1459,10 +1451,6 @@ function FeedbackPanel({
     setBuilder(initialBuilder);
   }, [initialBuilder, token]);
 
-  // Applies a draft the parent seeded (e.g. the stage crash card's "Fix it" button),
-  // keyed on `seq` so a second click after the box was edited still overwrites it.
-  // Consuming clears the parent's copy so reopening the rail by hand later doesn't
-  // repopulate a stale prompt.
   useEffect(() => {
     if (!draft) return;
     setText(draft.text);

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -568,6 +568,8 @@
       "idleResume": "Paused — idle. Tap to resume.",
       "crashedTitle": "This build crashed.",
       "drewNothingTitle": "This build didn't draw anything.",
+      "fixIt": "Fix it",
+      "fixItPrompt": "The game crashed with this error:\n\n{{message}}\n\nPlease fix it.",
       "backTo": "Back to {{time}}",
       "newBuildStaged": "New build staged ({{time}})",
       "restartOnIt": "Restart on it",

--- a/apps/web/src/i18n/locales/pl.json
+++ b/apps/web/src/i18n/locales/pl.json
@@ -574,6 +574,8 @@
       "idleResume": "Zapauzowano — bezczynność. Stuknij, aby wznowić.",
       "crashedTitle": "Ta wersja się wysypała.",
       "drewNothingTitle": "Ta wersja niczego nie narysowała.",
+      "fixIt": "Napraw to",
+      "fixItPrompt": "Gra wysypała się z tym błędem:\n\n{{message}}\n\nProszę to napraw.",
       "backTo": "Wróć do {{time}}",
       "newBuildStaged": "Nowa wersja gotowa ({{time}})",
       "restartOnIt": "Zrestartuj na niej",


### PR DESCRIPTION
## Summary
Adds a "Fix it" button to the stage crash card that allows users to quickly open the chat rail with a pre-filled prompt describing the crash error. This streamlines the workflow for addressing build failures.

## Key Changes

- **StudioStage**: Added `onFixIt` callback prop that fires when the "Fix it" button is clicked, passing the crash message. The button appears conditionally when a handler is provided and becomes the primary action, demoting the "Back to" button to secondary.

- **CreatorStudioView**: Implements the `onFixIt` handler by:
  - Creating a `chatDraft` state to hold the seeded prompt
  - Generating a prompt message from the crash error using i18n
  - Opening the chat rail automatically when "Fix it" is clicked
  - Passing the draft to `SubmissionStatusView` and clearing it once consumed

- **SubmissionStatusView & FeedbackPanel**: Added `draft` and `onDraftConsumed` props to support seeding the composer with parent-supplied text. The draft is keyed by `seq` (timestamp) so clicking "Fix it" again after editing still overwrites the box. The composer calls `onDraftConsumed` once applied, allowing the parent to clear its copy and prevent stale repopulation on re-render.

- **Localization**: Added "fixIt" button label and "fixItPrompt" message template to English and Polish translations.

## Implementation Details

- The draft consumption uses a `useEffect` keyed on `draft?.seq` to detect new drafts even with identical text
- The composer auto-focuses and auto-sizes the textarea when a draft is applied
- The crash card conditionally renders the "Fix it" button only when `onFixIt` is provided, maintaining backward compatibility
- Tests verify both the happy path (button appears and calls handler) and the case where no handler is wired (button omitted)

https://claude.ai/code/session_017mKDZFGo7oMTaZ4ZCdAKH8