### PR TITLE
Add separate daily refine quota for bot accounts

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -37,6 +37,9 @@
 # BETA_ALLOWED_EMAILS=
 # ADMIN_UIDS=
 # DAILY_GENERATION_QUOTA=20
+# DAILY_REFINE_QUOTA=20
+# Automation ceiling for bot: accounts — the deploy gate spends one refine per deploy.
+# DAILY_REFINE_QUOTA_BOT=200
 
 # --- Remote MCP --------------------------------------------------------------------
 # MCP_UI=true turns on MCP Apps views (SEP-1865) on /api/mcp: a ui:// resource registry

--- a/apps/api/src/refine.test.ts
+++ b/apps/api/src/refine.test.ts
@@ -178,6 +178,54 @@ describe('POST /api/submissions/refine', () => {
     await testApp.close();
   });
 
+  it('gives a bot account the automation ceiling, so the deploy gate cannot lock the pipeline out', async () => {
+    const previous = {
+      human: process.env.DAILY_REFINE_QUOTA,
+      bot: process.env.DAILY_REFINE_QUOTA_BOT,
+    };
+    process.env.DAILY_REFINE_QUOTA = '1';
+    process.env.DAILY_REFINE_QUOTA_BOT = '3';
+
+    const store = new InMemoryStore();
+    await store.upsertUser({ uid: 'g:test-user' });
+    await store.upsertUser({ uid: 'bot:e2e' });
+    const testApp = await buildApp({
+      store,
+      sessionSecret,
+      specRefiner: new StubSpecRefiner({
+        questions: [{ id: 'style', question: 'Which style?', options: [{ label: 'Pixel' }] }],
+      }),
+      contentChecker: new PatternChecker(),
+    });
+
+    // Distinct concepts: a repeat is cache-served and proves nothing.
+    const refine = (uid: string, concept: string) =>
+      testApp.inject({
+        method: 'POST',
+        url: '/api/submissions/refine',
+        headers: { cookie: `${SESSION_COOKIE_NAME}=${mintSessionToken(uid, sessionSecret)}` },
+        payload: { concept },
+      });
+
+    expect((await refine('g:test-user', 'A human creator asking about a first arcade idea')).statusCode).toBe(200);
+    const humanSecond = await refine('g:test-user', 'A human creator asking about a second arcade idea');
+    expect(humanSecond.statusCode).toBe(429);
+    expect(humanSecond.json().error).toBe('daily refine quota exceeded');
+
+    expect((await refine('bot:e2e', 'The deploy gate probing refine on the first deploy')).statusCode).toBe(200);
+    expect((await refine('bot:e2e', 'The deploy gate probing refine on the second deploy')).statusCode).toBe(200);
+    expect((await refine('bot:e2e', 'The deploy gate probing refine on the third deploy')).statusCode).toBe(200);
+
+    // Higher, not unlimited.
+    expect((await refine('bot:e2e', 'The deploy gate probing refine on the fourth deploy')).statusCode).toBe(429);
+
+    await testApp.close();
+    process.env.DAILY_REFINE_QUOTA = previous.human;
+    process.env.DAILY_REFINE_QUOTA_BOT = previous.bot;
+    if (previous.human === undefined) delete process.env.DAILY_REFINE_QUOTA;
+    if (previous.bot === undefined) delete process.env.DAILY_REFINE_QUOTA_BOT;
+  });
+
   it('never caches a totally empty answer, so one flaky call cannot pin an empty panel', async () => {
     const store = new InMemoryStore();
     await store.upsertUser({ uid: 'g:test-user' });

--- a/apps/api/src/refine.ts
+++ b/apps/api/src/refine.ts
@@ -6,7 +6,7 @@ import { checkUserAccess } from './auth.js';
 import { createVertexClient, type VertexGenerationConfig } from './genai.js';
 import type { ContentChecker } from './moderation.js';
 import { sanitizeCreatorText } from './submission-status.js';
-import type { Store } from './store.js';
+import { BOT_UID_PREFIX, type Store } from './store.js';
 import { logModerationRejection } from './moderation-metrics.js';
 import { normalizeLocale } from './translate.js';
 
@@ -321,6 +321,11 @@ export interface RefineRouteOptions {
   contentChecker: ContentChecker;
   specRefiner?: SpecRefiner;
   dailyRefineQuota?: number;
+  botDailyRefineQuota?: number;
+}
+
+function refineQuotaFor(uid: string, humanQuota: number, botQuota: number): number {
+  return uid.startsWith(BOT_UID_PREFIX) ? botQuota : humanQuota;
 }
 
 function isRateLimited(
@@ -346,6 +351,7 @@ export async function registerRefineRoute(app: FastifyInstance, options: RefineR
   const contentChecker = options.contentChecker;
   const specRefiner = options.specRefiner ?? new VertexSpecRefiner();
   const dailyRefineQuota = options.dailyRefineQuota ?? Number(process.env.DAILY_REFINE_QUOTA ?? '20');
+  const botDailyRefineQuota = options.botDailyRefineQuota ?? Number(process.env.DAILY_REFINE_QUOTA_BOT ?? '200');
 
   const refinesByIp = new Map<string, number[]>();
   const rateLimitWindowMs = 60 * 60 * 1000;
@@ -431,7 +437,9 @@ export async function registerRefineRoute(app: FastifyInstance, options: RefineR
     // 3. Daily refine quota check
     const dateStr = new Date(currentTime).toISOString().slice(0, 10);
     if (store) {
-      const quota = await store.checkAndIncrementQuota(request.user!.uid, dateStr, dailyRefineQuota, 'refines');
+      const uid = request.user!.uid;
+      const limit = refineQuotaFor(uid, dailyRefineQuota, botDailyRefineQuota);
+      const quota = await store.checkAndIncrementQuota(uid, dateStr, limit, 'refines');
       if (!quota.allowed) {
         if (quota.tier === 'blocked') {
           return reply.status(403).send({ error: 'account is blocked' });

--- a/docs/creator-qa-plan.md
+++ b/docs/creator-qa-plan.md
@@ -80,7 +80,9 @@ prompt → L1 moderation (422 on reject)
 
 `POST /api/submissions/refine` — session + quota-free (does NOT consume the
 daily submission quota; it has its own cheaper rate limit, e.g. 20/day/uid,
-env-tunable `DAILY_REFINE_QUOTA`), body `{ title, spec }`:
+env-tunable `DAILY_REFINE_QUOTA`; `bot:` accounts get the higher automation
+ceiling `DAILY_REFINE_QUOTA_BOT`, default 200, so the deploy gate's own smoke
+cannot spend the pipeline out of the ability to ship), body `{ title, spec }`:
 
 - Runs L1 moderation first (same 422 contract as submit — reject early, spend
   nothing).


### PR DESCRIPTION
## Summary
Introduces a separate, higher daily refine quota for bot accounts (those with `bot:` UID prefix) to prevent automated deployment gates from exhausting the refine quota and blocking the pipeline.

## Key Changes
- Added `DAILY_REFINE_QUOTA_BOT` environment variable (default: 200) for bot account quota, separate from human quota (default: 20)
- Implemented `refineQuotaFor()` helper function to determine the appropriate quota limit based on UID prefix
- Updated the refine route to use the bot-specific quota when the requesting user is a bot account
- Added comprehensive test case verifying bot accounts get the higher automation ceiling while human accounts remain rate-limited
- Updated documentation and `.env.example` to explain the new bot quota configuration

## Implementation Details
- Bot accounts are identified by the `BOT_UID_PREFIX` (imported from store module)
- The quota check in the refine route now calls `refineQuotaFor()` to select the correct limit before calling `store.checkAndIncrementQuota()`
- The test demonstrates that a human user with quota of 1 is rate-limited on the second request, while a bot user with quota of 3 can make three requests before hitting the limit
- Environment variables are properly restored after the test to avoid side effects

https://claude.ai/code/session_01T15qo4ALVFVniBX3awdLa5