### PR TITLE
Persist code undo history across Play

### DIFF
--- a/apps/web/src/CodeMirrorEditor.tsx
+++ b/apps/web/src/CodeMirrorEditor.tsx
@@ -44,6 +44,11 @@ import {
 import type { WorkerShape } from '@valtown/codemirror-ts/worker';
 import type { CodeLanguage } from './codeTokens.js';
 import { vsCodeSearchPanel } from './codeMirrorSearchPanel.js';
+import {
+  restoreCodeSurfaceEditorState,
+  serializeCodeSurfaceEditorState,
+  type CodeSurfaceEditorState,
+} from './codeSurfaceEditorState.js';
 import { recordCodeCompletion } from './visitTelemetry.js';
 
 // CodeMirror 6 (CE-14): lazy chunk; keyed by file path to remount.
@@ -69,6 +74,9 @@ export type CodeMirrorEditorProps = {
   initialSelection?: { anchor: number; head: number };
   // TA-02: ghost-text proposal for the window around the cursor.
   fetchGhostText?: (prefixWindow: string, suffixWindow: string, signal: AbortSignal) => Promise<string>;
+  // Saved per-file state lets the undo stack survive switching to Play.
+  initialEditorState?: CodeSurfaceEditorState;
+  onEditorStateChange?: (state: CodeSurfaceEditorState) => void;
 };
 
 function languageExtension(language: CodeLanguage): Extension | null {
@@ -741,6 +749,8 @@ export default function CodeMirrorEditor({
   onGotoDefinition,
   initialSelection,
   fetchGhostText,
+  initialEditorState,
+  onEditorStateChange,
 }: CodeMirrorEditorProps) {
   const containerRef = useRef<HTMLDivElement | null>(null);
   const viewRef = useRef<EditorView | null>(null);
@@ -755,6 +765,8 @@ export default function CodeMirrorEditor({
   onGotoDefinitionRef.current = onGotoDefinition;
   const fetchGhostTextRef = useRef(fetchGhostText);
   fetchGhostTextRef.current = fetchGhostText;
+  const onEditorStateChangeRef = useRef(onEditorStateChange);
+  onEditorStateChangeRef.current = onEditorStateChange;
   // GA-05: reconfigured live below — a ready worker never remounts.
   const languageServiceCompartmentRef = useRef(new Compartment());
 
@@ -763,10 +775,10 @@ export default function CodeMirrorEditor({
     const langExt = languageExtension(language);
     const view = new EditorView({
       parent: containerRef.current,
-      state: EditorState.create({
-        doc: value,
-        selection: initialSelection,
-        extensions: [
+      state: restoreCodeSurfaceEditorState(
+        initialEditorState,
+        value,
+        [
           basicSetup,
           // After basicSetup, so this createPanel wins over the stock search bar.
           search({ top: true, createPanel: vsCodeSearchPanel }),
@@ -793,10 +805,12 @@ export default function CodeMirrorEditor({
           syntaxHighlighting(darkHighlight),
           darkChrome,
         ],
-      }),
+        initialSelection,
+      ),
     });
     viewRef.current = view;
     return () => {
+      onEditorStateChangeRef.current?.(serializeCodeSurfaceEditorState(view.state));
       view.destroy();
       viewRef.current = null;
     };

--- a/apps/web/src/CodeSurface.test.tsx
+++ b/apps/web/src/CodeSurface.test.tsx
@@ -4,21 +4,35 @@ import { act, createElement } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { CodeSurface } from './CodeSurface.js';
-import { resetCodeSurfaceSessionState } from './codeSurfaceSessionState.js';
+import { getCodeSurfaceSessionState, resetCodeSurfaceSessionState } from './codeSurfaceSessionState.js';
 import * as codeSurfaceApi from './codeSurfaceApi.js';
 import i18n from './i18n/index.js';
 import type { EditorContentDoc, GameEditorState } from './studioApi.js';
+
+const codeMirrorMock = vi.hoisted(() => ({
+  current: null as {
+    initialEditorState?: unknown;
+    onEditorStateChange?: (state: unknown) => void;
+  } | null,
+}));
 
 // The real CodeMirror editor needs DOM layout measurement jsdom cannot provide, and
 // its dynamic import races the plain-textarea Suspense fallback these tests rely on —
 // a stand-in with the same value/onChange contract keeps that race out of the picture.
 vi.mock('./CodeMirrorEditor.js', () => ({
-  default: (props: { value: string; onChange: (value: string) => void }) =>
-    createElement('textarea', {
+  default: (props: {
+    value: string;
+    onChange: (value: string) => void;
+    initialEditorState?: unknown;
+    onEditorStateChange?: (state: unknown) => void;
+  }) => {
+    codeMirrorMock.current = props;
+    return createElement('textarea', {
       className: 'code-surface-editor',
       value: props.value,
       onChange: (event: { target: { value: string } }) => props.onChange(event.target.value),
-    }),
+    });
+  },
 }));
 
 vi.mock('./codeSurfaceApi.js', async () => {
@@ -80,6 +94,7 @@ describe('CodeSurface', () => {
     mocked.discardCodeSurfaceEdits.mockReset();
     mocked.deliverCodeSurface.mockReset();
     mockedStudioApi.fetchGameEditor.mockReset();
+    codeMirrorMock.current = null;
     mocked.rebuildCodeSurfaceStage.mockResolvedValue({ scheduled: true });
     mocked.requestCodeSurfacePreview.mockResolvedValue({ html: '<html></html>', engineRef: 'abc123' });
     container = document.createElement('div');
@@ -359,6 +374,25 @@ describe('CodeSurface', () => {
     const active = container.querySelector('.code-surface-rail-item.is-active');
     expect(active?.textContent).toContain('game/render.ts');
     expect(container.querySelector('textarea')!.value).toContain('tweaked');
+  });
+
+  it('restores the per-file undo history after switching to Play and back', async () => {
+    mocked.fetchCodeSurfaceSources.mockResolvedValue(sourcesFor());
+
+    await render();
+    const savedEditorState = {
+      doc: 'export const boot = () => { /* edited */ };',
+      selection: { ranges: [{ anchor: 0, head: 0 }], main: 0 },
+      history: { done: [], undone: [] },
+    };
+    codeMirrorMock.current?.onEditorStateChange?.(savedEditorState);
+    expect(getCodeSurfaceSessionState('sky-dodge')?.editorStates?.['game.ts']).toEqual(savedEditorState);
+
+    await act(async () => root.unmount());
+    root = createRoot(container);
+    await render();
+
+    expect(codeMirrorMock.current?.initialEditorState).toEqual(savedEditorState);
   });
 
   it('shows Discard when the buffer has owner changes, and discard reloads the delivered tree', async () => {

--- a/apps/web/src/CodeSurface.tsx
+++ b/apps/web/src/CodeSurface.tsx
@@ -116,6 +116,8 @@ export type CodeSurfaceProps = {
   onPendingActionsModeConsumed?: () => void;
   // Track 2: shows a synchronous rebuild the instant it's ready.
   onPreviewReady?: (html: string) => void;
+  // Fires when the menu closes with nothing picked.
+  onActionsMenuCancelled?: () => void;
 };
 
 const LOCKED_DIRS = ['shared/', 'tools/'] as const;
@@ -170,6 +172,7 @@ export function CodeSurface({
   pendingActionsMode,
   onPendingActionsModeConsumed,
   onPreviewReady,
+  onActionsMenuCancelled,
 }: CodeSurfaceProps) {
   const { t, i18n } = useTranslation();
   const [sources, setSources] = useState<CodeSurfaceSources | null>(null);
@@ -305,7 +308,10 @@ export function CodeSurface({
     return () => document.removeEventListener('keydown', onKeyDown);
   }, [filePickerOpen]);
 
-  const openActionsMenu = useCallback((mode: CodeActionsMode) => {
+  const openedViaPendingRef = useRef(false);
+
+  const openActionsMenu = useCallback((mode: CodeActionsMode, viaPending = false) => {
+    openedViaPendingRef.current = viaPending;
     setActionsMenu((current) => {
       if (!current) {
         const focused = document.activeElement;
@@ -315,15 +321,19 @@ export function CodeSurface({
     });
   }, []);
 
-  const closeActionsMenu = useCallback(() => {
+  const closeActionsMenu = useCallback((acted = false) => {
     setActionsMenu(null);
     const previous = actionsReturnFocusRef.current;
     actionsReturnFocusRef.current = null;
     if (previous?.isConnected) previous.focus();
+    if (!acted && openedViaPendingRef.current) onActionsMenuCancelledRef.current?.();
+    openedViaPendingRef.current = false;
   }, []);
 
   const onPendingActionsModeConsumedRef = useRef(onPendingActionsModeConsumed);
   onPendingActionsModeConsumedRef.current = onPendingActionsModeConsumed;
+  const onActionsMenuCancelledRef = useRef(onActionsMenuCancelled);
+  onActionsMenuCancelledRef.current = onActionsMenuCancelled;
   const pendingActionsModeRef = useRef(pendingActionsMode);
   pendingActionsModeRef.current = pendingActionsMode;
   const pendingActionsConsumedRef = useRef(false);
@@ -331,7 +341,7 @@ export function CodeSurface({
   useEffect(() => {
     if (!pendingActionsMode || !sources || pendingActionsConsumedRef.current) return;
     pendingActionsConsumedRef.current = true;
-    openActionsMenu(pendingActionsMode.mode);
+    openActionsMenu(pendingActionsMode.mode, true);
     onPendingActionsModeConsumedRef.current?.();
   }, [pendingActionsMode, sources, openActionsMenu]);
 
@@ -558,14 +568,14 @@ export function CodeSurface({
     // Rides the pendingJump path search matches use — the new editor claims focus.
     if (path !== selected) setPendingJump({ path, from: 0, to: 0 });
     selectFile(path);
-    closeActionsMenu();
+    closeActionsMenu(true);
   }
 
   // A search hit rides GA-09's jump and lands as a selection.
   function handleOpenSearchMatch(match: CodeActionsSearchMatch) {
     setPendingJump({ path: match.path, from: match.from, to: match.to });
     selectFile(match.path);
-    closeActionsMenu();
+    closeActionsMenu(true);
   }
 
   const schedulePreviewRebuild = useCallback(() => {

--- a/apps/web/src/CodeSurface.tsx
+++ b/apps/web/src/CodeSurface.tsx
@@ -33,7 +33,11 @@ import {
   type CodeSurfaceFile,
   type CodeSurfaceSources,
 } from './codeSurfaceApi.js';
-import { getCodeSurfaceSessionState, setCodeSurfaceSessionState } from './codeSurfaceSessionState.js';
+import {
+  getCodeSurfaceSessionState,
+  setCodeSurfaceEditorState,
+  setCodeSurfaceSessionState,
+} from './codeSurfaceSessionState.js';
 import {
   createCodeSurfaceLanguageService,
   fromVfsPath,
@@ -112,8 +116,6 @@ export type CodeSurfaceProps = {
   onPendingActionsModeConsumed?: () => void;
   // Track 2: shows a synchronous rebuild the instant it's ready.
   onPreviewReady?: (html: string) => void;
-  // Fires when the menu closes with nothing picked.
-  onActionsMenuCancelled?: () => void;
 };
 
 const LOCKED_DIRS = ['shared/', 'tools/'] as const;
@@ -168,7 +170,6 @@ export function CodeSurface({
   pendingActionsMode,
   onPendingActionsModeConsumed,
   onPreviewReady,
-  onActionsMenuCancelled,
 }: CodeSurfaceProps) {
   const { t, i18n } = useTranslation();
   const [sources, setSources] = useState<CodeSurfaceSources | null>(null);
@@ -286,7 +287,11 @@ export function CodeSurface({
   }, [sources?.readOnly, load]);
 
   useEffect(() => {
-    setCodeSurfaceSessionState(slug, { selected, drafts });
+    setCodeSurfaceSessionState(slug, {
+      selected,
+      drafts,
+      editorStates: getCodeSurfaceSessionState(slug)?.editorStates,
+    });
   }, [slug, selected, drafts]);
 
   useEffect(() => {
@@ -300,10 +305,7 @@ export function CodeSurface({
     return () => document.removeEventListener('keydown', onKeyDown);
   }, [filePickerOpen]);
 
-  const openedViaPendingRef = useRef(false);
-
-  const openActionsMenu = useCallback((mode: CodeActionsMode, viaPending = false) => {
-    openedViaPendingRef.current = viaPending;
+  const openActionsMenu = useCallback((mode: CodeActionsMode) => {
     setActionsMenu((current) => {
       if (!current) {
         const focused = document.activeElement;
@@ -313,19 +315,15 @@ export function CodeSurface({
     });
   }, []);
 
-  const closeActionsMenu = useCallback((acted = false) => {
+  const closeActionsMenu = useCallback(() => {
     setActionsMenu(null);
     const previous = actionsReturnFocusRef.current;
     actionsReturnFocusRef.current = null;
     if (previous?.isConnected) previous.focus();
-    if (!acted && openedViaPendingRef.current) onActionsMenuCancelledRef.current?.();
-    openedViaPendingRef.current = false;
   }, []);
 
   const onPendingActionsModeConsumedRef = useRef(onPendingActionsModeConsumed);
   onPendingActionsModeConsumedRef.current = onPendingActionsModeConsumed;
-  const onActionsMenuCancelledRef = useRef(onActionsMenuCancelled);
-  onActionsMenuCancelledRef.current = onActionsMenuCancelled;
   const pendingActionsModeRef = useRef(pendingActionsMode);
   pendingActionsModeRef.current = pendingActionsMode;
   const pendingActionsConsumedRef = useRef(false);
@@ -333,7 +331,7 @@ export function CodeSurface({
   useEffect(() => {
     if (!pendingActionsMode || !sources || pendingActionsConsumedRef.current) return;
     pendingActionsConsumedRef.current = true;
-    openActionsMenu(pendingActionsMode.mode, true);
+    openActionsMenu(pendingActionsMode.mode);
     onPendingActionsModeConsumedRef.current?.();
   }, [pendingActionsMode, sources, openActionsMenu]);
 
@@ -560,14 +558,14 @@ export function CodeSurface({
     // Rides the pendingJump path search matches use — the new editor claims focus.
     if (path !== selected) setPendingJump({ path, from: 0, to: 0 });
     selectFile(path);
-    closeActionsMenu(true);
+    closeActionsMenu();
   }
 
   // A search hit rides GA-09's jump and lands as a selection.
   function handleOpenSearchMatch(match: CodeActionsSearchMatch) {
     setPendingJump({ path: match.path, from: match.from, to: match.to });
     selectFile(match.path);
-    closeActionsMenu(true);
+    closeActionsMenu();
   }
 
   const schedulePreviewRebuild = useCallback(() => {
@@ -1075,6 +1073,10 @@ export function CodeSurface({
                   onGotoDefinition={handleGotoDefinition}
                   initialSelection={initialSelectionForEditor}
                   fetchGhostText={fetchGhostText}
+                  initialEditorState={selected ? getCodeSurfaceSessionState(slug)?.editorStates?.[selected] : undefined}
+                  onEditorStateChange={(state) => {
+                    if (selected) setCodeSurfaceEditorState(slug, selected, state);
+                  }}
                 />
               </Suspense>
             </CodeMirrorBoundary>

--- a/apps/web/src/codeSurfaceEditorState.test.ts
+++ b/apps/web/src/codeSurfaceEditorState.test.ts
@@ -1,0 +1,33 @@
+// @vitest-environment jsdom
+
+import { history, undo, undoDepth } from '@codemirror/commands';
+import { EditorState } from '@codemirror/state';
+import { describe, expect, it } from 'vitest';
+import { restoreCodeSurfaceEditorState, serializeCodeSurfaceEditorState } from './codeSurfaceEditorState.js';
+
+function applyChange(state: EditorState, from: number, to: number, insert: string): EditorState {
+  return state.update({ changes: { from, to, insert } }).state;
+}
+
+describe('code surface editor state', () => {
+  it('restores CodeMirror history for the current document', () => {
+    const original = 'const color = "#fff";';
+    const edited = 'const color = "#00e4ac";';
+    const state = applyChange(EditorState.create({ doc: original, extensions: [history()] }), 15, 19, '#00e4ac');
+    const saved = serializeCodeSurfaceEditorState(state);
+
+    let restored = restoreCodeSurfaceEditorState(saved, edited, [history()]);
+    expect(undoDepth(restored)).toBe(1);
+    expect(undo({ state: restored, dispatch: (transaction) => (restored = transaction.state) })).toBe(true);
+    expect(restored.doc.toString()).toBe(original);
+  });
+
+  it('drops stale history when the document no longer matches', () => {
+    const state = EditorState.create({ doc: 'old', extensions: [history()] });
+    const saved = serializeCodeSurfaceEditorState(applyChange(state, 3, 3, '!'));
+
+    const restored = restoreCodeSurfaceEditorState(saved, 'new', [history()]);
+    expect(undoDepth(restored)).toBe(0);
+    expect(restored.doc.toString()).toBe('new');
+  });
+});

--- a/apps/web/src/codeSurfaceEditorState.ts
+++ b/apps/web/src/codeSurfaceEditorState.ts
@@ -1,0 +1,35 @@
+import { historyField } from '@codemirror/commands';
+import { EditorState, type Extension } from '@codemirror/state';
+
+export type CodeSurfaceEditorState = {
+  doc: string;
+  selection: unknown;
+  history: unknown;
+};
+
+export function serializeCodeSurfaceEditorState(state: EditorState): CodeSurfaceEditorState {
+  return state.toJSON({ history: historyField }) as CodeSurfaceEditorState;
+}
+
+function documentFromJson(value: unknown): string | null {
+  if (typeof value === 'string') return value;
+  if (!Array.isArray(value) || !value.every((line) => typeof line === 'string')) return null;
+  return value.join('\n');
+}
+
+export function restoreCodeSurfaceEditorState(
+  saved: unknown,
+  value: string,
+  extensions: Extension,
+  selection?: { anchor: number; head: number },
+): EditorState {
+  const config = { doc: value, selection, extensions };
+  if (typeof saved !== 'object' || saved === null || documentFromJson((saved as { doc?: unknown }).doc) !== value) {
+    return EditorState.create(config);
+  }
+  try {
+    return EditorState.fromJSON(saved, config, { history: historyField });
+  } catch {
+    return EditorState.create(config);
+  }
+}

--- a/apps/web/src/codeSurfaceSessionState.ts
+++ b/apps/web/src/codeSurfaceSessionState.ts
@@ -1,6 +1,12 @@
-// Selection/drafts kept across the panel's unmounts.
+import type { CodeSurfaceEditorState } from './codeSurfaceEditorState.js';
 
-export type CodeSurfaceSessionState = { selected: string | null; drafts: Record<string, string> };
+// Selection, drafts, and editor history kept across panel unmounts.
+
+export type CodeSurfaceSessionState = {
+  selected: string | null;
+  drafts: Record<string, string>;
+  editorStates?: Record<string, CodeSurfaceEditorState>;
+};
 
 const sessionStateBySlug = new Map<string, CodeSurfaceSessionState>();
 
@@ -10,6 +16,14 @@ export function getCodeSurfaceSessionState(slug: string): CodeSurfaceSessionStat
 
 export function setCodeSurfaceSessionState(slug: string, state: CodeSurfaceSessionState): void {
   sessionStateBySlug.set(slug, state);
+}
+
+export function setCodeSurfaceEditorState(slug: string, path: string, state: CodeSurfaceEditorState): void {
+  const current = sessionStateBySlug.get(slug) ?? { selected: null, drafts: {} };
+  sessionStateBySlug.set(slug, {
+    ...current,
+    editorStates: { ...current.editorStates, [path]: state },
+  });
 }
 
 // Test seam: the module-level cache outlives tests.


### PR DESCRIPTION
## What changed

- Persist CodeMirror undo/redo state per file in the existing Creator Studio session cache.
- Restore history when returning to Code, while rejecting history whose document no longer matches.
- Add regression coverage for real undo restoration, stale history, and CodeSurface remounts.

## Why

Switching from Code to Play unmounted CodeMirror. The draft text survived, but CodeMirror's internal history stack did not, so returning to the editor made Cmd/Ctrl+Z ineffective.

## Validation

- Focused CodeSurface and editor-state tests: passing
- `npm run lint`: passing
- `npm run type-check`: passing
- `npm run build`: passing
- The full suite's web tests pass; socket-based API/world tests are blocked in this sandbox by `listen EPERM`.