### PR TITLE
fix(studio): clarify the Code surface Publish hint isn't a per-edit step

### DIFF
--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -343,8 +343,8 @@
       "discard": "Discard changes",
       "discarding": "Discarding…",
       "discardError": "Could not discard — try again",
-      "publishHint": "Confirms your right to use this work.",
-      "publishHintTitle": "Publishing confirms this is your own work (or you have the right to use it), runs the game gate, and an operator reviews it before anything goes live.",
+      "publishHint": "Edits already save and preview live. Confirms your right to use this work when you publish.",
+      "publishHintTitle": "Edits already save automatically and preview live as you work — you don't need to publish after every change. Publishing confirms this is your own work (or you have the right to use it), runs the game gate, and an operator reviews it before this version replaces what's live.",
       "workingCopy": {
         "clean": "No local changes",
         "changed_one": "1 file changed · not published",

--- a/apps/web/src/i18n/locales/pl.json
+++ b/apps/web/src/i18n/locales/pl.json
@@ -345,8 +345,8 @@
       "discard": "Odrzuć zmiany",
       "discarding": "Odrzucanie…",
       "discardError": "Nie udało się odrzucić — spróbuj ponownie",
-      "publishHint": "Potwierdzasz prawo do użycia tej pracy.",
-      "publishHintTitle": "Publikacja potwierdza, że to Twoja własna praca (lub masz prawo jej używać), uruchamia bramkę, a operator zatwierdza wejście na żywo.",
+      "publishHint": "Zmiany zapisują się i widać je na żywo w podglądzie. Publikacja potwierdza Twoje prawo do użycia tej pracy.",
+      "publishHintTitle": "Zmiany zapisują się automatycznie i widać je na żywo w podglądzie — nie trzeba publikować po każdej zmianie. Publikacja potwierdza, że to Twoja własna praca (lub masz prawo jej używać), uruchamia bramkę, a operator zatwierdza wejście tej wersji na żywo.",
       "workingCopy": {
         "clean": "Brak lokalnych zmian",
         "changed_one": "1 plik zmieniony · nieopublikowany",


### PR DESCRIPTION
## Summary

Found while walking through the newly-shipped live-editing stack (#834/#835/#837/#838/#840): the only copy next to the Code surface's Publish button explains what clicking it *legally confirms*, but never says edits already autosave and preview live on their own. An always-visible, primary-styled button sitting right there reads as "do this next" — a creator could easily think they need to hit Publish after every edit.

## Change

`apps/web/src/i18n/locales/en.json` + `pl.json` — reworded the hint next to Publish:

- Visible hint, before: *"Confirms your right to use this work."*
- Visible hint, now: *"Edits already save and preview live. Confirms your right to use this work when you publish."*
- Tooltip (on hover) now leads with *"...you don't need to publish after every change."* before the existing rights/gate/review explanation.

No behavior change — copy only. The rights-confirmation language is preserved (still an `attestation:true` signal server-side on Publish), just no longer the only thing a creator reads.

## Test plan
- [x] `npx vitest run apps/web/src/CodeSurface.test.tsx` — 21/21 (including the test asserting the hint's text/title survive the reword)
- [x] `npx vitest run apps/web/src/i18n/locales.test.ts` — en/pl key-parity, 5/5

Co-Authored-By: Claude Sonnet 5

https://claude.ai/code/session_01Ptra1eaV7EdeeS8MZP7USJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ptra1eaV7EdeeS8MZP7USJ)_