### PR TITLE
Studio live-editing, Track 3: scrubbable EDITOR.json params

### DIFF
--- a/apps/web/src/CodeSurface.test.tsx
+++ b/apps/web/src/CodeSurface.test.tsx
@@ -761,5 +761,43 @@ describe('CodeSurface', () => {
 
       expect(container.textContent).not.toContain('Live');
     });
+
+    it('Track 3: scrubbing a declared param pushes live through the same tier-1 path', async () => {
+      mocked.fetchCodeSurfaceSources.mockResolvedValue(sourcesWithEditorJson());
+      mocked.stageCodeSurfaceFile.mockResolvedValue({
+        accepted: true,
+        path: 'EDITOR.json',
+        bytes: 10,
+        staged: { totalBytes: 10, maxBytes: 1_000_000, maxFiles: 60, updatedAt: null },
+      });
+      mockedStudioApi.fetchGameEditor.mockResolvedValue({
+        version: 'v1',
+        definition: { version: 1, content: {} },
+        content: { params: { speed: 5 } },
+        draft: null,
+      });
+      const pushRef: { current: ((content: EditorContentDoc) => void) | null } = { current: vi.fn() };
+
+      await render('sky-dodge', pushRef);
+      const editorTab = [...container.querySelectorAll('.code-surface-rail-item')].find((b) =>
+        b.textContent?.includes('EDITOR.json'),
+      ) as HTMLButtonElement;
+      await act(async () => {
+        editorTab.click();
+      });
+
+      const scrubber = container.querySelector('.number-scrubber[aria-label="Speed"]') as HTMLElement;
+      expect(scrubber).not.toBeNull();
+      expect(scrubber.getAttribute('aria-valuenow')).toBe('5');
+
+      await act(async () => {
+        scrubber.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }));
+        await flush();
+      });
+
+      // A 1-10 range's step is (10-1)/100 = 0.09.
+      expect(pushRef.current).toHaveBeenCalledWith({ params: { speed: 5.09 } });
+      expect(container.textContent).toContain('Live');
+    });
   });
 });

--- a/apps/web/src/CodeSurface.test.tsx
+++ b/apps/web/src/CodeSurface.test.tsx
@@ -799,5 +799,44 @@ describe('CodeSurface', () => {
       expect(pushRef.current).toHaveBeenCalledWith({ params: { speed: 5.09 } });
       expect(container.textContent).toContain('Live');
     });
+
+    it('gives every param control an accessible name, not just the scrubber', async () => {
+      mocked.fetchCodeSurfaceSources.mockResolvedValue(
+        sourcesFor({
+          files: [
+            { path: 'game.ts', content: 'export const boot = () => {};' },
+            {
+              path: 'EDITOR.json',
+              content: JSON.stringify({
+                content: {},
+                params: {
+                  color: { type: 'enum', label: { en: 'Color', pl: 'Kolor' }, values: ['red', 'blue'], default: 'red' },
+                  loud: { type: 'bool', label: { en: 'Loud', pl: 'Głośno' }, default: false },
+                  title: { type: 'text', label: { en: 'Title', pl: 'Tytuł' }, max: 20, default: 'Hi' },
+                },
+              }),
+            },
+          ],
+        }),
+      );
+      mockedStudioApi.fetchGameEditor.mockResolvedValue({
+        version: 'v1',
+        definition: { version: 1, content: {} },
+        content: { params: {} },
+        draft: null,
+      });
+
+      await render();
+      const editorTab = [...container.querySelectorAll('.code-surface-rail-item')].find((b) =>
+        b.textContent?.includes('EDITOR.json'),
+      ) as HTMLButtonElement;
+      await act(async () => {
+        editorTab.click();
+      });
+
+      expect(container.querySelector('.code-surface-param-select[aria-label="Color"]')).not.toBeNull();
+      expect(container.querySelector('input[type="checkbox"][aria-label="Loud"]')).not.toBeNull();
+      expect(container.querySelector('.code-surface-param-text[aria-label="Title"]')).not.toBeNull();
+    });
   });
 });

--- a/apps/web/src/CodeSurface.tsx
+++ b/apps/web/src/CodeSurface.tsx
@@ -44,6 +44,8 @@ import {
 import { type CodeLanguage, tokenizeLine } from './codeTokens.js';
 import { diffLines } from './diffLines.js';
 import { declaredParamDefaultChanges, type DeclaredParamChange } from './editorJsonLiveDiff.js';
+import { clampParamValue, parseEditorParams, scrubStep, withParamDefault } from './editorParamsScrub.js';
+import { NumberScrubber } from './NumberScrubber.js';
 import { PixelIcon } from './PixelIcon.js';
 import { fetchGameEditor, type EditorContentDoc, type EditorParamValue } from './studioApi.js';
 import type { EditorContentPush } from './editorBridge.js';
@@ -165,7 +167,7 @@ export function CodeSurface({
   onPendingActionsModeConsumed,
   onPreviewReady,
 }: CodeSurfaceProps) {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
   const [sources, setSources] = useState<CodeSurfaceSources | null>(null);
   const [loadError, setLoadError] = useState<string | null>(null);
   const [selected, setSelected] = useState<string | null>(() => getCodeSurfaceSessionState(slug)?.selected ?? null);
@@ -442,6 +444,12 @@ export function CodeSurface({
     if (file?.base === undefined) return null;
     return diffLines(file.base, content);
   }, [file, content]);
+  // Track 3: EDITOR.json's declared params, shown above the raw text.
+  const editorParams = useMemo(() => {
+    if (file?.path !== 'EDITOR.json') return null;
+    const parsed = parseEditorParams(content);
+    return parsed && Object.keys(parsed.params).length > 0 ? parsed.params : null;
+  }, [file, content]);
 
   // GA-05: memoized so a keystroke doesn't re-trigger the editor.
   const languageServiceForEditor = useMemo(() => {
@@ -710,6 +718,13 @@ export function CodeSurface({
     }, TYPECHECK_DEBOUNCE_MS);
   }
 
+  // A scrub drives the same path a typed edit would.
+  function scrubParamDefault(key: string, value: EditorParamValue) {
+    if (selected !== 'EDITOR.json') return;
+    const next = withParamDefault(content, key, value);
+    if (next !== null) onEdit(next);
+  }
+
   async function discardWorkingCopy() {
     if (discardState === 'discarding') return;
     setDiscardState('discarding');
@@ -958,6 +973,58 @@ export function CodeSurface({
         </nav>
 
         <div className="code-surface-viewer">
+          {editorParams && !showDiff ? (
+            <div className="code-surface-params" role="group" aria-label={t('studioPanel.code.paramsPanel')}>
+              {Object.entries(editorParams).map(([key, spec]) => {
+                const label = i18n.language?.startsWith('pl') ? spec.label.pl : spec.label.en;
+                return (
+                  <div key={key} className="code-surface-param-row">
+                    <span className="code-surface-param-label">{label}</span>
+                    {spec.type === 'int' || spec.type === 'number' ? (
+                      <NumberScrubber
+                        value={spec.default as number}
+                        min={spec.min}
+                        max={spec.max}
+                        step={scrubStep(spec)}
+                        ariaLabel={label}
+                        disabled={!editable}
+                        onChange={(next) => scrubParamDefault(key, clampParamValue(spec, next))}
+                      />
+                    ) : spec.type === 'enum' ? (
+                      <select
+                        className="code-surface-param-select"
+                        value={spec.default as string}
+                        disabled={!editable}
+                        onChange={(event) => scrubParamDefault(key, event.target.value)}
+                      >
+                        {spec.values.map((option) => (
+                          <option key={option} value={option}>
+                            {option}
+                          </option>
+                        ))}
+                      </select>
+                    ) : spec.type === 'bool' ? (
+                      <input
+                        type="checkbox"
+                        checked={spec.default as boolean}
+                        disabled={!editable}
+                        onChange={(event) => scrubParamDefault(key, event.target.checked)}
+                      />
+                    ) : (
+                      <input
+                        type="text"
+                        className="code-surface-param-text"
+                        value={spec.default as string}
+                        disabled={!editable}
+                        maxLength={spec.max}
+                        onChange={(event) => scrubParamDefault(key, event.target.value)}
+                      />
+                    )}
+                  </div>
+                );
+              })}
+            </div>
+          ) : null}
           {!file ? (
             <p className="code-surface-empty">{t('studioPanel.code.noFiles')}</p>
           ) : showDiff ? (

--- a/apps/web/src/CodeSurface.tsx
+++ b/apps/web/src/CodeSurface.tsx
@@ -995,6 +995,7 @@ export function CodeSurface({
                         className="code-surface-param-select"
                         value={spec.default as string}
                         disabled={!editable}
+                        aria-label={label}
                         onChange={(event) => scrubParamDefault(key, event.target.value)}
                       >
                         {spec.values.map((option) => (
@@ -1008,6 +1009,7 @@ export function CodeSurface({
                         type="checkbox"
                         checked={spec.default as boolean}
                         disabled={!editable}
+                        aria-label={label}
                         onChange={(event) => scrubParamDefault(key, event.target.checked)}
                       />
                     ) : (
@@ -1017,6 +1019,7 @@ export function CodeSurface({
                         value={spec.default as string}
                         disabled={!editable}
                         maxLength={spec.max}
+                        aria-label={label}
                         onChange={(event) => scrubParamDefault(key, event.target.value)}
                       />
                     )}

--- a/apps/web/src/NumberScrubber.test.tsx
+++ b/apps/web/src/NumberScrubber.test.tsx
@@ -1,0 +1,98 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { NumberScrubber, type NumberScrubberProps } from './NumberScrubber.js';
+
+describe('NumberScrubber', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+    // jsdom does not implement pointer capture; the component must tolerate its absence.
+    if (!HTMLElement.prototype.setPointerCapture) {
+      HTMLElement.prototype.setPointerCapture = () => {};
+    }
+  });
+
+  afterEach(async () => {
+    await act(async () => root.unmount());
+    container.remove();
+  });
+
+  function render(props: Partial<NumberScrubberProps> = {}) {
+    const onChange = vi.fn();
+    const full: NumberScrubberProps = {
+      value: 4,
+      min: 1,
+      max: 10,
+      step: 1,
+      onChange,
+      ariaLabel: 'Speed',
+      ...props,
+    };
+    act(() => {
+      root.render(createElement(NumberScrubber, full));
+    });
+    return { onChange, el: container.querySelector('[role="slider"]') as HTMLDivElement };
+  }
+
+  it('shows the current value and its aria bounds', () => {
+    const { el } = render({ value: 4, min: 1, max: 10 });
+    expect(el.textContent).toBe('4');
+    expect(el.getAttribute('aria-valuemin')).toBe('1');
+    expect(el.getAttribute('aria-valuemax')).toBe('10');
+    expect(el.getAttribute('aria-valuenow')).toBe('4');
+  });
+
+  it('formats the displayed value when a formatter is given', () => {
+    const { el } = render({ value: 4, formatValue: (v) => `${v}x` });
+    expect(el.textContent).toBe('4x');
+  });
+
+  it('nudges by step on ArrowRight/ArrowLeft, clamped to the range', () => {
+    const { el, onChange } = render({ value: 9, min: 1, max: 10, step: 1 });
+    act(() => {
+      el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }));
+    });
+    expect(onChange).toHaveBeenLastCalledWith(10);
+
+    const { el: el2, onChange: onChange2 } = render({ value: 1, min: 1, max: 10, step: 1 });
+    act(() => {
+      el2.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowLeft', bubbles: true }));
+    });
+    expect(onChange2).toHaveBeenLastCalledWith(1);
+  });
+
+  it('takes a coarser step with Shift held', () => {
+    const { el, onChange } = render({ value: 5, min: 1, max: 100, step: 1 });
+    act(() => {
+      el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight', shiftKey: true, bubbles: true }));
+    });
+    expect(onChange).toHaveBeenLastCalledWith(15);
+  });
+
+  it('does nothing on keyboard input while disabled', () => {
+    const { el, onChange } = render({ value: 5, disabled: true });
+    act(() => {
+      el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }));
+    });
+    expect(onChange).not.toHaveBeenCalled();
+    expect(el.getAttribute('tabindex')).toBe('-1');
+  });
+
+  it('scrubs via pointer drag, scaled by pixels-per-step, and clamps at the max', () => {
+    const { el, onChange } = render({ value: 4, min: 1, max: 10, step: 1 });
+    act(() => {
+      el.dispatchEvent(new PointerEvent('pointerdown', { pointerId: 1, clientX: 100, button: 0, bubbles: true }));
+      el.dispatchEvent(new PointerEvent('pointermove', { pointerId: 1, clientX: 140, bubbles: true }));
+    });
+    // 40px at 4px/step clamps 4 to the max of 10.
+    expect(onChange).toHaveBeenLastCalledWith(10);
+  });
+});

--- a/apps/web/src/NumberScrubber.tsx
+++ b/apps/web/src/NumberScrubber.tsx
@@ -1,0 +1,86 @@
+import { useCallback, useRef, useState } from 'react';
+
+// Drag-to-scrub for a declared EDITOR.json param.
+
+const PIXELS_PER_STEP = 4;
+const COARSE_MULTIPLIER = 10;
+
+export type NumberScrubberProps = {
+  value: number;
+  min: number;
+  max: number;
+  step: number;
+  onChange: (value: number) => void;
+  ariaLabel: string;
+  formatValue?: (value: number) => string;
+  disabled?: boolean;
+};
+
+export function NumberScrubber({
+  value,
+  min,
+  max,
+  step,
+  onChange,
+  ariaLabel,
+  formatValue,
+  disabled,
+}: NumberScrubberProps) {
+  const [dragging, setDragging] = useState(false);
+  const dragState = useRef<{ pointerId: number; startX: number; startValue: number } | null>(null);
+
+  const clamp = useCallback((next: number) => Math.min(max, Math.max(min, next)), [min, max]);
+
+  function onPointerDown(event: React.PointerEvent<HTMLDivElement>) {
+    if (disabled || event.button !== 0) return;
+    event.currentTarget.setPointerCapture(event.pointerId);
+    dragState.current = { pointerId: event.pointerId, startX: event.clientX, startValue: value };
+    setDragging(true);
+  }
+
+  function onPointerMove(event: React.PointerEvent<HTMLDivElement>) {
+    const drag = dragState.current;
+    if (!drag || drag.pointerId !== event.pointerId) return;
+    const pixels = event.clientX - drag.startX;
+    const multiplier = event.shiftKey ? COARSE_MULTIPLIER : 1;
+    onChange(clamp(drag.startValue + (pixels / PIXELS_PER_STEP) * step * multiplier));
+  }
+
+  function endDrag(event: React.PointerEvent<HTMLDivElement>) {
+    if (dragState.current?.pointerId !== event.pointerId) return;
+    dragState.current = null;
+    setDragging(false);
+  }
+
+  function onKeyDown(event: React.KeyboardEvent<HTMLDivElement>) {
+    if (disabled) return;
+    const multiplier = event.shiftKey ? COARSE_MULTIPLIER : 1;
+    if (event.key === 'ArrowRight' || event.key === 'ArrowUp') {
+      event.preventDefault();
+      onChange(clamp(value + step * multiplier));
+    } else if (event.key === 'ArrowLeft' || event.key === 'ArrowDown') {
+      event.preventDefault();
+      onChange(clamp(value - step * multiplier));
+    }
+  }
+
+  return (
+    <div
+      className={`number-scrubber${dragging ? ' is-dragging' : ''}${disabled ? ' is-disabled' : ''}`}
+      role="slider"
+      tabIndex={disabled ? -1 : 0}
+      aria-label={ariaLabel}
+      aria-valuemin={min}
+      aria-valuemax={max}
+      aria-valuenow={value}
+      aria-disabled={disabled}
+      onPointerDown={onPointerDown}
+      onPointerMove={onPointerMove}
+      onPointerUp={endDrag}
+      onPointerCancel={endDrag}
+      onKeyDown={onKeyDown}
+    >
+      {formatValue ? formatValue(value) : value}
+    </div>
+  );
+}

--- a/apps/web/src/editorParamsScrub.test.ts
+++ b/apps/web/src/editorParamsScrub.test.ts
@@ -42,6 +42,20 @@ describe('parseEditorParams', () => {
     const result = parseEditorParams(JSON.stringify({ params: { ok: EDITOR_JSON, broken: { foo: 'bar' } } }));
     expect(result).toEqual({ params: {}, rest: {} });
   });
+
+  it('skips a param missing its label, even with type and default present', () => {
+    const result = parseEditorParams(
+      JSON.stringify({ params: { speed: { type: 'number', min: 1, max: 10, default: 4 } } }),
+    );
+    expect(result).toEqual({ params: {}, rest: {} });
+  });
+
+  it('skips an enum param missing its values array', () => {
+    const result = parseEditorParams(
+      JSON.stringify({ params: { color: { type: 'enum', default: 'red', label: { en: 'Color', pl: 'Kolor' } } } }),
+    );
+    expect(result).toEqual({ params: {}, rest: {} });
+  });
 });
 
 describe('withParamDefault', () => {

--- a/apps/web/src/editorParamsScrub.test.ts
+++ b/apps/web/src/editorParamsScrub.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from 'vitest';
+import { clampParamValue, parseEditorParams, scrubStep, withParamDefault } from './editorParamsScrub.js';
+
+const EDITOR_JSON = JSON.stringify({
+  version: 1,
+  params: {
+    speed: { type: 'number', min: 1, max: 10, default: 4, label: { en: 'Speed', pl: 'Prędkość' } },
+    lives: { type: 'int', min: 1, max: 9, default: 3, label: { en: 'Lives', pl: 'Życia' } },
+    color: { type: 'enum', values: ['red', 'blue'], default: 'red', label: { en: 'Color', pl: 'Kolor' } },
+  },
+});
+
+describe('parseEditorParams', () => {
+  it('extracts declared params and everything else as rest', () => {
+    const result = parseEditorParams(EDITOR_JSON);
+    expect(result).not.toBeNull();
+    expect(Object.keys(result!.params)).toEqual(['speed', 'lives', 'color']);
+    expect(result!.params.speed).toEqual({
+      type: 'number',
+      min: 1,
+      max: 10,
+      default: 4,
+      label: { en: 'Speed', pl: 'Prędkość' },
+    });
+    expect(result!.rest).toEqual({ version: 1 });
+  });
+
+  it('returns an empty param map for a file with no params key', () => {
+    const result = parseEditorParams(JSON.stringify({ version: 1 }));
+    expect(result).toEqual({ params: {}, rest: { version: 1 } });
+  });
+
+  it('returns null for invalid JSON', () => {
+    expect(parseEditorParams('{not json')).toBeNull();
+  });
+
+  it('returns null when params is not an object', () => {
+    expect(parseEditorParams(JSON.stringify({ params: [] }))).toBeNull();
+  });
+
+  it('skips a malformed param entry rather than failing the whole file', () => {
+    const result = parseEditorParams(JSON.stringify({ params: { ok: EDITOR_JSON, broken: { foo: 'bar' } } }));
+    expect(result).toEqual({ params: {}, rest: {} });
+  });
+});
+
+describe('withParamDefault', () => {
+  it('rewrites only the named param, leaving everything else intact', () => {
+    const next = withParamDefault(EDITOR_JSON, 'speed', 7);
+    expect(next).not.toBeNull();
+    const parsed = JSON.parse(next!);
+    expect(parsed.params.speed.default).toBe(7);
+    expect(parsed.params.lives.default).toBe(3);
+    expect(parsed.params.color.default).toBe('red');
+    expect(parsed.version).toBe(1);
+  });
+
+  it('round-trips through the tier-1 diff as a pure default change', async () => {
+    const { declaredParamDefaultChanges } = await import('./editorJsonLiveDiff.js');
+    const next = withParamDefault(EDITOR_JSON, 'lives', 5)!;
+    const changes = declaredParamDefaultChanges(EDITOR_JSON, next);
+    expect(changes).toEqual([{ key: 'lives', value: 5 }]);
+  });
+
+  it('returns null for an unknown param key', () => {
+    expect(withParamDefault(EDITOR_JSON, 'nope', 1)).toBeNull();
+  });
+
+  it('returns null for invalid JSON', () => {
+    expect(withParamDefault('{not json', 'speed', 1)).toBeNull();
+  });
+});
+
+describe('scrubStep', () => {
+  it('is 1 for an int param regardless of range', () => {
+    expect(scrubStep({ type: 'int', min: 1, max: 9 })).toBe(1);
+  });
+
+  it('is one hundredth of the range for a number param', () => {
+    expect(scrubStep({ type: 'number', min: 1, max: 10 })).toBeCloseTo(0.09);
+  });
+
+  it('falls back to a small positive step for a zero-span range', () => {
+    expect(scrubStep({ type: 'number', min: 5, max: 5 })).toBeGreaterThan(0);
+  });
+});
+
+describe('clampParamValue', () => {
+  it('clamps to the declared range', () => {
+    expect(clampParamValue({ type: 'number', min: 1, max: 10 }, 15)).toBe(10);
+    expect(clampParamValue({ type: 'number', min: 1, max: 10 }, -3)).toBe(1);
+  });
+
+  it('rounds an int param after clamping', () => {
+    expect(clampParamValue({ type: 'int', min: 1, max: 9 }, 4.6)).toBe(5);
+  });
+
+  it('leaves a number param fractional', () => {
+    expect(clampParamValue({ type: 'number', min: 1, max: 10 }, 4.6)).toBe(4.6);
+  });
+});

--- a/apps/web/src/editorParamsScrub.ts
+++ b/apps/web/src/editorParamsScrub.ts
@@ -1,6 +1,6 @@
 // Produces new EDITOR.json text for a scrub.
 
-import type { EditorParamSpec, EditorParamValue } from './studioApi.js';
+import type { EditorLabel, EditorParamSpec, EditorParamValue } from './studioApi.js';
 
 export type ParsedEditorJson = { params: Record<string, EditorParamSpec>; rest: Record<string, unknown> } | null;
 
@@ -8,11 +8,26 @@ function isPlainObject(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
 
-// A param failing this shape just gets no control, not an error.
+function isEditorLabel(value: unknown): value is EditorLabel {
+  return isPlainObject(value) && typeof value.en === 'string' && typeof value.pl === 'string';
+}
+
+// A param failing this shape gets no control, not a crash.
 function isParamSpec(value: unknown): value is EditorParamSpec {
-  if (!isPlainObject(value) || !('type' in value) || !('default' in value)) return false;
-  const type = value.type;
-  return type === 'text' || type === 'int' || type === 'number' || type === 'enum' || type === 'bool';
+  if (!isPlainObject(value) || !('default' in value) || !isEditorLabel(value.label)) return false;
+  switch (value.type) {
+    case 'text':
+      return typeof value.max === 'number';
+    case 'int':
+    case 'number':
+      return typeof value.min === 'number' && typeof value.max === 'number';
+    case 'enum':
+      return Array.isArray(value.values) && value.values.length > 0 && value.values.every((v) => typeof v === 'string');
+    case 'bool':
+      return true;
+    default:
+      return false;
+  }
 }
 
 // Parses EDITOR.json text into its declared params, or null if unparseable.

--- a/apps/web/src/editorParamsScrub.ts
+++ b/apps/web/src/editorParamsScrub.ts
@@ -1,0 +1,63 @@
+// Produces new EDITOR.json text for a scrub.
+
+import type { EditorParamSpec, EditorParamValue } from './studioApi.js';
+
+export type ParsedEditorJson = { params: Record<string, EditorParamSpec>; rest: Record<string, unknown> } | null;
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+// A param failing this shape just gets no control, not an error.
+function isParamSpec(value: unknown): value is EditorParamSpec {
+  if (!isPlainObject(value) || !('type' in value) || !('default' in value)) return false;
+  const type = value.type;
+  return type === 'text' || type === 'int' || type === 'number' || type === 'enum' || type === 'bool';
+}
+
+// Parses EDITOR.json text into its declared params, or null if unparseable.
+export function parseEditorParams(text: string): ParsedEditorJson {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    return null;
+  }
+  if (!isPlainObject(parsed)) return null;
+  const { params, ...rest } = parsed;
+  if (params === undefined) return { params: {}, rest };
+  if (!isPlainObject(params)) return null;
+  const out: Record<string, EditorParamSpec> = {};
+  for (const [key, spec] of Object.entries(params)) {
+    if (isParamSpec(spec)) out[key] = spec;
+  }
+  return { params: out, rest };
+}
+
+// Rewrites `key`'s default — the whole diff a scrub produces.
+export function withParamDefault(text: string, key: string, value: EditorParamValue): string | null {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    return null;
+  }
+  if (!isPlainObject(parsed) || !isPlainObject(parsed.params) || !isParamSpec(parsed.params[key])) return null;
+  const next = { ...parsed, params: { ...parsed.params, [key]: { ...parsed.params[key], default: value } } };
+  return `${JSON.stringify(next, null, 2)}\n`;
+}
+
+type NumericRange = { type: 'int' | 'number'; min: number; max: number };
+
+// Reasonable step for the range: 1 for int, else 1%.
+export function scrubStep(spec: NumericRange): number {
+  if (spec.type === 'int') return 1;
+  const span = spec.max - spec.min;
+  return span > 0 ? span / 100 : 0.01;
+}
+
+// Clamps to range and, for int, rounds.
+export function clampParamValue(spec: NumericRange, value: number): number {
+  const clamped = Math.min(spec.max, Math.max(spec.min, value));
+  return spec.type === 'int' ? Math.round(clamped) : clamped;
+}

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -327,6 +327,7 @@
       "showDiff": "Diff vs live",
       "showCode": "Show code",
       "diffNoBase": "This file has no live version to compare against yet.",
+      "paramsPanel": "Tunable parameters",
       "budget": "{{lines}}/{{maxLines}} lines",
       "livePush": "Live — running game updated, no rebuild",
       "roundOpened": "Opened a new round for this edit — this game had already published",

--- a/apps/web/src/i18n/locales/pl.json
+++ b/apps/web/src/i18n/locales/pl.json
@@ -329,6 +329,7 @@
       "showDiff": "Różnice względem wersji na żywo",
       "showCode": "Pokaż kod",
       "diffNoBase": "Ten plik nie ma jeszcze wersji na żywo do porównania.",
+      "paramsPanel": "Parametry do dostrojenia",
       "budget": "{{lines}}/{{maxLines}} linii",
       "livePush": "Na żywo — gra zaktualizowana, bez przebudowy",
       "roundOpened": "Otwarto nową rundę dla tej zmiany — ta gra była już opublikowana",

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -11945,6 +11945,75 @@ button.builder-mode-selector:disabled {
   overflow-wrap: anywhere;
 }
 
+.code-surface-params {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding: 10px 14px;
+  border-bottom: 1px solid var(--panel-border);
+}
+
+.code-surface-param-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 4px 0;
+}
+
+.code-surface-param-label {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 0.8rem;
+  color: var(--text);
+}
+
+.code-surface-param-select,
+.code-surface-param-text {
+  flex: none;
+  width: 140px;
+  padding: 4px 8px;
+  border-radius: 6px;
+  border: 1px solid var(--panel-border);
+  background: transparent;
+  color: var(--text);
+  font: inherit;
+  font-size: 0.8rem;
+}
+
+.number-scrubber {
+  flex: none;
+  width: 80px;
+  padding: 4px 8px;
+  border-radius: 6px;
+  border: 1px solid var(--panel-border);
+  background: rgba(148, 163, 184, 0.08);
+  color: var(--text);
+  font-family: var(--mono-font, monospace);
+  font-size: 0.8rem;
+  text-align: center;
+  cursor: ew-resize;
+  user-select: none;
+  touch-action: none;
+}
+
+.number-scrubber:hover,
+.number-scrubber:focus-visible {
+  border-color: rgba(0, 228, 172, 0.5);
+}
+
+.number-scrubber.is-dragging {
+  border-color: var(--turquoise);
+  background: rgba(0, 228, 172, 0.12);
+}
+
+.number-scrubber.is-disabled {
+  cursor: default;
+  opacity: 0.6;
+}
+
 .code-surface-diff-view {
   margin: 0;
   padding: 12px 0;


### PR DESCRIPTION
## Summary

Fourth of the stacked series (stacked on #837 → #835 → #834; this PR's own diff is scoped to the files below).

Implements §E.5 step 1 of the ops repo's `realtime-game-editing-plan.md`: "scrubbable literals for already-declared params in the Code surface — pure client work over a bridge that exists." A drag-to-scrub panel now renders above EDITOR.json's text view, one row per declared param:

- `number`/`int` → a draggable `NumberScrubber` (pointer drag, arrow-key nudge, Shift for a coarser step)
- `enum` → a `<select>`
- `bool` → a checkbox
- `text` → a text input

Every change routes through the **exact same tier-1 live-push path** a hand-typed EDITOR.json edit already uses (`editorJsonLiveDiff.ts`'s `declaredParamDefaultChanges` → the existing `pushLiveParamChanges`) — this PR adds a new front end over already-proven plumbing, not a new mechanism. The existing "Live" badge already serves as the lane indicator, since both typing and scrubbing funnel through the same push — no separate indicator work was needed.

New files: `editorParamsScrub.ts` (pure logic: parse a param map out of EDITOR.json text, produce new text for one param's default, compute a sane scrub step/clamp per param range) and `NumberScrubber.tsx` (the reusable pointer/keyboard control).

## Codex review fixes
- **A malformed param spec crashed the render.** The type guard checked only `type`+`default`, so a param mid-edit that was missing its `label` or (for enum) its `values` array still passed, and `CodeSurface` then crashed dereferencing `spec.label.pl`/`en` or calling `spec.values.map`. The guard now validates every type-dependent field before a param gets a control.
- **Missing accessible names.** Only `NumberScrubber` had an accessible name; the enum select, bool checkbox, and text input controls had a sibling label `<span>` with no programmatic association. All four now carry `aria-label`.

## Deliberately out of scope

**Promoting a not-yet-declared constant** (§E.5 step 3) — turning a bare literal in `game.ts` into a declared, tunable param. That needs an actual source rewrite plus changes to the games repo's `editor-contract.ts` twin and its Check 31 drift check: real cross-repo contract work I think deserves its own reviewed pass rather than folding into this one. Coverage is unchanged by this PR (7/115 games declare any params today); promotion is what would grow that number, and remains the clear next step whenever you want it taken up.

## Test plan
- [x] New tests: `editorParamsScrub` (parse/rewrite/step/clamp/reject-malformed, 17 tests), `NumberScrubber` (render, keyboard nudge + Shift-coarse, disabled, pointer drag + clamping, 6 tests), `CodeSurface` integration tests proving a scrub reaches the running game through the identical tier-1 path a typed edit does, and that every control (not just the scrubber) gets an accessible name
- [x] All pre-existing EDITOR.json live-push tests still pass unmodified — the panel is additive, the text editor underneath is untouched
- [x] Full web suite: 163 files / 1415 tests green
- [x] `eslint` + `comment-prose` clean, repo-wide budget unchanged
- [x] `tsc --noEmit` clean

Co-Authored-By: Claude Sonnet 5 

https://claude.ai/code/session_01Ptra1eaV7EdeeS8MZP7USJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ptra1eaV7EdeeS8MZP7USJ)_