### PR TITLE
feat(studio): compact the Code surface footer into a VS Code-style status bar

### DIFF
--- a/apps/web/src/CodeSurface.test.tsx
+++ b/apps/web/src/CodeSurface.test.tsx
@@ -97,9 +97,10 @@ describe('CodeSurface', () => {
     slug = 'sky-dodge',
     editorPushRef?: { current: ((content: EditorContentDoc) => void) | null },
     onPreviewReady?: (html: string) => void,
+    onBack: () => void = () => {},
   ) {
     await act(async () => {
-      root.render(createElement(CodeSurface, { slug, onBack: () => {}, editorPushRef, onPreviewReady }));
+      root.render(createElement(CodeSurface, { slug, onBack, editorPushRef, onPreviewReady }));
     });
     await act(async () => {
       await flush();
@@ -250,6 +251,55 @@ describe('CodeSurface', () => {
 
     expect(mocked.requestCodeSurfacePreview).toHaveBeenCalledWith('sky-dodge');
     expect(onPreviewReady).toHaveBeenCalledWith('<html>fast</html>');
+  });
+
+  it('shows a spinner while the fast preview is in flight, then a clickable "preview ready" link', async () => {
+    mocked.fetchCodeSurfaceSources.mockResolvedValue(sourcesFor());
+    mocked.stageCodeSurfaceFile.mockResolvedValue({
+      accepted: true,
+      path: 'game.ts',
+      bytes: 40,
+      staged: { totalBytes: 40, maxBytes: 1_000_000, maxFiles: 60, updatedAt: '2026-08-10T00:00:00.000Z' },
+    });
+    let resolvePreview: ((value: { html: string; engineRef: string }) => void) | undefined;
+    mocked.requestCodeSurfacePreview.mockReturnValue(
+      new Promise((resolve) => {
+        resolvePreview = resolve;
+      }),
+    );
+    const onBack = vi.fn();
+
+    await render('sky-dodge', undefined, undefined, onBack);
+    const textarea = container.querySelector('textarea')!;
+
+    await act(async () => {
+      typeInto(textarea, 'export const boot = () => { /* edited */ };');
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1500);
+      await flush();
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2_500);
+      await flush();
+    });
+
+    expect(container.querySelector('.code-surface-preview-status.is-pending')).not.toBeNull();
+    expect(container.querySelector('.code-surface-preview-status.is-ready')).toBeNull();
+
+    await act(async () => {
+      resolvePreview?.({ html: '<html>fast</html>', engineRef: 'abc123' });
+      await flush();
+    });
+
+    expect(container.querySelector('.code-surface-preview-status.is-pending')).toBeNull();
+    const readyLink = container.querySelector<HTMLButtonElement>('.code-surface-preview-status.is-ready')!;
+    expect(readyLink.textContent).toContain('Preview ready');
+
+    await act(async () => {
+      readyLink.click();
+    });
+    expect(onBack).toHaveBeenCalled();
   });
 
   it('CE-17: shows a notice when a staging write reports it opened a fresh round', async () => {

--- a/apps/web/src/CodeSurface.test.tsx
+++ b/apps/web/src/CodeSurface.test.tsx
@@ -302,6 +302,46 @@ describe('CodeSurface', () => {
     expect(onBack).toHaveBeenCalled();
   });
 
+  it('clears a stale "preview ready" link the moment a new edit is saved, not when the next request starts', async () => {
+    mocked.fetchCodeSurfaceSources.mockResolvedValue(sourcesFor());
+    mocked.stageCodeSurfaceFile.mockResolvedValue({
+      accepted: true,
+      path: 'game.ts',
+      bytes: 40,
+      staged: { totalBytes: 40, maxBytes: 1_000_000, maxFiles: 60, updatedAt: '2026-08-10T00:00:00.000Z' },
+    });
+    mocked.requestCodeSurfacePreview.mockResolvedValue({ html: '<html>first</html>', engineRef: 'abc123' });
+
+    await render();
+    const textarea = container.querySelector('textarea')!;
+
+    await act(async () => {
+      typeInto(textarea, 'export const boot = () => { /* first edit */ };');
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1500);
+      await flush();
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2_500);
+      await flush();
+    });
+
+    expect(container.querySelector('.code-surface-preview-status.is-ready')).not.toBeNull();
+
+    // The second edit's own preview debounce hasn't even started yet.
+    await act(async () => {
+      typeInto(textarea, 'export const boot = () => { /* second edit */ };');
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1500);
+      await flush();
+    });
+
+    expect(container.querySelector('.code-surface-preview-status.is-ready')).toBeNull();
+    expect(container.querySelector('.code-surface-preview-status.is-pending')).toBeNull();
+  });
+
   it('CE-17: shows a notice when a staging write reports it opened a fresh round', async () => {
     mocked.fetchCodeSurfaceSources.mockResolvedValue(sourcesFor());
     mocked.stageCodeSurfaceFile.mockResolvedValue({

--- a/apps/web/src/CodeSurface.tsx
+++ b/apps/web/src/CodeSurface.tsx
@@ -101,6 +101,8 @@ const STAGE_REBUILD_COOLDOWN_MS = 25_000;
 type SaveState = 'clean' | 'dirty' | 'saving' | 'saved' | 'error';
 type RebuildState = 'idle' | 'pending' | 'cooling';
 type DiscardState = 'idle' | 'discarding';
+// Track 2's near-instant preview, distinct from the debounced `rebuildState`.
+type SyncPreviewState = 'idle' | 'pending' | 'ready';
 
 export type CodeSurfaceProps = {
   slug: string;
@@ -179,6 +181,7 @@ export function CodeSurface({
   const [diagnostics, setDiagnostics] = useState<string[] | null>(null);
   const [rebuildState, setRebuildState] = useState<RebuildState>('idle');
   const [rebuildError, setRebuildError] = useState(false);
+  const [syncPreviewState, setSyncPreviewState] = useState<SyncPreviewState>('idle');
   const [discardState, setDiscardState] = useState<DiscardState>('idle');
   const [deliverState, setDeliverState] = useState<'idle' | 'delivering' | 'delivered'>('idle');
   const [deliverMessage, setDeliverMessage] = useState<string | null>(null);
@@ -586,9 +589,13 @@ export function CodeSurface({
       setRebuildError(false);
       setRebuildState('pending');
       // Track 2: shows the synchronous rebuild the instant it lands.
+      setSyncPreviewState('pending');
       void requestCodeSurfacePreview(slug)
-        .then((result) => onPreviewReadyRef.current?.(result.html))
-        .catch(() => {});
+        .then((result) => {
+          onPreviewReadyRef.current?.(result.html);
+          setSyncPreviewState('ready');
+        })
+        .catch(() => setSyncPreviewState('idle'));
       void rebuildCodeSurfaceStage(slug)
         .then(() => {
           recordCodeStep('previewed');
@@ -1097,12 +1104,6 @@ export function CodeSurface({
         </div>
       </div>
 
-      {liveBudget ? (
-        <div className={`code-surface-budget${liveBudget.oversize ? ' is-oversize' : ''}`}>
-          {t('studioPanel.code.budget', { lines: liveBudget.lines, maxLines: liveBudget.maxLines })}
-        </div>
-      ) : null}
-
       {diagnostics && diagnostics.length > 0 ? (
         <ul className="code-surface-diagnostics" role="alert">
           {diagnostics.map((diagnostic, index) => (
@@ -1112,43 +1113,77 @@ export function CodeSurface({
       ) : null}
 
       {editable ? (
-        <footer className="code-surface-foot">
-          <div className="code-surface-working-copy">
+        // A thin VS Code-style status bar, not a padded footer.
+        <footer className="code-surface-statusbar">
+          <div className="code-surface-statusbar-left">
+            {liveBudget ? (
+              <span
+                className={`code-surface-statusbar-item code-surface-budget${liveBudget.oversize ? ' is-oversize' : ''}`}
+              >
+                {t('studioPanel.code.budget', { lines: liveBudget.lines, maxLines: liveBudget.maxLines })}
+              </span>
+            ) : null}
             <span
-              className={`code-surface-save-state is-${saveState}${hasWorkingCopy ? ' has-changes' : ''}`}
+              className={`code-surface-statusbar-item code-surface-save-state is-${saveState}${hasWorkingCopy ? ' has-changes' : ''}`}
               aria-live="polite"
               data-testid="code-working-copy-status"
             >
               {workingCopyLabel}
             </span>
+            {syncPreviewState === 'pending' ? (
+              <span className="code-surface-statusbar-item code-surface-preview-status is-pending" aria-live="polite">
+                <span className="status-preview-spinner" aria-hidden="true" /> {t('studioPanel.code.previewSyncing')}
+              </span>
+            ) : null}
+            {syncPreviewState === 'ready' ? (
+              <button
+                type="button"
+                className="code-surface-statusbar-item code-surface-preview-status is-ready"
+                onClick={onBack}
+              >
+                {t('studioPanel.code.previewSyncReady')}
+              </button>
+            ) : null}
             {livePush ? (
-              <span className="code-surface-live-push" aria-live="polite">
+              <span className="code-surface-statusbar-item code-surface-live-push" aria-live="polite">
                 {t('studioPanel.code.livePush')}
               </span>
             ) : null}
             {roundOpenedNotice ? (
-              <span className="code-surface-round-opened" aria-live="polite">
+              <span className="code-surface-statusbar-item code-surface-round-opened" aria-live="polite">
                 {t('studioPanel.code.roundOpened')}
               </span>
             ) : null}
             {rebuildError ? (
-              <span className="code-surface-rebuild-error">{t('studioPanel.code.rebuildError')}</span>
+              <span className="code-surface-statusbar-item code-surface-rebuild-error">
+                {t('studioPanel.code.rebuildError')}
+              </span>
             ) : null}
+            {deliverMessage ? (
+              // Anything short of a delivered outcome is a problem report — muted grey
+              // buries the one line telling the creator why nothing shipped.
+              <span
+                className={`code-surface-statusbar-item code-surface-deliver-message${deliverState === 'delivered' ? '' : ' is-error'}`}
+                role="status"
+              >
+                {deliverMessage}
+              </span>
+            ) : null}
+          </div>
+
+          <div className="code-surface-deliver">
             {hasWorkingCopy ? (
               <button
                 type="button"
-                className="code-surface-discard"
+                className="code-surface-statusbar-item code-surface-discard"
                 disabled={discardState === 'discarding' || deliverState === 'delivering'}
                 onClick={() => void discardWorkingCopy()}
               >
                 {discardState === 'discarding' ? t('studioPanel.code.discarding') : t('studioPanel.code.discard')}
               </button>
             ) : null}
-          </div>
-
-          <div className="code-surface-deliver">
             <span
-              className="code-surface-publish-hint"
+              className="code-surface-statusbar-item code-surface-publish-hint"
               aria-label={t('studioPanel.code.publishHintTitle')}
               tabIndex={0}
               title={t('studioPanel.code.publishHintTitle')}
@@ -1157,24 +1192,13 @@ export function CodeSurface({
             </span>
             <button
               type="button"
-              className="code-surface-deliver-btn studio-head-action is-primary"
+              className="code-surface-statusbar-item code-surface-deliver-btn"
               disabled={!hasWorkingCopy || deliverState === 'delivering' || discardState === 'discarding'}
               onClick={() => void deliver()}
             >
               {deliverState === 'delivering' ? t('studioPanel.code.delivering') : t('studioPanel.code.deliver')}
             </button>
           </div>
-
-          {deliverMessage ? (
-            // Anything short of a delivered outcome is a problem report — muted grey
-            // for those buried the one line telling the creator why nothing shipped.
-            <span
-              className={`code-surface-deliver-message${deliverState === 'delivered' ? '' : ' is-error'}`}
-              role="status"
-            >
-              {deliverMessage}
-            </span>
-          ) : null}
         </footer>
       ) : null}
 

--- a/apps/web/src/CodeSurface.tsx
+++ b/apps/web/src/CodeSurface.tsx
@@ -211,6 +211,8 @@ export function CodeSurface({
   const previewTimerRef = useRef<number | null>(null);
   const cooldownTimerRef = useRef<number | null>(null);
   const lastRebuildAtRef = useRef(0);
+  // Bumped by every edit, to detect a superseded sync preview.
+  const syncPreviewGenerationRef = useRef(0);
   const draftsRef = useRef(drafts);
   draftsRef.current = drafts;
   /** The content doc believed live in the game now — lazy-fetched, kept current by pushes. */
@@ -579,6 +581,9 @@ export function CodeSurface({
       window.clearTimeout(cooldownTimerRef.current);
       cooldownTimerRef.current = null;
     }
+    // A new edit invalidates any earlier in-flight or ready preview.
+    syncPreviewGenerationRef.current += 1;
+    setSyncPreviewState('idle');
     const arm = () => {
       previewTimerRef.current = null;
       const since = Date.now() - lastRebuildAtRef.current;
@@ -589,13 +594,16 @@ export function CodeSurface({
       setRebuildError(false);
       setRebuildState('pending');
       // Track 2: shows the synchronous rebuild the instant it lands.
+      const generation = syncPreviewGenerationRef.current;
       setSyncPreviewState('pending');
       void requestCodeSurfacePreview(slug)
         .then((result) => {
           onPreviewReadyRef.current?.(result.html);
-          setSyncPreviewState('ready');
+          if (syncPreviewGenerationRef.current === generation) setSyncPreviewState('ready');
         })
-        .catch(() => setSyncPreviewState('idle'));
+        .catch(() => {
+          if (syncPreviewGenerationRef.current === generation) setSyncPreviewState('idle');
+        });
       void rebuildCodeSurfaceStage(slug)
         .then(() => {
           recordCodeStep('previewed');
@@ -1115,90 +1123,92 @@ export function CodeSurface({
       {editable ? (
         // A thin VS Code-style status bar, not a padded footer.
         <footer className="code-surface-statusbar">
-          <div className="code-surface-statusbar-left">
-            {liveBudget ? (
+          <div className="code-surface-statusbar-row">
+            <div className="code-surface-statusbar-left">
+              {liveBudget ? (
+                <span
+                  className={`code-surface-statusbar-item code-surface-budget${liveBudget.oversize ? ' is-oversize' : ''}`}
+                >
+                  {t('studioPanel.code.budget', { lines: liveBudget.lines, maxLines: liveBudget.maxLines })}
+                </span>
+              ) : null}
               <span
-                className={`code-surface-statusbar-item code-surface-budget${liveBudget.oversize ? ' is-oversize' : ''}`}
+                className={`code-surface-statusbar-item code-surface-save-state is-${saveState}${hasWorkingCopy ? ' has-changes' : ''}`}
+                aria-live="polite"
+                data-testid="code-working-copy-status"
               >
-                {t('studioPanel.code.budget', { lines: liveBudget.lines, maxLines: liveBudget.maxLines })}
+                {workingCopyLabel}
               </span>
-            ) : null}
-            <span
-              className={`code-surface-statusbar-item code-surface-save-state is-${saveState}${hasWorkingCopy ? ' has-changes' : ''}`}
-              aria-live="polite"
-              data-testid="code-working-copy-status"
-            >
-              {workingCopyLabel}
-            </span>
-            {syncPreviewState === 'pending' ? (
-              <span className="code-surface-statusbar-item code-surface-preview-status is-pending" aria-live="polite">
-                <span className="status-preview-spinner" aria-hidden="true" /> {t('studioPanel.code.previewSyncing')}
+              {syncPreviewState === 'pending' ? (
+                <span className="code-surface-statusbar-item code-surface-preview-status is-pending" aria-live="polite">
+                  <span className="status-preview-spinner" aria-hidden="true" /> {t('studioPanel.code.previewSyncing')}
+                </span>
+              ) : null}
+              {syncPreviewState === 'ready' ? (
+                <button
+                  type="button"
+                  className="code-surface-statusbar-item code-surface-preview-status is-ready"
+                  onClick={onBack}
+                >
+                  {t('studioPanel.code.previewSyncReady')}
+                </button>
+              ) : null}
+              {livePush ? (
+                <span className="code-surface-statusbar-item code-surface-live-push" aria-live="polite">
+                  {t('studioPanel.code.livePush')}
+                </span>
+              ) : null}
+              {roundOpenedNotice ? (
+                <span className="code-surface-statusbar-item code-surface-round-opened" aria-live="polite">
+                  {t('studioPanel.code.roundOpened')}
+                </span>
+              ) : null}
+              {rebuildError ? (
+                <span className="code-surface-statusbar-item code-surface-rebuild-error">
+                  {t('studioPanel.code.rebuildError')}
+                </span>
+              ) : null}
+            </div>
+
+            <div className="code-surface-deliver">
+              {hasWorkingCopy ? (
+                <button
+                  type="button"
+                  className="code-surface-statusbar-item code-surface-discard"
+                  disabled={discardState === 'discarding' || deliverState === 'delivering'}
+                  onClick={() => void discardWorkingCopy()}
+                >
+                  {discardState === 'discarding' ? t('studioPanel.code.discarding') : t('studioPanel.code.discard')}
+                </button>
+              ) : null}
+              <span
+                className="code-surface-statusbar-item code-surface-publish-hint"
+                aria-label={t('studioPanel.code.publishHintTitle')}
+                tabIndex={0}
+                title={t('studioPanel.code.publishHintTitle')}
+              >
+                {t('studioPanel.code.publishHint')}
               </span>
-            ) : null}
-            {syncPreviewState === 'ready' ? (
               <button
                 type="button"
-                className="code-surface-statusbar-item code-surface-preview-status is-ready"
-                onClick={onBack}
+                className="code-surface-statusbar-item code-surface-deliver-btn"
+                disabled={!hasWorkingCopy || deliverState === 'delivering' || discardState === 'discarding'}
+                onClick={() => void deliver()}
               >
-                {t('studioPanel.code.previewSyncReady')}
+                {deliverState === 'delivering' ? t('studioPanel.code.delivering') : t('studioPanel.code.deliver')}
               </button>
-            ) : null}
-            {livePush ? (
-              <span className="code-surface-statusbar-item code-surface-live-push" aria-live="polite">
-                {t('studioPanel.code.livePush')}
-              </span>
-            ) : null}
-            {roundOpenedNotice ? (
-              <span className="code-surface-statusbar-item code-surface-round-opened" aria-live="polite">
-                {t('studioPanel.code.roundOpened')}
-              </span>
-            ) : null}
-            {rebuildError ? (
-              <span className="code-surface-statusbar-item code-surface-rebuild-error">
-                {t('studioPanel.code.rebuildError')}
-              </span>
-            ) : null}
-            {deliverMessage ? (
-              // Anything short of a delivered outcome is a problem report — muted grey
-              // buries the one line telling the creator why nothing shipped.
-              <span
-                className={`code-surface-statusbar-item code-surface-deliver-message${deliverState === 'delivered' ? '' : ' is-error'}`}
-                role="status"
-              >
-                {deliverMessage}
-              </span>
-            ) : null}
+            </div>
           </div>
 
-          <div className="code-surface-deliver">
-            {hasWorkingCopy ? (
-              <button
-                type="button"
-                className="code-surface-statusbar-item code-surface-discard"
-                disabled={discardState === 'discarding' || deliverState === 'delivering'}
-                onClick={() => void discardWorkingCopy()}
-              >
-                {discardState === 'discarding' ? t('studioPanel.code.discarding') : t('studioPanel.code.discard')}
-              </button>
-            ) : null}
+          {deliverMessage ? (
+            // Outside the scroller — a failure must stay visible, not hide.
             <span
-              className="code-surface-statusbar-item code-surface-publish-hint"
-              aria-label={t('studioPanel.code.publishHintTitle')}
-              tabIndex={0}
-              title={t('studioPanel.code.publishHintTitle')}
+              className={`code-surface-deliver-message${deliverState === 'delivered' ? '' : ' is-error'}`}
+              role="status"
             >
-              {t('studioPanel.code.publishHint')}
+              {deliverMessage}
             </span>
-            <button
-              type="button"
-              className="code-surface-statusbar-item code-surface-deliver-btn"
-              disabled={!hasWorkingCopy || deliverState === 'delivering' || discardState === 'discarding'}
-              onClick={() => void deliver()}
-            >
-              {deliverState === 'delivering' ? t('studioPanel.code.delivering') : t('studioPanel.code.deliver')}
-            </button>
-          </div>
+          ) : null}
         </footer>
       ) : null}
 

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -334,6 +334,8 @@
       "rebuildError": "Could not update the preview — try again",
       "previewUpdating": "Updating preview…",
       "previewReady": "Preview updated",
+      "previewSyncing": "Updating…",
+      "previewSyncReady": "Preview ready — view",
       "deliver": "Publish",
       "delivering": "Publishing…",
       "deliverSuccess": "Published — the gate is checking it now.",
@@ -343,7 +345,7 @@
       "discard": "Discard changes",
       "discarding": "Discarding…",
       "discardError": "Could not discard — try again",
-      "publishHint": "Edits already save and preview live. Confirms your right to use this work when you publish.",
+      "publishHint": "Confirms your right to use this work.",
       "publishHintTitle": "Edits already save automatically and preview live as you work — you don't need to publish after every change. Publishing confirms this is your own work (or you have the right to use it), runs the game gate, and an operator reviews it before this version replaces what's live.",
       "workingCopy": {
         "clean": "No local changes",

--- a/apps/web/src/i18n/locales/pl.json
+++ b/apps/web/src/i18n/locales/pl.json
@@ -336,6 +336,8 @@
       "rebuildError": "Nie udało się zaktualizować podglądu — spróbuj ponownie",
       "previewUpdating": "Aktualizowanie podglądu…",
       "previewReady": "Podgląd zaktualizowany",
+      "previewSyncing": "Aktualizowanie…",
+      "previewSyncReady": "Podgląd gotowy — zobacz",
       "deliver": "Opublikuj",
       "delivering": "Publikowanie…",
       "deliverSuccess": "Opublikowano — bramka właśnie to sprawdza.",
@@ -345,7 +347,7 @@
       "discard": "Odrzuć zmiany",
       "discarding": "Odrzucanie…",
       "discardError": "Nie udało się odrzucić — spróbuj ponownie",
-      "publishHint": "Zmiany zapisują się i widać je na żywo w podglądzie. Publikacja potwierdza Twoje prawo do użycia tej pracy.",
+      "publishHint": "Potwierdzasz prawo do użycia tej pracy.",
       "publishHintTitle": "Zmiany zapisują się automatycznie i widać je na żywo w podglądzie — nie trzeba publikować po każdej zmianie. Publikacja potwierdza, że to Twoja własna praca (lub masz prawo jej używać), uruchamia bramkę, a operator zatwierdza wejście tej wersji na żywo.",
       "workingCopy": {
         "clean": "Brak lokalnych zmian",

--- a/apps/web/src/styles.codeSurfaceButtons.test.ts
+++ b/apps/web/src/styles.codeSurfaceButtons.test.ts
@@ -17,13 +17,13 @@ function ruleFor(selector: string): string {
 
 describe('the Code surface Publish button', () => {
   it('is a filled turquoise CTA, not the unstyled native default', () => {
-    const rule = ruleFor('.code-surface-deliver-btn.is-primary');
+    const rule = ruleFor('.code-surface-deliver-btn');
     expect(rule).toMatch(/background:\s*var\(--turquoise\)/);
     expect(rule).toMatch(/color:\s*#08241d/);
   });
 
   it('has an explicit disabled treatment distinct from the enabled fill', () => {
-    const rule = ruleFor('.code-surface-deliver-btn.is-primary:disabled');
+    const rule = ruleFor('.code-surface-deliver-btn:disabled');
     expect(rule).toMatch(/color:\s*var\(--muted\)/);
   });
 

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -12210,13 +12210,19 @@ button.builder-mode-selector:disabled {
 .code-surface-statusbar {
   flex: none;
   display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 12px;
+  flex-direction: column;
+  gap: 4px;
   min-height: 28px;
   padding: 3px 10px;
   border-top: 1px solid var(--panel-border);
   background: rgba(148, 163, 184, 0.05);
+}
+
+.code-surface-statusbar-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
 }
 
 .code-surface-statusbar-left {
@@ -12343,6 +12349,8 @@ button.builder-mode-selector:disabled {
 }
 
 .code-surface-deliver-message {
+  display: block;
+  font-size: 0.72rem;
   color: var(--muted);
 }
 
@@ -12370,7 +12378,7 @@ button.builder-mode-selector:disabled {
 
 /* Narrow phones: let the bar wrap into two lines rather than clip actions. */
 @media (max-width: 640px) {
-  .code-surface-statusbar {
+  .code-surface-statusbar-row {
     flex-wrap: wrap;
     height: auto;
   }

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -12192,18 +12192,6 @@ button.builder-mode-selector:disabled {
   color: #d2a8ff;
 }
 
-.code-surface-budget {
-  flex: none;
-  padding: 4px 14px;
-  font-size: 0.74rem;
-  color: var(--muted);
-  border-top: 1px solid var(--panel-border);
-}
-
-.code-surface-budget.is-oversize {
-  color: #f0b429;
-}
-
 .code-surface-diagnostics {
   flex: none;
   margin: 0;
@@ -12217,24 +12205,51 @@ button.builder-mode-selector:disabled {
   overflow-y: auto;
 }
 
-.code-surface-foot {
+/* A thin, single-row status bar (VS Code's bottom bar) instead of a padded footer:
+   status segments on the left, actions on the right, everything the same small size. */
+.code-surface-statusbar {
   flex: none;
   display: flex;
-  flex-direction: column;
-  gap: 8px;
-  padding: 8px 14px;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  min-height: 28px;
+  padding: 3px 10px;
   border-top: 1px solid var(--panel-border);
+  background: rgba(148, 163, 184, 0.05);
 }
 
-.code-surface-working-copy {
+.code-surface-statusbar-left {
   display: flex;
   align-items: center;
-  flex-wrap: wrap;
-  gap: 10px;
+  gap: 12px;
+  min-width: 0;
+  overflow-x: auto;
+  scrollbar-width: none;
+}
+
+.code-surface-statusbar-left::-webkit-scrollbar {
+  display: none;
+}
+
+.code-surface-statusbar-item {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  flex: none;
+  white-space: nowrap;
+  font-size: 0.72rem;
+}
+
+.code-surface-budget {
+  color: var(--muted);
+}
+
+.code-surface-budget.is-oversize {
+  color: #f0b429;
 }
 
 .code-surface-save-state {
-  font-size: 0.78rem;
   color: var(--muted);
 }
 
@@ -12248,28 +12263,55 @@ button.builder-mode-selector:disabled {
 }
 
 .code-surface-rebuild-error {
-  font-size: 0.78rem;
   color: #ff7b72;
 }
 
 .code-surface-live-push {
-  font-size: 0.78rem;
   color: var(--success, #2e8b57);
 }
 
 .code-surface-round-opened {
-  font-size: 0.78rem;
   color: var(--muted);
 }
 
+.code-surface-preview-status.is-pending {
+  color: var(--muted);
+}
+
+.code-surface-preview-status.is-pending .status-preview-spinner {
+  width: 10px;
+  height: 10px;
+  border-width: 2px;
+}
+
+.code-surface-preview-status.is-ready {
+  border: none;
+  background: none;
+  padding: 0;
+  color: var(--turquoise);
+  font-weight: 600;
+  cursor: pointer;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+.code-surface-preview-status.is-ready:hover {
+  color: var(--text);
+}
+
+.code-surface-deliver {
+  display: flex;
+  align-items: center;
+  flex: none;
+  gap: 8px;
+}
+
 .code-surface-discard {
-  margin-left: auto;
   border: 1px solid var(--panel-border);
   background: transparent;
   color: var(--muted);
-  font-size: 0.78rem;
-  padding: 6px 10px;
-  border-radius: 8px;
+  padding: 3px 8px;
+  border-radius: 4px;
   cursor: pointer;
 }
 
@@ -12283,39 +12325,24 @@ button.builder-mode-selector:disabled {
   cursor: default;
 }
 
-/* Belt and braces with the `studio-head-action is-primary` class the Publish button
-   also carries (pill shape, hover glow — Play's exact look): this self-contained
-   rule keeps the fill guaranteed even if that pairing drifts, and the regression
-   test reads it. */
-.code-surface-deliver-btn.is-primary {
+.code-surface-deliver-btn {
   border: 1px solid var(--turquoise);
   background: var(--turquoise);
   color: #08241d;
   font-weight: 700;
+  padding: 3px 10px;
+  border-radius: 4px;
+  cursor: pointer;
 }
 
-.code-surface-deliver-btn.is-primary:disabled {
+.code-surface-deliver-btn:disabled {
   border-color: var(--panel-border);
   background: rgba(148, 163, 184, 0.12);
   color: var(--muted);
   cursor: default;
-  filter: none;
-  box-shadow: none;
-}
-
-.code-surface-deliver {
-  display: flex;
-  align-items: center;
-  flex-wrap: wrap;
-  gap: 10px;
-}
-
-.code-surface-deliver-btn {
-  margin-left: auto;
 }
 
 .code-surface-deliver-message {
-  font-size: 0.76rem;
   color: var(--muted);
 }
 
@@ -12326,20 +12353,31 @@ button.builder-mode-selector:disabled {
 }
 
 .code-surface-publish-hint {
-  flex: 1 1 auto;
-  min-width: 0;
+  display: inline-block;
+  max-width: 160px;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  font-size: 0.68rem;
   color: var(--muted);
-  line-height: 1.25;
   cursor: help;
+  vertical-align: middle;
 }
 
 .code-surface-publish-hint:focus-visible {
   outline: 2px solid rgba(0, 228, 172, 0.5);
   outline-offset: 2px;
+}
+
+/* Narrow phones: let the bar wrap into two lines rather than clip actions. */
+@media (max-width: 640px) {
+  .code-surface-statusbar {
+    flex-wrap: wrap;
+    height: auto;
+  }
+
+  .code-surface-publish-hint {
+    display: none;
+  }
 }
 
 /* Actions menu (quick open / commands / project search): one top-anchored palette,


### PR DESCRIPTION
## Summary

Stacked on #846 (touches the same `publishHint` copy — this PR trims it further now that the new preview indicator carries part of that job).

Two related UX issues from walking through the Track 2/3/4 live-editing stack:

1. **No visibility into the fast preview.** Track 2's sync preview (`POST /sources/preview`, ~100-300ms) had zero UI — it silently updates the hidden stage behind the Code overlay, with no way to know it landed short of leaving the editor to check.
2. **Publish read as a per-edit action.** The footer was a padded, multi-row block, and Publish carried the same big primary-pill treatment as the top bar's Play button — visual weight that doesn't match how rare/deliberate a real publish is.

## Change

Rebuilt `apps/web/src/CodeSurface.tsx`'s footer as a single-row, VS Code-style status bar instead of a padded multi-row block:

- **Left:** line budget, save-state, a new sync-preview indicator (spinner while the fast rebuild is in flight → converts to a clickable **"Preview ready — view"** link once it lands, which jumps back to the stage), live-push badge, round-opened notice, rebuild/deliver errors.
- **Right:** Discard, the rights hint (now short — the preview indicator itself teaches "edits already preview live," so the always-visible text no longer has to), Publish — all compact segments, same small size, no more oversized pill.

`apps/web/src/styles.css`: replaced the old `.code-surface-foot`/`.code-surface-working-copy`/`.code-surface-deliver` column layout with `.code-surface-statusbar` (thin single row) and shared `.code-surface-statusbar-item` sizing; Publish drops the `studio-head-action is-primary` classes (Play's pill/glow look) for its own compact accent style; narrow phones (≤640px) get a wrap fallback.

## Screenshots

Fast preview in flight → ready to view (rendered from the actual component + real stylesheet, headless):

Pending: spinner + "Updating…" next to the working-copy status.
Ready: the same spot becomes a clickable turquoise "Preview ready — view" link.

(Screenshots shared in chat — not attached here since this environment has no image-upload path to the PR.)

## Test plan
- [x] New test: `CodeSurface.test.tsx` — spinner while the fast preview is in flight, then a clickable "Preview ready" link that calls back to the stage
- [x] Updated `styles.codeSurfaceButtons.test.ts` — the CSS regression tests for the Publish button's filled/disabled treatment, now against the plain `.code-surface-deliver-btn` selector (no longer `.is-primary`)
- [x] `npx vitest run --root apps/web` (CI-matching env, `GITHUB_TOKEN` unset) — 165 files / 1434 tests green
- [x] `npx tsc --noEmit` clean
- [x] `eslint` + `comment-prose` clean (net comment words: 645, under the 647 baseline)

Co-Authored-By: Claude Sonnet 5

https://claude.ai/code/session_01Ptra1eaV7EdeeS8MZP7USJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ptra1eaV7EdeeS8MZP7USJ)_