### PR TITLE
Fix "click below" copy in draft-ready banner

### DIFF
--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -739,7 +739,7 @@
     "runningFor": "Running for {{time}}",
     "completedIn": "Completed in {{time}}",
     "statusReadyLabel": "Draft Ready",
-    "readyBanner": "Draft ready — click below to play your game preview!",
+    "readyBanner": "Draft ready — click \"Play Draft in Studio\" to play your game preview!",
     "playDraft": "Play Draft in Studio",
     "primerTitle": "How to steer the agent",
     "primerSteer": "In Studio, type what to change while it builds — the agent picks it up on the next update.",

--- a/apps/web/src/i18n/locales/pl.json
+++ b/apps/web/src/i18n/locales/pl.json
@@ -747,7 +747,7 @@
     "runningFor": "Trwa {{time}}",
     "completedIn": "Ukończono w {{time}}",
     "statusReadyLabel": "Draft Gotowy",
-    "readyBanner": "Draft gotowy — kliknij poniżej, aby zagrać w podgląd gry!",
+    "readyBanner": "Draft gotowy — kliknij „Zagraj w Studio”, aby zagrać w podgląd gry!",
     "playDraft": "Zagraj w Studio",
     "primerTitle": "Jak sterować agentem",
     "primerSteer": "W Studio napisz, co zmienić, podczas gdy gra powstaje — agent podejmie to przy następnej aktualizacji.",


### PR DESCRIPTION
## Summary
- The draft-ready banner in the Studio welcome view said "click below" ("kliknij poniżej") to play the preview, but the actual "Zagraj w Studio" / "Play Draft in Studio" button sits in a fixed footer far from the banner text, not directly below it.
- Reworded the copy in `apps/web/src/i18n/locales/pl.json` and `en.json` to reference the button by name instead of its (incorrect) position.

## Test plan
- [x] Validated both locale JSON files parse correctly
- [ ] Could not run the web test suite locally (vitest/deps not installed in this environment) — this is a pure copy-string change with no logic touched

---
_Generated by [Claude Code](https://claude.ai/code/session_012u27kMqTNWDA3gJQ3fNvkE)_