### PR TITLE
Add credentials management to account settings modal

### DIFF
--- a/apps/web/src/AccountSettingsModal.test.tsx
+++ b/apps/web/src/AccountSettingsModal.test.tsx
@@ -1,0 +1,93 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import i18n from './i18n/index.js';
+
+const connectApi = vi.hoisted(() => ({
+  getCreatorAgentKey: vi.fn(),
+  mintCreatorAgentKey: vi.fn(),
+  rotateCreatorAgentKey: vi.fn(),
+  revokeCreatorAgentKey: vi.fn(),
+  listOAuthGrants: vi.fn(),
+  revokeOAuthGrant: vi.fn(),
+}));
+
+vi.mock('./connectApi.js', () => connectApi);
+
+vi.mock('./AuthContext.js', () => ({
+  useAuth: () => ({ deleteAccount: vi.fn(), user: { uid: 'g:test', handle: null } }),
+}));
+
+const { AccountSettingsModal } = await import('./AccountSettingsModal.js');
+
+async function flush() {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+describe('AccountSettingsModal', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(async () => {
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    await i18n.changeLanguage('en');
+    connectApi.getCreatorAgentKey.mockResolvedValue({
+      key: 'ck_live_secret',
+      keyGeneration: 1,
+      expiresAt: Math.floor(Date.now() / 1000) + 86400,
+      fingerprint: '9a10e',
+      authorizationHeader: 'Authorization: Bearer ck_live_secret',
+      authorizationHeaderMasked: 'Authorization: Bearer ····9a10e',
+      revoked: false,
+    });
+    connectApi.listOAuthGrants.mockResolvedValue([
+      {
+        grantId: 'grant-111111',
+        clientId: 'chatgpt',
+        clientLabel: 'chatgpt.com',
+        createdAt: '2026-08-03T15:40:00.000Z',
+        lastUsedAt: null,
+      },
+    ]);
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    document.body.querySelectorAll('.modal-backdrop').forEach((node) => node.remove());
+    vi.clearAllMocks();
+  });
+
+  it('offers the coding-agent key and connected agents alongside account deletion', async () => {
+    await act(async () => {
+      root.render(createElement(AccountSettingsModal, { isOpen: true, onClose: () => {} }));
+      await flush();
+    });
+
+    const card = document.body.querySelector('.account-settings-modal-card');
+    expect(card).not.toBeNull();
+    expect(card?.querySelector('[data-testid="creator-key-masked"]')?.textContent).toBe(
+      'Authorization: Bearer ····9a10e',
+    );
+    expect(card?.innerHTML).not.toContain('ck_live_secret');
+    expect(card?.querySelectorAll('.studio-oauth-client-row')).toHaveLength(1);
+    expect(card?.textContent).toContain('Connection 111111');
+  });
+
+  it('renders nothing — and asks for no credentials — while closed', async () => {
+    await act(async () => {
+      root.render(createElement(AccountSettingsModal, { isOpen: false, onClose: () => {} }));
+      await flush();
+    });
+
+    expect(document.body.querySelector('.account-settings-modal-card')).toBeNull();
+    expect(connectApi.getCreatorAgentKey).not.toHaveBeenCalled();
+    expect(connectApi.listOAuthGrants).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/AccountSettingsModal.tsx
+++ b/apps/web/src/AccountSettingsModal.tsx
@@ -2,6 +2,8 @@ import { useEffect, useId, useRef } from 'react';
 import { createPortal } from 'react-dom';
 import { useTranslation } from 'react-i18next';
 import { AccountDeletionControl } from './AccountDeletionControl.js';
+import { StudioCreatorAgentKeyPanel } from './StudioCreatorAgentKeyPanel.js';
+import { StudioOAuthClientsPanel } from './StudioOAuthClientsPanel.js';
 
 /** Account settings remain reachable even before a creator claims a public handle. */
 export function AccountSettingsModal({ isOpen, onClose }: { isOpen: boolean; onClose: () => void }) {
@@ -45,6 +47,17 @@ export function AccountSettingsModal({ isOpen, onClose }: { isOpen: boolean; onC
         <header className="claim-handle-modal-head">
           <h2 id={headingId}>{t('creatorProfile.accountSettings')}</h2>
         </header>
+        <section className="account-settings-credentials" aria-labelledby={`${headingId}-credentials`}>
+          <h3 id={`${headingId}-credentials`} className="account-settings-section-title">
+            {t('creatorProfile.accountCredentials')}
+          </h3>
+          <p className="studio-rail-credentials-hint">{t('studioPanel.rail.credentialsHint')}</p>
+          <div className="studio-rail-credentials-body">
+            <StudioCreatorAgentKeyPanel />
+            <StudioOAuthClientsPanel />
+          </div>
+        </section>
+
         <AccountDeletionControl labelledBy={`${headingId}-danger`} />
       </div>
     </div>,

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -1267,6 +1267,7 @@
     "available": "Available",
     "accountHeading": "Account",
     "accountSettings": "Account settings",
+    "accountCredentials": "Keys and connected agents",
     "deleteAccountSummary": "Schedule your account and personal data for deletion after a 14-day recovery window.",
     "deleteAccount": "Schedule account deletion",
     "deleteDialogTitle": "Schedule account deletion?",

--- a/apps/web/src/i18n/locales/pl.json
+++ b/apps/web/src/i18n/locales/pl.json
@@ -1279,6 +1279,7 @@
     "available": "Dostępny",
     "accountHeading": "Konto",
     "accountSettings": "Ustawienia konta",
+    "accountCredentials": "Klucze i połączone agenty",
     "deleteAccountSummary": "Zaplanuj usunięcie konta i danych osobowych po 14-dniowym okresie na zmianę decyzji.",
     "deleteAccount": "Zaplanuj usunięcie konta",
     "deleteDialogTitle": "Zaplanować usunięcie konta?",

--- a/apps/web/src/styles.codeSurfaceButtons.test.ts
+++ b/apps/web/src/styles.codeSurfaceButtons.test.ts
@@ -40,7 +40,7 @@ describe('the Code surface Publish button', () => {
   });
 
   it('keeps Code full-bleed when params-only Edit docks beside the stage', () => {
-    expect(ruleFor('.studio-edit-overlay:not(.studio-code-overlay)[data-surface="docked"]')).toMatch(
+    expect(ruleFor(".studio-edit-overlay:not(.studio-code-overlay)[data-surface='docked']")).toMatch(
       /width:\s*min\(360px,\s*100%\)/,
     );
     expect(css).not.toMatch(/\.studio-edit-overlay:not\(:has\(\.editor-board-col\)\)/);

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -11686,7 +11686,7 @@ button.builder-mode-selector:disabled {
 }
 
 /* Edit definitions without a board dock beside the running game. */
-.studio-edit-overlay:not(.studio-code-overlay)[data-surface="docked"] {
+.studio-edit-overlay:not(.studio-code-overlay)[data-surface='docked'] {
   inset: 0 0 0 auto;
   width: min(360px, 100%);
   border-left: 1px solid var(--panel-border);
@@ -17658,6 +17658,15 @@ body.remix-entry-open {
 
 .account-settings-modal-card {
   width: min(92vw, 520px);
+}
+
+.account-settings-credentials {
+  margin-top: 0.75rem;
+}
+
+.account-settings-section-title {
+  margin: 0 0 0.35rem;
+  font-size: 0.9rem;
 }
 
 .creator-profile-danger {

--- a/apps/web/src/styles.editorSurface.test.ts
+++ b/apps/web/src/styles.editorSurface.test.ts
@@ -27,7 +27,7 @@ describe('layered editor surface CSS contract', () => {
   });
 
   it('pins the edit overlay dock posture used by layered definitions', () => {
-    const dock = '.studio-edit-overlay:not(.studio-code-overlay)[data-surface="docked"]';
+    const dock = ".studio-edit-overlay:not(.studio-code-overlay)[data-surface='docked']";
     expect(declarations(dock)).toMatch(/inset:\s*0 0 0 auto/);
     expect(declarations(dock)).toMatch(/width:\s*min\(360px, 100%\)/);
   });


### PR DESCRIPTION
## Summary
Integrates creator agent key and OAuth client management panels into the account settings modal, allowing users to view and manage their API credentials and connected applications alongside account deletion options.

## Key Changes
- **AccountSettingsModal.tsx**: Added new credentials section displaying `StudioCreatorAgentKeyPanel` and `StudioOAuthClientsPanel` components
- **AccountSettingsModal.test.tsx**: Added comprehensive test suite covering:
  - Rendering of creator agent key (masked) and OAuth grants when modal is open
  - Verification that sensitive data (full API key) is not exposed in the DOM
  - Confirmation that no API calls are made when modal is closed
- **styles.css**: Added styling for credentials section and section titles within account settings
- **i18n locales**: Added translation keys for "Keys and connected agents" section header in English and Polish

## Implementation Details
- The credentials section is conditionally rendered only when the modal is open, preventing unnecessary API calls
- API keys are properly masked in the UI (showing only the last 5 characters via fingerprint)
- Full secret keys are never rendered to the DOM
- Maintains existing account deletion functionality while adding new credential management features

https://claude.ai/code/session_01MLYE2oU9EzwuwBMAebRrfW