### PR TITLE
Fix mobile UX cramping in Studio header and code editor

### DIFF
--- a/apps/e2e/src/studio-shell.test.ts
+++ b/apps/e2e/src/studio-shell.test.ts
@@ -83,16 +83,12 @@ function fixtureGames() {
     lastKnownStatus: 'published' as const,
     slug: i === 0 ? FIXTURE_SLUG : `${FIXTURE_SLUG}-${i}`,
     publishedAt: '2026-01-02T00:00:00.000Z',
-    // Only the fixture game needs the Code tab open-able; the rest just pad the shelf.
+    // Only game 0 exposes Code; the rest pad the shelf.
     codeSurface: i === 0,
   }));
 }
 
-/**
- * Serve the Code surface's own sources route with a read-only fixture — the state that
- * motivated the header wrap/touch-target fix below (#862) and the one a gate skipped if
- * it never opened Code at all.
- */
+// Code surface sources route, stubbed read-only (#862).
 async function stubCodeSurfaceData(page: Page) {
   await page.route(`**/api/me/studio/games/${FIXTURE_SLUG}/sources**`, async (route) => {
     const request = route.request();
@@ -111,7 +107,7 @@ async function stubCodeSurfaceData(page: Page) {
         version: '1',
         files: [{ path: 'game.ts', content: "import { startGame } from './game/runtime.ts';\n\nstartGame();\n" }],
         deleted: [],
-        // agent_round: the exact state whose banner made the header row overflow.
+        // agent_round: the banner state that crowded Akcje (#862).
         readOnly: true,
         reason: 'agent_round',
         staged: { totalBytes: 0, maxBytes: 200_000, maxFiles: 50, updatedAt: null },
@@ -376,9 +372,7 @@ describe.skipIf(!prereq.ok)('the studio thread as an app screen', () => {
         expect(sendIsHittable, `.${bar} covers the composer's send button at ${viewport.width}px`).toBe(true);
       }
 
-      // Below 801px the strip's actions collapse into the 4-column icon grid (#862):
-      // padding alone left each pill ~24px tall, well under the touch target a phone
-      // needs. Every pill in the grid must clear it, not just the primary Play button.
+      // #862: padding alone left each strip pill ~24px tall below 801px.
       if (viewport.width <= 800) {
         const pillHeights = await page.evaluate(() =>
           Array.from(document.querySelectorAll('.studio-strip-actions .studio-head-action')).map(
@@ -515,14 +509,7 @@ describe.skipIf(!prereq.ok)('the studio thread as an app screen', () => {
     });
   }
 
-  /**
-   * The Code surface's header (back / Kod / diff-toggle / read-only banner / Akcje) had
-   * no `flex-wrap` at all below 1099px (#862): with the read-only banner an agent round
-   * puts on screen, Akcje's right-pinned `margin-left: auto` had nowhere to go but off
-   * the edge or hard against the banner. Cover the band the fix actually changed (≤1099)
-   * against the band it deliberately left alone (desktop), with the exact banner state
-   * that motivated the patch — not an empty header nothing would crowd.
-   */
+  // #862: no flex-wrap below 1099px let Akcje crowd the banner.
   const CODE_HEADER_VIEWPORTS = [
     { label: 'phone', width: 390, height: 844, wraps: true },
     { label: 'wide tablet', width: 850, height: 900, wraps: true },
@@ -564,8 +551,7 @@ describe.skipIf(!prereq.ok)('the studio thread as an app screen', () => {
           headClientWidth: head.clientWidth,
           pageScrollWidth: document.documentElement.scrollWidth,
           viewportWidth: window.innerWidth,
-          // A dropped-to-its-own-line Akcje sits meaningfully below the back button;
-          // sharing the row keeps their tops within a couple of px of each other.
+          // A wrapped Akcje sits well below the back button's row.
           akcjeWrapped: actionsRect.top - backRect.top > 8,
           actionsRight: actionsRect.right,
           headRight: headRect.right,
@@ -577,8 +563,6 @@ describe.skipIf(!prereq.ok)('the studio thread as an app screen', () => {
         return;
       }
 
-      // No horizontal scroll anywhere the fix touches — the header row itself and the
-      // page, since the header sits inside the same window the studio otherwise owns.
       expect(
         geometry.headScrollWidth,
         `code-surface-head overflows horizontally at ${viewport.width}px (${geometry.headScrollWidth} > ${geometry.headClientWidth})`,
@@ -586,8 +570,7 @@ describe.skipIf(!prereq.ok)('the studio thread as an app screen', () => {
       expect(geometry.pageScrollWidth, `the page scrolls horizontally at ${viewport.width}px`).toBeLessThanOrEqual(
         geometry.viewportWidth + 1,
       );
-      // Whatever line Akcje lands on, it must end inside the viewport — not clipped
-      // past the right edge, which is exactly what the un-wrapped row used to do.
+      // Akcje's right edge must stay inside the header, wrapped or not.
       expect(
         geometry.actionsRight,
         `Akcje's right edge (${geometry.actionsRight}) sits past the head's own bound (${geometry.headRight}) at ${viewport.width}px`,

--- a/apps/e2e/src/studio-shell.test.ts
+++ b/apps/e2e/src/studio-shell.test.ts
@@ -83,7 +83,43 @@ function fixtureGames() {
     lastKnownStatus: 'published' as const,
     slug: i === 0 ? FIXTURE_SLUG : `${FIXTURE_SLUG}-${i}`,
     publishedAt: '2026-01-02T00:00:00.000Z',
+    // Only the fixture game needs the Code tab open-able; the rest just pad the shelf.
+    codeSurface: i === 0,
   }));
+}
+
+/**
+ * Serve the Code surface's own sources route with a read-only fixture — the state that
+ * motivated the header wrap/touch-target fix below (#862) and the one a gate skipped if
+ * it never opened Code at all.
+ */
+async function stubCodeSurfaceData(page: Page) {
+  await page.route(`**/api/me/studio/games/${FIXTURE_SLUG}/sources**`, async (route) => {
+    const request = route.request();
+    if (request.method() !== 'GET') {
+      await route.fulfill({ status: 405, contentType: 'application/json', body: '{"error":"method not allowed"}' });
+      return;
+    }
+    const path = new URL(request.url()).pathname.replace(/\/$/, '');
+    if (path.endsWith('/sources/kit-declaration')) {
+      await route.fulfill({ status: 404, contentType: 'application/json', body: '{"error":"not found"}' });
+      return;
+    }
+    if (path.endsWith('/sources')) {
+      await fulfillJson(route, {
+        slug: FIXTURE_SLUG,
+        version: '1',
+        files: [{ path: 'game.ts', content: "import { startGame } from './game/runtime.ts';\n\nstartGame();\n" }],
+        deleted: [],
+        // agent_round: the exact state whose banner made the header row overflow.
+        readOnly: true,
+        reason: 'agent_round',
+        staged: { totalBytes: 0, maxBytes: 200_000, maxFiles: 50, updatedAt: null },
+      });
+      return;
+    }
+    await route.fulfill({ status: 404, contentType: 'application/json', body: '{"error":"not found"}' });
+  });
 }
 
 /**
@@ -140,6 +176,7 @@ describe.skipIf(!prereq.ok)('the studio thread as an app screen', () => {
     const context = await signedInContext(browser, api);
     page = await context.newPage();
     await stubStudioThreadData(page);
+    await stubCodeSurfaceData(page);
   });
 
   afterAll(async () => {
@@ -339,6 +376,23 @@ describe.skipIf(!prereq.ok)('the studio thread as an app screen', () => {
         expect(sendIsHittable, `.${bar} covers the composer's send button at ${viewport.width}px`).toBe(true);
       }
 
+      // Below 801px the strip's actions collapse into the 4-column icon grid (#862):
+      // padding alone left each pill ~24px tall, well under the touch target a phone
+      // needs. Every pill in the grid must clear it, not just the primary Play button.
+      if (viewport.width <= 800) {
+        const pillHeights = await page.evaluate(() =>
+          Array.from(document.querySelectorAll('.studio-strip-actions .studio-head-action')).map(
+            (el) => el.getBoundingClientRect().height,
+          ),
+        );
+        expect(pillHeights.length, 'the strip should still render its action pills').toBeGreaterThan(0);
+        for (const height of pillHeights) {
+          expect(height, `a strip action pill is only ${height}px tall at ${viewport.width}px`).toBeGreaterThanOrEqual(
+            44,
+          );
+        }
+      }
+
       expect(describeProblems(watcher.drain())).toBe('');
     });
   }
@@ -458,6 +512,95 @@ describe.skipIf(!prereq.ok)('the studio thread as an app screen', () => {
         release();
         await page.unroute('**/api/me/studio**', holdShelf);
       }
+    });
+  }
+
+  /**
+   * The Code surface's header (back / Kod / diff-toggle / read-only banner / Akcje) had
+   * no `flex-wrap` at all below 1099px (#862): with the read-only banner an agent round
+   * puts on screen, Akcje's right-pinned `margin-left: auto` had nowhere to go but off
+   * the edge or hard against the banner. Cover the band the fix actually changed (≤1099)
+   * against the band it deliberately left alone (desktop), with the exact banner state
+   * that motivated the patch — not an empty header nothing would crowd.
+   */
+  const CODE_HEADER_VIEWPORTS = [
+    { label: 'phone', width: 390, height: 844, wraps: true },
+    { label: 'wide tablet', width: 850, height: 900, wraps: true },
+    { label: 'desktop', width: 1440, height: 900, wraps: false },
+  ] as const;
+
+  for (const viewport of CODE_HEADER_VIEWPORTS) {
+    it(`keeps the Code header wrapped and on-screen on a ${viewport.label}`, async () => {
+      const watcher = collectProblems(page);
+
+      await page.setViewportSize({ width: viewport.width, height: viewport.height });
+      await visit(page, '/studio', 4_000);
+      await page.waitForSelector('.status-composer.is-compact', { state: 'visible', timeout: 15_000 });
+
+      const codeToggle = page.locator('.studio-strip-actions button[aria-label="Code"]');
+      try {
+        await codeToggle.waitFor({ state: 'visible', timeout: 15_000 });
+      } catch {
+        expect.fail('the Code tab toggle never appeared — the fixture game must expose codeSurface');
+      }
+      await codeToggle.click();
+
+      try {
+        await page.waitForSelector('.code-surface-readonly-banner', { state: 'visible', timeout: 15_000 });
+      } catch {
+        expect.fail('the read-only banner never rendered — the exact header state #862 fixed would go unchecked');
+      }
+
+      const geometry = await page.evaluate(() => {
+        const head = document.querySelector('.code-surface-head');
+        const back = document.querySelector('.code-surface-head .studio-head-action');
+        const actions = document.querySelector('.code-surface-actions-trigger');
+        if (!head || !back || !actions) return null;
+        const headRect = head.getBoundingClientRect();
+        const backRect = back.getBoundingClientRect();
+        const actionsRect = actions.getBoundingClientRect();
+        return {
+          headScrollWidth: head.scrollWidth,
+          headClientWidth: head.clientWidth,
+          pageScrollWidth: document.documentElement.scrollWidth,
+          viewportWidth: window.innerWidth,
+          // A dropped-to-its-own-line Akcje sits meaningfully below the back button;
+          // sharing the row keeps their tops within a couple of px of each other.
+          akcjeWrapped: actionsRect.top - backRect.top > 8,
+          actionsRight: actionsRect.right,
+          headRight: headRect.right,
+        };
+      });
+
+      if (!geometry) {
+        expect.fail('the Code header, back button, or Akcje trigger did not mount');
+        return;
+      }
+
+      // No horizontal scroll anywhere the fix touches — the header row itself and the
+      // page, since the header sits inside the same window the studio otherwise owns.
+      expect(
+        geometry.headScrollWidth,
+        `code-surface-head overflows horizontally at ${viewport.width}px (${geometry.headScrollWidth} > ${geometry.headClientWidth})`,
+      ).toBeLessThanOrEqual(geometry.headClientWidth + 1);
+      expect(geometry.pageScrollWidth, `the page scrolls horizontally at ${viewport.width}px`).toBeLessThanOrEqual(
+        geometry.viewportWidth + 1,
+      );
+      // Whatever line Akcje lands on, it must end inside the viewport — not clipped
+      // past the right edge, which is exactly what the un-wrapped row used to do.
+      expect(
+        geometry.actionsRight,
+        `Akcje's right edge (${geometry.actionsRight}) sits past the head's own bound (${geometry.headRight}) at ${viewport.width}px`,
+      ).toBeLessThanOrEqual(geometry.headRight + 1);
+
+      expect(
+        geometry.akcjeWrapped,
+        viewport.wraps
+          ? `Akcje should have dropped to its own line below ${1100}px but stayed on the back button's row`
+          : `Akcje should share the back button's row above 1099px but wrapped instead`,
+      ).toBe(viewport.wraps);
+
+      expect(describeProblems(watcher.drain())).toBe('');
     });
   }
 });

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -6591,7 +6591,7 @@ a.user-name--profile:focus-visible {
     grid-template-columns: repeat(4, minmax(0, 1fr));
     width: 100%;
     flex: 1 0 100%;
-    gap: 6px;
+    gap: 8px;
   }
 
   .app:has(.studio-layout.is-game-open) .studio-strip-actions > *,
@@ -6605,8 +6605,12 @@ a.user-name--profile:focus-visible {
     grid-column: span 2;
   }
 
+  /* 24px tall icon pills read as cramped and undershoot the ~44px touch target
+     phones need — min-height keeps the row compact while making each pill
+     actually easy to tap. */
   .app:has(.studio-layout.is-game-open) .studio-head-action {
     padding: 6px 10px;
+    min-height: 44px;
   }
 
   /* Icon-only peers in the title row — Share / Details / Edit / Claim were enough to
@@ -13127,6 +13131,24 @@ button.builder-mode-selector:disabled {
 
   .code-surface-readonly-banner-compact {
     display: inline;
+  }
+
+  /* Back / Kod / diff-toggle / banners had no wrap at all, so a read-only or
+     agent-active banner could shove Akcje hard against — or past — the right
+     edge on a phone. Let the row wrap, and always give Akcje its own full-width
+     line: a right-pinned button on a wrapped line lands in an unpredictable spot
+     otherwise. */
+  .code-surface-head {
+    flex-wrap: wrap;
+    row-gap: 8px;
+  }
+
+  .code-surface-actions-trigger,
+  .code-surface-readonly-banner ~ .code-surface-actions-trigger {
+    flex: 1 1 100%;
+    margin-left: 0;
+    justify-content: center;
+    padding: 8px;
   }
 }
 


### PR DESCRIPTION
Studio strip icon pills undershot the ~44px touch target on phones
(padding 6px 10px alone left them ~24px tall); add min-height so the
grid stays compact but each pill is actually easy to tap.

The code editor header (back/Kod/diff-toggle/banners/Akcje) had no
flex-wrap at all, so a read-only or agent-active banner could shove
the right-pinned Akcje button hard against or past the screen edge on
narrow viewports. Let the row wrap and give Akcje its own full-width
line instead of an unpredictable right-pinned spot.