### PR TITLE
Don't force-navigate to Code just to show the actions menu

### DIFF
--- a/apps/web/src/CodeActionsMenu.tsx
+++ b/apps/web/src/CodeActionsMenu.tsx
@@ -49,7 +49,8 @@ export type CodeActionsMenuProps = {
   selectedPath: string | null;
   onOpenFile: (path: string) => void;
   onOpenMatch: (match: CodeActionsSearchMatch) => void;
-  onClose: () => void;
+  // acted=true for a command run; omitted (falsy) for a plain dismiss.
+  onClose: (acted?: boolean) => void;
 };
 
 const SEARCH_MIN_CHARS = 2;
@@ -219,7 +220,7 @@ export function CodeActionsMenu({
       inputRef.current?.focus();
       return;
     }
-    onClose();
+    onClose(true);
     item.command.run();
   }
 
@@ -281,7 +282,7 @@ export function CodeActionsMenu({
   ];
 
   return (
-    <div className="code-surface-palette-backdrop" role="presentation" onClick={onClose}>
+    <div className="code-surface-palette-backdrop" role="presentation" onClick={() => onClose()}>
       <section
         className="code-surface-palette"
         role="dialog"
@@ -307,7 +308,7 @@ export function CodeActionsMenu({
           <button
             type="button"
             className="modal-close-btn"
-            onClick={onClose}
+            onClick={() => onClose()}
             aria-label={t('studioPanel.code.actions.close')}
           >
             <PixelIcon name="close" size={13} />

--- a/apps/web/src/CodeSurface.tsx
+++ b/apps/web/src/CodeSurface.tsx
@@ -112,6 +112,8 @@ export type CodeSurfaceProps = {
   onPendingActionsModeConsumed?: () => void;
   // Track 2: shows a synchronous rebuild the instant it's ready.
   onPreviewReady?: (html: string) => void;
+  // Fires when the menu closes with nothing picked.
+  onActionsMenuCancelled?: () => void;
 };
 
 const LOCKED_DIRS = ['shared/', 'tools/'] as const;
@@ -166,6 +168,7 @@ export function CodeSurface({
   pendingActionsMode,
   onPendingActionsModeConsumed,
   onPreviewReady,
+  onActionsMenuCancelled,
 }: CodeSurfaceProps) {
   const { t, i18n } = useTranslation();
   const [sources, setSources] = useState<CodeSurfaceSources | null>(null);
@@ -297,7 +300,10 @@ export function CodeSurface({
     return () => document.removeEventListener('keydown', onKeyDown);
   }, [filePickerOpen]);
 
-  const openActionsMenu = useCallback((mode: CodeActionsMode) => {
+  const openedViaPendingRef = useRef(false);
+
+  const openActionsMenu = useCallback((mode: CodeActionsMode, viaPending = false) => {
+    openedViaPendingRef.current = viaPending;
     setActionsMenu((current) => {
       if (!current) {
         const focused = document.activeElement;
@@ -307,15 +313,19 @@ export function CodeSurface({
     });
   }, []);
 
-  const closeActionsMenu = useCallback(() => {
+  const closeActionsMenu = useCallback((acted = false) => {
     setActionsMenu(null);
     const previous = actionsReturnFocusRef.current;
     actionsReturnFocusRef.current = null;
     if (previous?.isConnected) previous.focus();
+    if (!acted && openedViaPendingRef.current) onActionsMenuCancelledRef.current?.();
+    openedViaPendingRef.current = false;
   }, []);
 
   const onPendingActionsModeConsumedRef = useRef(onPendingActionsModeConsumed);
   onPendingActionsModeConsumedRef.current = onPendingActionsModeConsumed;
+  const onActionsMenuCancelledRef = useRef(onActionsMenuCancelled);
+  onActionsMenuCancelledRef.current = onActionsMenuCancelled;
   const pendingActionsModeRef = useRef(pendingActionsMode);
   pendingActionsModeRef.current = pendingActionsMode;
   const pendingActionsConsumedRef = useRef(false);
@@ -323,7 +333,7 @@ export function CodeSurface({
   useEffect(() => {
     if (!pendingActionsMode || !sources || pendingActionsConsumedRef.current) return;
     pendingActionsConsumedRef.current = true;
-    openActionsMenu(pendingActionsMode.mode);
+    openActionsMenu(pendingActionsMode.mode, true);
     onPendingActionsModeConsumedRef.current?.();
   }, [pendingActionsMode, sources, openActionsMenu]);
 
@@ -550,14 +560,14 @@ export function CodeSurface({
     // Rides the pendingJump path search matches use — the new editor claims focus.
     if (path !== selected) setPendingJump({ path, from: 0, to: 0 });
     selectFile(path);
-    closeActionsMenu();
+    closeActionsMenu(true);
   }
 
   // A search hit rides GA-09's jump and lands as a selection.
   function handleOpenSearchMatch(match: CodeActionsSearchMatch) {
     setPendingJump({ path: match.path, from: match.from, to: match.to });
     selectFile(match.path);
-    closeActionsMenu();
+    closeActionsMenu(true);
   }
 
   const schedulePreviewRebuild = useCallback(() => {

--- a/apps/web/src/CreatorStudioView.codeActions.test.tsx
+++ b/apps/web/src/CreatorStudioView.codeActions.test.tsx
@@ -129,10 +129,9 @@ describe('CreatorStudioView — Code actions shortcut reaches beyond the Code ta
     const container = document.createElement('div');
     document.body.appendChild(container);
     const root = createRoot(container);
+    const onNavigate = vi.fn();
     await act(async () => {
-      root.render(
-        createElement(CreatorStudioView, { selectedGame: 'token-coded', onNavigate: vi.fn(), onPlay: vi.fn() }),
-      );
+      root.render(createElement(CreatorStudioView, { selectedGame: 'token-coded', onNavigate, onPlay: vi.fn() }));
     });
     await act(async () => {
       await fetchStudioGames.mock.results[0]?.value;
@@ -141,7 +140,7 @@ describe('CreatorStudioView — Code actions shortcut reaches beyond the Code ta
       await fetchStudioSuggestions.mock.results[0]?.value;
       await flush();
     });
-    return { container, root };
+    return { container, root, onNavigate };
   }
 
   it('Ctrl+P from the thread tab switches to Code and opens quick open once sources load', async () => {
@@ -212,7 +211,7 @@ describe('CreatorStudioView — Code actions shortcut reaches beyond the Code ta
   });
 
   it('Escape without picking anything sends the creator back to where they were', async () => {
-    const { container, root } = await render();
+    const { container, root, onNavigate } = await render();
     expect(container.querySelector('[aria-label="Code"]')?.getAttribute('aria-pressed')).toBe('false');
 
     await pressGlobal('p');
@@ -220,6 +219,7 @@ describe('CreatorStudioView — Code actions shortcut reaches beyond the Code ta
       await flush();
     });
     expect(container.querySelector('[data-testid="code-actions-menu"]')).not.toBeNull();
+    onNavigate.mockClear();
 
     const input = container.querySelector<HTMLInputElement>('.code-surface-palette-input');
     await act(async () => {
@@ -229,6 +229,8 @@ describe('CreatorStudioView — Code actions shortcut reaches beyond the Code ta
     expect(container.querySelector('[data-testid="code-actions-menu"]')).toBeNull();
     expect(container.querySelector('[aria-label="Code"]')?.getAttribute('aria-pressed')).toBe('false');
     expect(container.querySelector('.code-surface')).toBeNull();
+    // Undoes the transient hop — Back must not land on Code.
+    expect(onNavigate).toHaveBeenCalledWith('/studio/sky-dodge/thread', { replace: true });
 
     root.unmount();
   });

--- a/apps/web/src/CreatorStudioView.codeActions.test.tsx
+++ b/apps/web/src/CreatorStudioView.codeActions.test.tsx
@@ -211,6 +211,48 @@ describe('CreatorStudioView — Code actions shortcut reaches beyond the Code ta
     root.unmount();
   });
 
+  it('Escape without picking anything sends the creator back to where they were', async () => {
+    const { container, root } = await render();
+    expect(container.querySelector('[aria-label="Code"]')?.getAttribute('aria-pressed')).toBe('false');
+
+    await pressGlobal('p');
+    await act(async () => {
+      await flush();
+    });
+    expect(container.querySelector('[data-testid="code-actions-menu"]')).not.toBeNull();
+
+    const input = container.querySelector<HTMLInputElement>('.code-surface-palette-input');
+    await act(async () => {
+      input!.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true, cancelable: true }));
+    });
+
+    expect(container.querySelector('[data-testid="code-actions-menu"]')).toBeNull();
+    expect(container.querySelector('[aria-label="Code"]')?.getAttribute('aria-pressed')).toBe('false');
+    expect(container.querySelector('.code-surface')).toBeNull();
+
+    root.unmount();
+  });
+
+  it('picking a file from the shortcut-opened menu stays on Code, no snap back', async () => {
+    const { container, root } = await render();
+
+    await pressGlobal('p');
+    await act(async () => {
+      await flush();
+    });
+    const fileOption = Array.from(container.querySelectorAll<HTMLButtonElement>('.code-surface-palette-option')).find(
+      (el) => el.textContent?.includes('game.ts'),
+    );
+    await act(async () => {
+      fileOption!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
+    expect(container.querySelector('[data-testid="code-actions-menu"]')).toBeNull();
+    expect(container.querySelector('[aria-label="Code"]')?.getAttribute('aria-pressed')).toBe('true');
+
+    root.unmount();
+  });
+
   it('does nothing when the active game has no Code surface — no tab switch, no preventDefault', async () => {
     const { container, root } = await render({ codeSurface: false });
     expect(container.querySelector('[aria-label="Code"]')).toBeNull();

--- a/apps/web/src/CreatorStudioView.tsx
+++ b/apps/web/src/CreatorStudioView.tsx
@@ -585,14 +585,16 @@ export function CreatorStudioView({
     void next;
   });
 
-  function openTab(next: StudioTab) {
+  function openTab(next: StudioTab, options?: NavigateOptions) {
     if (!activeGame || !tabAvailable(activeGame, next)) return;
     setShareMenuOpen(false);
     setTab(next);
     if ((next === 'edit' || next === 'code' || next === 'details') && posture === 'play') {
       setPosture('watch');
     }
-    onNavigate(studioPath(studioAddress(activeGame), next));
+    const path = studioPath(studioAddress(activeGame), next);
+    if (options) onNavigate(path, options);
+    else onNavigate(path);
   }
   openTabRef.current = openTab;
 
@@ -630,7 +632,8 @@ export function CreatorStudioView({
     const restore = forcedCodeReturnRef.current;
     forcedCodeReturnRef.current = null;
     if (!restore) return;
-    openTab(restore.tab);
+    // Replaces the transient Code entry rather than stacking a third history entry.
+    openTab(restore.tab, { replace: true });
     setPosture(restore.posture);
   }
 

--- a/apps/web/src/CreatorStudioView.tsx
+++ b/apps/web/src/CreatorStudioView.tsx
@@ -598,8 +598,10 @@ export function CreatorStudioView({
 
   // Queued so the Code actions shortcut survives a switch from another tab.
   const [pendingCodeActions, setPendingCodeActions] = useState<{ mode: CodeActionsMode; nonce: number } | null>(null);
-  const codeShortcutStateRef = useRef({ tab, activeGame });
-  codeShortcutStateRef.current = { tab, activeGame };
+  const codeShortcutStateRef = useRef({ tab, activeGame, posture });
+  codeShortcutStateRef.current = { tab, activeGame, posture };
+  // Tab/posture to restore if the shortcut-opened menu gets cancelled.
+  const forcedCodeReturnRef = useRef<{ tab: StudioTab; posture: StagePosture } | null>(null);
 
   useEffect(() => {
     function onKeyDown(event: KeyboardEvent) {
@@ -608,10 +610,11 @@ export function CreatorStudioView({
       const isQuickOpen = key === 'p';
       const isSearch = key === 'f' && event.shiftKey;
       if (!isQuickOpen && !isSearch) return;
-      const { tab: currentTab, activeGame: currentGame } = codeShortcutStateRef.current;
+      const { tab: currentTab, activeGame: currentGame, posture: currentPosture } = codeShortcutStateRef.current;
       // CodeSurface owns the shortcut itself once Code is the open tab.
       if (currentTab === 'code' || !currentGame || !tabAvailable(currentGame, 'code')) return;
       event.preventDefault();
+      forcedCodeReturnRef.current = { tab: currentTab, posture: currentPosture };
       setPendingCodeActions((current) => ({
         mode: isQuickOpen ? (event.shiftKey ? 'commands' : 'files') : 'search',
         nonce: (current?.nonce ?? 0) + 1,
@@ -621,6 +624,15 @@ export function CreatorStudioView({
     document.addEventListener('keydown', onKeyDown, true);
     return () => document.removeEventListener('keydown', onKeyDown, true);
   }, []);
+
+  // Nothing was picked — undo the forced hop into Code.
+  function handleCodeActionsMenuCancelled() {
+    const restore = forcedCodeReturnRef.current;
+    forcedCodeReturnRef.current = null;
+    if (!restore) return;
+    openTab(restore.tab);
+    setPosture(restore.posture);
+  }
 
   // Share is about the permalink, not about the draft switch: a game already live in
   // the catalog has nothing to toggle, but it still needs a way to hand the link out.
@@ -1068,6 +1080,7 @@ export function CreatorStudioView({
                               pendingActionsMode={pendingCodeActions}
                               onPendingActionsModeConsumed={() => setPendingCodeActions(null)}
                               onPreviewReady={stageSource.pushPreview}
+                              onActionsMenuCancelled={handleCodeActionsMenuCancelled}
                             />
                           </div>
                         ) : null}


### PR DESCRIPTION
## Summary

- Fixes a follow-on nit from #841: pressing the Code actions shortcut from Play or Edit immediately jumped to the Code tab (and flipped play posture to watch) before the creator had picked anything from the palette — jarring even when they just meant to peek at the menu and cancel.
- Canceling the shortcut-opened menu (Escape, backdrop click, close button) now returns the creator to the tab and posture they were on. Picking a file, a search match, or running a command still lands on Code, since that's the point of taking the action.
- `CodeActionsMenu`'s `onClose` now optionally signals whether a command was actually run (`onClose(true)`), so `CodeSurface` can tell a genuine cancel from an executed command and only report "cancelled" for the specific menu instance the shortcut opened — not one opened locally while already on Code.

## Test plan

- [x] `npx vitest run src/CodeSurface.actionsMenu.test.tsx src/CreatorStudioView.codeActions.test.tsx src/CreatorStudioView.test.tsx src/CreatorStudioView.theater.test.tsx src/CreatorStudioView.handoff.test.tsx` — 69 passed
- [x] Full `apps/web` suite: `npx vitest run` — 1435 passed
- [x] `npm run lint` (ESLint + comment-prose baseline) — clean
- [x] `npx tsc --noEmit` — clean
- [x] New "Escape without picking anything sends the creator back to where they were" test verified red before the fix (`git stash` the fix, confirm failure, then restore) and green after

---
_Generated by [Claude Code](https://claude.ai/code/session_016eWMP7PAZK4JtgGEQtGcV3)_