### PR TITLE
Add site chrome to unpublished play loading/error states

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1141,9 +1141,30 @@ export function App() {
     return <AppLoadingScreen />;
   }
 
-  // Unpublished /play: theater owns the viewport; no chrome.
+  // Unpublished /play: theater covers the viewport when a game loads, but the
+  // loading/error sub-states are regular panels and need the site chrome around
+  // them (same wrapper as the notFound branch above).
   if (unpublishedPlayTheater) {
-    return <UnpublishedPlayView slug={route.slug} onExit={exitOverlay} onTitle={setUnpublishedPlayTitle} />;
+    return (
+      <div className="app app--unpublished-play">
+        <NavHeader
+          activeBuildCount={activeBuildCount}
+          onHome={() => navigate('/')}
+          onStudio={() => navigate(studioPath())}
+          onAdmin={() => navigate(adminPath())}
+          onReview={() => navigate(reviewPath())}
+          onCreate={handleCreateNav}
+          onPlay={() => handleHomeAnchorNav('play-anchor')}
+          onParty={() => handleHomeAnchorNav('party-rail')}
+          upTarget={headerUp}
+          onUp={navigate}
+        />
+        <main className="content">
+          <UnpublishedPlayView slug={route.slug} onExit={exitOverlay} onTitle={setUnpublishedPlayTitle} />
+        </main>
+        <SiteFooter />
+      </div>
+    );
   }
 
   // Bridge catalog-ready → auto-open so GameDetailPage does not flash first.


### PR DESCRIPTION
## Summary
Updated the unpublished play theater view to include the site navigation header and footer when displaying loading and error states, while keeping the theater full-viewport during active gameplay.

## Key Changes
- Wrapped `UnpublishedPlayView` with the standard app layout structure (`NavHeader`, `main.content`, and `SiteFooter`)
- Added `app--unpublished-play` class to the container div for styling purposes
- Updated the comment to clarify that the theater covers the viewport only during active game play, but loading/error sub-states display as regular panels with full site chrome
- Maintained all existing navigation callbacks and header functionality

## Implementation Details
The unpublished play view now follows the same layout pattern as other main app sections, ensuring consistent navigation and footer visibility during loading and error states. The `UnpublishedPlayView` component itself handles the full-viewport theater display when a game is actively loaded.

https://claude.ai/code/session_01FkyPVzUypAvsaN1LJLNfLx