### PR TITLE
Home page follow-ups: nav link, composer contrast, catalog shelves, scroll fix

### DIFF
--- a/apps/api/src/visit-funnel.test.ts
+++ b/apps/api/src/visit-funnel.test.ts
@@ -419,6 +419,8 @@ describe('summarizeVisitFunnel', () => {
       { via: 'grid', plays: 1 },
       { via: 'composer_match', plays: 0 },
       { via: 'create_showcase', plays: 0 },
+      { via: 'shelf', plays: 0 },
+      { via: 'featured_similar', plays: 0 },
       { via: 'unknown', plays: 1 },
     ]);
   });

--- a/apps/api/src/visit-funnel.ts
+++ b/apps/api/src/visit-funnel.ts
@@ -194,6 +194,8 @@ export const PLAY_VIAS = [
   'grid',
   'composer_match',
   'create_showcase',
+  'shelf',
+  'featured_similar',
 ] as const;
 
 export type PlayVia = (typeof PLAY_VIAS)[number];

--- a/apps/api/src/visit-telemetry.ts
+++ b/apps/api/src/visit-telemetry.ts
@@ -199,6 +199,8 @@ const PlayViaSchema = z.enum([
   'grid',
   'composer_match',
   'create_showcase',
+  'shelf',
+  'featured_similar',
 ]);
 /**
  * Acquisition strings are re-validated here rather than trusted from the client. The

--- a/apps/web/src/App.createGameFocus.test.ts
+++ b/apps/web/src/App.createGameFocus.test.ts
@@ -105,9 +105,12 @@ describe('Create Game menu focus', () => {
 
     expect(window.location.pathname).toBe('/');
 
+    const scrollTo = vi.spyOn(window, 'scrollTo').mockImplementation(() => undefined);
     await openCreateGame(container);
 
     expect(window.location.pathname).toBe('/create');
+    // A scrolled home page must not land /create mid-page too.
+    expect(scrollTo).toHaveBeenCalledWith(0, 0);
     const prompt = container.querySelector<HTMLTextAreaElement>('.big-prompt-input');
     expect(prompt).not.toBeNull();
     // A deliberate tap focuses even on this forced-narrow viewport.

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -795,6 +795,8 @@ export function App() {
     flushSync(() => {
       navigate(createPath());
     });
+    // A new page starts at the top, not the old offset.
+    window.scrollTo(0, 0);
     const input = document.querySelector<HTMLTextAreaElement>('#hero-prompt .big-prompt-input');
     input?.focus({ preventScroll: true });
   }

--- a/apps/web/src/ArcadeCatalog.test.tsx
+++ b/apps/web/src/ArcadeCatalog.test.tsx
@@ -688,6 +688,217 @@ describe('ArcadeCatalog curated surfaces', () => {
   });
 });
 
+describe('ArcadeCatalog shelves', () => {
+  beforeEach(async () => {
+    installIntersectionObserverMock();
+    mockSignedOutAuth();
+    sessionStorage.setItem(
+      'gdpl.catalogSortSignals',
+      JSON.stringify({ viewer: '', items: [], popularity: [], lastPlayed: [], newest: [] }),
+    );
+    // jsdom has no scrollIntoView; stub it first so spyOn can restore it.
+    Object.defineProperty(Element.prototype, 'scrollIntoView', {
+      configurable: true,
+      writable: true,
+      value: () => undefined,
+    });
+    vi.spyOn(Element.prototype, 'scrollIntoView').mockImplementation(() => undefined);
+    await i18n.changeLanguage('en');
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = '';
+    sessionStorage.clear();
+    localStorage.clear();
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  function stubHomeFetches(overrides?: { featuredSlugs?: string[] }) {
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async (input) => {
+      const url = String(input);
+      if (url.includes('/api/featured')) {
+        return new Response(JSON.stringify({ slugs: overrides?.featuredSlugs ?? [] }));
+      }
+      if (url.includes('/api/recommendations')) {
+        return new Response(JSON.stringify({ items: [], popularity: [], lastPlayed: [], newest: [] }));
+      }
+      return new Response(JSON.stringify({ items: [] }));
+    });
+  }
+
+  function makeEntry(partial: Partial<CatalogEntry> & Pick<CatalogEntry, 'slug' | 'title' | 'genre'>): CatalogEntry {
+    return {
+      controls: 'Arrow keys',
+      status: 'published',
+      media: null,
+      multiplayer: null,
+      saves: null,
+      world: null,
+      sensing: null,
+      orientation: 'any',
+      touch: null,
+      submittedBy: null,
+      ...partial,
+    };
+  }
+
+  const shelfEntries: CatalogEntry[] = [
+    makeEntry({ slug: 'rpg-1', title: 'Roam Quest', genre: 'Roguelike' }),
+    makeEntry({ slug: 'sim-1', title: 'Sim City Life', genre: 'City builder' }),
+    makeEntry({ slug: 'puzzle-1', title: 'Gem Match', genre: 'Match-3 puzzle' }),
+    makeEntry({ slug: 'arcade-1', title: 'Pixel Dash', genre: 'Arcade' }),
+    makeEntry({
+      slug: 'arcade-mp',
+      title: 'Kart Brawl',
+      genre: 'Arcade racing (3D)',
+      multiplayer: { mode: 'controllers', minPlayers: 2, maxPlayers: 4 },
+    }),
+  ];
+
+  async function renderShelves(entriesToRender: CatalogEntry[], overrides?: { featuredSlugs?: string[] }) {
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    stubHomeFetches(overrides);
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    const onPlayGame = vi.fn();
+    const onPlayTogether = vi.fn();
+
+    await act(async () => {
+      root.render(
+        createElement(ArcadeCatalog, {
+          catalogStatus: 'ready',
+          catalogError: null,
+          catalogEntries: entriesToRender,
+          onPlayGame,
+          onPlayTogether,
+          onRetryCatalog: vi.fn(),
+        }),
+      );
+      await flushEffects();
+      await flushEffects();
+    });
+
+    return { container, root, onPlayGame, onPlayTogether };
+  }
+
+  it('groups the catalog into shelves by category, with a jump bar chip per shelf', async () => {
+    const { container, root } = await renderShelves(shelfEntries);
+
+    const shelfHeadings = [...container.querySelectorAll('.catalog-shelf .catalog-rail-heading')].map(
+      (el) => el.textContent,
+    );
+    expect(shelfHeadings).toEqual(
+      expect.arrayContaining([
+        'Arcade & Racing',
+        'RPG & Adventure',
+        'Strategy & Sim',
+        'Puzzle & Story',
+        'Multiplayer & Party',
+      ]),
+    );
+
+    const jumpChips = [...container.querySelectorAll('.jump-chip')].map((el) => el.textContent);
+    expect(jumpChips[0]).toBe('All');
+    expect(jumpChips).toEqual(expect.arrayContaining(['Arcade & Racing', 'Multiplayer & Party']));
+
+    // A multiplayer racer sits in both its genre shelf and party.
+    const arcadeShelf = [...container.querySelectorAll('.catalog-shelf')].find((section) =>
+      section.textContent?.includes('Arcade & Racing'),
+    );
+    const partyShelf = [...container.querySelectorAll('.catalog-shelf')].find((section) =>
+      section.textContent?.includes('Multiplayer & Party'),
+    );
+    expect(arcadeShelf?.textContent).toContain('Kart Brawl');
+    expect(partyShelf?.textContent).toContain('Kart Brawl');
+
+    await act(async () => root.unmount());
+  });
+
+  it('plays a shelf card tagged via=shelf', async () => {
+    const { container, onPlayGame, root } = await renderShelves(shelfEntries);
+
+    const arcadeShelf = [...container.querySelectorAll('.catalog-shelf')].find((section) =>
+      section.textContent?.includes('Arcade & Racing'),
+    );
+    const playButton = arcadeShelf?.querySelector<HTMLButtonElement>('.rail-card-play');
+    await act(async () => {
+      playButton?.click();
+    });
+    expect(onPlayGame).toHaveBeenCalledWith(expect.objectContaining({ slug: 'arcade-1' }), 'shelf');
+
+    await act(async () => root.unmount());
+  });
+
+  it('"See all" filters Browse everything to that shelf, with a chip to clear it', async () => {
+    const { container, root } = await renderShelves(shelfEntries);
+
+    const rpgShelf = [...container.querySelectorAll('.catalog-shelf')].find((section) =>
+      section.textContent?.includes('RPG & Adventure'),
+    );
+    await act(async () => {
+      rpgShelf?.querySelector<HTMLButtonElement>('.catalog-rail-see-all')?.click();
+    });
+
+    expect(container.querySelector('.catalog-category-active')?.textContent).toContain('RPG & Adventure');
+    const browseTitles = [...container.querySelectorAll('#browse-everything ~ .catalog-grid .card-title')].map(
+      (el) => el.textContent,
+    );
+    expect(browseTitles).toEqual(['Roam Quest']);
+
+    await act(async () => {
+      container.querySelector<HTMLButtonElement>('.catalog-category-clear')?.click();
+    });
+    expect(container.querySelector('.catalog-category-active')).toBeNull();
+
+    await act(async () => root.unmount());
+  });
+
+  it('fills the featured card with More like this picks from its own shelf', async () => {
+    const { container, root } = await renderShelves(shelfEntries, { featuredSlugs: ['arcade-1'] });
+
+    expect(container.querySelector('.featured-game-title')?.textContent).toBe('Pixel Dash');
+    const thumbTitles = [...container.querySelectorAll('.more-like-this-thumb span')].map((el) => el.textContent);
+    expect(thumbTitles).toEqual(['Kart Brawl']);
+
+    await act(async () => root.unmount());
+  });
+
+  it('paginates Browse everything instead of listing every game on one page', async () => {
+    const manyEntries = Array.from({ length: 30 }, (_, i) =>
+      makeEntry({ slug: `page-game-${i}`, title: `Page Game ${i}`, genre: 'Arcade' }),
+    );
+    const { container, root } = await renderShelves(manyEntries);
+
+    const gridSelector = '#browse-everything ~ .catalog-grid';
+    expect(container.querySelectorAll(`${gridSelector} .catalog-card`)).toHaveLength(24);
+    const pager = container.querySelector('.catalog-pager');
+    expect(pager).not.toBeNull();
+
+    await act(async () => {
+      [...container.querySelectorAll<HTMLButtonElement>('.catalog-pager button')]
+        .find((btn) => btn.textContent === '2')
+        ?.click();
+    });
+    expect(container.querySelectorAll(`${gridSelector} .catalog-card`)).toHaveLength(6);
+
+    // Sort changes reset the page instead of stranding the reader.
+    await act(async () => {
+      container.querySelector<HTMLButtonElement>('.catalog-sort-trigger')?.click();
+    });
+    await act(async () => {
+      [...container.querySelectorAll<HTMLButtonElement>('.catalog-sort-option')]
+        .find((btn) => btn.textContent?.includes('A–Z'))
+        ?.click();
+    });
+    expect(container.querySelectorAll(`${gridSelector} .catalog-card`)).toHaveLength(24);
+    expect(container.querySelector('.catalog-pager button.is-active')?.textContent).toBe('1');
+
+    await act(async () => root.unmount());
+  });
+});
+
 describe('ArcadeCatalog soft-refresh failure', () => {
   beforeEach(async () => {
     installIntersectionObserverMock();

--- a/apps/web/src/ArcadeCatalog.test.tsx
+++ b/apps/web/src/ArcadeCatalog.test.tsx
@@ -876,12 +876,15 @@ describe('ArcadeCatalog shelves', () => {
     const pager = container.querySelector('.catalog-pager');
     expect(pager).not.toBeNull();
 
+    const scrollSpy = vi.spyOn(Element.prototype, 'scrollIntoView');
     await act(async () => {
       [...container.querySelectorAll<HTMLButtonElement>('.catalog-pager button')]
         .find((btn) => btn.textContent === '2')
         ?.click();
     });
     expect(container.querySelectorAll(`${gridSelector} .catalog-card`)).toHaveLength(6);
+    // A page change must not strand the reader down at the pager.
+    expect(scrollSpy).toHaveBeenCalled();
 
     // Sort changes reset the page instead of stranding the reader.
     await act(async () => {

--- a/apps/web/src/ArcadeCatalog.test.tsx
+++ b/apps/web/src/ArcadeCatalog.test.tsx
@@ -640,6 +640,9 @@ describe('ArcadeCatalog curated surfaces', () => {
 
     // No pool: falls back to catalog order's first entry.
     expect(container.querySelector('.featured-game-title')?.textContent).toBe(entries[0]!.title);
+    // The featured poster is clickable too, not just the Play button.
+    const featuredHitArea = container.querySelector<HTMLAnchorElement>('.featured-game-hit-area');
+    expect(featuredHitArea?.getAttribute('href')).toContain('?via=featured');
     // Nothing left over for Start here.
     expect(
       [...container.querySelectorAll('.catalog-rail-section')].some((s) => s.textContent?.includes('Start here')),

--- a/apps/web/src/ArcadeCatalog.tsx
+++ b/apps/web/src/ArcadeCatalog.tsx
@@ -826,6 +826,12 @@ export function ArcadeCatalog({
     scrollToBrowseEverything();
   }
 
+  // A shorter destination page must not leave the reader stranded past its end.
+  function changeBrowsePage(next: number) {
+    setBrowsePage(next);
+    scrollToBrowseEverything();
+  }
+
   // Shelves below the fold, same order as the grid, grouped by category.
   const shelfCategories = useMemo(
     () =>
@@ -1059,7 +1065,7 @@ export function ArcadeCatalog({
                   type="button"
                   disabled={clampedBrowsePage === 1}
                   aria-label={t('catalog.pagination.prev')}
-                  onClick={() => setBrowsePage((p) => Math.max(1, p - 1))}
+                  onClick={() => changeBrowsePage(Math.max(1, clampedBrowsePage - 1))}
                 >
                   &larr;
                 </button>
@@ -1075,7 +1081,7 @@ export function ArcadeCatalog({
                       className={token === clampedBrowsePage ? 'is-active' : undefined}
                       aria-current={token === clampedBrowsePage ? 'page' : undefined}
                       aria-label={t('catalog.pagination.page', { page: token })}
-                      onClick={() => setBrowsePage(token)}
+                      onClick={() => changeBrowsePage(token)}
                     >
                       {token}
                     </button>
@@ -1085,7 +1091,7 @@ export function ArcadeCatalog({
                   type="button"
                   disabled={clampedBrowsePage === browsePageCount}
                   aria-label={t('catalog.pagination.next')}
-                  onClick={() => setBrowsePage((p) => Math.min(browsePageCount, p + 1))}
+                  onClick={() => changeBrowsePage(Math.min(browsePageCount, clampedBrowsePage + 1))}
                 >
                   &rarr;
                 </button>

--- a/apps/web/src/ArcadeCatalog.tsx
+++ b/apps/web/src/ArcadeCatalog.tsx
@@ -9,6 +9,13 @@ import {
   type CatalogEntry,
 } from './catalog.js';
 import {
+  CATALOG_CATEGORY_IDS,
+  categorizeCatalogEntry,
+  entriesInCategory,
+  type CatalogCategoryId,
+} from './catalogCategory.js';
+import { buildCatalogPageTokens, CATALOG_PAGE_SIZE } from './catalogPagination.js';
+import {
   applyCatalogFilters,
   CATALOG_SORT_MODES,
   catalogSortNeedsSignals,
@@ -552,6 +559,9 @@ export function ArcadeCatalog({
   const [displayedEntries, setDisplayedEntries] = useState<CatalogEntry[]>([]);
   const desiredOrderRef = useRef<CatalogEntry[]>([]);
   const paintedOrderKeyRef = useRef<string | null>(null);
+  // Set by a shelf's See all; cleared by All or Clear.
+  const [categoryFilter, setCategoryFilter] = useState<CatalogCategoryId | null>(null);
+  const [browsePage, setBrowsePage] = useState(1);
 
   useEffect(() => watchCatalogScrollIdle(), []);
 
@@ -688,6 +698,11 @@ export function ArcadeCatalog({
   // recommendationsRefreshKey: post-play re-rank is deliberate user-visible intent.
   const userOrderKey = `${sortMode}|${filterKey}|${viewerUid ?? ''}|r${recommendationsRefreshKey}`;
 
+  // A stale page number from a filtered list is not a page.
+  useEffect(() => {
+    setBrowsePage(1);
+  }, [userOrderKey, categoryFilter]);
+
   const awaitingSignals =
     catalogStatus === 'ready' && catalogEntries.length > 0 && catalogSortNeedsSignals(sortMode) && !signalsReady;
   // Hold the grid while auth is unknown, and while a signed-in shelf is still loading.
@@ -718,6 +733,15 @@ export function ArcadeCatalog({
     () => flagshipEntries.filter((entry) => entry.slug !== featuredEntry?.slug).slice(0, RAIL_CARD_LIMIT),
     [flagshipEntries, featuredEntry],
   );
+
+  // Fills the featured card's dead space with picks from its shelf.
+  const featuredMoreLikeThis = useMemo(() => {
+    if (!featuredEntry) return [];
+    const [primaryCategory] = categorizeCatalogEntry(featuredEntry);
+    return entriesInCategory(desiredOrder, primaryCategory)
+      .filter((entry) => entry.slug !== featuredEntry.slug)
+      .slice(0, 3);
+  }, [featuredEntry, desiredOrder]);
 
   // Not memoized — recomputes every render, cheap and always fresh.
   const continuePlayingBySlug = new Map(catalogEntries.map((entry) => [entry.slug, entry]));
@@ -784,6 +808,45 @@ export function ArcadeCatalog({
     });
   }
 
+  function scrollToShelf(id: CatalogCategoryId) {
+    document.getElementById(`shelf-${id}`)?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+  }
+
+  function scrollToBrowseEverything() {
+    document.getElementById('browse-everything')?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+  }
+
+  function jumpToAll() {
+    setCategoryFilter(null);
+    scrollToBrowseEverything();
+  }
+
+  function seeAllInCategory(id: CatalogCategoryId) {
+    setCategoryFilter(id);
+    scrollToBrowseEverything();
+  }
+
+  // Shelves below the fold, same order as the grid, grouped by category.
+  const shelfCategories = useMemo(
+    () =>
+      CATALOG_CATEGORY_IDS.map((id) => ({
+        id,
+        entries: entriesInCategory(displayedEntries, id).slice(0, RAIL_CARD_LIMIT),
+      })).filter((shelf) => shelf.entries.length > 0),
+    [displayedEntries],
+  );
+
+  const browseEntries = useMemo(
+    () => (categoryFilter ? entriesInCategory(displayedEntries, categoryFilter) : displayedEntries),
+    [displayedEntries, categoryFilter],
+  );
+  const browsePageCount = Math.max(1, Math.ceil(browseEntries.length / CATALOG_PAGE_SIZE));
+  const clampedBrowsePage = Math.min(browsePage, browsePageCount);
+  const pageEntries = useMemo(
+    () => browseEntries.slice((clampedBrowsePage - 1) * CATALOG_PAGE_SIZE, clampedBrowsePage * CATALOG_PAGE_SIZE),
+    [browseEntries, clampedBrowsePage],
+  );
+
   const emptyMessage =
     yourGamesOnly && notPlayedOnly && (catalogEntries.length > 0 || mySlugs.size > 0)
       ? t('catalog.emptyYourGamesNotPlayed')
@@ -793,11 +856,19 @@ export function ArcadeCatalog({
           ? t('catalog.emptyNotPlayed')
           : t('catalog.empty');
   const showEmpty = layoutReady && displayedEntries.length === 0;
+  // Category filter emptied the shelf, but the wider catalog is not empty.
+  const showCategoryEmpty =
+    layoutReady && displayedEntries.length > 0 && categoryFilter !== null && browseEntries.length === 0;
 
   return (
     <>
       {showCurated && featuredEntry && (
-        <FeaturedGame entry={featuredEntry} onPlayGame={onPlayGame} onPlayTogether={onPlayTogether} />
+        <FeaturedGame
+          entry={featuredEntry}
+          onPlayGame={onPlayGame}
+          onPlayTogether={onPlayTogether}
+          moreLikeThis={featuredMoreLikeThis}
+        />
       )}
       {showCurated && (
         <>
@@ -829,10 +900,37 @@ export function ArcadeCatalog({
           />
         </>
       )}
+      {showCurated && shelfCategories.length > 0 && (
+        <>
+          <nav className="catalog-jumpbar" aria-label={t('catalog.jumpBarLabel')}>
+            <button type="button" className="jump-chip is-all" onClick={jumpToAll}>
+              {t('catalog.jumpAll')}
+            </button>
+            {shelfCategories.map((shelf) => (
+              <button key={shelf.id} type="button" className="jump-chip" onClick={() => scrollToShelf(shelf.id)}>
+                <span className={`jump-chip-dot cat-${shelf.id}`} aria-hidden="true" />
+                {t(`catalog.categories.${shelf.id}`)}
+              </button>
+            ))}
+          </nav>
+          {shelfCategories.map((shelf) => (
+            <div id={`shelf-${shelf.id}`} key={shelf.id} className={`catalog-shelf cat-${shelf.id}`}>
+              <CatalogRail
+                heading={t(`catalog.categories.${shelf.id}`)}
+                entries={shelf.entries}
+                via="shelf"
+                onPlayGame={onPlayGame}
+                onPlayTogether={onPlayTogether}
+                onSeeAll={() => seeAllInCategory(shelf.id)}
+              />
+            </div>
+          ))}
+        </>
+      )}
       <section id="arcade" className="arcade-section">
-        <div className="arcade-header">
+        <div id="browse-everything" className="arcade-header">
           <div className="arcade-title-row">
-            <h2 className="arcade-title">{t('catalog.title')}</h2>
+            <h2 className="arcade-title">{t('catalog.browseEverything')}</h2>
           </div>
           {showControls ? (
             <div className="catalog-toolbar" role="group" aria-label={t('catalog.toolbarLabel')}>
@@ -895,6 +993,15 @@ export function ArcadeCatalog({
           ) : null}
         </div>
 
+        {categoryFilter ? (
+          <div className="catalog-category-active">
+            <span>{t('catalog.categoryFilterActive', { category: t(`catalog.categories.${categoryFilter}`) })}</span>
+            <button type="button" className="catalog-category-clear" onClick={() => setCategoryFilter(null)}>
+              {t('catalog.clearFilters')}
+            </button>
+          </div>
+        ) : null}
+
         {catalogStatus === 'ready' && catalogError ? (
           <div className="catalog-refresh-error" role="status">
             <p className="catalog-refresh-error__text">{t('catalog.refreshError', { message: catalogError })}</p>
@@ -926,18 +1033,65 @@ export function ArcadeCatalog({
               </button>
             ) : null}
           </MascotMoment>
+        ) : showCategoryEmpty ? (
+          <MascotMoment className="catalog-state" emotion="curious" size={64} title={t('mascot.curiousAlt')}>
+            <p>{t('catalog.emptyCategory', { category: t(`catalog.categories.${categoryFilter}`) })}</p>
+            <button type="button" className="secondary-btn" onClick={() => setCategoryFilter(null)}>
+              {t('catalog.clearFilters')}
+            </button>
+          </MascotMoment>
         ) : (
-          <div className="catalog-grid">
-            {displayedEntries.map((entry) => (
-              <CatalogCard
-                key={entry.slug}
-                entry={entry}
-                isYours={mySlugs.has(entry.slug)}
-                onPlayGame={(game) => onPlayGame(game, 'grid')}
-                onPlayTogether={(game) => onPlayTogether(game, 'grid')}
-              />
-            ))}
-          </div>
+          <>
+            <div className="catalog-grid">
+              {pageEntries.map((entry) => (
+                <CatalogCard
+                  key={entry.slug}
+                  entry={entry}
+                  isYours={mySlugs.has(entry.slug)}
+                  onPlayGame={(game) => onPlayGame(game, 'grid')}
+                  onPlayTogether={(game) => onPlayTogether(game, 'grid')}
+                />
+              ))}
+            </div>
+            {browsePageCount > 1 ? (
+              <nav className="catalog-pager" aria-label={t('catalog.pagination.label')}>
+                <button
+                  type="button"
+                  disabled={clampedBrowsePage === 1}
+                  aria-label={t('catalog.pagination.prev')}
+                  onClick={() => setBrowsePage((p) => Math.max(1, p - 1))}
+                >
+                  &larr;
+                </button>
+                {buildCatalogPageTokens(clampedBrowsePage, browsePageCount).map((token, index) =>
+                  token === 'ellipsis' ? (
+                    <span key={`ellipsis-${index}`} className="catalog-pager-ellipsis">
+                      &hellip;
+                    </span>
+                  ) : (
+                    <button
+                      key={token}
+                      type="button"
+                      className={token === clampedBrowsePage ? 'is-active' : undefined}
+                      aria-current={token === clampedBrowsePage ? 'page' : undefined}
+                      aria-label={t('catalog.pagination.page', { page: token })}
+                      onClick={() => setBrowsePage(token)}
+                    >
+                      {token}
+                    </button>
+                  ),
+                )}
+                <button
+                  type="button"
+                  disabled={clampedBrowsePage === browsePageCount}
+                  aria-label={t('catalog.pagination.next')}
+                  onClick={() => setBrowsePage((p) => Math.min(browsePageCount, p + 1))}
+                >
+                  &rarr;
+                </button>
+              </nav>
+            ) : null}
+          </>
         )}
       </section>
     </>

--- a/apps/web/src/CatalogRail.tsx
+++ b/apps/web/src/CatalogRail.tsx
@@ -113,6 +113,11 @@ export function FeaturedGame({ entry, onPlayGame, onPlayTogether }: FeaturedGame
   return (
     <article className="featured-game">
       <div className="featured-game-media">
+        <a
+          className="featured-game-hit-area"
+          href={`${gamePath(gamePageHandle(entry), entry.slug)}?via=featured`}
+          aria-label={`${entry.title} — ${t('catalog.openGame')}`}
+        />
         {posterUrl ? <img src={posterUrl} alt="" loading="eager" decoding="async" /> : null}
       </div>
       <div className="featured-game-body">

--- a/apps/web/src/CatalogRail.tsx
+++ b/apps/web/src/CatalogRail.tsx
@@ -77,16 +77,32 @@ type CatalogRailProps = {
   onPlayTogether?: (game: CatalogEntry, via?: PlayVia) => void;
   // Right-aligned count/link next to the heading.
   headingAside?: string;
+  // Only shelves pass this — curated rails have nowhere to send it.
+  onSeeAll?: () => void;
 };
 
 // Hides itself when empty — no empty-rail state to design.
-export function CatalogRail({ heading, entries, via, onPlayGame, onPlayTogether, headingAside }: CatalogRailProps) {
+export function CatalogRail({
+  heading,
+  entries,
+  via,
+  onPlayGame,
+  onPlayTogether,
+  headingAside,
+  onSeeAll,
+}: CatalogRailProps) {
+  const { t } = useTranslation();
   if (entries.length === 0) return null;
   return (
     <section className="catalog-rail-section">
       <div className="catalog-rail-head">
         <h3 className="catalog-rail-heading">{heading}</h3>
         {headingAside ? <span className="catalog-rail-aside">{headingAside}</span> : null}
+        {onSeeAll ? (
+          <button type="button" className="catalog-rail-see-all" onClick={onSeeAll}>
+            {t('catalog.seeAll')} &rarr;
+          </button>
+        ) : null}
       </div>
       <div className="catalog-rail-track">
         {entries.map((entry) => (
@@ -101,10 +117,30 @@ type FeaturedGameProps = {
   entry: CatalogEntry;
   onPlayGame: (game: CatalogEntry, via?: PlayVia) => void;
   onPlayTogether: (game: CatalogEntry, via?: PlayVia) => void;
+  // Same shelf as the featured pick, minus itself.
+  moreLikeThis?: CatalogEntry[];
 };
 
+function MoreLikeThisThumb({ entry }: { entry: CatalogEntry }) {
+  const screenshots = entry.media?.screenshots ?? [];
+  const selected = screenshots[defaultScreenshotIndex(screenshots)];
+  const posterUrl = selected ? catalogMediaUrl(entry.slug, selected.file, 160) : undefined;
+  return (
+    <a className="more-like-this-thumb" href={`${gamePath(gamePageHandle(entry), entry.slug)}?via=featured_similar`}>
+      {posterUrl ? (
+        <img src={posterUrl} alt="" loading="lazy" decoding="async" />
+      ) : (
+        <div className="more-like-this-thumb-fallback" aria-hidden="true">
+          {entry.title.charAt(0)}
+        </div>
+      )}
+      <span>{entry.title}</span>
+    </a>
+  );
+}
+
 // The curated, daily rotating hero pick above the rails.
-export function FeaturedGame({ entry, onPlayGame, onPlayTogether }: FeaturedGameProps) {
+export function FeaturedGame({ entry, onPlayGame, onPlayTogether, moreLikeThis = [] }: FeaturedGameProps) {
   const { t } = useTranslation();
   const screenshots = entry.media?.screenshots ?? [];
   const selected = screenshots[defaultScreenshotIndex(screenshots)];
@@ -154,6 +190,16 @@ export function FeaturedGame({ entry, onPlayGame, onPlayTogether }: FeaturedGame
             </button>
           )}
         </div>
+        {moreLikeThis.length > 0 ? (
+          <div className="more-like-this">
+            <div className="more-like-this-label">{t('catalog.moreLikeThis')}</div>
+            <div className="more-like-this-thumbs">
+              {moreLikeThis.map((similar) => (
+                <MoreLikeThisThumb key={similar.slug} entry={similar} />
+              ))}
+            </div>
+          </div>
+        ) : null}
       </div>
     </article>
   );

--- a/apps/web/src/NavHeader.test.tsx
+++ b/apps/web/src/NavHeader.test.tsx
@@ -279,8 +279,8 @@ describe('NavHeader menu', () => {
       await Promise.resolve();
     });
 
-    const createGame = Array.from(container.querySelectorAll<HTMLButtonElement>('.nav-link')).find((btn) =>
-      /Create Game/i.test(btn.textContent ?? ''),
+    const createGame = Array.from(container.querySelectorAll<HTMLButtonElement>('.dropdown-menu .nav-link')).find(
+      (btn) => /Create Game/i.test(btn.textContent ?? ''),
     );
     expect(createGame).toBeDefined();
     expect(createGame?.className).toContain('is-active');
@@ -291,6 +291,58 @@ describe('NavHeader menu', () => {
 
     expect(onCreate).toHaveBeenCalled();
     expect(container.querySelector('.dropdown-menu')).toBeNull();
+
+    await act(async () => root.unmount());
+  });
+
+  it('also offers Create Game in the always-visible header nav', async () => {
+    const onCreate = vi.fn();
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async (input) => {
+      const url = String(input);
+      if (url.endsWith('/api/auth/me')) {
+        return new Response(JSON.stringify({ user: null }));
+      }
+      if (url.endsWith('/api/health')) {
+        return new Response(JSON.stringify({ status: 'ok', provider: 'mock', privateBeta: false }));
+      }
+      return new Response('{}', { status: 404 });
+    });
+
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    await act(async () => {
+      root.render(
+        createElement(
+          AuthProvider,
+          null,
+          createElement(NavHeader, {
+            activeBuildCount: 0,
+            onCreate,
+            isOnCreate: true,
+            onHome: vi.fn(),
+            onStudio: vi.fn(),
+            onAdmin: vi.fn(),
+            onReview: vi.fn(),
+            upTarget: null,
+          }),
+        ),
+      );
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    const headerNavCreate = Array.from(container.querySelectorAll<HTMLButtonElement>('.header-nav .nav-link')).find(
+      (btn) => /Create Game/i.test(btn.textContent ?? ''),
+    );
+    expect(headerNavCreate).toBeDefined();
+    expect(headerNavCreate?.className).toContain('is-active');
+    await act(async () => {
+      headerNavCreate?.click();
+      await Promise.resolve();
+    });
+    expect(onCreate).toHaveBeenCalled();
 
     await act(async () => root.unmount());
   });

--- a/apps/web/src/NavHeader.tsx
+++ b/apps/web/src/NavHeader.tsx
@@ -172,6 +172,12 @@ export function NavHeader({
         </a>
       </div>
 
+      <nav className="header-nav">
+        <button type="button" className={`nav-link${isOnCreate ? ' is-active' : ''}`} onClick={onCreate}>
+          <PixelIcon name="sparkle" size={14} /> {t('header.navPrompt')}
+        </button>
+      </nav>
+
       <div className="header-actions">
         {user ? (
           <div className="user-profile-badge">

--- a/apps/web/src/VisitFunnelPanel.tsx
+++ b/apps/web/src/VisitFunnelPanel.tsx
@@ -112,6 +112,8 @@ const PLAY_VIA_LABELS: Record<string, string> = {
   grid: 'catalog grid',
   composer_match: 'composer match card',
   create_showcase: '/create showcase',
+  shelf: 'catalog shelf',
+  featured_similar: 'featured "more like this"',
   unknown: 'unknown (direct link, party, etc.)',
 };
 

--- a/apps/web/src/catalogCategory.test.ts
+++ b/apps/web/src/catalogCategory.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest';
+import type { CatalogEntry } from './catalog.js';
+import { categorizeCatalogEntry, entriesInCategory, isCatalogCategoryId } from './catalogCategory.js';
+
+function entry(partial: Partial<CatalogEntry> & Pick<CatalogEntry, 'slug' | 'title'>): CatalogEntry {
+  return {
+    genre: 'Arcade',
+    controls: 'keys',
+    status: 'published',
+    media: null,
+    multiplayer: null,
+    saves: null,
+    world: null,
+    sensing: null,
+    orientation: 'any',
+    touch: null,
+    submittedBy: null,
+    ...partial,
+  };
+}
+
+describe('categorizeCatalogEntry', () => {
+  it('maps a genre keyword to its shelf', () => {
+    expect(categorizeCatalogEntry(entry({ slug: 'a', title: 'A', genre: 'Vertical shmup' }))).toEqual([
+      'arcade_racing',
+    ]);
+    expect(categorizeCatalogEntry(entry({ slug: 'b', title: 'B', genre: 'Western RPG' }))).toEqual(['rpg_adventure']);
+    expect(categorizeCatalogEntry(entry({ slug: 'c', title: 'C', genre: 'City builder' }))).toEqual(['strategy_sim']);
+    expect(categorizeCatalogEntry(entry({ slug: 'd', title: 'D', genre: 'Match-3 puzzle' }))).toEqual(['puzzle_story']);
+  });
+
+  it('falls back to more_to_explore for an unmatched or missing genre', () => {
+    expect(categorizeCatalogEntry(entry({ slug: 'a', title: 'A', genre: 'Bureaucracy paperwork' }))).toEqual([
+      'more_to_explore',
+    ]);
+    expect(categorizeCatalogEntry(entry({ slug: 'b', title: 'B', genre: '' }))).toEqual(['more_to_explore']);
+  });
+
+  it('grants multiplayer_party on top of the genre category, not instead of it', () => {
+    const multiplayer = { mode: 'controllers' as const, minPlayers: 2, maxPlayers: 4 };
+    expect(categorizeCatalogEntry(entry({ slug: 'a', title: 'A', genre: 'Arcade racing (3D)', multiplayer }))).toEqual([
+      'arcade_racing',
+      'multiplayer_party',
+    ]);
+    expect(categorizeCatalogEntry(entry({ slug: 'b', title: 'B', genre: '', multiplayer }))).toEqual([
+      'more_to_explore',
+      'multiplayer_party',
+    ]);
+  });
+
+  it('is case-insensitive', () => {
+    expect(categorizeCatalogEntry(entry({ slug: 'a', title: 'A', genre: 'SOULSLIKE' }))).toEqual(['rpg_adventure']);
+  });
+});
+
+describe('isCatalogCategoryId', () => {
+  it('accepts every real id and rejects anything else', () => {
+    expect(isCatalogCategoryId('arcade_racing')).toBe(true);
+    expect(isCatalogCategoryId('multiplayer_party')).toBe(true);
+    expect(isCatalogCategoryId('bogus')).toBe(false);
+    expect(isCatalogCategoryId(undefined)).toBe(false);
+  });
+});
+
+describe('entriesInCategory', () => {
+  it('keeps only entries carrying the given shelf, in their original order', () => {
+    const entries = [
+      entry({ slug: 'a', title: 'A', genre: 'Roguelike' }),
+      entry({ slug: 'b', title: 'B', genre: 'City builder' }),
+      entry({ slug: 'c', title: 'C', genre: 'Soulslike' }),
+    ];
+    expect(entriesInCategory(entries, 'rpg_adventure').map((e) => e.slug)).toEqual(['a', 'c']);
+    expect(entriesInCategory(entries, 'strategy_sim').map((e) => e.slug)).toEqual(['b']);
+    expect(entriesInCategory(entries, 'puzzle_story')).toEqual([]);
+  });
+});

--- a/apps/web/src/catalogCategory.ts
+++ b/apps/web/src/catalogCategory.ts
@@ -1,0 +1,52 @@
+import type { CatalogEntry } from './catalog.js';
+
+// Coarse shelves, distinct from genre — free text can't group itself.
+export const CATALOG_CATEGORY_IDS = [
+  'arcade_racing',
+  'rpg_adventure',
+  'strategy_sim',
+  'puzzle_story',
+  'multiplayer_party',
+  'more_to_explore',
+] as const;
+
+export type CatalogCategoryId = (typeof CATALOG_CATEGORY_IDS)[number];
+
+export function isCatalogCategoryId(value: unknown): value is CatalogCategoryId {
+  return typeof value === 'string' && (CATALOG_CATEGORY_IDS as readonly string[]).includes(value);
+}
+
+// Checked in order; first keyword match wins. multiplayer_party is granted separately.
+const GENRE_KEYWORDS: ReadonlyArray<[Exclude<CatalogCategoryId, 'multiplayer_party' | 'more_to_explore'>, string[]]> = [
+  [
+    'arcade_racing',
+    ['arcade', 'racing', 'shmup', 'shooter', 'runner', 'platformer', 'pinball', 'brawler', 'stealth', 'rhythm'],
+  ],
+  ['rpg_adventure', ['rpg', 'adventure', 'roguelike', 'soulslike', 'dungeon', 'horror', 'metroidvania']],
+  [
+    'strategy_sim',
+    ['strategy', 'sim', 'builder', 'tycoon', 'trading', 'management', 'sandbox', 'farming', 'tower defense'],
+  ],
+  [
+    'puzzle_story',
+    ['puzzle', 'match-3', 'match 3', 'visual novel', 'narrative', 'word', 'trivia', 'quiz', 'collecting'],
+  ],
+];
+
+// Genre gives one shelf; multiplayer_party is additive on top.
+export function categorizeCatalogEntry(entry: Pick<CatalogEntry, 'genre' | 'multiplayer'>): CatalogCategoryId[] {
+  const categories: CatalogCategoryId[] = [];
+  const genre = entry.genre?.toLowerCase() ?? '';
+  const fromGenre = GENRE_KEYWORDS.find(([, keywords]) => keywords.some((keyword) => genre.includes(keyword)));
+  categories.push(fromGenre ? fromGenre[0] : 'more_to_explore');
+  if (entry.multiplayer) categories.push('multiplayer_party');
+  return categories;
+}
+
+// Entries carrying a given shelf, in the caller's own order.
+export function entriesInCategory<T extends Pick<CatalogEntry, 'genre' | 'multiplayer'>>(
+  entries: T[],
+  category: CatalogCategoryId,
+): T[] {
+  return entries.filter((entry) => categorizeCatalogEntry(entry).includes(category));
+}

--- a/apps/web/src/catalogPagination.test.ts
+++ b/apps/web/src/catalogPagination.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import { buildCatalogPageTokens } from './catalogPagination.js';
+
+describe('buildCatalogPageTokens', () => {
+  it('returns a single page when there is nothing to paginate', () => {
+    expect(buildCatalogPageTokens(1, 1)).toEqual([1]);
+    expect(buildCatalogPageTokens(1, 0)).toEqual([1]);
+  });
+
+  it('lists every page when the run is short', () => {
+    expect(buildCatalogPageTokens(1, 3)).toEqual([1, 2, 3]);
+    expect(buildCatalogPageTokens(2, 5)).toEqual([1, 2, 3, 4, 5]);
+  });
+
+  it('collapses a long run around the current page with ellipses', () => {
+    expect(buildCatalogPageTokens(1, 10)).toEqual([1, 2, 'ellipsis', 10]);
+    expect(buildCatalogPageTokens(5, 10)).toEqual([1, 'ellipsis', 4, 5, 6, 'ellipsis', 10]);
+    expect(buildCatalogPageTokens(10, 10)).toEqual([1, 'ellipsis', 9, 10]);
+  });
+
+  it('never emits two ellipses back to back near the edges', () => {
+    expect(buildCatalogPageTokens(2, 10)).toEqual([1, 2, 3, 'ellipsis', 10]);
+    expect(buildCatalogPageTokens(9, 10)).toEqual([1, 'ellipsis', 8, 9, 10]);
+  });
+});

--- a/apps/web/src/catalogPagination.ts
+++ b/apps/web/src/catalogPagination.ts
@@ -1,0 +1,19 @@
+export const CATALOG_PAGE_SIZE = 24;
+
+export type CatalogPageToken = number | 'ellipsis';
+
+// Pager tokens: first, last, and a window around the current page.
+export function buildCatalogPageTokens(current: number, total: number): CatalogPageToken[] {
+  if (total <= 1) return [1];
+  const window = new Set<number>([1, total, current - 1, current, current + 1]);
+  const pages = [...window].filter((page) => page >= 1 && page <= total).sort((a, b) => a - b);
+  const tokens: CatalogPageToken[] = [];
+  for (let i = 0; i < pages.length; i++) {
+    const gap = i > 0 ? pages[i] - pages[i - 1] : 0;
+    // A single skipped page is cheaper to show than to elide.
+    if (gap === 2) tokens.push(pages[i - 1] + 1);
+    else if (gap > 2) tokens.push('ellipsis');
+    tokens.push(pages[i]);
+  }
+  return tokens;
+}

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -206,6 +206,28 @@
       "party": "Party mode",
       "recentlyAdded": "Recently added"
     },
+    "categories": {
+      "arcade_racing": "Arcade & Racing",
+      "rpg_adventure": "RPG & Adventure",
+      "strategy_sim": "Strategy & Sim",
+      "puzzle_story": "Puzzle & Story",
+      "multiplayer_party": "Multiplayer & Party",
+      "more_to_explore": "More to explore"
+    },
+    "jumpBarLabel": "Jump to a shelf",
+    "jumpAll": "All",
+    "seeAll": "See all",
+    "browseEverything": "Browse everything",
+    "categoryFilterActive": "Showing: {{category}}",
+    "emptyCategory": "No {{category}} games match your filters yet.",
+    "moreLikeThis": "More like this",
+    "openGame": "Open game",
+    "pagination": {
+      "label": "Pages",
+      "prev": "Previous page",
+      "next": "Next page",
+      "page": "Page {{page}}"
+    },
     "loading": "Loading games…",
     "gameLoading": "Loading game…",
     "gameLoadError": "Could not load this game.",

--- a/apps/web/src/i18n/locales/pl.json
+++ b/apps/web/src/i18n/locales/pl.json
@@ -206,6 +206,28 @@
       "party": "Tryb imprezowy",
       "recentlyAdded": "Ostatnio dodane"
     },
+    "categories": {
+      "arcade_racing": "Zręcznościowe i wyścigi",
+      "rpg_adventure": "RPG i przygodowe",
+      "strategy_sim": "Strategie i symulacje",
+      "puzzle_story": "Łamigłówki i fabuła",
+      "multiplayer_party": "Wieloosobowe i imprezowe",
+      "more_to_explore": "Więcej do odkrycia"
+    },
+    "jumpBarLabel": "Przejdź do kategorii",
+    "jumpAll": "Wszystkie",
+    "seeAll": "Zobacz wszystkie",
+    "browseEverything": "Przeglądaj wszystko",
+    "categoryFilterActive": "Wyświetlane: {{category}}",
+    "emptyCategory": "Żadna gra z kategorii {{category}} nie pasuje jeszcze do filtrów.",
+    "moreLikeThis": "Podobne gry",
+    "openGame": "Otwórz grę",
+    "pagination": {
+      "label": "Strony",
+      "prev": "Poprzednia strona",
+      "next": "Następna strona",
+      "page": "Strona {{page}}"
+    },
     "loading": "Wczytywanie gier…",
     "gameLoading": "Wczytywanie gry…",
     "gameLoadError": "Nie udało się wczytać tej gry.",

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -427,14 +427,17 @@ a {
   height: auto;
   min-height: 0;
   box-sizing: border-box;
-  background: rgba(22, 28, 34, 0.92);
-  border: 1px solid rgba(255, 255, 255, 0.1);
+  background: rgba(32, 42, 51, 0.97);
+  border: 1px solid rgba(0, 228, 172, 0.22);
   border-radius: 999px;
   padding: 4px 8px;
-  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.28);
+  box-shadow:
+    0 8px 24px rgba(0, 0, 0, 0.32),
+    0 0 0 1px rgba(0, 0, 0, 0.2);
   transition:
     border-color 0.25s ease,
-    box-shadow 0.25s ease;
+    box-shadow 0.25s ease,
+    background-color 0.25s ease;
 }
 
 .hero-prompt-card:focus-within .prompt-composer-bar {

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -1152,6 +1152,17 @@ button:disabled {
   display: block;
 }
 
+.featured-game-hit-area {
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+}
+
+.featured-game-hit-area:focus-visible {
+  outline: 3px solid var(--turquoise);
+  outline-offset: -3px;
+}
+
 .featured-game-body {
   display: flex;
   flex-direction: column;
@@ -3419,9 +3430,9 @@ body.player-open {
     margin-right: 8px;
   }
 
+  /* The hamburger owns navigation on a phone — this row would be a second one. */
   .header-nav {
-    flex-wrap: wrap;
-    justify-content: center;
+    display: none;
   }
 
   .nav-link {

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -40,6 +40,14 @@
   --turquoise-glow: rgba(0, 228, 172, 0.35);
   --accent-blue: #38bdf8;
   --error: #ff6b6b;
+
+  /* Shelf identity dots only — never a CTA color, that stays turquoise. */
+  --cat-arcade-racing: #f2b84b;
+  --cat-rpg-adventure: #a78bfa;
+  --cat-strategy-sim: #4ade80;
+  --cat-puzzle-story: #38bdf8;
+  --cat-multiplayer-party: #fb923c;
+  --cat-more-to-explore: #94a3b8;
 }
 
 * {
@@ -1216,6 +1224,60 @@ button:disabled {
   margin-top: 4px;
 }
 
+.more-like-this {
+  width: 100%;
+  margin-top: auto;
+  padding-top: 16px;
+}
+
+.more-like-this-label {
+  font-size: 0.68rem;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--muted);
+  margin-bottom: 8px;
+}
+
+.more-like-this-thumbs {
+  display: flex;
+  gap: 8px;
+}
+
+.more-like-this-thumb {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  color: var(--text);
+}
+
+.more-like-this-thumb img,
+.more-like-this-thumb-fallback {
+  width: 100%;
+  aspect-ratio: 16 / 10;
+  border-radius: 6px;
+  object-fit: cover;
+  display: block;
+}
+
+.more-like-this-thumb-fallback {
+  display: grid;
+  place-items: center;
+  background: var(--panel);
+  color: var(--muted);
+  font-weight: 700;
+}
+
+.more-like-this-thumb span {
+  font-size: 0.72rem;
+  font-weight: 600;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
 @media (max-width: 768px) {
   .featured-game {
     grid-template-columns: 1fr;
@@ -1254,6 +1316,27 @@ button:disabled {
 .catalog-rail-aside {
   font-size: 0.8rem;
   color: var(--muted);
+}
+
+.catalog-rail-see-all {
+  margin-left: auto;
+  background: transparent;
+  border: none;
+  color: var(--muted);
+  font-size: 0.8rem;
+  font-weight: 600;
+  cursor: pointer;
+  padding: 4px 0;
+}
+
+.catalog-rail-see-all:hover,
+.catalog-rail-see-all:focus-visible {
+  color: var(--turquoise);
+}
+
+.catalog-shelf {
+  /* Clears the sticky header when a jump-bar chip scrolls a shelf into view. */
+  scroll-margin-top: 88px;
 }
 
 .catalog-rail-track {
@@ -1427,6 +1510,143 @@ button:disabled {
   margin: 0;
   letter-spacing: -0.3px;
   min-width: 0;
+}
+
+#browse-everything {
+  /* Clears the sticky header when a "See all" link scrolls this into view. */
+  scroll-margin-top: 88px;
+}
+
+.catalog-jumpbar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin: 8px 0 30px;
+}
+
+.jump-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  border: 1px solid var(--panel-border);
+  background: var(--panel-card);
+  border-radius: 999px;
+  padding: 7px 14px 7px 10px;
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: var(--text);
+  cursor: pointer;
+}
+
+.jump-chip:hover,
+.jump-chip:focus-visible {
+  border-color: var(--turquoise);
+}
+
+.jump-chip.is-all {
+  color: var(--turquoise);
+  border-color: rgba(0, 228, 172, 0.35);
+}
+
+.jump-chip-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex: none;
+}
+
+.jump-chip-dot.cat-arcade_racing {
+  background: var(--cat-arcade-racing);
+}
+
+.jump-chip-dot.cat-rpg_adventure {
+  background: var(--cat-rpg-adventure);
+}
+
+.jump-chip-dot.cat-strategy_sim {
+  background: var(--cat-strategy-sim);
+}
+
+.jump-chip-dot.cat-puzzle_story {
+  background: var(--cat-puzzle-story);
+}
+
+.jump-chip-dot.cat-multiplayer_party {
+  background: var(--cat-multiplayer-party);
+}
+
+.jump-chip-dot.cat-more_to_explore {
+  background: var(--cat-more-to-explore);
+}
+
+.catalog-category-active {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 16px;
+  font-size: 0.85rem;
+  color: var(--muted);
+}
+
+.catalog-category-clear {
+  background: transparent;
+  border: 1px solid var(--panel-border);
+  border-radius: 999px;
+  padding: 4px 12px;
+  color: var(--text);
+  font-size: 0.78rem;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.catalog-category-clear:hover,
+.catalog-category-clear:focus-visible {
+  border-color: var(--turquoise);
+  color: var(--turquoise);
+}
+
+.catalog-pager {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  margin-top: 26px;
+}
+
+.catalog-pager button {
+  min-width: 34px;
+  height: 34px;
+  padding: 0 8px;
+  border-radius: 8px;
+  border: 1px solid var(--panel-border);
+  background: transparent;
+  color: var(--muted);
+  font-weight: 600;
+  font-size: 0.85rem;
+  font-variant-numeric: tabular-nums;
+  cursor: pointer;
+}
+
+.catalog-pager button:disabled {
+  opacity: 0.4;
+  cursor: default;
+}
+
+.catalog-pager button:not(:disabled):hover,
+.catalog-pager button:not(:disabled):focus-visible {
+  border-color: var(--turquoise);
+  color: var(--turquoise);
+}
+
+.catalog-pager button.is-active {
+  background: var(--panel-card);
+  border-color: var(--turquoise);
+  color: var(--turquoise);
+}
+
+.catalog-pager-ellipsis {
+  color: var(--muted);
+  padding: 0 2px;
 }
 
 /* Compact Studio entry in the top nav — live count + wrench in one control so

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -200,6 +200,14 @@ a {
   gap: 8px;
 }
 
+@media (max-width: 1099px) {
+  /* Signed-in chrome (name, bell, Studio chip, language) is already tight in this
+     range — the hamburger's own Create Game row covers it, same as on a phone. */
+  .header-nav {
+    display: none;
+  }
+}
+
 .nav-link {
   background: transparent;
   border: 1px solid transparent;
@@ -3651,11 +3659,6 @@ body.player-open {
     width: 28px;
     height: 28px;
     margin-right: 8px;
-  }
-
-  /* The hamburger owns navigation on a phone — this row would be a second one. */
-  .header-nav {
-    display: none;
   }
 
   .nav-link {

--- a/apps/web/src/visitTelemetry.ts
+++ b/apps/web/src/visitTelemetry.ts
@@ -160,6 +160,8 @@ export const PLAY_VIA_VALUES = [
   'grid',
   'composer_match',
   'create_showcase',
+  'shelf',
+  'featured_similar',
 ] as const;
 export type PlayVia = (typeof PLAY_VIA_VALUES)[number];
 


### PR DESCRIPTION
## Summary

Follow-up fixes and a feature addition to the home page redesign (#860), driven by review of the merged design against the live site.

**Header & featured card fixes**
- Wires up a previously-dead `.header-nav` CSS class so "Create Game" is a visible link on desktop, not just buried in the hamburger.
- The featured game's poster is now clickable (matching rail cards), not just the Play button.
- Raises the composer bar's resting-state contrast — its background was nearly the same tone as the page, so the primary CTA barely read as its own surface until focused.

**Catalog shelves (Steam-inspired reorg)**
The "All Games" section was a single dense, unpaginated grid. Replaces it with:
- A small coarse category taxonomy (`catalogCategory.ts`), distinct from the existing free-text `genre` field which is near-unique per game and can't group itself
- Five themed shelves + a jump bar to scroll between them, reusing the existing `CatalogRail` component
- A "See all" link per shelf that filters Browse Everything to that category, with a clear chip
- Browse Everything is now paginated with real page numbers instead of listing every game at once
- The featured card's "More like this" strip fills its previously-empty space with picks from its own shelf

New `PlayVia` telemetry values: `shelf` and `featured_similar`.

**Mobile scroll fix**
Scrolling down on home, then opening Create Game from the hamburger, landed on `/create` at the same scroll offset — the composer it had just focused was off-screen. `focus({preventScroll: true})` was suppressing the one thing that would've scrolled it into view; now scrolls to top explicitly first.

## Test plan
- [x] `npm run type-check`, `npm run lint`, `npm test` all green across every workspace (api, web, world, eslint-rules, packages)
- [x] Live Playwright verification against the dev server (desktop + mobile) for every visual change, including the actual production catalog data for the shelves feature
- [x] Reproduced and verified the mobile scroll bug and its fix with a real browser (scrollY 1600 → 0)


---
_Generated by [Claude Code](https://claude.ai/code/session_011NBEzZgRhyHfgBwXd8UzWm)_