### PR TITLE
fix(ci): pin game publish to validated commit

### DIFF
--- a/.github/workflows/games-catalog-gate.yml
+++ b/.github/workflows/games-catalog-gate.yml
@@ -30,6 +30,10 @@ on:
         type: string
         required: false
         default: '0'
+    outputs:
+      games_sha:
+        description: 'Commit SHA checked by every gate job'
+        value: ${{ jobs.catalog-gate.outputs.games_sha }}
     secrets:
       GAMES_REPO_TOKEN:
         required: true
@@ -53,6 +57,7 @@ jobs:
     timeout-minutes: 180
     outputs:
       games_ref: ${{ steps.resolve.outputs.games_ref }}
+      games_sha: ${{ steps.checkout_sha.outputs.games_sha }}
       mode: ${{ steps.resolve.outputs.mode }}
       slugs: ${{ steps.resolve.outputs.slugs }}
       need_webkit: ${{ steps.resolve.outputs.need_webkit }}
@@ -125,6 +130,11 @@ jobs:
           token: ${{ secrets.GAMES_REPO_TOKEN }}
           path: games-repo
           persist-credentials: false
+
+      - name: Resolve checked out games commit
+        id: checkout_sha
+        working-directory: games-repo
+        run: echo "games_sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
       - name: Check Playwright image matches games package
         working-directory: games-repo
@@ -264,7 +274,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: ${{ env.GAMES_REPO }}
-          ref: ${{ needs.catalog-gate.outputs.games_ref }}
+          ref: ${{ needs.catalog-gate.outputs.games_sha }}
           token: ${{ secrets.GAMES_REPO_TOKEN }}
           path: games-repo
           persist-credentials: false

--- a/.github/workflows/publish-games.yml
+++ b/.github/workflows/publish-games.yml
@@ -87,28 +87,21 @@ jobs:
 
       - name: Resolve games-repo ref
         env:
-          DISPATCH_REF: ${{ github.event.client_payload.ref }}
-          DISPATCH_SHA: ${{ github.event.client_payload.sha }}
-          INPUT_REF: ${{ github.event.inputs.ref }}
+          VALIDATED_SHA: ${{ needs.validate-games.outputs.games_sha }}
         run: |
-          # Payload values come from another repository's workflow, so they are
-          # treated as data: passed through the environment (never interpolated
-          # into the script) and constrained before use.
-          REF="${DISPATCH_REF:-${INPUT_REF:-main}}"
-          case "$REF" in
-            *[!A-Za-z0-9._/-]*)
-              echo "Error: refusing to bake from a ref with unexpected characters"
+          # Bake exactly the tree the reusable gate checked, including nightly runs.
+          case "$VALIDATED_SHA" in
+            "")
+              echo "Error: games catalog gate did not return a commit SHA"
+              exit 1
+              ;;
+            *[!0-9a-fA-F]*)
+              echo "Error: games catalog gate returned an invalid commit SHA"
               exit 1
               ;;
           esac
-          echo "SNAPSHOT_REF=${REF}" >> "$GITHUB_ENV"
-          case "$DISPATCH_SHA" in
-            "" ) ;;
-            *[!0-9a-fA-F]* )
-              echo "::warning::ignoring malformed commit sha in dispatch payload"
-              ;;
-            * ) echo "SNAPSHOT_SHA=${DISPATCH_SHA}" >> "$GITHUB_ENV" ;;
-          esac
+          echo "SNAPSHOT_REF=${VALIDATED_SHA}" >> "$GITHUB_ENV"
+          echo "SNAPSHOT_SHA=${VALIDATED_SHA}" >> "$GITHUB_ENV"
 
       - name: Authenticate to GCP via Workload Identity Federation
         if: ${{ github.event.inputs.dry_run != 'true' }}


### PR DESCRIPTION
## Summary

- Export the exact games commit checked by the reusable catalog gate.
- Run WebKit and snapshot publishing against that exact SHA.
- Prevent scheduled publishes from mixing a moving `main` ref with SHA-resolved archive reads.

## Root cause

Scheduled runs validated `main`, then the publish job downloaded `main` while the snapshot client resolved engine reads to a commit SHA. The archive-backed reads rejected that ref mismatch, so every game failed with errors such as:

`games-repo archive holds main, not <resolved commit>`

The reusable gate now records the commit actually checked out, and both downstream consumers use that SHA.

## Validation

- `npm run type-check`
- `npm run lint`
- `npm run test`
- `npm run build`

