### PR TITLE
Add VS Code-style search panel to CodeMirror editor

### DIFF
--- a/apps/web/src/CodeMirrorEditor.tsx
+++ b/apps/web/src/CodeMirrorEditor.tsx
@@ -6,6 +6,7 @@ import { javascript } from '@codemirror/lang-javascript';
 import { json } from '@codemirror/lang-json';
 import { markdown } from '@codemirror/lang-markdown';
 import { HighlightStyle, syntaxHighlighting } from '@codemirror/language';
+import { search } from '@codemirror/search';
 import { forceLinting, linter, lintGutter, type Diagnostic as CmDiagnostic } from '@codemirror/lint';
 import { Compartment, EditorState, type Extension } from '@codemirror/state';
 import { EditorView, keymap } from '@codemirror/view';
@@ -25,6 +26,7 @@ import {
 } from '@valtown/codemirror-ts';
 import type { WorkerShape } from '@valtown/codemirror-ts/worker';
 import type { CodeLanguage } from './codeTokens.js';
+import { vsCodeSearchPanel } from './codeMirrorSearchPanel.js';
 
 // CodeMirror 6 (CE-14): lazy chunk; keyed by file path to remount.
 
@@ -94,12 +96,14 @@ const darkChrome = EditorView.theme(
       backgroundColor: 'rgba(0, 228, 172, 0.16)',
     },
     '.cm-selectionMatch': { backgroundColor: 'rgba(0, 228, 172, 0.12)' },
+    '.cm-searchMatch': { backgroundColor: 'rgba(56, 189, 248, 0.22)', borderRadius: '2px' },
+    '.cm-searchMatch.cm-searchMatch-selected': { backgroundColor: 'rgba(0, 228, 172, 0.38)' },
     '&.cm-focused .cm-matchingBracket': { backgroundColor: 'rgba(0, 228, 172, 0.2)', outline: 'none' },
     '&.cm-focused .cm-nonmatchingBracket': { backgroundColor: 'rgba(255, 123, 114, 0.2)' },
     '.cm-gutters': { backgroundColor: 'transparent', color: 'var(--muted, #8b949e)', border: 'none' },
     '.cm-foldGutter, .cm-lineNumbers': { color: 'var(--muted, #8b949e)' },
     '.cm-tooltip': {
-      backgroundColor: 'var(--panel-bg, #0c1218)',
+      backgroundColor: 'var(--panel, #161c22)',
       color: 'var(--text, #e6edf3)',
       border: '1px solid rgba(148, 163, 184, 0.25)',
       borderRadius: '8px',
@@ -108,7 +112,121 @@ const darkChrome = EditorView.theme(
       backgroundColor: 'rgba(0, 228, 172, 0.16)',
       color: 'var(--text, #e6edf3)',
     },
-    '.cm-panels': { backgroundColor: 'var(--panel-bg, #0c1218)', color: 'var(--text, #e6edf3)' },
+    // The search widget floats over the editor, so panels reserve no space.
+    '.cm-panels': { backgroundColor: 'transparent', color: 'var(--text, #e6edf3)' },
+    '.cm-panels.cm-panels-top': {
+      position: 'absolute',
+      top: 0,
+      right: 0,
+      left: 'auto',
+      zIndex: 12,
+      borderBottom: 'none',
+    },
+    '.cm-vs-search': {
+      display: 'flex',
+      alignItems: 'flex-start',
+      gap: '2px',
+      margin: '6px 16px 0 6px',
+      padding: '6px 6px 6px 2px',
+      borderRadius: '10px',
+      border: '1px solid var(--panel-border, rgba(148, 163, 184, 0.25))',
+      backgroundColor: 'var(--panel, #161c22)',
+      boxShadow: '0 10px 30px rgba(0, 0, 0, 0.45)',
+      fontSize: '0.76rem',
+      maxWidth: 'calc(100% - 22px)',
+    },
+    '.cm-vs-body': { display: 'flex', flexDirection: 'column', gap: '4px', minWidth: 0 },
+    // Wraps rather than overflowing the editor on a narrow viewport.
+    '.cm-vs-row': { display: 'flex', flexWrap: 'wrap', alignItems: 'center', gap: '2px', minWidth: 0 },
+    // Without this, display:flex beats the hidden attribute and replace never collapses.
+    '.cm-vs-row[hidden]': { display: 'none' },
+    // The chevron spans both rows, as in VS Code.
+    '.cm-vs-expand': { alignSelf: 'stretch', height: 'auto', flex: 'none' },
+    '.cm-vs-expanded .cm-vs-expand svg': { transform: 'rotate(90deg)' },
+    '.cm-vs-expand svg': { transition: 'transform 120ms ease' },
+    '.cm-vs-field-wrap': {
+      display: 'flex',
+      alignItems: 'center',
+      gap: '2px',
+      // Fixed, not growing, so both fields match width.
+      flex: '0 1 15rem',
+      width: '15rem',
+      minWidth: '6rem',
+      padding: '0 3px 0 7px',
+      borderRadius: '6px',
+      border: '1px solid var(--panel-border, rgba(148, 163, 184, 0.25))',
+      backgroundColor: 'rgba(9, 13, 17, 0.7)',
+    },
+    '.cm-vs-field-wrap:focus-within': {
+      borderColor: 'var(--turquoise, #00e4ac)',
+      boxShadow: '0 0 0 1px rgba(0, 228, 172, 0.35)',
+    },
+    '.cm-vs-invalid .cm-vs-field-wrap:first-of-type': { borderColor: 'var(--error, #ff6b6b)' },
+    '.cm-vs-field': {
+      flex: 1,
+      minWidth: 0,
+      border: 'none',
+      outline: 'none',
+      background: 'transparent',
+      color: 'var(--text, #e6edf3)',
+      fontFamily: 'var(--mono-font, monospace)',
+      fontSize: '0.76rem',
+      padding: '5px 0',
+    },
+    '.cm-vs-field::placeholder': { color: 'var(--muted, #8b949e)' },
+    '.cm-vs-toggles': { display: 'flex', alignItems: 'center', gap: '1px', flex: 'none' },
+    '.cm-vs-toggle': {
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+      width: '20px',
+      height: '20px',
+      padding: 0,
+      border: 'none',
+      borderRadius: '4px',
+      background: 'transparent',
+      color: 'var(--muted, #8b949e)',
+      font: 'inherit',
+      fontSize: '0.68rem',
+      lineHeight: 1,
+      cursor: 'pointer',
+    },
+    '.cm-vs-toggle:hover': { backgroundColor: 'rgba(148, 163, 184, 0.16)', color: 'var(--text, #e6edf3)' },
+    '.cm-vs-toggle[aria-pressed=true]': {
+      backgroundColor: 'rgba(0, 228, 172, 0.18)',
+      color: 'var(--turquoise, #00e4ac)',
+    },
+    '.cm-vs-count': {
+      flex: 'none',
+      minWidth: '4.6rem',
+      padding: '0 4px',
+      color: 'var(--muted, #8b949e)',
+      fontSize: '0.7rem',
+      whiteSpace: 'nowrap',
+      textAlign: 'right',
+    },
+    '.cm-vs-icon-button': {
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+      flex: 'none',
+      width: '24px',
+      height: '24px',
+      padding: 0,
+      border: 'none',
+      borderRadius: '5px',
+      background: 'transparent',
+      color: 'var(--muted, #8b949e)',
+      font: 'inherit',
+      cursor: 'pointer',
+    },
+    '.cm-vs-text-button': { width: 'auto', padding: '0 7px', fontSize: '0.72rem', fontWeight: 500 },
+    '.cm-vs-icon-button:hover': { backgroundColor: 'rgba(148, 163, 184, 0.16)', color: 'var(--text, #e6edf3)' },
+    '.cm-vs-icon-button:active': { backgroundColor: 'rgba(0, 228, 172, 0.2)' },
+    '.cm-vs-search button:focus-visible': {
+      outline: '1px solid var(--turquoise, #00e4ac)',
+      outlineOffset: '-1px',
+    },
   },
   { dark: true },
 );
@@ -211,6 +329,8 @@ export default function CodeMirrorEditor({
         selection: initialSelection,
         extensions: [
           basicSetup,
+          // After basicSetup, so this createPanel wins over the stock search bar.
+          search({ top: true, createPanel: vsCodeSearchPanel }),
           keymap.of([
             indentWithTab,
             {

--- a/apps/web/src/codeMirrorSearchPanel.test.ts
+++ b/apps/web/src/codeMirrorSearchPanel.test.ts
@@ -1,0 +1,81 @@
+import { SearchQuery } from '@codemirror/search';
+import { EditorState } from '@codemirror/state';
+import { describe, expect, it } from 'vitest';
+import { countMatches, describeCount, MATCH_LIMIT } from './codeMirrorSearchPanel.js';
+
+// The panel needs a laid-out EditorView; only the counter is pure.
+
+const DOC = `lem.y += lem.vy;
+if (Lem.y > 0) {
+  lem.done = true;
+}`;
+
+function stateWith(doc: string, selection?: { anchor: number; head: number }) {
+  return EditorState.create({ doc, selection });
+}
+
+describe('countMatches', () => {
+  it('counts every match when the cursor is not on one', () => {
+    const state = stateWith(DOC);
+    expect(countMatches(state, new SearchQuery({ search: 'lem' }))).toEqual({
+      total: 4,
+      current: 0,
+      capped: false,
+    });
+  });
+
+  it('honours case sensitivity', () => {
+    const state = stateWith(DOC);
+    const query = new SearchQuery({ search: 'lem', caseSensitive: true });
+    expect(countMatches(state, query).total).toBe(3);
+  });
+
+  it('reports the 1-based index of the match under the selection', () => {
+    // The second `lem`, at "lem.vy".
+    const at = DOC.indexOf('lem', 4);
+    const state = stateWith(DOC, { anchor: at, head: at + 3 });
+    expect(countMatches(state, new SearchQuery({ search: 'lem' }))).toEqual({
+      total: 4,
+      current: 2,
+      capped: false,
+    });
+  });
+
+  it('treats a partially covered match as no current match', () => {
+    const at = DOC.indexOf('lem');
+    const state = stateWith(DOC, { anchor: at, head: at + 2 });
+    expect(countMatches(state, new SearchQuery({ search: 'lem' })).current).toBe(0);
+  });
+
+  it('returns nothing for an invalid query', () => {
+    const state = stateWith(DOC);
+    const query = new SearchQuery({ search: 'lem(', regexp: true });
+    expect(query.valid).toBe(false);
+    expect(countMatches(state, query)).toEqual({ total: 0, current: 0, capped: false });
+  });
+
+  it('stops counting at the cap instead of walking a huge document', () => {
+    const state = stateWith('x '.repeat(MATCH_LIMIT + 50));
+    const counted = countMatches(state, new SearchQuery({ search: 'x' }));
+    expect(counted).toEqual({ total: MATCH_LIMIT, current: 0, capped: true });
+  });
+});
+
+describe('describeCount', () => {
+  it('names the empty case rather than showing a zero', () => {
+    expect(describeCount({ total: 0, current: 0, capped: false })).toBe('No results');
+  });
+
+  it('reads as a position when the cursor sits on a match', () => {
+    expect(describeCount({ total: 14, current: 3, capped: false })).toBe('3 of 14');
+  });
+
+  it('reads as a total when it does not', () => {
+    expect(describeCount({ total: 14, current: 0, capped: false })).toBe('14 results');
+  });
+
+  it('marks a capped count as approximate', () => {
+    expect(describeCount({ total: 999, current: 0, capped: true })).toBe('999+ results');
+    expect(describeCount({ total: 999, current: 5, capped: true })).toBe('5 of 999+');
+  });
+});

--- a/apps/web/src/codeMirrorSearchPanel.ts
+++ b/apps/web/src/codeMirrorSearchPanel.ts
@@ -1,0 +1,258 @@
+import {
+  closeSearchPanel,
+  findNext,
+  findPrevious,
+  getSearchQuery,
+  replaceAll,
+  replaceNext,
+  selectMatches,
+  setSearchQuery,
+  SearchQuery,
+} from '@codemirror/search';
+import type { EditorState } from '@codemirror/state';
+import type { EditorView, Panel } from '@codemirror/view';
+
+// CE-14: a VS Code shaped find panel, not the stock bar.
+
+// Counting every match in a huge file would block typing.
+export const MATCH_LIMIT = 999;
+
+const ICONS = {
+  chevron: '<path d="M5 3.5 9.5 8 5 12.5" />',
+  up: '<path d="M8 12.5V4M4 7.5 8 3.5l4 4" />',
+  down: '<path d="M8 3.5V12M4 8.5l4 4 4-4" />',
+  close: '<path d="M4 4l8 8M12 4l-8 8" />',
+  replace: '<path d="M3 4.5h6M3 8h4M3 11.5h6" /><path d="M11 6v5M9 9l2 2 2-2" />',
+  replaceAll: '<path d="M3 4h9M3 7.5h9M3 11h5" /><path d="M11 9v4M9.5 11.5 11 13l1.5-1.5" />',
+};
+
+function icon(name: keyof typeof ICONS): string {
+  return `<svg viewBox="0 0 16 16" width="14" height="14" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">${ICONS[name]}</svg>`;
+}
+
+function iconButton(name: keyof typeof ICONS, label: string, extraClass = ''): HTMLButtonElement {
+  const button = document.createElement('button');
+  button.type = 'button';
+  button.className = `cm-vs-icon-button ${extraClass}`.trim();
+  button.title = label;
+  button.setAttribute('aria-label', label);
+  button.innerHTML = icon(name);
+  return button;
+}
+
+// Glyph-labelled, like VS Code; the title carries the real name.
+function toggleButton(glyph: string, label: string): HTMLButtonElement {
+  const button = document.createElement('button');
+  button.type = 'button';
+  button.className = 'cm-vs-toggle';
+  button.title = label;
+  button.textContent = glyph;
+  button.setAttribute('aria-label', label);
+  button.setAttribute('aria-pressed', 'false');
+  return button;
+}
+
+function field(placeholder: string, label: string): HTMLInputElement {
+  const input = document.createElement('input');
+  input.className = 'cm-vs-field';
+  input.type = 'text';
+  input.placeholder = placeholder;
+  input.setAttribute('aria-label', label);
+  input.setAttribute('autocomplete', 'off');
+  input.setAttribute('autocorrect', 'off');
+  input.setAttribute('spellcheck', 'false');
+  return input;
+}
+
+export type MatchCount = { total: number; current: number; capped: boolean };
+
+// `current` is 1-based; 0 means no match under the cursor.
+export function countMatches(state: EditorState, query: SearchQuery): MatchCount {
+  if (!query.valid) return { total: 0, current: 0, capped: false };
+  const selection = state.selection.main;
+  const cursor = query.getCursor(state);
+  let total = 0;
+  let current = 0;
+  for (;;) {
+    const next = cursor.next();
+    if (next.done) break;
+    total++;
+    if (next.value.from === selection.from && next.value.to === selection.to) current = total;
+    if (total >= MATCH_LIMIT) return { total, current, capped: true };
+  }
+  return { total, current, capped: false };
+}
+
+export function describeCount({ total, current, capped }: MatchCount): string {
+  if (total === 0) return 'No results';
+  const shown = capped ? `${total}+` : `${total}`;
+  return current > 0 ? `${current} of ${shown}` : `${shown} results`;
+}
+
+export function vsCodeSearchPanel(view: EditorView): Panel {
+  const initial = getSearchQuery(view.state);
+
+  const dom = document.createElement('div');
+  dom.className = 'cm-search cm-vs-search';
+  dom.setAttribute('role', 'search');
+  // Else the editor keymap steals what users type here.
+  dom.addEventListener('keydown', (event) => event.stopPropagation());
+
+  const expand = iconButton('chevron', 'Toggle Replace', 'cm-vs-expand');
+  const body = document.createElement('div');
+  body.className = 'cm-vs-body';
+
+  const findRow = document.createElement('div');
+  findRow.className = 'cm-vs-row';
+  const replaceRow = document.createElement('div');
+  replaceRow.className = 'cm-vs-row';
+
+  const findWrap = document.createElement('div');
+  findWrap.className = 'cm-vs-field-wrap';
+  const findInput = field('Find', 'Find');
+  findInput.value = initial.search;
+  const caseToggle = toggleButton('Aa', 'Match Case');
+  const wordToggle = toggleButton('ab', 'Match Whole Word');
+  const regexpToggle = toggleButton('.*', 'Use Regular Expression');
+  const toggles = document.createElement('div');
+  toggles.className = 'cm-vs-toggles';
+  toggles.append(caseToggle, wordToggle, regexpToggle);
+  findWrap.append(findInput, toggles);
+
+  const count = document.createElement('div');
+  count.className = 'cm-vs-count';
+  count.setAttribute('aria-live', 'polite');
+
+  const prevButton = iconButton('up', 'Previous Match');
+  const nextButton = iconButton('down', 'Next Match');
+  const allButton = document.createElement('button');
+  allButton.type = 'button';
+  allButton.className = 'cm-vs-icon-button cm-vs-text-button';
+  allButton.textContent = 'All';
+  allButton.title = 'Select All Matches';
+  const closeButton = iconButton('close', 'Close');
+
+  findRow.append(findWrap, count, prevButton, nextButton, allButton, closeButton);
+
+  const replaceWrap = document.createElement('div');
+  replaceWrap.className = 'cm-vs-field-wrap';
+  const replaceInput = field('Replace', 'Replace');
+  replaceInput.value = initial.replace;
+  replaceWrap.append(replaceInput);
+  const replaceButton = iconButton('replace', 'Replace');
+  const replaceAllButton = iconButton('replaceAll', 'Replace All');
+  replaceRow.append(replaceWrap, replaceButton, replaceAllButton);
+
+  body.append(findRow, replaceRow);
+  dom.append(expand, body);
+
+  let expanded = false;
+  const setExpanded = (next: boolean) => {
+    expanded = next;
+    dom.classList.toggle('cm-vs-expanded', expanded);
+    expand.setAttribute('aria-expanded', String(expanded));
+    replaceRow.hidden = !expanded;
+  };
+  setExpanded(false);
+
+  const currentQuery = () =>
+    new SearchQuery({
+      search: findInput.value,
+      caseSensitive: caseToggle.getAttribute('aria-pressed') === 'true',
+      wholeWord: wordToggle.getAttribute('aria-pressed') === 'true',
+      regexp: regexpToggle.getAttribute('aria-pressed') === 'true',
+      replace: replaceInput.value,
+    });
+
+  const commit = () => {
+    const query = currentQuery();
+    if (!query.eq(getSearchQuery(view.state))) view.dispatch({ effects: setSearchQuery.of(query) });
+    renderCount();
+  };
+
+  function renderCount() {
+    const query = getSearchQuery(view.state);
+    const invalid = findInput.value.length > 0 && !query.valid;
+    dom.classList.toggle('cm-vs-invalid', invalid);
+    if (!findInput.value) {
+      count.textContent = '';
+      return;
+    }
+    count.textContent = invalid ? 'Invalid regexp' : describeCount(countMatches(view.state, query));
+  }
+
+  const runAndRefresh = (command: (target: EditorView) => boolean) => () => {
+    command(view);
+    view.focus();
+    renderCount();
+  };
+
+  findInput.addEventListener('input', commit);
+  replaceInput.addEventListener('input', commit);
+
+  for (const toggle of [caseToggle, wordToggle, regexpToggle]) {
+    toggle.addEventListener('click', () => {
+      toggle.setAttribute('aria-pressed', String(toggle.getAttribute('aria-pressed') !== 'true'));
+      commit();
+    });
+  }
+
+  expand.addEventListener('click', () => {
+    setExpanded(!expanded);
+    (expanded ? replaceInput : findInput).focus();
+  });
+
+  prevButton.addEventListener('click', runAndRefresh(findPrevious));
+  nextButton.addEventListener('click', runAndRefresh(findNext));
+  allButton.addEventListener('click', runAndRefresh(selectMatches));
+  replaceButton.addEventListener('click', runAndRefresh(replaceNext));
+  replaceAllButton.addEventListener('click', runAndRefresh(replaceAll));
+  closeButton.addEventListener('click', () => closeSearchPanel(view));
+
+  // Focus stays here, so repeated Enter walks the matches.
+  findInput.addEventListener('keydown', (event) => {
+    if (event.key === 'Escape') {
+      event.preventDefault();
+      closeSearchPanel(view);
+    } else if (event.key === 'Enter') {
+      event.preventDefault();
+      (event.shiftKey ? findPrevious : findNext)(view);
+      renderCount();
+    }
+  });
+
+  replaceInput.addEventListener('keydown', (event) => {
+    if (event.key === 'Escape') {
+      event.preventDefault();
+      closeSearchPanel(view);
+    } else if (event.key === 'Enter') {
+      event.preventDefault();
+      (event.ctrlKey || event.metaKey ? replaceAll : replaceNext)(view);
+      renderCount();
+    }
+  });
+
+  return {
+    dom,
+    top: true,
+    mount() {
+      findInput.focus();
+      findInput.select();
+      renderCount();
+    },
+    update(update) {
+      // A query set elsewhere — searching the selection, say — must show up here.
+      for (const tr of update.transactions) {
+        for (const effect of tr.effects) {
+          if (!effect.is(setSearchQuery)) continue;
+          findInput.value = effect.value.search;
+          replaceInput.value = effect.value.replace;
+          caseToggle.setAttribute('aria-pressed', String(effect.value.caseSensitive));
+          wordToggle.setAttribute('aria-pressed', String(effect.value.wholeWord));
+          regexpToggle.setAttribute('aria-pressed', String(effect.value.regexp));
+        }
+      }
+      if (update.docChanged || update.selectionSet || update.transactions.length) renderCount();
+    },
+  };
+}


### PR DESCRIPTION
## Summary
Implements a custom VS Code-shaped search and replace panel for the CodeMirror editor, replacing the default search bar with a more feature-rich interface that includes match counting, regex support, and replace functionality.

## Key Changes
- **New search panel component** (`codeMirrorSearchPanel.ts`): 
  - Custom panel with find/replace fields, toggle buttons for case sensitivity, whole word, and regex matching
  - Match counter that displays current position and total matches (capped at 999 to avoid blocking on large files)
  - Support for previous/next match navigation, select all matches, and replace/replace all operations
  - Keyboard shortcuts: Enter to find next, Shift+Enter for previous, Escape to close
  - Expandable replace section with chevron toggle

- **Integration with CodeMirror editor** (`CodeMirrorEditor.tsx`):
  - Added search extension with custom panel creator
  - Updated theme styling for search matches and the new panel UI
  - Positioned panel absolutely at top-right to float over editor content
  - Added comprehensive styling for search widget components (fields, buttons, toggles, count display)

- **Test coverage** (`codeMirrorSearchPanel.test.ts`):
  - Unit tests for match counting logic with various scenarios (case sensitivity, selection tracking, invalid regex, performance capping)
  - Tests for match count description formatting

## Notable Implementation Details
- Match counting stops at a limit (999) to prevent blocking editor responsiveness on huge files
- Panel floats over editor rather than reserving space, keeping layout compact
- Keyboard event propagation is stopped on the panel to prevent editor keybindings from interfering
- Search state updates from external sources (e.g., searching selection) are reflected in the UI
- Accessibility features included: ARIA labels, live regions for match count updates, proper button semantics

https://claude.ai/code/session_01JoeVxHoN3B3y4x56ppw7rn