### PR TITLE
Fix oversized empty Studio prompt field

### DIFF
--- a/apps/web/src/SubmissionStatusView.test.ts
+++ b/apps/web/src/SubmissionStatusView.test.ts
@@ -1696,6 +1696,9 @@ describe('SubmissionStatusView', () => {
     });
 
     const textarea = container.querySelector<HTMLTextAreaElement>('.status-feedback-input');
+    // Embedded Studio uses the compact composer, whose empty state must keep the CSS height.
+    expect(textarea).not.toBeNull();
+    expect(textarea?.style.height).toBe('');
     await act(async () => {
       if (textarea) {
         const setter = Object.getOwnPropertyDescriptor(HTMLTextAreaElement.prototype, 'value')?.set;

--- a/apps/web/src/SubmissionStatusView.test.ts
+++ b/apps/web/src/SubmissionStatusView.test.ts
@@ -1695,7 +1695,7 @@ describe('SubmissionStatusView', () => {
     });
 
     const textarea = container.querySelector<HTMLTextAreaElement>('.status-feedback-input');
-    // Embedded Studio uses the compact composer, whose empty state must keep the CSS height.
+    // Compact Studio composer must preserve CSS height while empty.
     expect(textarea).not.toBeNull();
     expect(textarea?.style.height).toBe('');
     await act(async () => {

--- a/apps/web/src/SubmissionStatusView.test.ts
+++ b/apps/web/src/SubmissionStatusView.test.ts
@@ -1580,7 +1580,6 @@ describe('SubmissionStatusView', () => {
     // The feedback panel is offered once a draft is playable.
     const textarea = container.querySelector<HTMLTextAreaElement>('.status-feedback-input');
     expect(textarea).not.toBeNull();
-    expect(textarea?.style.height).toBe('');
     const sendButton = container.querySelector<HTMLButtonElement>('.status-feedback .primary-btn');
     // Empty / too-short feedback keeps the button disabled.
     expect(sendButton?.disabled).toBe(true);

--- a/apps/web/src/SubmissionStatusView.test.ts
+++ b/apps/web/src/SubmissionStatusView.test.ts
@@ -1580,6 +1580,7 @@ describe('SubmissionStatusView', () => {
     // The feedback panel is offered once a draft is playable.
     const textarea = container.querySelector<HTMLTextAreaElement>('.status-feedback-input');
     expect(textarea).not.toBeNull();
+    expect(textarea?.style.height).toBe('');
     const sendButton = container.querySelector<HTMLButtonElement>('.status-feedback .primary-btn');
     // Empty / too-short feedback keeps the button disabled.
     expect(sendButton?.disabled).toBe(true);

--- a/apps/web/src/SubmissionStatusView.tsx
+++ b/apps/web/src/SubmissionStatusView.tsx
@@ -1463,6 +1463,10 @@ function FeedbackPanel({
   useEffect(() => {
     const input = inputRef.current;
     if (!input) return;
+    if (text.length === 0) {
+      input.style.height = '';
+      return;
+    }
     input.style.height = 'auto';
     input.style.height = `${Math.min(input.scrollHeight, 220)}px`;
   }, [text]);


### PR DESCRIPTION
## Summary

- Clear the auto-grow inline height when the compact feedback composer is empty.
- Add a regression assertion covering the empty composer state.

## Root cause

The resize effect ran on the initial empty render and applied the textarea's measured height, overriding the CSS one-line height and leaving a large blank prompt field.

## User impact

An empty Studio prompt now stays at its compact CSS height. Typed or seeded feedback still auto-grows up to the existing 220px cap.

## Checks

- `npm run type-check` ✅
- `npm run lint` ✅
- `npm run build` ✅
- `npm run test:rules` ✅
- `npm test --workspace apps/web -- --run src/SubmissionStatusView.test.ts` ✅ (70 tests)
- `npm test` ⚠️ 3,156 passed; 8 existing/unrelated API-suite failures/timeouts remain in agent-build-reads, creator-studio, editor-drafts, mcp-server, stage-hints, telemetry, and typecheck-preflight. The web (1,372 tests) and world (20 tests) suites passed.