### PR TITLE
feat(studio): preserve round state across an idle-triggered hot swap

### DIFF
--- a/apps/web/src/StudioStage.test.tsx
+++ b/apps/web/src/StudioStage.test.tsx
@@ -37,6 +37,12 @@ const mockedRequestStateRestore = vi.mocked(requestStateRestore);
 
 const GAME_A = '<!doctype html><html><head></head><body><canvas id="game">A</canvas></body></html>';
 const GAME_B = '<!doctype html><html><head></head><body><canvas id="game">B</canvas></body></html>';
+const GAME_C = '<!doctype html><html><head></head><body><canvas id="game">C</canvas></body></html>';
+
+async function flushPromises() {
+  await Promise.resolve();
+  await Promise.resolve();
+}
 
 function baseProps(overrides: Partial<StudioStageProps> = {}): StudioStageProps {
   return {
@@ -193,6 +199,47 @@ describe('StudioStage', () => {
     unmount();
   });
 
+  it('never re-applies a stale build once a newer one lands while its snapshot is in flight', async () => {
+    vi.useFakeTimers();
+    let resolveSnapshot: ((value: unknown) => void) | null = null;
+    mockedRequestStateSnapshot.mockReturnValueOnce(
+      new Promise((resolve) => {
+        resolveSnapshot = resolve;
+      }),
+    );
+    const props = baseProps({ posture: 'play' });
+    const { host, rerender, unmount } = await mount(props);
+
+    await act(async () => sendGameActivity(host));
+    await rerender({
+      ...props,
+      source: { html: GAME_B, rawHtml: GAME_B, origin: { kind: 'staged', at: Date.now(), versionLabel: null } },
+    });
+    // Idle triggers the swap to B, which stalls snapshotting A.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(500);
+    });
+    expect(mockedRequestStateSnapshot).toHaveBeenCalledTimes(1);
+    expect(host.querySelector('iframe')?.getAttribute('srcdoc')).toContain('>A<');
+
+    // Build C arrives while idle — applies immediately, superseding B.
+    await act(async () => {
+      await rerender({
+        ...props,
+        source: { html: GAME_C, rawHtml: GAME_C, origin: { kind: 'staged', at: Date.now(), versionLabel: null } },
+      });
+    });
+    expect(host.querySelector('iframe')?.getAttribute('srcdoc')).toContain('>C<');
+
+    // B's stalled snapshot resolves — must not overwrite C.
+    await act(async () => {
+      resolveSnapshot!(null);
+      await flushPromises();
+    });
+    expect(host.querySelector('iframe')?.getAttribute('srcdoc')).toContain('>C<');
+    unmount();
+  });
+
   it('keeps a held stage while a pointer is held past the idle window, and applies it on release', async () => {
     vi.useFakeTimers();
     const props = baseProps({ posture: 'play' });
@@ -210,10 +257,10 @@ describe('StudioStage', () => {
     });
     expect(host.querySelector('iframe')?.getAttribute('srcdoc')).toContain('>A<');
 
-    // Releasing restarts the idle countdown; once it elapses, the held build applies.
+    // Release restarts the countdown; the build applies once idle and snapshotted.
     await act(async () => sendPointerHeld(host, false));
     await act(async () => {
-      await vi.advanceTimersByTimeAsync(500);
+      await vi.advanceTimersByTimeAsync(900);
     });
     expect(host.querySelector('iframe')?.getAttribute('srcdoc')).toContain('>B<');
     unmount();

--- a/apps/web/src/StudioStage.test.tsx
+++ b/apps/web/src/StudioStage.test.tsx
@@ -4,7 +4,13 @@ import { act } from 'react';
 import { createRoot } from 'react-dom/client';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import i18n from './i18n/index.js';
-import { embedGameHtml, postGameHostMessage, withGameLocale } from './gamePlayer.js';
+import {
+  embedGameHtml,
+  postGameHostMessage,
+  requestStateRestore,
+  requestStateSnapshot,
+  withGameLocale,
+} from './gamePlayer.js';
 import { StudioStage, type StudioStageProps } from './StudioStage.js';
 
 vi.mock('./submissionApi.js', async () => {
@@ -17,10 +23,17 @@ vi.mock('./studioApi.js', async () => {
 });
 vi.mock('./gamePlayer.js', async () => {
   const actual = await vi.importActual<typeof import('./gamePlayer.js')>('./gamePlayer.js');
-  return { ...actual, postGameHostMessage: vi.fn(actual.postGameHostMessage) };
+  return {
+    ...actual,
+    postGameHostMessage: vi.fn(actual.postGameHostMessage),
+    requestStateSnapshot: vi.fn(actual.requestStateSnapshot),
+    requestStateRestore: vi.fn(actual.requestStateRestore),
+  };
 });
 
 const mockedPostGameHostMessage = vi.mocked(postGameHostMessage);
+const mockedRequestStateSnapshot = vi.mocked(requestStateSnapshot);
+const mockedRequestStateRestore = vi.mocked(requestStateRestore);
 
 const GAME_A = '<!doctype html><html><head></head><body><canvas id="game">A</canvas></body></html>';
 const GAME_B = '<!doctype html><html><head></head><body><canvas id="game">B</canvas></body></html>';
@@ -66,6 +79,8 @@ describe('StudioStage', () => {
   afterEach(() => {
     document.body.innerHTML = '';
     vi.useRealTimers();
+    mockedRequestStateSnapshot.mockClear();
+    mockedRequestStateRestore.mockClear();
   });
 
   it('is pointer-inert in watch posture — a window, not a place to play', async () => {
@@ -124,11 +139,57 @@ describe('StudioStage', () => {
     expect(host.querySelector('iframe')?.getAttribute('srcdoc')).toContain('>A<');
     expect(host.querySelector('.studio-swap-toast')).toBeNull();
 
-    // Once input goes idle, the held build applies on its own.
+    // Once idle, the held build applies after its snapshot request times out.
     await act(async () => {
-      await vi.advanceTimersByTimeAsync(500);
+      await vi.advanceTimersByTimeAsync(900);
     });
     expect(host.querySelector('iframe')?.getAttribute('srcdoc')).toContain('>B<');
+    // Nothing to restore without a snapshot.
+    expect(mockedRequestStateRestore).not.toHaveBeenCalled();
+    unmount();
+  });
+
+  it('snapshots state before an idle-triggered swap applies, then restores it on the new frame', async () => {
+    vi.useFakeTimers();
+    mockedRequestStateSnapshot.mockResolvedValueOnce({ score: 7 });
+    mockedRequestStateRestore.mockResolvedValueOnce(true);
+    const props = baseProps({ posture: 'play' });
+    const { host, rerender, unmount } = await mount(props);
+
+    await act(async () => sendGameActivity(host));
+    const oldFrame = host.querySelector('iframe');
+    await rerender({
+      ...props,
+      source: { html: GAME_B, rawHtml: GAME_B, origin: { kind: 'staged', at: Date.now(), versionLabel: null } },
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(700);
+    });
+
+    expect(mockedRequestStateSnapshot).toHaveBeenCalledExactlyOnceWith(oldFrame);
+    expect(host.querySelector('iframe')?.getAttribute('srcdoc')).toContain('>B<');
+    // Restores against the now-swapped frame, which is the same DOM node.
+    expect(mockedRequestStateRestore).toHaveBeenCalledExactlyOnceWith(host.querySelector('iframe'), { score: 7 });
+    unmount();
+  });
+
+  it('retries a restore that the new frame is not ready for yet, up to the retry schedule', async () => {
+    vi.useFakeTimers();
+    mockedRequestStateSnapshot.mockResolvedValueOnce({ score: 7 });
+    mockedRequestStateRestore.mockResolvedValueOnce(false).mockResolvedValueOnce(false).mockResolvedValueOnce(true);
+    const props = baseProps({ posture: 'play' });
+    const { host, rerender, unmount } = await mount(props);
+
+    await act(async () => sendGameActivity(host));
+    await rerender({
+      ...props,
+      source: { html: GAME_B, rawHtml: GAME_B, origin: { kind: 'staged', at: Date.now(), versionLabel: null } },
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2000);
+    });
+
+    expect(mockedRequestStateRestore).toHaveBeenCalledTimes(3);
     unmount();
   });
 

--- a/apps/web/src/StudioStage.tsx
+++ b/apps/web/src/StudioStage.tsx
@@ -131,6 +131,8 @@ export function StudioStage({
   // True while a pointer or touch is held down.
   const pointerHeldRef = useRef(false);
   const inputIdleTimerRef = useRef<number | null>(null);
+  // Bumped by every applySwap, to detect a swap superseded mid-flight.
+  const swapGenerationRef = useRef(0);
   const lastGoodRef = useRef<string | null>(source.rawHtml);
   const lastGoodOriginRef = useRef<StageOrigin>(source.origin);
   const lastGoodAtRef = useRef<number | null>(source.origin.at);
@@ -201,6 +203,7 @@ export function StudioStage({
   }, [shownOrigin]);
 
   function applySwap(next: string | null, origin: StageOrigin) {
+    swapGenerationRef.current += 1;
     swapWatchRef.current?.stop();
     const showShimmer = !reducedMotion && next != null && shownHtml != null;
     setShimmer(showShimmer);
@@ -215,11 +218,16 @@ export function StudioStage({
 
   // Snapshots, swaps, then retries restoring — a no-op without .persist().
   async function applySwapPreservingState(next: string, origin: StageOrigin) {
+    const generation = swapGenerationRef.current;
     const snapshot = await requestStateSnapshot(frameRef.current);
+    // A newer swap already landed while snapshotting — this one is stale.
+    if (swapGenerationRef.current !== generation) return;
     applySwap(next, origin);
     if (snapshot === null) return;
+    const myGeneration = swapGenerationRef.current;
     for (const delay of STATE_RESTORE_RETRY_DELAYS_MS) {
       await new Promise((resolve) => window.setTimeout(resolve, delay));
+      if (swapGenerationRef.current !== myGeneration) return;
       if (await requestStateRestore(frameRef.current, snapshot)) return;
     }
   }

--- a/apps/web/src/StudioStage.tsx
+++ b/apps/web/src/StudioStage.tsx
@@ -1,7 +1,14 @@
 import { useCallback, useEffect, useRef, useState, type MutableRefObject } from 'react';
 import { useTranslation } from 'react-i18next';
 import { GameFrame } from './GameFrame.js';
-import { useCreatorPlaytest, useGamePlayer, postGameHostMessage, type PlaytestInstrumentation } from './gamePlayer.js';
+import {
+  useCreatorPlaytest,
+  useGamePlayer,
+  postGameHostMessage,
+  requestStateSnapshot,
+  requestStateRestore,
+  type PlaytestInstrumentation,
+} from './gamePlayer.js';
 import { useEditorDraftBridge, type EditorContentPush } from './editorBridge.js';
 import { PixelIcon } from './PixelIcon.js';
 import { submitFeedback, type FeedbackContext, type SubmissionApiError } from './submissionApi.js';
@@ -35,6 +42,8 @@ const DREW_NOTHING_CHECK_MS = 5_500;
 const IDLE_THROTTLE_MS = 10 * 60 * 1000;
 // Idle window before a held swap auto-applies.
 const INPUT_IDLE_MS = 400;
+// Spaced retries for a frame whose harness hasn't mounted yet.
+const STATE_RESTORE_RETRY_DELAYS_MS = [150, 350, 600];
 
 function toContext(
   pngBase64: string | null | undefined,
@@ -170,7 +179,7 @@ export function StudioStage({
       if (cancelled) return;
       const idleFor = Date.now() - lastInputAtRef.current;
       if (idleFor >= INPUT_IDLE_MS && !pointerHeldRef.current) {
-        applySwap(pendingHtml, pendingOrigin ?? source.origin);
+        void applySwapPreservingState(pendingHtml, pendingOrigin ?? source.origin);
         setPendingHtml(null);
         setPendingOrigin(null);
         return;
@@ -201,6 +210,17 @@ export function StudioStage({
     if (next) watchSwappedDocument(next, origin);
     if (showShimmer) {
       window.setTimeout(() => setShimmer(false), 400);
+    }
+  }
+
+  // Snapshots, swaps, then retries restoring — a no-op without .persist().
+  async function applySwapPreservingState(next: string, origin: StageOrigin) {
+    const snapshot = await requestStateSnapshot(frameRef.current);
+    applySwap(next, origin);
+    if (snapshot === null) return;
+    for (const delay of STATE_RESTORE_RETRY_DELAYS_MS) {
+      await new Promise((resolve) => window.setTimeout(resolve, delay));
+      if (await requestStateRestore(frameRef.current, snapshot)) return;
     }
   }
 

--- a/apps/web/src/gamePlayer.stateBridge.test.ts
+++ b/apps/web/src/gamePlayer.stateBridge.test.ts
@@ -1,0 +1,89 @@
+// @vitest-environment jsdom
+
+import { describe, expect, it, vi } from 'vitest';
+import { requestStateRestore, requestStateSnapshot } from './gamePlayer.js';
+
+function makeFrame(): { frame: HTMLIFrameElement; posted: Array<Record<string, unknown>> } {
+  const frame = document.createElement('iframe');
+  const posted: Array<Record<string, unknown>> = [];
+  Object.defineProperty(frame, 'contentWindow', {
+    value: { postMessage: vi.fn((message: Record<string, unknown>) => posted.push(message)) },
+  });
+  return { frame, posted };
+}
+
+function replyFromGame(data: Record<string, unknown>) {
+  window.dispatchEvent(new MessageEvent('message', { origin: 'null', data: { source: 'gdpl-player', ...data } }));
+}
+
+describe('requestStateSnapshot', () => {
+  it('posts snapshotState and resolves with the reply data', async () => {
+    const { frame, posted } = makeFrame();
+    const pending = requestStateSnapshot(frame);
+    expect(posted).toEqual([{ source: 'gdpl-host', type: 'snapshotState' }]);
+    replyFromGame({ type: 'stateSnapshot', data: { score: 7 } });
+    await expect(pending).resolves.toEqual({ score: 7 });
+  });
+
+  it('resolves null when the game has nothing to snapshot', async () => {
+    const { frame } = makeFrame();
+    const pending = requestStateSnapshot(frame);
+    replyFromGame({ type: 'stateSnapshot', data: null });
+    await expect(pending).resolves.toBeNull();
+  });
+
+  it('resolves null on a frame with no contentWindow', async () => {
+    const frame = document.createElement('iframe');
+    await expect(requestStateSnapshot(frame)).resolves.toBeNull();
+  });
+
+  it('resolves null after the timeout when the game never replies', async () => {
+    vi.useFakeTimers();
+    try {
+      const { frame } = makeFrame();
+      const pending = requestStateSnapshot(frame, 50);
+      vi.advanceTimersByTime(50);
+      await expect(pending).resolves.toBeNull();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('ignores a reply of the wrong type or from a stale request', async () => {
+    const { frame } = makeFrame();
+    const pending = requestStateSnapshot(frame, 50);
+    replyFromGame({ type: 'stateRestored', ok: true });
+    replyFromGame({ source: 'other', type: 'stateSnapshot', data: { score: 1 } });
+    replyFromGame({ type: 'stateSnapshot', data: { score: 2 } });
+    await expect(pending).resolves.toEqual({ score: 2 });
+  });
+});
+
+describe('requestStateRestore', () => {
+  it('posts restoreState with the snapshot and resolves true on ok', async () => {
+    const { frame, posted } = makeFrame();
+    const pending = requestStateRestore(frame, { score: 7 });
+    expect(posted).toEqual([{ source: 'gdpl-host', type: 'restoreState', data: { score: 7 } }]);
+    replyFromGame({ type: 'stateRestored', ok: true });
+    await expect(pending).resolves.toBe(true);
+  });
+
+  it('resolves false when the game declines the restore', async () => {
+    const { frame } = makeFrame();
+    const pending = requestStateRestore(frame, { score: 7 });
+    replyFromGame({ type: 'stateRestored', ok: false });
+    await expect(pending).resolves.toBe(false);
+  });
+
+  it('resolves false after the timeout when the frame has not booted yet', async () => {
+    vi.useFakeTimers();
+    try {
+      const { frame } = makeFrame();
+      const pending = requestStateRestore(frame, { score: 7 }, 50);
+      vi.advanceTimersByTime(50);
+      await expect(pending).resolves.toBe(false);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/apps/web/src/gamePlayer.ts
+++ b/apps/web/src/gamePlayer.ts
@@ -305,6 +305,19 @@ const BRIDGE = `(function(){
       post({type:'resumed'});
     }
   }
+  // Track 4: __GAME_HARNESS__ is the same versioned surface the gate's capture
+  // tooling already calls directly (screenshot()) — snapshotState/restoreState are
+  // absent on a game built against an older kit, hence the typeof guards.
+  function sendStateSnapshot(){
+    var h=window.__GAME_HARNESS__;
+    var data=(h&&typeof h.snapshotState==='function')?h.snapshotState():null;
+    post({type:'stateSnapshot',data:data});
+  }
+  function applyStateRestore(data){
+    var h=window.__GAME_HARNESS__;
+    var ok=(h&&typeof h.restoreState==='function')?!!h.restoreState(data):false;
+    post({type:'stateRestored',ok:ok});
+  }
   addEventListener('message',function(e){
     var m=e.data||{};
     if(m.source!=='${HOST}')return;
@@ -313,6 +326,8 @@ const BRIDGE = `(function(){
     else if(m.type==='pause'){setPaused(true);}
     else if(m.type==='resume'){setPaused(false);}
     else if(m.type==='capture'){sendSnapshot('capture');}
+    else if(m.type==='snapshotState'){sendStateSnapshot();}
+    else if(m.type==='restoreState'){applyStateRestore(m.data);}
   });
   var lastActivity=0;
   function reportActivity(){
@@ -445,13 +460,55 @@ export function embedGameHtml(html: string): string {
 /**
  * Sends one host message into an embedded game frame.
  *
- * The bridge's message contract (`pause`, `resume`, `setSound`, `capture`, `hello`) is
- * useful to callers that want none of the state the hooks below keep — the floating live
- * preview wants to mute and freeze a frame it never subscribes to. Exported so the
- * envelope tag stays in this file, which is the only place that knows it.
+ * The bridge's contract (`pause`, `resume`, `setSound`, `capture`, `hello`,
+ * `snapshotState`, `restoreState`) is useful to callers that want none of the state the
+ * hooks below keep — the floating live preview wants to mute and freeze a frame it never
+ * subscribes to. Exported because the envelope tag lives only in this file.
  */
 export function postGameHostMessage(frame: HTMLIFrameElement | null, message: Record<string, unknown>): void {
   frame?.contentWindow?.postMessage({ source: HOST, ...message }, '*');
+}
+
+// Awaits one reply of `type` from `frame`, or null/false after `timeoutMs`.
+function awaitBridgeReply<T>(
+  frame: HTMLIFrameElement | null,
+  type: string,
+  extract: (data: Record<string, unknown>) => T,
+  fallback: T,
+  timeoutMs: number,
+): Promise<T> {
+  const contentWindow = frame?.contentWindow;
+  if (!contentWindow) return Promise.resolve(fallback);
+  return new Promise((resolve) => {
+    const timer = window.setTimeout(() => {
+      window.removeEventListener('message', onMessage);
+      resolve(fallback);
+    }, timeoutMs);
+    function onMessage(event: MessageEvent) {
+      if (event.origin !== 'null') return;
+      if (event.source !== null && event.source !== contentWindow) return;
+      const data = event.data as { source?: string; type?: string } | null;
+      if (!data || data.source !== PLAYER || data.type !== type) return;
+      window.clearTimeout(timer);
+      window.removeEventListener('message', onMessage);
+      resolve(extract(data as Record<string, unknown>));
+    }
+    window.addEventListener('message', onMessage);
+  });
+}
+
+// Null on a game with no `.persist(...)` declared, or on timeout.
+export function requestStateSnapshot(frame: HTMLIFrameElement | null, timeoutMs = 400): Promise<unknown | null> {
+  const reply = awaitBridgeReply(frame, 'stateSnapshot', (data) => data.data ?? null, null, timeoutMs);
+  postGameHostMessage(frame, { type: 'snapshotState' });
+  return reply;
+}
+
+// False means the game declined or the request timed out.
+export function requestStateRestore(frame: HTMLIFrameElement | null, data: unknown, timeoutMs = 400): Promise<boolean> {
+  const reply = awaitBridgeReply(frame, 'stateRestored', (msg) => Boolean(msg.ok), false, timeoutMs);
+  postGameHostMessage(frame, { type: 'restoreState', data });
+  return reply;
 }
 
 /** en/pl are the only locales games ship strings for; anything else maps to en. */


### PR DESCRIPTION
## Summary
Stack: Track 0 (#834) → Track 1 (#835) → Track 2 (#837) → Track 3 (#838) → **this PR (Track 4)**.

Today every code swap in Studio's live-editing fast lane restarts the game — even mid-playtest. This is the host-side half of "state survival": when a held swap applies (the idle-triggered branch of the input-aware swap policy from Track 2), the stage now:
1. Asks the outgoing frame's bridge for a state snapshot (`snapshotState`, new bridge verb).
2. Applies the swap as before.
3. Retries handing the snapshot to the new frame (`restoreState`, new bridge verb) on a short backoff (`150ms, 350ms, 600ms`) until it's accepted or the retries run out — the new document needs a moment to boot before its harness is ready.

Both verbs are no-ops for a game that hasn't opted in kit-side (`window.__GAME_HARNESS__.snapshotState`/`restoreState` absent) — `snapshotState` resolves `null` and the restore loop is skipped entirely, so nothing changes for a game that doesn't declare state persistence. The "leaving play" swap path is untouched: it still applies immediately with no round-trip, since there's no time to await one there.

The companion kit-side PR is `gamedevpl/www.gamedev.pl-games#747`, which adds the opt-in `defineGame().persist(toJSON, fromJSON)` builder step, fixes a lifecycle-restore bug Codex found there too, and pilots it on `serpent-loop`.

## Changes
- `apps/web/src/gamePlayer.ts`: two new bridge verbs (`snapshotState`/`restoreState`) inside the injected `BRIDGE` script; `requestStateSnapshot`/`requestStateRestore` helpers that post a request and await one typed reply or time out.
- `apps/web/src/StudioStage.tsx`: `applySwapPreservingState`, wired into the pending-watcher effect's idle-triggered branch only.

## Codex review fix
**A swap superseded mid-snapshot could still apply.** If a newer build landed in `source.rawHtml` while a state-preserving swap was still awaiting its snapshot, the older swap's continuation applied unconditionally once the snapshot resolved — overwriting the already-shown newer document with stale content. `applySwap` now bumps a generation counter; `applySwapPreservingState` checks it before applying and before each restore retry, and abandons the swap the moment a newer one has already landed.

## Test plan
- [x] `npm run type-check -w @gamedevpl/web`
- [x] `npx eslint apps/web/src/StudioStage.tsx apps/web/src/gamePlayer.ts apps/web/src/StudioStage.test.tsx apps/web/src/gamePlayer.stateBridge.test.ts`
- [x] `npx vitest run --root apps/web` — 163 files / 1415 tests
- [x] New tests: `gamePlayer.stateBridge.test.ts` (bridge request/reply helpers — reply, decline, no-contentWindow, timeout, stale/wrong-type replies ignored); `StudioStage.test.tsx` cases for snapshot-then-restore, retry-until-success, no-snapshot-no-restore, and the supersede race (a newer build landing mid-snapshot is never clobbered by the stale one resolving late)
- [x] `npm run comment-prose` (repo-wide) — clean

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ptra1eaV7EdeeS8MZP7USJ)_