### PR TITLE
Improve code editor hover and completion

### DIFF
--- a/apps/api/src/admin.test.ts
+++ b/apps/api/src/admin.test.ts
@@ -244,6 +244,35 @@ describe('GET /api/admin/telemetry/visits', () => {
     expect(body.days).toContain(today);
   });
 
+  it('keeps completion diagnostics out of the core event read budget', async () => {
+    const coreEvents = Array.from({ length: 1000 }, (_, index) =>
+      visitEvent({ visitId: `core-${index}`, type: 'play_started' }),
+    );
+    await store.appendVisitEvents(today, [
+      ...coreEvents,
+      visitEvent({
+        visitId: 'completion-visit',
+        type: 'code_completion',
+        kind: 'language_service',
+        outcome: 'shown',
+        latencyMs: 120,
+      }),
+    ]);
+
+    const app = await appWith(store);
+    const response = await app.inject({
+      method: 'GET',
+      url: '/api/admin/telemetry/visits?days=1',
+      headers: authHeaders('g:boss'),
+    });
+
+    expect(response.statusCode).toBe(200);
+    const body = response.json() as VisitsResponse;
+    expect(body.funnel.completion.requests).toBe(1);
+    expect(body.funnel.completion.shown).toBe(1);
+    expect(body.truncated).toBe(true);
+  });
+
   it('is invisible to a signed-in non-admin', async () => {
     const app = await appWith(store);
     const response = await app.inject({

--- a/apps/api/src/admin.ts
+++ b/apps/api/src/admin.ts
@@ -72,6 +72,7 @@ const MAX_TREND_DAYS = 90;
 const DEFAULT_TREND_DAYS = 30;
 /** Per-partition read cap, matching the store's own default. */
 const MAX_EVENTS_PER_DAY = 1000;
+const MAX_COMPLETION_EVENTS_PER_DAY = 500;
 /**
  * Documents one request may read in total, across every partition it touches.
  *
@@ -82,6 +83,7 @@ const MAX_EVENTS_PER_DAY = 1000;
  * degrade by narrowing the window rather than by silently costing thirty times more.
  */
 const MAX_EVENTS_PER_REQUEST = 5_000;
+const MAX_COMPLETION_EVENTS_PER_REQUEST = 2_000;
 /** Trends walk every day in the window and discard events after summarizing, so the
  *  total can be wider than the funnel reads without holding them all in memory. */
 const MAX_TREND_EVENTS_PER_REQUEST = 20_000;
@@ -732,11 +734,19 @@ export async function registerAdminRoutes(app: FastifyInstance, options: AdminRo
     }
 
     const requested = recentPartitions(parsed.data.days ?? DEFAULT_DAYS, now());
-    const { events, scanned, truncated } = await scanPartitions<VisitEvent>(
+    const core = await scanPartitions<VisitEvent>(
       requested,
       REQUEST_BUDGET,
-      (dateStr, limit) => store.listVisitEvents(dateStr, { limit }),
+      (dateStr, limit) => store.listVisitEvents(dateStr, { limit, excludeType: 'code_completion' }),
     );
+    const completion = await scanPartitions<VisitEvent>(
+      requested,
+      { perDay: MAX_COMPLETION_EVENTS_PER_DAY, total: MAX_COMPLETION_EVENTS_PER_REQUEST },
+      (dateStr, limit) => store.listVisitEvents(dateStr, { limit, type: 'code_completion' }),
+    );
+    const events = [...core.events, ...completion.events];
+    const scanned = [...new Set([...core.scanned, ...completion.scanned])];
+    const truncated = core.truncated || completion.truncated;
 
     const body: VisitsResponse = { days: scanned, truncated, funnel: summarizeVisitFunnel(events) };
     return reply.status(200).send(body);

--- a/apps/api/src/store.ts
+++ b/apps/api/src/store.ts
@@ -1,5 +1,5 @@
 import { createHash, randomBytes, randomUUID } from 'node:crypto';
-import { FieldValue, Firestore, type DocumentData } from '@google-cloud/firestore';
+import { FieldValue, Firestore, type DocumentData, type Query } from '@google-cloud/firestore';
 import type { AgentTaskState } from './agent-state.js';
 import type { SeedFiles } from './agent-backend.js';
 import type { BuilderKind } from './builder.js';
@@ -2098,7 +2098,10 @@ export interface Store {
   /** Appends visit-level events to one day's partition. */
   appendVisitEvents(dateStr: string, events: VisitEvent[]): Promise<void>;
   /** One day's visit events — funnel, depth, and acquisition reads. */
-  listVisitEvents(dateStr: string, opts?: { visitId?: string; limit?: number }): Promise<VisitEvent[]>;
+  listVisitEvents(
+    dateStr: string,
+    opts?: { visitId?: string; limit?: number; type?: VisitEvent['type']; excludeType?: VisitEvent['type'] },
+  ): Promise<VisitEvent[]>;
   /** Today's usage counters for a user, without incrementing anything. */
   getUsage(uid: string, dateStr: string): Promise<UsageCounters>;
   /** Most recently published submissions, newest first — the build-time sample. */
@@ -3737,9 +3740,14 @@ export class InMemoryStore implements Store {
     this.visits.set(dateStr, existing);
   }
 
-  async listVisitEvents(dateStr: string, opts?: { visitId?: string; limit?: number }): Promise<VisitEvent[]> {
+  async listVisitEvents(
+    dateStr: string,
+    opts?: { visitId?: string; limit?: number; type?: VisitEvent['type']; excludeType?: VisitEvent['type'] },
+  ): Promise<VisitEvent[]> {
     return (this.visits.get(dateStr) ?? [])
       .filter((event) => opts?.visitId === undefined || event.visitId === opts.visitId)
+      .filter((event) => opts?.type === undefined || event.type === opts.type)
+      .filter((event) => opts?.excludeType === undefined || event.type !== opts.excludeType)
       .slice(0, opts?.limit ?? 1000)
       .map((event) => ({ ...event }));
   }
@@ -6285,9 +6293,15 @@ export class FirestoreStore implements Store {
     await batch.commit();
   }
 
-  async listVisitEvents(dateStr: string, opts?: { visitId?: string; limit?: number }): Promise<VisitEvent[]> {
+  async listVisitEvents(
+    dateStr: string,
+    opts?: { visitId?: string; limit?: number; type?: VisitEvent['type']; excludeType?: VisitEvent['type'] },
+  ): Promise<VisitEvent[]> {
     const base = this.visitCollection(dateStr);
-    const query = opts?.visitId === undefined ? base : base.where('visitId', '==', opts.visitId);
+    let query: Query<DocumentData> = base;
+    if (opts?.visitId !== undefined) query = query.where('visitId', '==', opts.visitId);
+    if (opts?.type !== undefined) query = query.where('type', '==', opts.type);
+    if (opts?.excludeType !== undefined) query = query.where('type', '!=', opts.excludeType);
     const snap = await query.limit(opts?.limit ?? 1000).get();
     return snap.docs.map((doc) => {
       const event = doc.data();

--- a/apps/api/src/store.ts
+++ b/apps/api/src/store.ts
@@ -832,7 +832,8 @@ export interface VisitEvent {
     | 'editor_step'
     | 'assist_step'
     | 'remix_step'
-    | 'code_step';
+    | 'code_step'
+    | 'code_completion';
   /** Server-anchored instant, derived like `TelemetryEvent.at`. */
   at: string;
   /** Milliseconds from visit start — the trustworthy measure of within-visit timing. */
@@ -877,6 +878,11 @@ export interface VisitEvent {
    * ambiguous. Absent on events recorded before it existed; never a game identity.
    */
   control?: string;
+  kind?: string;
+  outcome?: string;
+  latencyMs?: number;
+  candidateCount?: number;
+  completionChars?: number;
   /**
    * `how_to_play_opened`: true when this open is a second-or-later open of the *same*
    * theater card (same published play). Absent means first open — or a legacy event

--- a/apps/api/src/visit-funnel.test.ts
+++ b/apps/api/src/visit-funnel.test.ts
@@ -230,6 +230,58 @@ describe('summarizeVisitFunnel', () => {
     ]);
   });
 
+  it('reports completion health and latency separately for each lane', () => {
+    const completion = (
+      visitId: string,
+      kind: 'language_service' | 'ghost_text',
+      outcome: 'shown' | 'empty' | 'failed',
+      latencyMs: number,
+    ): VisitEvent =>
+      ({
+        visitId,
+        type: 'code_completion',
+        at: '2026-08-15T10:00:00.000Z',
+        msSinceStart: latencyMs,
+        kind,
+        outcome,
+        latencyMs,
+      }) as VisitEvent;
+
+    const funnel = summarizeVisitFunnel([
+      completion('a', 'language_service', 'shown', 100),
+      completion('a', 'language_service', 'empty', 200),
+      completion('b', 'ghost_text', 'shown', 500),
+      completion('b', 'ghost_text', 'failed', 900),
+    ]);
+
+    expect(funnel.completion).toEqual({
+      requests: 4,
+      shown: 2,
+      empty: 1,
+      failed: 1,
+      byKind: [
+        {
+          kind: 'language_service',
+          requests: 2,
+          shown: 1,
+          empty: 1,
+          failed: 0,
+          medianLatencyMs: 150,
+          p90LatencyMs: 200,
+        },
+        {
+          kind: 'ghost_text',
+          requests: 2,
+          shown: 1,
+          empty: 0,
+          failed: 1,
+          medianLatencyMs: 700,
+          p90LatencyMs: 900,
+        },
+      ],
+    });
+  });
+
   it('keeps editor steps out of the create and waitlist funnels', () => {
     // All three event types share the `step` field on the wire; separate Sets are what
     // stop an editor save from ever reading as a create or waitlist rung.

--- a/apps/api/src/visit-funnel.ts
+++ b/apps/api/src/visit-funnel.ts
@@ -80,6 +80,7 @@ export interface VisitFunnel {
    */
   editing: Array<{ step: EditorStep; visits: number }>;
   coding: Array<{ step: CodeStep; visits: number }>;
+  completion: CodeCompletionFunnel;
   /**
    * The NL tuning lane, against `asked` as its denominator: of the sittings that
    * typed a request, how many got a patch, were told honestly that it needs code,
@@ -157,6 +158,25 @@ export interface HowToPlayFunnel {
    */
   byEntry: Array<{ entry: string; playingVisits: number; visits: number; opens: number }>;
 }
+
+export interface CodeCompletionFunnel {
+  requests: number;
+  shown: number;
+  empty: number;
+  failed: number;
+  byKind: Array<{
+    kind: CodeCompletionKind;
+    requests: number;
+    shown: number;
+    empty: number;
+    failed: number;
+    medianLatencyMs: number | null;
+    p90LatencyMs: number | null;
+  }>;
+}
+
+export const CODE_COMPLETION_KINDS = ['language_service', 'ghost_text'] as const;
+export type CodeCompletionKind = (typeof CODE_COMPLETION_KINDS)[number];
 
 export const HOW_TO_PLAY_VIAS = ['bar', 'more'] as const;
 
@@ -321,6 +341,12 @@ function median(values: number[]): number {
   return sorted.length % 2 === 0 ? (sorted[middle - 1] + sorted[middle]) / 2 : sorted[middle];
 }
 
+function percentile(values: number[], fraction: number): number | null {
+  if (values.length === 0) return null;
+  const sorted = [...values].sort((a, b) => a - b);
+  return sorted[Math.min(sorted.length - 1, Math.ceil(sorted.length * fraction) - 1)] ?? null;
+}
+
 /** Sorts a count map into rows, busiest first, with a stable tiebreak on the row. */
 function rank<T, R extends { visits: number }>(entries: Map<string, T>, toRow: (key: string, value: T) => R): R[] {
   return Array.from(entries, ([key, value]) => toRow(key, value)).sort(
@@ -330,6 +356,10 @@ function rank<T, R extends { visits: number }>(entries: Map<string, T>, toRow: (
 
 export function summarizeVisitFunnel(events: VisitEvent[]): VisitFunnel {
   const visits = new Map<string, VisitRollup>();
+  const completion = new Map<
+    CodeCompletionKind,
+    { requests: number; shown: number; empty: number; failed: number; latencies: number[] }
+  >();
 
   for (const event of events) {
     const rollup = visits.get(event.visitId) ?? {
@@ -371,6 +401,17 @@ export function summarizeVisitFunnel(events: VisitEvent[]): VisitFunnel {
       if (event.step) rollup.assistSteps.add(event.step);
     } else if (event.type === 'code_step') {
       if (event.step) rollup.codeSteps.add(event.step);
+    } else if (event.type === 'code_completion') {
+      const kind = event.kind as CodeCompletionKind;
+      if (!CODE_COMPLETION_KINDS.includes(kind)) continue;
+      if (event.outcome !== 'shown' && event.outcome !== 'empty' && event.outcome !== 'failed') continue;
+      const stats = completion.get(kind) ?? { requests: 0, shown: 0, empty: 0, failed: 0, latencies: [] };
+      stats.requests += 1;
+      if (event.outcome === 'shown') stats.shown += 1;
+      else if (event.outcome === 'empty') stats.empty += 1;
+      else stats.failed += 1;
+      stats.latencies.push(event.latencyMs ?? 0);
+      completion.set(kind, stats);
     } else if (event.type === 'remix_step') {
       if (event.step) rollup.remixSteps.add(event.step);
       if (event.step === 'painted' && rollup.paintedVia === undefined) {
@@ -408,6 +449,18 @@ export function summarizeVisitFunnel(events: VisitEvent[]): VisitFunnel {
 
   const rollups = Array.from(visits.values());
   const playing = rollups.filter((rollup) => rollup.plays > 0);
+  const completionRows = CODE_COMPLETION_KINDS.map((kind) => {
+    const stats = completion.get(kind) ?? { requests: 0, shown: 0, empty: 0, failed: 0, latencies: [] };
+    return {
+      kind,
+      requests: stats.requests,
+      shown: stats.shown,
+      empty: stats.empty,
+      failed: stats.failed,
+      medianLatencyMs: stats.latencies.length ? median(stats.latencies) : null,
+      p90LatencyMs: percentile(stats.latencies, 0.9),
+    };
+  });
 
   const depthCounts = new Map<number, number>();
   playing.forEach((rollup) => depthCounts.set(rollup.plays, (depthCounts.get(rollup.plays) ?? 0) + 1));
@@ -555,6 +608,13 @@ export function summarizeVisitFunnel(events: VisitEvent[]): VisitFunnel {
       step,
       visits: rollups.filter((rollup) => rollup.codeSteps.has(step)).length,
     })),
+    completion: {
+      requests: completionRows.reduce((total, row) => total + row.requests, 0),
+      shown: completionRows.reduce((total, row) => total + row.shown, 0),
+      empty: completionRows.reduce((total, row) => total + row.empty, 0),
+      failed: completionRows.reduce((total, row) => total + row.failed, 0),
+      byKind: completionRows,
+    },
     assisting: ASSIST_STEPS.map((step) => ({
       step,
       visits: rollups.filter((rollup) => rollup.assistSteps.has(step)).length,

--- a/apps/api/src/visit-telemetry.test.ts
+++ b/apps/api/src/visit-telemetry.test.ts
@@ -225,6 +225,52 @@ describe('POST /api/telemetry/visit', () => {
     expect(bad.statusCode).toBe(400);
   });
 
+  it('records bounded completion health without source identity', async () => {
+    const response = await post(app, {
+      visitId,
+      flushMsSinceStart: 900,
+      events: [
+        {
+          type: 'code_completion',
+          kind: 'language_service',
+          outcome: 'shown',
+          latencyMs: 123,
+          candidateCount: 8,
+          msSinceStart: 800,
+        },
+        {
+          type: 'code_completion',
+          kind: 'ghost_text',
+          outcome: 'empty',
+          latencyMs: 456,
+          completionChars: 0,
+          msSinceStart: 900,
+        },
+      ],
+    });
+
+    expect(response.statusCode).toBe(202);
+    const events = await store.listVisitEvents(today(), { visitId });
+    expect(events).toEqual([
+      expect.objectContaining({
+        type: 'code_completion',
+        kind: 'language_service',
+        outcome: 'shown',
+        latencyMs: 123,
+        candidateCount: 8,
+      }),
+      expect.objectContaining({
+        type: 'code_completion',
+        kind: 'ghost_text',
+        outcome: 'empty',
+        latencyMs: 456,
+        completionChars: 0,
+      }),
+    ]);
+    expect(JSON.stringify(events)).not.toContain('path');
+    expect(JSON.stringify(events)).not.toContain('slug');
+  });
+
   it('records a waitlist step and rejects one outside the enum', async () => {
     const ok = await post(app, {
       visitId,

--- a/apps/api/src/visit-telemetry.test.ts
+++ b/apps/api/src/visit-telemetry.test.ts
@@ -497,6 +497,39 @@ describe('POST /api/telemetry/visit', () => {
     expect(overflow.json()).toEqual({ accepted: 0 });
   });
 
+  it('keeps completion diagnostics in a separate per-visit lane', async () => {
+    const completion = {
+      type: 'code_completion' as const,
+      kind: 'language_service' as const,
+      outcome: 'empty' as const,
+      latencyMs: 1,
+      msSinceStart: 0,
+    };
+    for (let batch = 0; batch < 2; batch += 1) {
+      const response = await post(app, {
+        visitId,
+        flushMsSinceStart: 0,
+        events: Array.from({ length: 25 }, () => completion),
+      });
+      expect(response.json()).toEqual({ accepted: 25 });
+    }
+
+    const completionOverflow = await post(app, {
+      visitId,
+      flushMsSinceStart: 0,
+      events: [completion],
+    });
+    expect(completionOverflow.json()).toEqual({ accepted: 0 });
+
+    const core = await post(app, {
+      visitId,
+      flushMsSinceStart: 0,
+      events: [{ type: 'play_started', msSinceStart: 0 }],
+    });
+    expect(core.json()).toEqual({ accepted: 1 });
+    expect(await store.listVisitEvents(today(), { visitId })).toHaveLength(51);
+  });
+
   it('never fails a visit when the store is unhappy', async () => {
     const failing = new InMemoryStore();
     await failing.upsertUser({ uid: 'g:me' });

--- a/apps/api/src/visit-telemetry.ts
+++ b/apps/api/src/visit-telemetry.ts
@@ -134,6 +134,8 @@ const CodeStepSchema = z.enum([
   'conflict_seen',
   'round_reopened',
 ]);
+const CodeCompletionKindSchema = z.enum(['language_service', 'ghost_text']);
+const CodeCompletionOutcomeSchema = z.enum(['shown', 'empty', 'failed']);
 /** The player-side remix funnel — see visit-funnel's REMIX_STEPS for the order's meaning. */
 const RemixStepSchema = z.enum([
   'offered',
@@ -232,6 +234,15 @@ const EventSchema = z.discriminatedUnion('type', [
     ...offsetField,
   }),
   z.object({ type: z.literal('code_step'), step: CodeStepSchema, ...offsetField }),
+  z.object({
+    type: z.literal('code_completion'),
+    kind: CodeCompletionKindSchema,
+    outcome: CodeCompletionOutcomeSchema,
+    latencyMs: z.number().int().min(0).max(30_000),
+    candidateCount: z.number().int().min(0).max(5_000).optional(),
+    completionChars: z.number().int().min(0).max(4_000).optional(),
+    ...offsetField,
+  }),
 ]);
 
 const RequestSchema = z.object({
@@ -348,6 +359,16 @@ export async function registerVisitTelemetryRoutes(
           return { ...base, type: event.type, step: event.step };
         case 'code_step':
           return { ...base, type: event.type, step: event.step };
+        case 'code_completion':
+          return {
+            ...base,
+            type: event.type,
+            kind: event.kind,
+            outcome: event.outcome,
+            latencyMs: event.latencyMs,
+            ...(event.candidateCount === undefined ? {} : { candidateCount: event.candidateCount }),
+            ...(event.completionChars === undefined ? {} : { completionChars: event.completionChars }),
+          };
         case 'remix_step':
           return {
             ...base,

--- a/apps/api/src/visit-telemetry.ts
+++ b/apps/api/src/visit-telemetry.ts
@@ -23,8 +23,8 @@ import type { Store, VisitEvent } from './store.js';
  */
 
 const MAX_EVENTS_PER_REQUEST = 25;
-/** Ceiling per visit. A tab past this is looping, not browsing. */
 const MAX_EVENTS_PER_VISIT = 200;
+const MAX_COMPLETION_EVENTS_PER_VISIT = 50;
 const MAX_REQUESTS_PER_WINDOW = 60;
 const RATE_LIMIT_WINDOW_MS = 60 * 1000;
 const MAX_VISIT_MS = 24 * 60 * 60 * 1000;
@@ -275,8 +275,8 @@ export async function registerVisitTelemetryRoutes(
   const now = options.now ?? Date.now;
 
   const requestsByIp = new Map<string, number[]>();
-  /** visitId -> { count, lastSeen }. Capped and LRU-evicted — see bounded-map.ts. */
-  const visitCounts = new Map<string, { count: number; lastSeen: number }>();
+  /** visitId -> lane counts. Capped and LRU-evicted — see bounded-map.ts. */
+  const visitCounts = new Map<string, { coreCount: number; completionCount: number; lastSeen: number }>();
 
   app.post('/api/telemetry/visit', async (request, reply) => {
     const currentTime = now();
@@ -290,13 +290,18 @@ export async function registerVisitTelemetryRoutes(
       return reply.status(429).send({ error: 'too many telemetry requests' });
     }
 
-    const visit = visitCounts.get(parsed.data.visitId) ?? { count: 0, lastSeen: currentTime };
-    const room = MAX_EVENTS_PER_VISIT - visit.count;
-    if (room <= 0) {
+    const visit =
+      visitCounts.get(parsed.data.visitId) ??
+      ({ coreCount: 0, completionCount: 0, lastSeen: currentTime } satisfies {
+        coreCount: number;
+        completionCount: number;
+        lastSeen: number;
+      });
+    if (visit.coreCount >= MAX_EVENTS_PER_VISIT && visit.completionCount >= MAX_COMPLETION_EVENTS_PER_VISIT) {
       rememberBounded(
         visitCounts,
         parsed.data.visitId,
-        { count: visit.count, lastSeen: currentTime },
+        { ...visit, lastSeen: currentTime },
         MAX_TRACKED_VISITS,
       );
       return reply.status(202).send({ accepted: 0 });
@@ -313,7 +318,25 @@ export async function registerVisitTelemetryRoutes(
       return new Date(currentTime - backdateMs).toISOString();
     }
 
-    const events: VisitEvent[] = parsed.data.events.slice(0, room).map((event) => {
+    let coreCount = visit.coreCount;
+    let completionCount = visit.completionCount;
+    const acceptedInput = parsed.data.events.filter((event) => {
+      if (event.type === 'code_completion') {
+        if (completionCount >= MAX_COMPLETION_EVENTS_PER_VISIT) return false;
+        completionCount += 1;
+        return true;
+      }
+      if (coreCount >= MAX_EVENTS_PER_VISIT) return false;
+      coreCount += 1;
+      return true;
+    });
+
+    if (acceptedInput.length === 0) {
+      rememberBounded(visitCounts, parsed.data.visitId, { ...visit, lastSeen: currentTime }, MAX_TRACKED_VISITS);
+      return reply.status(202).send({ accepted: 0 });
+    }
+
+    const events: VisitEvent[] = acceptedInput.map((event) => {
       const base = {
         visitId: parsed.data.visitId,
         at: eventTimeIso(event.msSinceStart),
@@ -392,7 +415,7 @@ export async function registerVisitTelemetryRoutes(
     rememberBounded(
       visitCounts,
       parsed.data.visitId,
-      { count: visit.count + events.length, lastSeen: currentTime },
+      { coreCount, completionCount, lastSeen: currentTime },
       MAX_TRACKED_VISITS,
     );
 

--- a/apps/web/src/CodeMirrorEditor.tsx
+++ b/apps/web/src/CodeMirrorEditor.tsx
@@ -1,4 +1,10 @@
-import { autocompletion, completionStatus } from '@codemirror/autocomplete';
+import {
+  autocompletion,
+  completionStatus,
+  type CompletionContext,
+  type CompletionResult,
+  type CompletionSource,
+} from '@codemirror/autocomplete';
 import { indentWithTab } from '@codemirror/commands';
 import { css } from '@codemirror/lang-css';
 import { html } from '@codemirror/lang-html';
@@ -13,6 +19,9 @@ import {
   Decoration,
   type DecorationSet,
   EditorView,
+  activateHover,
+  closeHoverTooltips,
+  hoverTooltip,
   keymap,
   ViewPlugin,
   type ViewUpdate,
@@ -27,7 +36,6 @@ import {
   tsAutocomplete,
   tsFacet,
   tsGoto,
-  tsHover,
   tsLintSource,
   tsSync,
   type HoverInfo,
@@ -35,6 +43,7 @@ import {
 import type { WorkerShape } from '@valtown/codemirror-ts/worker';
 import type { CodeLanguage } from './codeTokens.js';
 import { vsCodeSearchPanel } from './codeMirrorSearchPanel.js';
+import { recordCodeCompletion } from './visitTelemetry.js';
 
 // CodeMirror 6 (CE-14): lazy chunk; keyed by file path to remount.
 
@@ -247,17 +256,157 @@ const tsAdvisoryLintSource = async (view: EditorView): Promise<CmDiagnostic[]> =
   return found.map((d) => (d.severity === 'error' ? { ...d, severity: 'warning' as const } : d));
 };
 
-// GA-07: default tsHover() drops documentation — this renderer adds it back.
-function renderHoverTooltip(info: HoverInfo) {
+// GA-07: compact by default, expanded while the modifier is held.
+function renderHoverTooltip(info: HoverInfo, expanded: boolean) {
   const dom = document.createElement('div');
+  dom.className = expanded ? 'cm-ts-hover cm-ts-hover-expanded' : 'cm-ts-hover cm-ts-hover-compact';
   if (info.quickInfo?.displayParts) dom.appendChild(renderDisplayParts(info.quickInfo.displayParts));
-  if (info.quickInfo?.documentation?.length) {
+  if (expanded && info.quickInfo?.documentation?.length) {
     const doc = document.createElement('div');
     doc.className = 'cm-ts-hover-doc';
     doc.textContent = info.quickInfo.documentation.map((part) => part.text).join('');
     dom.appendChild(doc);
   }
   return { dom };
+}
+
+type ModifierHoverState = {
+  held: boolean;
+  range: { from: number; to: number } | null;
+} | null;
+
+const setModifierHover = StateEffect.define<ModifierHoverState>();
+
+const modifierHoverState = StateField.define<ModifierHoverState>({
+  create: () => null,
+  update(value, transaction) {
+    if (transaction.docChanged) return null;
+    for (const effect of transaction.effects) {
+      if (effect.is(setModifierHover)) return effect.value;
+    }
+    return value;
+  },
+  provide: (field) =>
+    EditorView.decorations.from(field, (value) =>
+      value?.held && value.range
+        ? Decoration.set([
+            Decoration.mark({ class: 'cm-ts-navigable-link' }).range(value.range.from, value.range.to),
+          ])
+        : Decoration.none,
+    ),
+});
+
+function definitionRange(info: HoverInfo): { from: number; to: number } | null {
+  const definition = [...(info.typeDef ?? []), ...(info.def ?? [])].at(0);
+  if (!definition || !info.quickInfo) return null;
+  return { from: info.start, to: info.start + info.quickInfo.textSpan.length };
+}
+
+function modifierHeld(event: KeyboardEvent): boolean {
+  return event.metaKey || event.ctrlKey;
+}
+
+function modifierHoverExtension(hover: ReturnType<typeof hoverTooltip>): Extension {
+  return ViewPlugin.fromClass(
+    class {
+      private pointer: { x: number; y: number } | null = null;
+      private held = false;
+      private requestId = 0;
+      private lastPosition: number | null = null;
+
+      private readonly onKeyDown = (event: KeyboardEvent) => {
+        if (!modifierHeld(event)) return;
+        this.setHeld(true);
+      };
+
+      private readonly onKeyUp = (event: KeyboardEvent) => {
+        if (event.key === 'Meta' || event.key === 'Control' || !modifierHeld(event)) this.setHeld(false);
+      };
+
+      private readonly onBlur = () => this.setHeld(false);
+
+      private readonly onMouseMove = (event: MouseEvent) => {
+        this.pointer = { x: event.clientX, y: event.clientY };
+        if (!this.held) return;
+        const position = this.view.posAtCoords(this.pointer);
+        if (position === null || position === this.lastPosition) return;
+        this.lastPosition = position;
+        void this.refresh(true);
+      };
+
+      private readonly onMouseLeave = () => {
+        this.pointer = null;
+        this.requestId += 1;
+        this.lastPosition = null;
+        this.view.dispatch({ effects: [setModifierHover.of(null), closeHoverTooltips] });
+      };
+
+      constructor(private readonly view: EditorView) {
+        window.addEventListener('keydown', this.onKeyDown);
+        window.addEventListener('keyup', this.onKeyUp);
+        window.addEventListener('blur', this.onBlur);
+        view.dom.addEventListener('mousemove', this.onMouseMove);
+        view.dom.addEventListener('mouseleave', this.onMouseLeave);
+      }
+
+      private setHeld(held: boolean): void {
+        if (this.held === held) return;
+        this.held = held;
+        this.requestId += 1;
+        this.lastPosition = null;
+        this.view.dispatch({ effects: [setModifierHover.of(held ? { held, range: null } : null), closeHoverTooltips] });
+        if (!held || !this.pointer) return;
+        void this.refresh(true);
+      }
+
+      private async refresh(reopenTooltip = false): Promise<void> {
+        const pointer = this.pointer;
+        if (!this.held || !pointer) return;
+        const config = this.view.state.facet(tsFacet);
+        const pos = this.view.posAtCoords(pointer);
+        if (!config?.worker || pos === null) return;
+        this.lastPosition = pos;
+        const requestId = ++this.requestId;
+        try {
+          const info = await config.worker.getHover({ path: config.path, pos });
+          if (requestId !== this.requestId || !this.held || !info) return;
+          const range = definitionRange(info);
+          this.view.dispatch({ effects: setModifierHover.of({ held: true, range }) });
+          if (reopenTooltip) {
+            activateHover(this.view, pos, 1, {
+              tooltip: hover,
+              until: (transaction) => transaction.effects.some((effect) => effect.is(setModifierHover)),
+            });
+          }
+        } catch {
+          if (requestId === this.requestId) this.view.dispatch({ effects: setModifierHover.of(null) });
+        }
+      }
+
+      destroy(): void {
+        window.removeEventListener('keydown', this.onKeyDown);
+        window.removeEventListener('keyup', this.onKeyUp);
+        window.removeEventListener('blur', this.onBlur);
+        this.view.dom.removeEventListener('mousemove', this.onMouseMove);
+        this.view.dom.removeEventListener('mouseleave', this.onMouseLeave);
+      }
+    },
+  );
+}
+
+function modifierAwareHover(): ReturnType<typeof hoverTooltip> {
+  return hoverTooltip(async (view, pos) => {
+    const config = view.state.facet(tsFacet);
+    if (!config?.worker) return null;
+    const info = await config.worker.getHover({ path: config.path, pos });
+    if (!info || !info.quickInfo) return null;
+    const expanded = view.state.field(modifierHoverState, false)?.held === true;
+    return {
+      pos: info.start,
+      end: info.end,
+      create: () => renderHoverTooltip(info, expanded),
+    };
+  });
 }
 
 function toCmDiagnostics(view: EditorView, diagnostics: CodeMirrorDiagnostic[]): CmDiagnostic[] {
@@ -371,15 +520,37 @@ function ghostTextFetchPlugin(fetchGhostTextRef: { current: FetchGhostText | und
         const suffixWindow = state.sliceDoc(pos, Math.min(state.doc.length, pos + GHOST_TEXT_MAX_SUFFIX_CHARS));
         const controller = new AbortController();
         this.abortController = controller;
+        const startedAt = performance.now();
         let text: string;
         try {
           text = await fetchGhostTextRef.current(prefixWindow, suffixWindow, controller.signal);
         } catch {
+          if (!controller.signal.aborted) {
+            recordCodeCompletion({
+              kind: 'ghost_text',
+              outcome: 'failed',
+              latencyMs: performance.now() - startedAt,
+            });
+          }
           return;
         }
-        if (controller.signal.aborted || !text) return;
+        if (controller.signal.aborted) return;
+        if (!text) {
+          recordCodeCompletion({
+            kind: 'ghost_text',
+            outcome: 'empty',
+            latencyMs: performance.now() - startedAt,
+          });
+          return;
+        }
         // Nothing may have moved on while the network call was in flight.
         if (!view.state.doc.eq(state.doc) || view.state.selection.main.head !== pos) return;
+        recordCodeCompletion({
+          kind: 'ghost_text',
+          outcome: 'shown',
+          latencyMs: performance.now() - startedAt,
+          completionChars: text.length,
+        });
         view.dispatch({ effects: setGhostText.of({ text, forDoc: view.state.doc }) });
       }
 
@@ -437,17 +608,44 @@ function makeGhostTextExtension(fetchGhostTextRef: { current: FetchGhostText | u
   ];
 }
 
+function measuredTsAutocomplete(): CompletionSource {
+  const source = tsAutocomplete();
+  return async (context: CompletionContext): Promise<CompletionResult | null> => {
+    const startedAt = performance.now();
+    try {
+      const result = await source(context);
+      recordCodeCompletion({
+        kind: 'language_service',
+        outcome: result?.options.length ? 'shown' : 'empty',
+        latencyMs: performance.now() - startedAt,
+        candidateCount: result?.options.length ?? 0,
+      });
+      return result ? { ...result, validFor: result.validFor ?? /^[\w$]*$/ } : null;
+    } catch (error) {
+      recordCodeCompletion({
+        kind: 'language_service',
+        outcome: 'failed',
+        latencyMs: performance.now() - startedAt,
+      });
+      throw error;
+    }
+  };
+}
+
 // GA-05: ts extensions, or none — worker can turn ready mid-file.
 function languageServiceExtensions(
   languageService: CodeMirrorLanguageService | undefined,
   onGotoDefinitionRef: { current: GotoDefinitionHandler | undefined },
 ): Extension[] {
   if (!languageService) return [];
+  const hover = modifierAwareHover();
   return [
     tsFacet.of({ worker: languageService.worker, path: languageService.path }),
     tsSync(),
-    autocompletion({ override: [tsAutocomplete()] }),
-    tsHover({ renderTooltip: renderHoverTooltip }),
+    modifierHoverState,
+    autocompletion({ override: [measuredTsAutocomplete()] }),
+    hover,
+    modifierHoverExtension(hover),
     tsGoto({ gotoHandler: makeGotoHandler(onGotoDefinitionRef) }),
     linter(tsAdvisoryLintSource),
   ];

--- a/apps/web/src/CodeMirrorEditor.tsx
+++ b/apps/web/src/CodeMirrorEditor.tsx
@@ -1,6 +1,7 @@
 import {
   autocompletion,
   completionStatus,
+  currentCompletions,
   type CompletionContext,
   type CompletionResult,
   type CompletionSource,
@@ -608,18 +609,94 @@ function makeGhostTextExtension(fetchGhostTextRef: { current: FetchGhostText | u
   ];
 }
 
-function measuredTsAutocomplete(): CompletionSource {
+type CompletionAttempt = {
+  context: CompletionContext;
+  startedAt: number;
+  candidateCount: number;
+  options: CompletionResult['options'];
+  settled: boolean;
+};
+
+type CompletionTracker = { pending: CompletionAttempt[] };
+
+function settleCompletionAttempt(tracker: CompletionTracker, attempt: CompletionAttempt, shown: boolean): void {
+  if (attempt.settled) return;
+  attempt.settled = true;
+  tracker.pending = tracker.pending.filter((pending) => pending !== attempt);
+  recordCodeCompletion({
+    kind: 'language_service',
+    outcome: shown ? 'shown' : 'empty',
+    latencyMs: performance.now() - attempt.startedAt,
+    candidateCount: attempt.candidateCount,
+  });
+}
+
+function completionVisibilityExtension(tracker: CompletionTracker): Extension {
+  return ViewPlugin.fromClass(
+    class {
+      update(update: ViewUpdate): void {
+        if (tracker.pending.length === 0) return;
+        if (tracker.pending.some((attempt) => attempt.context.aborted)) {
+          for (const attempt of [...tracker.pending]) {
+            if (attempt.context.aborted) settleCompletionAttempt(tracker, attempt, false);
+          }
+        }
+
+        if (tracker.pending.length === 0) return;
+        const status = completionStatus(update.state);
+        if (status === 'pending') return;
+        const visibleOptions = currentCompletions(update.state);
+        for (const attempt of [...tracker.pending]) {
+          const shown = status === 'active' && visibleOptions.some((option) => attempt.options.includes(option));
+          const settledAsEmpty = status !== 'active' || visibleOptions.length === 0;
+          if (shown || settledAsEmpty) settleCompletionAttempt(tracker, attempt, shown);
+        }
+      }
+
+      destroy(): void {
+        for (const attempt of [...tracker.pending]) settleCompletionAttempt(tracker, attempt, false);
+      }
+    },
+  );
+}
+
+function measuredTsAutocomplete(tracker: CompletionTracker): CompletionSource {
   const source = tsAutocomplete();
   return async (context: CompletionContext): Promise<CompletionResult | null> => {
     const startedAt = performance.now();
     try {
       const result = await source(context);
-      recordCodeCompletion({
-        kind: 'language_service',
-        outcome: result?.options.length ? 'shown' : 'empty',
-        latencyMs: performance.now() - startedAt,
-        candidateCount: result?.options.length ?? 0,
-      });
+      if (context.aborted) {
+        recordCodeCompletion({
+          kind: 'language_service',
+          outcome: 'empty',
+          latencyMs: performance.now() - startedAt,
+          candidateCount: result?.options.length ?? 0,
+        });
+        return null;
+      }
+      if (!result?.options.length) {
+        recordCodeCompletion({
+          kind: 'language_service',
+          outcome: 'empty',
+          latencyMs: performance.now() - startedAt,
+          candidateCount: 0,
+        });
+        return result;
+      }
+      const attempt: CompletionAttempt = {
+        context,
+        startedAt,
+        candidateCount: result.options.length,
+        options: result.options,
+        settled: false,
+      };
+      tracker.pending.push(attempt);
+      context.addEventListener(
+        'abort',
+        () => settleCompletionAttempt(tracker, attempt, false),
+        { onDocChange: true },
+      );
       return result ? { ...result, validFor: result.validFor ?? /^[\w$]*$/ } : null;
     } catch (error) {
       recordCodeCompletion({
@@ -639,11 +716,13 @@ function languageServiceExtensions(
 ): Extension[] {
   if (!languageService) return [];
   const hover = modifierAwareHover();
+  const completionTracker: CompletionTracker = { pending: [] };
   return [
     tsFacet.of({ worker: languageService.worker, path: languageService.path }),
     tsSync(),
     modifierHoverState,
-    autocompletion({ override: [measuredTsAutocomplete()] }),
+    autocompletion({ override: [measuredTsAutocomplete(completionTracker)] }),
+    completionVisibilityExtension(completionTracker),
     hover,
     modifierHoverExtension(hover),
     tsGoto({ gotoHandler: makeGotoHandler(onGotoDefinitionRef) }),

--- a/apps/web/src/VisitFunnelPanel.test.tsx
+++ b/apps/web/src/VisitFunnelPanel.test.tsx
@@ -205,6 +205,46 @@ describe('VisitFunnelPanel', () => {
     expect(text).toContain('Nobody opened a game editor');
   });
 
+  it('renders completion health and latency by lane', () => {
+    const text = render(
+      response({
+        visits: 3,
+        completion: {
+          requests: 4,
+          shown: 2,
+          empty: 1,
+          failed: 1,
+          byKind: [
+            {
+              kind: 'language_service',
+              requests: 2,
+              shown: 1,
+              empty: 1,
+              failed: 0,
+              medianLatencyMs: 150,
+              p90LatencyMs: 200,
+            },
+            {
+              kind: 'ghost_text',
+              requests: 2,
+              shown: 1,
+              empty: 0,
+              failed: 1,
+              medianLatencyMs: 700,
+              p90LatencyMs: 900,
+            },
+          ],
+        },
+      }),
+    );
+    expect(text).toContain('Code completion');
+    expect(text).toContain('2 shown');
+    expect(text).toContain('TypeScript');
+    expect(text).toContain('150 ms');
+    expect(text).toContain('Ghost text');
+    expect(text).toContain('900 ms');
+  });
+
   it('reports how-to-play open rate against playing visits, not against all visits', () => {
     // 2 of 4 playing visits opened. Dividing by all visits (10) would show 20% and
     // misread the question the block exists to answer.

--- a/apps/web/src/VisitFunnelPanel.tsx
+++ b/apps/web/src/VisitFunnelPanel.tsx
@@ -473,6 +473,42 @@ export function VisitFunnelPanel({ data }: { data: VisitsResponse }) {
           )}
         </div>
 
+        {funnel.completion?.requests ? (
+          <div className="funnel-block">
+            <h3>Code completion</h3>
+            <p className="health-summary">
+              {funnel.completion.requests} requests · {funnel.completion.shown} shown · {funnel.completion.empty}{' '}
+              empty · {funnel.completion.failed} failed
+            </p>
+            <table className="health-table">
+              <thead>
+                <tr>
+                  <th scope="col">Lane</th>
+                  <th scope="col" className="num">
+                    Requests
+                  </th>
+                  <th scope="col" className="num">
+                    Median
+                  </th>
+                  <th scope="col" className="num">
+                    P90
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                {funnel.completion.byKind.map((row) => (
+                  <tr key={row.kind}>
+                    <td>{row.kind === 'language_service' ? 'TypeScript' : 'Ghost text'}</td>
+                    <td className="num">{row.requests}</td>
+                    <td className="num">{row.medianLatencyMs === null ? '—' : `${row.medianLatencyMs} ms`}</td>
+                    <td className="num">{row.p90LatencyMs === null ? '—' : `${row.p90LatencyMs} ms`}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        ) : null}
+
         <div className="funnel-block">
           <h3>How to play</h3>
           {funnel.howToPlay.opens === 0 ? (

--- a/apps/web/src/codeSurfaceApi.ts
+++ b/apps/web/src/codeSurfaceApi.ts
@@ -171,7 +171,7 @@ export async function fetchCodeSurfaceKitDeclaration(slug: string): Promise<Code
   }
 }
 
-// TA-01: advisory-only, like the kit declaration fetch — never throws.
+// TA-01: advisory-only; callers classify failures without surfacing them to users.
 export async function fetchCodeSurfaceCompletion(
   slug: string,
   path: string,
@@ -187,11 +187,12 @@ export async function fetchCodeSurfaceCompletion(
       body: JSON.stringify({ path, prefixWindow, suffixWindow }),
       signal,
     });
-    if (!response.ok) return '';
+    if (!response.ok) await throwResponseError(response);
     const body = (await response.json()) as { completion?: string };
     return body.completion ?? '';
-  } catch {
-    return '';
+  } catch (error) {
+    if (signal.aborted) return '';
+    throw error;
   }
 }
 

--- a/apps/web/src/healthApi.ts
+++ b/apps/web/src/healthApi.ts
@@ -92,6 +92,21 @@ export interface VisitFunnel {
    */
   assisting?: Array<{ step: string; visits: number }>;
   coding?: Array<{ step: string; visits: number }>;
+  completion?: {
+    requests: number;
+    shown: number;
+    empty: number;
+    failed: number;
+    byKind: Array<{
+      kind: string;
+      requests: number;
+      shown: number;
+      empty: number;
+      failed: number;
+      medianLatencyMs: number | null;
+      p90LatencyMs: number | null;
+    }>;
+  };
   /** The player-side remix loop. Optional for the same client-outlives-deploy reason. */
   remixing?: Array<{ step: string; visits: number }>;
   /** Which door brought painting visits to the brush. Optional, same reason. */

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -12131,6 +12131,36 @@ button.builder-mode-selector:disabled {
   pointer-events: none;
 }
 
+/* GA-09: VS Code-like affordance for modifier-click navigation. */
+.cm-ts-navigable-link {
+  color: #58a6ff;
+  cursor: pointer;
+  text-decoration: underline;
+  text-decoration-thickness: 1px;
+  text-underline-offset: 2px;
+}
+
+.cm-ts-hover {
+  padding: 2px;
+  font-family: var(--mono-font, monospace);
+  white-space: pre-wrap;
+}
+
+.cm-ts-hover-compact {
+  max-width: 28rem;
+}
+
+.cm-ts-hover-expanded {
+  max-width: min(52rem, calc(100vw - 32px));
+}
+
+.cm-ts-hover-doc {
+  margin-top: 0.5rem;
+  color: var(--muted);
+  font-family: inherit;
+  white-space: pre-wrap;
+}
+
 .code-tok-comment {
   color: var(--muted);
 }

--- a/apps/web/src/visitTelemetry.test.ts
+++ b/apps/web/src/visitTelemetry.test.ts
@@ -224,6 +224,30 @@ describe('VisitSession', () => {
     expect(session.record({ type: 'play_started' })).toBe(false);
   });
 
+  it('keeps completion diagnostics in a separate lane from core visit events', () => {
+    const { send } = capture();
+    const session = new VisitSession('v1', 0, send, () => 0);
+    for (let i = 0; i < 50; i += 1) {
+      session.record({
+        type: 'code_completion',
+        kind: 'language_service',
+        outcome: 'empty',
+        latencyMs: 1,
+      });
+    }
+
+    expect(
+      session.record({
+        type: 'code_completion',
+        kind: 'language_service',
+        outcome: 'empty',
+        latencyMs: 1,
+      }),
+    ).toBe(false);
+    expect(session.record({ type: 'play_started' })).toBe(true);
+    expect(session.count).toBe(51);
+  });
+
   it('ignores events after close', () => {
     const { batches, send } = capture();
     const session = new VisitSession('v1', 0, send, () => 0);

--- a/apps/web/src/visitTelemetry.test.ts
+++ b/apps/web/src/visitTelemetry.test.ts
@@ -11,6 +11,7 @@ import {
   readVisitIdentity,
   recordBetaInviteStep,
   recordBetaWelcomeStep,
+  recordCodeCompletion,
   recordCreateStep,
   recordStudioStep,
   recordVisitEvent,
@@ -305,6 +306,36 @@ describe('recordCreateStep', () => {
 
     // The second visit must record its own start; dedupe is per visit, not global.
     expect(second.batches[0].events).toHaveLength(1);
+  });
+});
+
+describe('recordCodeCompletion', () => {
+  it('clamps timing and optional counts before sending', () => {
+    const { batches, send } = capture();
+    const session = new VisitSession('v1', 0, send, () => 0);
+    setVisitSessionForTesting(session);
+
+    recordCodeCompletion({
+      kind: 'language_service',
+      outcome: 'shown',
+      latencyMs: 30_001.4,
+      candidateCount: 5_001.4,
+      completionChars: -4,
+    });
+    session.flush();
+    setVisitSessionForTesting(null);
+
+    expect(batches[0].events).toEqual([
+      {
+        type: 'code_completion',
+        kind: 'language_service',
+        outcome: 'shown',
+        latencyMs: 30_000,
+        candidateCount: 5_000,
+        completionChars: 0,
+        msSinceStart: 0,
+      },
+    ]);
   });
 });
 

--- a/apps/web/src/visitTelemetry.ts
+++ b/apps/web/src/visitTelemetry.ts
@@ -283,8 +283,8 @@ export type RemixControl = 'bar' | 'more' | 'page';
 
 const FLUSH_AT = 5;
 const MAX_BATCH = 25;
-/** A tab that exceeds this is looping, not browsing. */
 const MAX_EVENTS_PER_VISIT = 200;
+const MAX_COMPLETION_EVENTS_PER_VISIT = 50;
 const MAX_UTM_LENGTH = 40;
 const MAX_REFERRER_LENGTH = 80;
 /** Ceiling on a reported offset. Beyond this a visit is not a visit. */
@@ -473,6 +473,8 @@ export function readVisitIdentity(
 export class VisitSession {
   private queue: WireVisitEvent[] = [];
   private accepted = 0;
+  private acceptedCompletionEvents = 0;
+  private acceptedCoreEvents = 0;
   private closed = false;
 
   constructor(
@@ -491,9 +493,15 @@ export class VisitSession {
   }
 
   record(event: VisitEvent): boolean {
-    if (this.closed || this.accepted >= MAX_EVENTS_PER_VISIT) return false;
+    if (this.closed) return false;
+    const isCompletion = event.type === 'code_completion';
+    const laneCount = isCompletion ? this.acceptedCompletionEvents : this.acceptedCoreEvents;
+    const laneLimit = isCompletion ? MAX_COMPLETION_EVENTS_PER_VISIT : MAX_EVENTS_PER_VISIT;
+    if (laneCount >= laneLimit) return false;
     this.queue.push({ ...event, msSinceStart: this.elapsed() });
     this.accepted += 1;
+    if (isCompletion) this.acceptedCompletionEvents += 1;
+    else this.acceptedCoreEvents += 1;
     if (this.queue.length >= FLUSH_AT) this.flush();
     return true;
   }

--- a/apps/web/src/visitTelemetry.ts
+++ b/apps/web/src/visitTelemetry.ts
@@ -73,7 +73,15 @@ export type VisitEvent =
   | { type: 'editor_step'; step: EditorStep }
   | { type: 'assist_step'; step: AssistStep }
   | { type: 'remix_step'; step: RemixStep; via?: RemixPaintedVia; control?: RemixControl }
-  | { type: 'code_step'; step: CodeStep };
+  | { type: 'code_step'; step: CodeStep }
+  | {
+      type: 'code_completion';
+      kind: CodeCompletionKind;
+      outcome: CodeCompletionOutcome;
+      latencyMs: number;
+      candidateCount?: number;
+      completionChars?: number;
+    };
 
 /**
  * The creation funnel, in the order a creator meets it.
@@ -257,6 +265,9 @@ export type CodeStep =
   | 'conflict_seen'
   // CE-17: a staging write opened a fresh round implicitly.
   | 'round_reopened';
+
+export type CodeCompletionKind = 'language_service' | 'ghost_text';
+export type CodeCompletionOutcome = 'shown' | 'empty' | 'failed';
 
 /**
  * Which door was used to open a remix: the game page, the theater chrome bar,
@@ -633,6 +644,41 @@ export function recordCodeStep(step: CodeStep): void {
   if (!currentSession || recordedCodeSteps.has(step)) return;
   recordedCodeSteps.add(step);
   currentSession.record({ type: 'code_step', step });
+}
+
+const MAX_COMPLETION_LATENCY_MS = 30_000;
+const MAX_COMPLETION_CANDIDATES = 5_000;
+const MAX_COMPLETION_CHARS = 4_000;
+
+function boundedCompletionMetric(value: number, maximum: number): number {
+  return Number.isFinite(value) ? Math.min(maximum, Math.max(0, Math.round(value))) : 0;
+}
+
+export function recordCodeCompletion(input: {
+  kind: CodeCompletionKind;
+  outcome: CodeCompletionOutcome;
+  latencyMs: number;
+  candidateCount?: number;
+  completionChars?: number;
+}): void {
+  if (!currentSession) return;
+  const latencyMs = boundedCompletionMetric(input.latencyMs, MAX_COMPLETION_LATENCY_MS);
+  const candidateCount =
+    input.candidateCount === undefined
+      ? undefined
+      : boundedCompletionMetric(input.candidateCount, MAX_COMPLETION_CANDIDATES);
+  const completionChars =
+    input.completionChars === undefined
+      ? undefined
+      : boundedCompletionMetric(input.completionChars, MAX_COMPLETION_CHARS);
+  currentSession.record({
+    type: 'code_completion',
+    kind: input.kind,
+    outcome: input.outcome,
+    latencyMs,
+    ...(candidateCount === undefined ? {} : { candidateCount }),
+    ...(completionChars === undefined ? {} : { completionChars }),
+  });
 }
 
 let recordedRemixSteps = new Set<string>();


### PR DESCRIPTION
## Summary

- add VS Code-like compact hover info and Cmd/Ctrl-expanded documentation
- underline navigable symbols while the modifier is held
- reuse TypeScript completion results while the current identifier grows
- record anonymous completion health and latency separately for TypeScript and ghost text
- expose completion request counts and median/P90 latency in the admin funnel

## Why

The editor had a single hover presentation, no modifier navigation affordance, and no completion latency telemetry. The TypeScript completion adapter also did not provide a `validFor` range, so the worker could be queried again on every identifier character. Ghost-text failures were swallowed as empty responses, making failures indistinguishable from valid no-suggestion responses.

## Validation

- `npm run type-check`
- `npm run lint`
- `npm run build`
- focused editor, telemetry, and funnel tests passed
- full workspace tests were attempted; unrelated websocket/world suites cannot bind localhost in this sandbox (`listen EPERM`), which also causes cascading UI test timeouts