### PR TITLE
Code actions menu shortcut works outside the Code tab

### DIFF
--- a/apps/web/src/CodeSurface.tsx
+++ b/apps/web/src/CodeSurface.tsx
@@ -302,12 +302,25 @@ export function CodeSurface({
 
   const onPendingActionsModeConsumedRef = useRef(onPendingActionsModeConsumed);
   onPendingActionsModeConsumedRef.current = onPendingActionsModeConsumed;
+  const pendingActionsModeRef = useRef(pendingActionsMode);
+  pendingActionsModeRef.current = pendingActionsMode;
+  const pendingActionsConsumedRef = useRef(false);
 
   useEffect(() => {
-    if (!pendingActionsMode || !sources) return;
+    if (!pendingActionsMode || !sources || pendingActionsConsumedRef.current) return;
+    pendingActionsConsumedRef.current = true;
     openActionsMenu(pendingActionsMode.mode);
     onPendingActionsModeConsumedRef.current?.();
   }, [pendingActionsMode, sources, openActionsMenu]);
+
+  // Drops an unconsumed request on unmount so it can't replay later.
+  useEffect(() => {
+    return () => {
+      if (pendingActionsModeRef.current && !pendingActionsConsumedRef.current) {
+        onPendingActionsModeConsumedRef.current?.();
+      }
+    };
+  }, []);
 
   // VS Code keys; capture phase beats browser print/search and CodeMirror.
   useEffect(() => {

--- a/apps/web/src/CodeSurface.tsx
+++ b/apps/web/src/CodeSurface.tsx
@@ -103,6 +103,9 @@ export type CodeSurfaceProps = {
   onBack: () => void;
   /** Filled in by `StudioStage`; lets a live param edit reach the running game. */
   editorPushRef?: MutableRefObject<EditorContentPush | null>;
+  // Set by CreatorStudioView's own shortcut, fired before this surface existed.
+  pendingActionsMode?: { mode: CodeActionsMode; nonce: number } | null;
+  onPendingActionsModeConsumed?: () => void;
 };
 
 const LOCKED_DIRS = ['shared/', 'tools/'] as const;
@@ -150,7 +153,13 @@ function markFileStaged(sources: CodeSurfaceSources, path: string, content: stri
   };
 }
 
-export function CodeSurface({ slug, onBack, editorPushRef }: CodeSurfaceProps) {
+export function CodeSurface({
+  slug,
+  onBack,
+  editorPushRef,
+  pendingActionsMode,
+  onPendingActionsModeConsumed,
+}: CodeSurfaceProps) {
   const { t } = useTranslation();
   const [sources, setSources] = useState<CodeSurfaceSources | null>(null);
   const [loadError, setLoadError] = useState<string | null>(null);
@@ -290,6 +299,15 @@ export function CodeSurface({ slug, onBack, editorPushRef }: CodeSurfaceProps) {
     actionsReturnFocusRef.current = null;
     if (previous?.isConnected) previous.focus();
   }, []);
+
+  const onPendingActionsModeConsumedRef = useRef(onPendingActionsModeConsumed);
+  onPendingActionsModeConsumedRef.current = onPendingActionsModeConsumed;
+
+  useEffect(() => {
+    if (!pendingActionsMode || !sources) return;
+    openActionsMenu(pendingActionsMode.mode);
+    onPendingActionsModeConsumedRef.current?.();
+  }, [pendingActionsMode, sources, openActionsMenu]);
 
   // VS Code keys; capture phase beats browser print/search and CodeMirror.
   useEffect(() => {

--- a/apps/web/src/CreatorStudioView.codeActions.test.tsx
+++ b/apps/web/src/CreatorStudioView.codeActions.test.tsx
@@ -182,6 +182,35 @@ describe('CreatorStudioView — Code actions shortcut reaches beyond the Code ta
     root.unmount();
   });
 
+  it('a failed load drops the queued request instead of replaying it on the next successful open', async () => {
+    mockedFetchCodeSurfaceSources.mockRejectedValueOnce(new Error('network blip'));
+    const { container, root } = await render();
+
+    await pressGlobal('p');
+    await act(async () => {
+      await flush();
+    });
+    expect(container.querySelector('[data-testid="code-actions-menu"]')).toBeNull();
+    expect(container.querySelector('.code-surface-error')).not.toBeNull();
+
+    const back = container.querySelector<HTMLButtonElement>('.code-surface .studio-head-action');
+    await act(async () => {
+      back!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    expect(container.querySelector('.code-surface')).toBeNull();
+
+    const codeButton = container.querySelector<HTMLButtonElement>('[aria-label="Code"]');
+    await act(async () => {
+      codeButton!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      await flush();
+    });
+
+    expect(container.querySelector('.code-surface-rail-item')?.textContent).toContain('game.ts');
+    expect(container.querySelector('[data-testid="code-actions-menu"]')).toBeNull();
+
+    root.unmount();
+  });
+
   it('does nothing when the active game has no Code surface — no tab switch, no preventDefault', async () => {
     const { container, root } = await render({ codeSurface: false });
     expect(container.querySelector('[aria-label="Code"]')).toBeNull();

--- a/apps/web/src/CreatorStudioView.codeActions.test.tsx
+++ b/apps/web/src/CreatorStudioView.codeActions.test.tsx
@@ -1,0 +1,199 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from 'react';
+import { createRoot } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { CreatorStudioView } from './CreatorStudioView.js';
+import i18n from './i18n/index.js';
+import type { StudioGame, StudioGamesResponse } from './studioApi.js';
+import type { CodeSurfaceSources } from './codeSurfaceApi.js';
+
+// Verifies the shortcut redirect: CreatorStudioView catches it outside Code.
+
+const fetchStudioGames = vi.fn();
+const fetchStudioHealth = vi.fn();
+const fetchStudioScorecards = vi.fn();
+const fetchStudioSuggestions = vi.fn();
+let authUser: { uid: string; name: string } | null = null;
+
+vi.mock('./AuthContext', () => ({
+  useAuth: () => ({ user: authUser, logout: vi.fn() }),
+}));
+
+vi.mock('./studioApi', async () => {
+  const actual = await vi.importActual<typeof import('./studioApi.js')>('./studioApi.js');
+  return {
+    ...actual,
+    fetchStudioGames: (...args: unknown[]) => fetchStudioGames(...args),
+    fetchStudioHealth: (...args: unknown[]) => fetchStudioHealth(...args),
+    fetchStudioScorecards: (...args: unknown[]) => fetchStudioScorecards(...args),
+    fetchStudioSuggestions: (...args: unknown[]) => fetchStudioSuggestions(...args),
+    submitImprovement: vi.fn(),
+  };
+});
+
+vi.mock('./submissionApi', async () => {
+  const actual = await vi.importActual<typeof import('./submissionApi.js')>('./submissionApi.js');
+  return {
+    ...actual,
+    getSubmissionStatus: vi.fn(async () => ({ media: [] })),
+  };
+});
+
+vi.mock('./codeSurfaceApi', async () => {
+  const actual = await vi.importActual<typeof import('./codeSurfaceApi.js')>('./codeSurfaceApi.js');
+  return {
+    ...actual,
+    fetchCodeSurfaceSources: vi.fn(),
+  };
+});
+
+// CodeMirror stand-in: jsdom cannot lay it out.
+vi.mock('./CodeMirrorEditor.js', () => ({
+  default: (props: { value: string; onChange: (value: string) => void }) =>
+    createElement('textarea', {
+      className: 'code-surface-editor',
+      value: props.value,
+      onChange: (event: { target: { value: string } }) => props.onChange(event.target.value),
+    }),
+}));
+
+const mockedFetchCodeSurfaceSources = vi.mocked((await import('./codeSurfaceApi.js')).fetchCodeSurfaceSources);
+
+function studioShelf(games: StudioGame[]): StudioGamesResponse {
+  return { games, truncated: false, totalGames: games.length };
+}
+
+function sourcesFor(overrides: Partial<CodeSurfaceSources> = {}): CodeSurfaceSources {
+  return {
+    slug: 'sky-dodge',
+    version: 'v1',
+    readOnly: false,
+    deleted: [],
+    staged: { totalBytes: 0, maxBytes: 1_000_000, maxFiles: 60, updatedAt: null },
+    files: [{ path: 'game.ts', content: 'export const boot = () => {};' }],
+    ...overrides,
+  };
+}
+
+async function flush() {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+async function pressGlobal(key: string, options: { shift?: boolean } = {}) {
+  await act(async () => {
+    document.dispatchEvent(
+      new KeyboardEvent('keydown', {
+        key,
+        ctrlKey: true,
+        shiftKey: options.shift ?? false,
+        bubbles: true,
+        cancelable: true,
+      }),
+    );
+  });
+}
+
+describe('CreatorStudioView — Code actions shortcut reaches beyond the Code tab', () => {
+  beforeEach(() => {
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    authUser = { uid: 'g:studio-demo', name: 'Studio Demo' };
+    fetchStudioGames.mockReset();
+    fetchStudioHealth.mockReset().mockResolvedValue({ days: [], truncated: false, games: [] });
+    fetchStudioScorecards.mockReset().mockResolvedValue([]);
+    fetchStudioSuggestions.mockReset().mockResolvedValue([]);
+    mockedFetchCodeSurfaceSources.mockReset().mockResolvedValue(sourcesFor());
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  async function render(game: Partial<StudioGame> = {}) {
+    await i18n.changeLanguage('en');
+    fetchStudioGames.mockResolvedValue(
+      studioShelf([
+        {
+          token: 'token-coded',
+          title: 'Sky Dodge',
+          createdAt: '2026-07-30T09:00:00.000Z',
+          lastKnownStatus: 'building',
+          slug: 'sky-dodge',
+          codeSurface: true,
+          editable: true,
+          ...game,
+        },
+      ]),
+    );
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    await act(async () => {
+      root.render(
+        createElement(CreatorStudioView, { selectedGame: 'token-coded', onNavigate: vi.fn(), onPlay: vi.fn() }),
+      );
+    });
+    await act(async () => {
+      await fetchStudioGames.mock.results[0]?.value;
+      await fetchStudioHealth.mock.results[0]?.value;
+      await fetchStudioScorecards.mock.results[0]?.value;
+      await fetchStudioSuggestions.mock.results[0]?.value;
+      await flush();
+    });
+    return { container, root };
+  }
+
+  it('Ctrl+P from the thread tab switches to Code and opens quick open once sources load', async () => {
+    const { container, root } = await render();
+    expect(container.querySelector('[aria-label="Code"]')?.getAttribute('aria-pressed')).toBe('false');
+
+    await pressGlobal('p');
+    await act(async () => {
+      await flush();
+    });
+
+    expect(container.querySelector('[aria-label="Code"]')?.getAttribute('aria-pressed')).toBe('true');
+    const palette = container.querySelector('[data-testid="code-actions-menu"]');
+    expect(palette).not.toBeNull();
+    expect(palette?.textContent).toContain('game.ts');
+
+    root.unmount();
+  });
+
+  it('Ctrl+Shift+F from the Edit tab switches to Code and opens project search', async () => {
+    const { container, root } = await render();
+
+    const editButton = container.querySelector<HTMLButtonElement>('[aria-label="Edit"]');
+    await act(async () => {
+      editButton!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    expect(container.querySelector('.studio-edit-overlay:not(.studio-code-overlay)')).not.toBeNull();
+
+    await pressGlobal('F', { shift: true });
+    await act(async () => {
+      await flush();
+    });
+
+    expect(container.querySelector('[aria-label="Code"]')?.getAttribute('aria-pressed')).toBe('true');
+    const input = container.querySelector<HTMLInputElement>('.code-surface-palette-input');
+    expect(input?.placeholder).toBe('Search in all files…');
+
+    root.unmount();
+  });
+
+  it('does nothing when the active game has no Code surface — no tab switch, no preventDefault', async () => {
+    const { container, root } = await render({ codeSurface: false });
+    expect(container.querySelector('[aria-label="Code"]')).toBeNull();
+
+    await pressGlobal('p');
+    await act(async () => {
+      await flush();
+    });
+
+    expect(container.querySelector('[data-testid="code-actions-menu"]')).toBeNull();
+    expect(container.querySelector('.code-surface')).toBeNull();
+
+    root.unmount();
+  });
+});

--- a/apps/web/src/CreatorStudioView.tsx
+++ b/apps/web/src/CreatorStudioView.tsx
@@ -10,6 +10,7 @@ import { formatRelativeTime } from './relativeTime.js';
 import { playPath, studioPath, type StudioTab } from './router.js';
 import { abandonSubmission, handoffToPlatform } from './submissionApi.js';
 import { StudioShotToasts } from './StudioShotToasts.js';
+import { type CodeActionsMode } from './CodeActionsMenu.js';
 import { CodeSurface } from './CodeSurface.js';
 import { EditorPanel } from './EditorPanel.js';
 import { StudioStage, type StagePosture, type StageStatus } from './StudioStage.js';
@@ -595,6 +596,32 @@ export function CreatorStudioView({
   }
   openTabRef.current = openTab;
 
+  // Queued so the Code actions shortcut survives a switch from another tab.
+  const [pendingCodeActions, setPendingCodeActions] = useState<{ mode: CodeActionsMode; nonce: number } | null>(null);
+  const codeShortcutStateRef = useRef({ tab, activeGame });
+  codeShortcutStateRef.current = { tab, activeGame };
+
+  useEffect(() => {
+    function onKeyDown(event: KeyboardEvent) {
+      if (!(event.ctrlKey || event.metaKey) || event.altKey) return;
+      const key = event.key.toLowerCase();
+      const isQuickOpen = key === 'p';
+      const isSearch = key === 'f' && event.shiftKey;
+      if (!isQuickOpen && !isSearch) return;
+      const { tab: currentTab, activeGame: currentGame } = codeShortcutStateRef.current;
+      // CodeSurface owns the shortcut itself once Code is the open tab.
+      if (currentTab === 'code' || !currentGame || !tabAvailable(currentGame, 'code')) return;
+      event.preventDefault();
+      setPendingCodeActions((current) => ({
+        mode: isQuickOpen ? (event.shiftKey ? 'commands' : 'files') : 'search',
+        nonce: (current?.nonce ?? 0) + 1,
+      }));
+      openTabRef.current('code');
+    }
+    document.addEventListener('keydown', onKeyDown, true);
+    return () => document.removeEventListener('keydown', onKeyDown, true);
+  }, []);
+
   // Share is about the permalink, not about the draft switch: a game already live in
   // the catalog has nothing to toggle, but it still needs a way to hand the link out.
   // Hiding the control there left published games with no share affordance anywhere.
@@ -1038,6 +1065,8 @@ export function CreatorStudioView({
                               slug={activeGame.slug}
                               onBack={() => openTab('thread')}
                               editorPushRef={editorPushRef}
+                              pendingActionsMode={pendingCodeActions}
+                              onPendingActionsModeConsumed={() => setPendingCodeActions(null)}
                             />
                           </div>
                         ) : null}


### PR DESCRIPTION
## Summary

- Fixes a nit from #833: `Ctrl/Cmd+P` / `Ctrl/Cmd+Shift+P` / `Ctrl/Cmd+Shift+F` only worked while the Code tab was mounted. Switching to Play or Edit unmounted `CodeSurface` along with its keyboard listener, so the shortcut silently stopped doing anything.
- `CreatorStudioView` (which stays mounted across tab switches) now owns a second listener that only acts when Code isn't the currently open tab: it switches to Code and queues the requested mode (quick open / commands / search).
- `CodeSurface` picks the queued mode up and opens the actions menu once its sources have loaded, then clears the queue — so a background poll refresh or unrelated re-render can't reopen it.
- `CodeSurface` keeps handling the shortcut itself once Code is the active tab — unchanged behavior there.
- Games without a Code surface (`tabAvailable(game, 'code')` false) are unaffected: the shortcut falls through to the browser default, same as before this change.

## Test plan

- [x] `npm run type-check`
- [x] `npm run lint`
- [x] `npm run test` — full monorepo suite green (3 new tests in `CreatorStudioView.codeActions.test.tsx`: quick open from the thread tab, project search from the Edit tab, and a no-op check for games without a Code surface)
- [x] `npm run build`

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_016eWMP7PAZK4JtgGEQtGcV3

---
_Generated by [Claude Code](https://claude.ai/code/session_016eWMP7PAZK4JtgGEQtGcV3)_