### PR TITLE
fix: seed generation and Code lane silently 400ing on gemini-3.7-flash since #803

### DIFF
--- a/apps/api/src/code-lane.test.ts
+++ b/apps/api/src/code-lane.test.ts
@@ -30,6 +30,7 @@ function stubClient(responses: unknown[], usage = { inputTokens: 100, outputToke
     prompts.push(prompt);
     const payload = responses.shift();
     const chain = {
+      thinking: () => chain,
       temperature: () => chain,
       signal: () => chain,
       run: () => Promise.resolve({ parts: [{ type: 'text', text: JSON.stringify(payload) }], usage }),

--- a/apps/api/src/code-lane.ts
+++ b/apps/api/src/code-lane.ts
@@ -339,7 +339,6 @@ export class VertexCodeLane {
         defaultModel: DEFAULT_CODE_MODEL,
         generationConfig: {
           responseMimeType: 'application/json',
-          thinkingConfig: { thinkingBudget: 0 },
         } as VertexGenerationConfig,
       });
     return this.client;
@@ -360,6 +359,7 @@ export class VertexCodeLane {
     tokens: { input: number; output: number },
   ): Promise<T> {
     const result: GenerationResult = await this.getClient()(prompt)
+      .thinking({ level: 'low' })
       .temperature(0.1)
       .signal(AbortSignal.timeout(timeoutMs))
       .run();

--- a/apps/api/src/game-seed.test.ts
+++ b/apps/api/src/game-seed.test.ts
@@ -313,6 +313,7 @@ function stubClient(responses: { text: string; inputTokens?: number; outputToken
   const builder = () => {
     const response = responses[Math.min(call++, responses.length - 1)];
     const chain = {
+      thinking: () => chain,
       temperature: () => chain,
       maxOutputTokens: () => chain,
       signal: () => chain,
@@ -334,6 +335,7 @@ function stubClientWithPrompts(responses: { text: string }[]) {
     prompts.push(prompt);
     const response = responses[Math.min(call++, responses.length - 1)];
     const chain = {
+      thinking: () => chain,
       temperature: () => chain,
       maxOutputTokens: () => chain,
       signal: () => chain,
@@ -399,6 +401,30 @@ interface GameKitGameContext {
 
 describe('VertexGameSeeder', () => {
   const request = { slug: 'my-game', title: 'My Game', spec: 'A game about tanks' };
+
+  it('asks for the low thinking floor, not a raw budget gemini-3.7-flash rejects', async () => {
+    const thinkingArgs: unknown[] = [];
+    const chain = {
+      thinking: (arg: unknown) => {
+        thinkingArgs.push(arg);
+        return chain;
+      },
+      temperature: () => chain,
+      maxOutputTokens: () => chain,
+      signal: () => chain,
+      run: async () => ({
+        parts: [{ type: 'text' as const, text: '{"picks":["apex-sprint"]}' }],
+        model: 'gemini-3.7-flash',
+        usage: { inputTokens: 100, outputTokens: 10 },
+      }),
+    };
+    const client = (() => chain) as unknown as ConstructorParameters<typeof VertexGameSeeder>[0]['client'];
+    const seeder = new VertexGameSeeder({ context: stubContext(), client });
+
+    await seeder.seed(request);
+
+    expect(thinkingArgs).toEqual([{ level: 'low' }]);
+  });
 
   it('returns a draft with references, usage summed across both calls, and notes', async () => {
     const seeder = new VertexGameSeeder({
@@ -704,6 +730,7 @@ describe('knowledge context injection (KQ-11)', () => {
       prompts.push(prompt);
       const response = responses[Math.min(call++, responses.length - 1)];
       const chain = {
+        thinking: () => chain,
         temperature: () => chain,
         maxOutputTokens: () => chain,
         signal: () => chain,

--- a/apps/api/src/game-seed.ts
+++ b/apps/api/src/game-seed.ts
@@ -445,11 +445,9 @@ export interface VertexGameSeederOptions {
 /**
  * The production seeder: two Vertex calls, both bounded, all failures swallowed.
  *
- * The picker runs with thinking disabled — it is a classification over a few hundred
- * tokens of catalog, and the latency of reasoning about it costs more than the choice is
- * worth. Note that is a *flash-only* configuration: pro-tier models reject a zero
- * thinking budget outright with a 400, so the knob is applied by model family rather
- * than unconditionally.
+ * The picker runs at the cheap `'low'` thinking floor — it is a classification over
+ * a few hundred tokens of catalog, and the latency of reasoning about it costs more
+ * than the choice is worth.
  */
 export class VertexGameSeeder implements GameSeeder {
   private readonly references: number;
@@ -481,12 +479,7 @@ export class VertexGameSeeder implements GameSeeder {
   private client(kind: 'pick' | 'generate'): GenAIClient {
     if (this.options.client) return this.options.client;
     const generationConfig: Record<string, unknown> = {};
-    if (kind === 'pick') {
-      generationConfig.responseMimeType = 'application/json';
-      // Flash-only: a pro-tier model 400s on a zero thinking budget rather than
-      // ignoring it, which would turn the cheap call into the failing one.
-      if (this.model.includes('flash')) generationConfig.thinkingConfig = { thinkingBudget: 0 };
-    }
+    if (kind === 'pick') generationConfig.responseMimeType = 'application/json';
     const build = () =>
       createVertexClient({
         projectId: this.options.projectId,
@@ -501,7 +494,9 @@ export class VertexGameSeeder implements GameSeeder {
   }
 
   private async pickReferences(context: SeedContext, spec: string): Promise<{ picks: string[]; usage: SeedUsage }> {
+    // Raw thinkingBudget:0 also 400s on gemini-3.7-flash; 'low' is the floor.
     const result = await this.client('pick')(buildPickPrompt(context, spec, this.references))
+      .thinking({ level: 'low' })
       .temperature(0)
       .maxOutputTokens(512)
       .signal(AbortSignal.timeout(this.pickTimeoutMs))


### PR DESCRIPTION
## Summary

Found while live-testing #820: two real production seed-generation attempts on ordinary self-build rounds both came back `seedStatus: unavailable` instead of a draft. Traced to a regression, unrelated to #799/#820, that's been silently breaking two live features since **#803** merged (2026-08-13).

## Root cause

`game-seed.ts`'s picker call and `code-lane.ts`'s only call both set the *raw* Vertex `generationConfig.thinkingConfig = { thinkingBudget: 0 }` directly on client construction, instead of using genaicode's request-level `.thinking()` API every other Vertex caller in this codebase uses.

`#803` bumped `DEFAULT_SEED_MODEL` / `DEFAULT_CODE_MODEL` to `gemini-3.7-flash`. That model rejects a raw `thinkingBudget: 0` outright with `INVALID_ARGUMENT` — the same way it rejects the `MINIMAL` level genaicode's own auto-conversion maps a zero budget to. **`1e37e2d`** (merged the next day) already fixed this exact class of bug at five other call sites, but explicitly exempted these two:

> code-lane.ts and game-seed.ts use `.run()` with no `.json()`/`.thinking()`, so their provider-level thinkingConfig is not silently overwritten — left as is.

That reasoning is correct about a *different* bug (genaicode silently overwriting an *unset* thinking config to a value it then rejects) but doesn't apply here: the literal raw value these two files set was never valid for Gemini 3 to begin with, overwritten or not. Both calls are fail-open by design, so the failure produced no visible symptom anywhere — no error, no alert, just a log line — for two days.

## Blast radius

- **Seed generation**: every round-0 seed attempt (self/BYOCA and, since #820, managed `mcp`-lane rounds) has been failing since the #803 deploy.
- **Code surface** (`code-lane.ts`, in-app AI code editing): every request has been failing the same way — same root cause, same fail-open blind spot.

Confirmed unaffected, by re-checking every other file #803 touched: `refine.ts`, `moderation.ts`, `chat-agent.ts`, `editor-assist.ts`, `feedback-themes.ts` all already use the structured `.thinking()`/`.json()` API (several of them fixed by `1e37e2d` itself) and are fine — verified `refine.ts` live against production during this investigation.

## Fix

Matches `1e37e2d`'s own established pattern exactly: drop the raw `thinkingConfig`, add `.thinking({ level: 'low' })` — the actual accepted floor on `gemini-3.7-flash`, confirmed by the working call sites — to the request chain in both files.

## Testing

- Test fakes for both files needed a `thinking()` method added to their stub chain object (they didn't have one, which is exactly why this regression didn't show up in CI — the fakes were more permissive than the real API).
- New test in `game-seed.test.ts` captures the actual value passed to `.thinking()` and pins it to `{ level: 'low' }`; confirmed it fails against the old code (`.thinking(false)`) before restoring the real fix.
- Full suite: 3165 tests pass, lint (including `comment-prose`) and typecheck clean.

https://claude.ai/code/session_01DLh3ShdDejjF9Xn5HSAJ2Q

---
_Generated by [Claude Code](https://claude.ai/code/session_01DLh3ShdDejjF9Xn5HSAJ2Q)_