### PR TITLE
Add inline color pickers to code editor

### DIFF
--- a/apps/web/src/CodeMirrorEditor.test.tsx
+++ b/apps/web/src/CodeMirrorEditor.test.tsx
@@ -40,6 +40,7 @@ describe('CodeMirrorEditor color picker', () => {
     const picker = container.querySelector<HTMLInputElement>('.cm-color-picker');
     expect(picker).not.toBeNull();
     expect(picker?.value).toBe('#abcd12');
+    expect(picker?.title).toBe('Choose color #abcd1234');
 
     await act(async () => {
       const setter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, 'value')!.set!;

--- a/apps/web/src/CodeMirrorEditor.test.tsx
+++ b/apps/web/src/CodeMirrorEditor.test.tsx
@@ -32,6 +32,7 @@ describe('CodeMirrorEditor color picker', () => {
           language: 'typescript',
           onChange,
           diagnostics: [],
+          colorPickerLabel: 'Choose color',
         }),
       );
     });
@@ -47,5 +48,21 @@ describe('CodeMirrorEditor color picker', () => {
     });
 
     expect(onChange).toHaveBeenCalledWith("const color = '#11223334';");
+
+    await act(async () => {
+      root.render(
+        createElement(CodeMirrorEditor, {
+          value: "const color = '#abcd1234';",
+          language: 'typescript',
+          onChange,
+          diagnostics: [],
+          colorPickerLabel: 'Wybierz kolor',
+        }),
+      );
+    });
+
+    expect(container.querySelector<HTMLInputElement>('.cm-color-picker')?.getAttribute('aria-label')).toBe(
+      'Wybierz kolor #11223334',
+    );
   });
 });

--- a/apps/web/src/CodeMirrorEditor.test.tsx
+++ b/apps/web/src/CodeMirrorEditor.test.tsx
@@ -1,0 +1,51 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import CodeMirrorEditor from './CodeMirrorEditor.js';
+
+describe('CodeMirrorEditor color picker', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    Object.defineProperty(Range.prototype, 'getClientRects', { configurable: true, value: () => [] });
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  it('renders swatches and replaces the selected color literal', async () => {
+    const onChange = vi.fn();
+
+    await act(async () => {
+      root.render(
+        createElement(CodeMirrorEditor, {
+          value: "const color = '#abcd1234';",
+          language: 'typescript',
+          onChange,
+          diagnostics: [],
+        }),
+      );
+    });
+
+    const picker = container.querySelector<HTMLInputElement>('.cm-color-picker');
+    expect(picker).not.toBeNull();
+    expect(picker?.value).toBe('#abcd12');
+
+    await act(async () => {
+      const setter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, 'value')!.set!;
+      setter.call(picker, '#112233');
+      picker!.dispatchEvent(new Event('change', { bubbles: true }));
+    });
+
+    expect(onChange).toHaveBeenCalledWith("const color = '#11223334';");
+  });
+});

--- a/apps/web/src/CodeMirrorEditor.tsx
+++ b/apps/web/src/CodeMirrorEditor.tsx
@@ -15,7 +15,16 @@ import { markdown } from '@codemirror/lang-markdown';
 import { HighlightStyle, syntaxHighlighting } from '@codemirror/language';
 import { search } from '@codemirror/search';
 import { forceLinting, linter, lintGutter, type Diagnostic as CmDiagnostic } from '@codemirror/lint';
-import { Compartment, EditorState, Prec, StateEffect, StateField, type Extension, type Text } from '@codemirror/state';
+import {
+  Compartment,
+  EditorState,
+  Prec,
+  RangeSetBuilder,
+  StateEffect,
+  StateField,
+  type Extension,
+  type Text,
+} from '@codemirror/state';
 import {
   Decoration,
   type DecorationSet,
@@ -44,6 +53,7 @@ import {
 import type { WorkerShape } from '@valtown/codemirror-ts/worker';
 import type { CodeLanguage } from './codeTokens.js';
 import { vsCodeSearchPanel } from './codeMirrorSearchPanel.js';
+import { colorForPicker, colorFromPicker, findHexColors } from './codeMirrorColors.js';
 import { recordCodeCompletion } from './visitTelemetry.js';
 
 // CodeMirror 6 (CE-14): lazy chunk; keyed by file path to remount.
@@ -69,6 +79,7 @@ export type CodeMirrorEditorProps = {
   initialSelection?: { anchor: number; head: number };
   // TA-02: ghost-text proposal for the window around the cursor.
   fetchGhostText?: (prefixWindow: string, suffixWindow: string, signal: AbortSignal) => Promise<string>;
+  colorPickerLabel?: string;
 };
 
 function languageExtension(language: CodeLanguage): Extension | null {
@@ -86,6 +97,76 @@ function languageExtension(language: CodeLanguage): Extension | null {
     default:
       return null;
   }
+}
+
+class ColorSwatchWidget extends WidgetType {
+  constructor(
+    readonly color: string,
+    readonly from: number,
+    readonly to: number,
+    readonly label: string,
+    readonly onChange: (from: number, to: number, color: string) => void,
+  ) {
+    super();
+  }
+
+  eq(other: ColorSwatchWidget): boolean {
+    return other.color === this.color && other.from === this.from && other.to === this.to;
+  }
+
+  toDOM(): HTMLElement {
+    const input = document.createElement('input');
+    input.type = 'color';
+    input.value = colorForPicker(this.color);
+    input.className = 'cm-color-picker';
+    input.title = `${this.label} ${this.color}`;
+    input.setAttribute('aria-label', `${this.label} ${this.color}`);
+    input.addEventListener('change', () => this.onChange(this.from, this.to, colorFromPicker(this.color, input.value)));
+    return input;
+  }
+
+  ignoreEvent(): boolean {
+    return true;
+  }
+}
+
+function colorPickerExtension(label: string): Extension[] {
+  const plugin = ViewPlugin.fromClass(
+    class {
+      decorations: DecorationSet;
+
+      constructor(readonly view: EditorView) {
+        this.decorations = this.buildDecorations();
+      }
+
+      update(update: ViewUpdate): void {
+        if (update.docChanged || update.viewportChanged) this.decorations = this.buildDecorations();
+      }
+
+      private buildDecorations(): DecorationSet {
+        const builder = new RangeSetBuilder<Decoration>();
+        for (const match of findHexColors(this.view.state.doc.toString())) {
+          builder.add(
+            match.to,
+            match.to,
+            Decoration.widget({
+              widget: new ColorSwatchWidget(match.color, match.from, match.to, label, this.replaceColor),
+              side: 1,
+            }),
+          );
+        }
+        return builder.finish();
+      }
+
+      private replaceColor = (from: number, to: number, color: string): void => {
+        const current = this.view.state.doc.sliceString(from, to);
+        if (!/^#(?:[0-9a-f]{3}|[0-9a-f]{4}|[0-9a-f]{6}|[0-9a-f]{8})$/i.test(current)) return;
+        this.view.dispatch({ changes: { from, to, insert: color }, userEvent: 'input' });
+        this.view.focus();
+      };
+    },
+  );
+  return [plugin, EditorView.decorations.of((view) => view.plugin(plugin)?.decorations ?? Decoration.none)];
 }
 
 // Palette matches the read-only viewer's .code-tok-* colors.
@@ -290,9 +371,7 @@ const modifierHoverState = StateField.define<ModifierHoverState>({
   provide: (field) =>
     EditorView.decorations.from(field, (value) =>
       value?.held && value.range
-        ? Decoration.set([
-            Decoration.mark({ class: 'cm-ts-navigable-link' }).range(value.range.from, value.range.to),
-          ])
+        ? Decoration.set([Decoration.mark({ class: 'cm-ts-navigable-link' }).range(value.range.from, value.range.to)])
         : Decoration.none,
     ),
 });
@@ -692,11 +771,7 @@ function measuredTsAutocomplete(tracker: CompletionTracker): CompletionSource {
         settled: false,
       };
       tracker.pending.push(attempt);
-      context.addEventListener(
-        'abort',
-        () => settleCompletionAttempt(tracker, attempt, false),
-        { onDocChange: true },
-      );
+      context.addEventListener('abort', () => settleCompletionAttempt(tracker, attempt, false), { onDocChange: true });
       return result ? { ...result, validFor: result.validFor ?? /^[\w$]*$/ } : null;
     } catch (error) {
       recordCodeCompletion({
@@ -741,6 +816,7 @@ export default function CodeMirrorEditor({
   onGotoDefinition,
   initialSelection,
   fetchGhostText,
+  colorPickerLabel = 'Choose color',
 }: CodeMirrorEditorProps) {
   const containerRef = useRef<HTMLDivElement | null>(null);
   const viewRef = useRef<EditorView | null>(null);
@@ -785,6 +861,7 @@ export default function CodeMirrorEditor({
           linter((v) => toCmDiagnostics(v, diagnosticsRef.current)),
           languageServiceCompartmentRef.current.of(languageServiceExtensions(languageService, onGotoDefinitionRef)),
           ...(readOnly ? [] : makeGhostTextExtension(fetchGhostTextRef)),
+          ...(readOnly ? [] : colorPickerExtension(colorPickerLabel)),
           EditorView.editable.of(!readOnly),
           EditorView.updateListener.of((update) => {
             if (update.docChanged) onChangeRef.current(update.state.doc.toString());

--- a/apps/web/src/CodeMirrorEditor.tsx
+++ b/apps/web/src/CodeMirrorEditor.tsx
@@ -111,7 +111,7 @@ class ColorSwatchWidget extends WidgetType {
   }
 
   eq(other: ColorSwatchWidget): boolean {
-    return other.color === this.color && other.from === this.from && other.to === this.to;
+    return other.color === this.color && other.from === this.from && other.to === this.to && other.label === this.label;
   }
 
   toDOM(): HTMLElement {
@@ -130,7 +130,7 @@ class ColorSwatchWidget extends WidgetType {
   }
 }
 
-function colorPickerExtension(label: string): Extension[] {
+function colorPickerExtension(label: string): Extension {
   const plugin = ViewPlugin.fromClass(
     class {
       decorations: DecorationSet;
@@ -833,6 +833,7 @@ export default function CodeMirrorEditor({
   fetchGhostTextRef.current = fetchGhostText;
   // GA-05: reconfigured live below — a ready worker never remounts.
   const languageServiceCompartmentRef = useRef(new Compartment());
+  const colorPickerCompartmentRef = useRef(new Compartment());
 
   useEffect(() => {
     if (!containerRef.current) return undefined;
@@ -861,7 +862,7 @@ export default function CodeMirrorEditor({
           linter((v) => toCmDiagnostics(v, diagnosticsRef.current)),
           languageServiceCompartmentRef.current.of(languageServiceExtensions(languageService, onGotoDefinitionRef)),
           ...(readOnly ? [] : makeGhostTextExtension(fetchGhostTextRef)),
-          ...(readOnly ? [] : colorPickerExtension(colorPickerLabel)),
+          ...(readOnly ? [] : [colorPickerCompartmentRef.current.of(colorPickerExtension(colorPickerLabel))]),
           EditorView.editable.of(!readOnly),
           EditorView.updateListener.of((update) => {
             if (update.docChanged) onChangeRef.current(update.state.doc.toString());
@@ -907,6 +908,14 @@ export default function CodeMirrorEditor({
       ),
     });
   }, [languageService]);
+
+  useEffect(() => {
+    const view = viewRef.current;
+    if (!view || readOnly) return;
+    view.dispatch({
+      effects: colorPickerCompartmentRef.current.reconfigure(colorPickerExtension(colorPickerLabel)),
+    });
+  }, [colorPickerLabel, readOnly]);
 
   return <div ref={containerRef} className="code-surface-codemirror" data-testid="codemirror-editor" />;
 }

--- a/apps/web/src/CodeSurface.tsx
+++ b/apps/web/src/CodeSurface.tsx
@@ -112,6 +112,8 @@ export type CodeSurfaceProps = {
   onPendingActionsModeConsumed?: () => void;
   // Track 2: shows a synchronous rebuild the instant it's ready.
   onPreviewReady?: (html: string) => void;
+  // Fires when the menu closes with nothing picked.
+  onActionsMenuCancelled?: () => void;
 };
 
 const LOCKED_DIRS = ['shared/', 'tools/'] as const;
@@ -166,6 +168,7 @@ export function CodeSurface({
   pendingActionsMode,
   onPendingActionsModeConsumed,
   onPreviewReady,
+  onActionsMenuCancelled,
 }: CodeSurfaceProps) {
   const { t, i18n } = useTranslation();
   const [sources, setSources] = useState<CodeSurfaceSources | null>(null);
@@ -297,7 +300,10 @@ export function CodeSurface({
     return () => document.removeEventListener('keydown', onKeyDown);
   }, [filePickerOpen]);
 
-  const openActionsMenu = useCallback((mode: CodeActionsMode) => {
+  const openedViaPendingRef = useRef(false);
+
+  const openActionsMenu = useCallback((mode: CodeActionsMode, viaPending = false) => {
+    openedViaPendingRef.current = viaPending;
     setActionsMenu((current) => {
       if (!current) {
         const focused = document.activeElement;
@@ -307,15 +313,19 @@ export function CodeSurface({
     });
   }, []);
 
-  const closeActionsMenu = useCallback(() => {
+  const closeActionsMenu = useCallback((acted = false) => {
     setActionsMenu(null);
     const previous = actionsReturnFocusRef.current;
     actionsReturnFocusRef.current = null;
     if (previous?.isConnected) previous.focus();
+    if (!acted && openedViaPendingRef.current) onActionsMenuCancelledRef.current?.();
+    openedViaPendingRef.current = false;
   }, []);
 
   const onPendingActionsModeConsumedRef = useRef(onPendingActionsModeConsumed);
   onPendingActionsModeConsumedRef.current = onPendingActionsModeConsumed;
+  const onActionsMenuCancelledRef = useRef(onActionsMenuCancelled);
+  onActionsMenuCancelledRef.current = onActionsMenuCancelled;
   const pendingActionsModeRef = useRef(pendingActionsMode);
   pendingActionsModeRef.current = pendingActionsMode;
   const pendingActionsConsumedRef = useRef(false);
@@ -323,7 +333,7 @@ export function CodeSurface({
   useEffect(() => {
     if (!pendingActionsMode || !sources || pendingActionsConsumedRef.current) return;
     pendingActionsConsumedRef.current = true;
-    openActionsMenu(pendingActionsMode.mode);
+    openActionsMenu(pendingActionsMode.mode, true);
     onPendingActionsModeConsumedRef.current?.();
   }, [pendingActionsMode, sources, openActionsMenu]);
 
@@ -550,14 +560,14 @@ export function CodeSurface({
     // Rides the pendingJump path search matches use — the new editor claims focus.
     if (path !== selected) setPendingJump({ path, from: 0, to: 0 });
     selectFile(path);
-    closeActionsMenu();
+    closeActionsMenu(true);
   }
 
   // A search hit rides GA-09's jump and lands as a selection.
   function handleOpenSearchMatch(match: CodeActionsSearchMatch) {
     setPendingJump({ path: match.path, from: match.from, to: match.to });
     selectFile(match.path);
-    closeActionsMenu();
+    closeActionsMenu(true);
   }
 
   const schedulePreviewRebuild = useCallback(() => {

--- a/apps/web/src/CodeSurface.tsx
+++ b/apps/web/src/CodeSurface.tsx
@@ -112,8 +112,6 @@ export type CodeSurfaceProps = {
   onPendingActionsModeConsumed?: () => void;
   // Track 2: shows a synchronous rebuild the instant it's ready.
   onPreviewReady?: (html: string) => void;
-  // Fires when the menu closes with nothing picked.
-  onActionsMenuCancelled?: () => void;
 };
 
 const LOCKED_DIRS = ['shared/', 'tools/'] as const;
@@ -168,7 +166,6 @@ export function CodeSurface({
   pendingActionsMode,
   onPendingActionsModeConsumed,
   onPreviewReady,
-  onActionsMenuCancelled,
 }: CodeSurfaceProps) {
   const { t, i18n } = useTranslation();
   const [sources, setSources] = useState<CodeSurfaceSources | null>(null);
@@ -300,10 +297,7 @@ export function CodeSurface({
     return () => document.removeEventListener('keydown', onKeyDown);
   }, [filePickerOpen]);
 
-  const openedViaPendingRef = useRef(false);
-
-  const openActionsMenu = useCallback((mode: CodeActionsMode, viaPending = false) => {
-    openedViaPendingRef.current = viaPending;
+  const openActionsMenu = useCallback((mode: CodeActionsMode) => {
     setActionsMenu((current) => {
       if (!current) {
         const focused = document.activeElement;
@@ -313,19 +307,15 @@ export function CodeSurface({
     });
   }, []);
 
-  const closeActionsMenu = useCallback((acted = false) => {
+  const closeActionsMenu = useCallback(() => {
     setActionsMenu(null);
     const previous = actionsReturnFocusRef.current;
     actionsReturnFocusRef.current = null;
     if (previous?.isConnected) previous.focus();
-    if (!acted && openedViaPendingRef.current) onActionsMenuCancelledRef.current?.();
-    openedViaPendingRef.current = false;
   }, []);
 
   const onPendingActionsModeConsumedRef = useRef(onPendingActionsModeConsumed);
   onPendingActionsModeConsumedRef.current = onPendingActionsModeConsumed;
-  const onActionsMenuCancelledRef = useRef(onActionsMenuCancelled);
-  onActionsMenuCancelledRef.current = onActionsMenuCancelled;
   const pendingActionsModeRef = useRef(pendingActionsMode);
   pendingActionsModeRef.current = pendingActionsMode;
   const pendingActionsConsumedRef = useRef(false);
@@ -333,7 +323,7 @@ export function CodeSurface({
   useEffect(() => {
     if (!pendingActionsMode || !sources || pendingActionsConsumedRef.current) return;
     pendingActionsConsumedRef.current = true;
-    openActionsMenu(pendingActionsMode.mode, true);
+    openActionsMenu(pendingActionsMode.mode);
     onPendingActionsModeConsumedRef.current?.();
   }, [pendingActionsMode, sources, openActionsMenu]);
 
@@ -560,14 +550,14 @@ export function CodeSurface({
     // Rides the pendingJump path search matches use — the new editor claims focus.
     if (path !== selected) setPendingJump({ path, from: 0, to: 0 });
     selectFile(path);
-    closeActionsMenu(true);
+    closeActionsMenu();
   }
 
   // A search hit rides GA-09's jump and lands as a selection.
   function handleOpenSearchMatch(match: CodeActionsSearchMatch) {
     setPendingJump({ path: match.path, from: match.from, to: match.to });
     selectFile(match.path);
-    closeActionsMenu(true);
+    closeActionsMenu();
   }
 
   const schedulePreviewRebuild = useCallback(() => {
@@ -1075,6 +1065,7 @@ export function CodeSurface({
                   onGotoDefinition={handleGotoDefinition}
                   initialSelection={initialSelectionForEditor}
                   fetchGhostText={fetchGhostText}
+                  colorPickerLabel={t('studioPanel.code.colorPicker')}
                 />
               </Suspense>
             </CodeMirrorBoundary>

--- a/apps/web/src/codeMirrorColors.test.ts
+++ b/apps/web/src/codeMirrorColors.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+import { colorForPicker, colorFromPicker, expandHexColor, findHexColors, replaceHexColor } from './codeMirrorColors.js';
+
+describe('codeMirrorColors', () => {
+  it('finds supported color formats without matching longer hex values', () => {
+    const source = "fill: '#abc'; stroke: #12Ab34; shadow: #12345678; id: #abcdef0;";
+
+    expect(findHexColors(source)).toEqual([
+      { color: '#abc', from: 7, to: 11 },
+      { color: '#12Ab34', from: 22, to: 29 },
+      { color: '#12345678', from: 39, to: 48 },
+    ]);
+  });
+
+  it('expands shorthand colors for the native picker', () => {
+    expect(expandHexColor('#AbC')).toBe('#aabbcc');
+    expect(expandHexColor('#AbCf')).toBe('#aabbccff');
+    expect(expandHexColor('#12Ab34')).toBe('#12ab34');
+  });
+
+  it('preserves alpha while the native picker edits RGB', () => {
+    expect(colorForPicker('#12345678')).toBe('#123456');
+    expect(colorFromPicker('#12345678', '#abcdef')).toBe('#abcdef78');
+    expect(colorFromPicker('#abc', '#abcdef')).toBe('#abcdef');
+  });
+
+  it('replaces only the selected literal', () => {
+    const source = "fill: '#abc'; stroke: '#abc';";
+    const match = findHexColors(source)[1]!;
+
+    expect(replaceHexColor(source, match.from, match.to, '#112233')).toBe("fill: '#abc'; stroke: '#112233';");
+  });
+});

--- a/apps/web/src/codeMirrorColors.ts
+++ b/apps/web/src/codeMirrorColors.ts
@@ -1,0 +1,38 @@
+export type HexColorMatch = {
+  color: string;
+  from: number;
+  to: number;
+};
+
+const HEX_COLOR = /#(?:[0-9a-f]{3}|[0-9a-f]{4}|[0-9a-f]{6}|[0-9a-f]{8})(?![0-9a-f])/gi;
+
+export function findHexColors(source: string): HexColorMatch[] {
+  return [...source.matchAll(HEX_COLOR)].map((match) => ({
+    color: match[0],
+    from: match.index ?? 0,
+    to: (match.index ?? 0) + match[0].length,
+  }));
+}
+
+export function expandHexColor(color: string): string {
+  if (color.length === 4) {
+    return `#${color[1]}${color[1]}${color[2]}${color[2]}${color[3]}${color[3]}`.toLowerCase();
+  }
+  if (color.length === 5) {
+    return `#${color[1]}${color[1]}${color[2]}${color[2]}${color[3]}${color[3]}${color[4]}${color[4]}`.toLowerCase();
+  }
+  return color.toLowerCase();
+}
+
+export function colorForPicker(color: string): string {
+  return expandHexColor(color).slice(0, 7);
+}
+
+export function colorFromPicker(original: string, picked: string): string {
+  const expanded = expandHexColor(original);
+  return expanded.length === 9 ? `${picked}${expanded.slice(7)}` : picked;
+}
+
+export function replaceHexColor(source: string, from: number, to: number, color: string): string {
+  return `${source.slice(0, from)}${color}${source.slice(to)}`;
+}

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -326,6 +326,7 @@
       "noFiles": "Nothing to show yet",
       "showDiff": "Diff vs live",
       "showCode": "Show code",
+      "colorPicker": "Choose color",
       "diffNoBase": "This file has no live version to compare against yet.",
       "paramsPanel": "Tunable parameters",
       "budget": "{{lines}}/{{maxLines}} lines",

--- a/apps/web/src/i18n/locales/pl.json
+++ b/apps/web/src/i18n/locales/pl.json
@@ -328,6 +328,7 @@
       "noFiles": "Nie ma jeszcze nic do pokazania",
       "showDiff": "Różnice względem wersji na żywo",
       "showCode": "Pokaż kod",
+      "colorPicker": "Wybierz kolor",
       "diffNoBase": "Ten plik nie ma jeszcze wersji na żywo do porównania.",
       "paramsPanel": "Parametry do dostrojenia",
       "budget": "{{lines}}/{{maxLines}} linii",

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -11928,6 +11928,36 @@ button.builder-mode-selector:disabled {
   color: var(--muted);
 }
 
+.cm-color-picker {
+  width: 0.85rem;
+  height: 0.85rem;
+  margin: 0 0.25rem;
+  padding: 0;
+  border: 1px solid rgba(148, 163, 184, 0.5);
+  border-radius: 3px;
+  vertical-align: -0.12rem;
+  cursor: pointer;
+}
+
+.cm-color-picker::-webkit-color-swatch-wrapper {
+  padding: 1px;
+}
+
+.cm-color-picker::-webkit-color-swatch {
+  border: 0;
+  border-radius: 2px;
+}
+
+.cm-color-picker::-moz-color-swatch {
+  border: 0;
+  border-radius: 2px;
+}
+
+.cm-color-picker:focus-visible {
+  outline: 1px solid var(--turquoise);
+  outline-offset: 2px;
+}
+
 .code-surface-readonly-view {
   margin: 0;
   padding: 12px 0;


### PR DESCRIPTION
## What changed

- Adds inline native color-picker swatches beside hex color literals in the editable CodeMirror editor.
- Supports `#RGB`, `#RGBA`, `#RRGGBB`, and `#RRGGBBAA`.
- Preserves alpha channels when editing colors.
- Adds localized English and Polish accessibility labels.
- Adds unit and editor interaction coverage.

## User impact

Color adjustments can be made directly from the Code tab without manually searching and replacing hex values. The existing editor change flow continues to handle updates and autosave.

## Validation

- Full type-check passed.
- Full lint passed.
- Full test suite passed: web 1,440 tests, world 20 tests, rules 36 tests.
- Production build passed.