### PR TITLE
Hero preview video and a bottom CTA to fill the footer gap

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -70,6 +70,7 @@ import { saveLastBuilder, type BuilderKind } from './builderKind.js';
 import { clearPendingQa, loadPendingQa, savePendingQa, type PendingQaAnswers } from './pendingQa.js';
 import { useAuth } from './AuthContext.js';
 import { AuthModal } from './AuthModal.js';
+import { BottomCta } from './BottomCta.js';
 import { recordCreateStep, recordStudioStep, type PlayVia } from './visitTelemetry.js';
 import { ClosedBetaSplash } from './ClosedBetaSplash.js';
 import { BetaInvitePage } from './BetaInvitePage.js';
@@ -1294,6 +1295,10 @@ export function App() {
                 creatorGamesRefreshKey={myGamesRefreshKey}
               />
             )}
+
+            {/* Both pages' real content can run shorter than the viewport, leaving a
+                bare gap above the sticky footer — fill it with a reason to scroll back up. */}
+            {(route.view === 'home' || route.view === 'create') && <BottomCta />}
           </>
         )}
       </main>

--- a/apps/web/src/BottomCta.test.tsx
+++ b/apps/web/src/BottomCta.test.tsx
@@ -1,0 +1,62 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { BottomCta } from './BottomCta.js';
+import i18n from './i18n/index.js';
+
+let container: HTMLDivElement;
+let root: Root | null = null;
+
+beforeEach(async () => {
+  (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  await i18n.changeLanguage('en');
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  if (!Object.getOwnPropertyDescriptor(Element.prototype, 'scrollIntoView')) {
+    Object.defineProperty(Element.prototype, 'scrollIntoView', { value: () => {}, writable: true });
+  }
+});
+
+afterEach(() => {
+  act(() => root?.unmount());
+  root = null;
+  container.remove();
+});
+
+describe('BottomCta', () => {
+  it('scrolls the composer into view when the action is pressed', () => {
+    const composer = document.createElement('div');
+    composer.id = 'hero-prompt';
+    document.body.appendChild(composer);
+    const scrollIntoView = vi.fn();
+    composer.scrollIntoView = scrollIntoView;
+
+    root = createRoot(container);
+    act(() => {
+      root!.render(createElement(BottomCta));
+    });
+
+    expect(container.textContent).toContain('Have your own idea?');
+    act(() => {
+      container.querySelector<HTMLButtonElement>('.bottom-cta-action')!.click();
+    });
+    expect(scrollIntoView).toHaveBeenCalled();
+
+    composer.remove();
+  });
+
+  it('does nothing when the composer is not on the page', () => {
+    root = createRoot(container);
+    act(() => {
+      root!.render(createElement(BottomCta));
+    });
+
+    expect(() => {
+      act(() => {
+        container.querySelector<HTMLButtonElement>('.bottom-cta-action')!.click();
+      });
+    }).not.toThrow();
+  });
+});

--- a/apps/web/src/BottomCta.tsx
+++ b/apps/web/src/BottomCta.tsx
@@ -1,0 +1,23 @@
+import { useTranslation } from 'react-i18next';
+import { PixelIcon } from './PixelIcon.js';
+
+// Fills the footer gap on short pages, nudging back to the composer.
+export function BottomCta() {
+  const { t } = useTranslation();
+
+  function scrollToComposer() {
+    document.getElementById('hero-prompt')?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+  }
+
+  return (
+    <section className="bottom-cta">
+      <div className="bottom-cta-copy">
+        <h3 className="bottom-cta-headline">{t('bottomCta.headline')}</h3>
+        <p className="bottom-cta-sub">{t('bottomCta.sub')}</p>
+      </div>
+      <button type="button" className="primary-btn bottom-cta-action" onClick={scrollToComposer}>
+        <PixelIcon name="sparkle" size={13} /> {t('bottomCta.action')}
+      </button>
+    </section>
+  );
+}

--- a/apps/web/src/CatalogRail.test.tsx
+++ b/apps/web/src/CatalogRail.test.tsx
@@ -3,7 +3,7 @@
 import { act, createElement } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { CatalogRail } from './CatalogRail.js';
+import { CatalogRail, FeaturedGame } from './CatalogRail.js';
 import type { CatalogEntry } from './catalog.js';
 import i18n from './i18n/index.js';
 
@@ -123,5 +123,58 @@ describe('RailCard hover video preview', () => {
       media.blur();
     });
     expect(container.querySelector('video')).toBeNull();
+  });
+});
+
+describe('FeaturedGame hero preview', () => {
+  function renderHero(entry: CatalogEntry) {
+    root = createRoot(container);
+    act(() => {
+      root!.render(
+        createElement(FeaturedGame, {
+          entry,
+          onPlayGame: vi.fn(),
+          onPlayTogether: vi.fn(),
+        }),
+      );
+    });
+  }
+
+  it('starts on the poster and swaps in the trailer on tap, without autoplaying', () => {
+    renderHero(withVideo);
+
+    expect(container.querySelector('img')).not.toBeNull();
+    expect(container.querySelector('video')).toBeNull();
+
+    const toggle = container.querySelector<HTMLButtonElement>('.featured-game-preview-toggle');
+    expect(toggle).not.toBeNull();
+    expect(toggle?.getAttribute('aria-pressed')).toBe('false');
+
+    act(() => toggle?.click());
+
+    const video = container.querySelector<HTMLVideoElement>('video');
+    expect(video?.getAttribute('src')).toBe('/api/games/neon-courier/media/trailer.mp4');
+    expect(container.querySelector('img')).toBeNull();
+    expect(container.querySelector('.featured-game-preview-toggle')?.getAttribute('aria-pressed')).toBe('true');
+    expect(container.querySelector('.featured-game-preview-toggle')?.classList.contains('is-playing')).toBe(true);
+  });
+
+  it('pauses back to the poster on a second tap', () => {
+    renderHero(withVideo);
+
+    const toggle = () => container.querySelector<HTMLButtonElement>('.featured-game-preview-toggle')!;
+    act(() => toggle().click());
+    expect(container.querySelector('video')).not.toBeNull();
+
+    act(() => toggle().click());
+    expect(container.querySelector('video')).toBeNull();
+    expect(container.querySelector('img')).not.toBeNull();
+    expect(toggle().getAttribute('aria-pressed')).toBe('false');
+  });
+
+  it('has no preview toggle for a game with no video', () => {
+    renderHero(withoutVideo);
+    expect(container.querySelector('.featured-game-preview-toggle')).toBeNull();
+    expect(container.querySelector('img')).not.toBeNull();
   });
 });

--- a/apps/web/src/CatalogRail.tsx
+++ b/apps/web/src/CatalogRail.tsx
@@ -252,9 +252,26 @@ function MoreLikeThisThumb({ entry }: { entry: CatalogEntry }) {
 // The curated, daily rotating hero pick above the rails.
 export function FeaturedGame({ entry, onPlayGame, onPlayTogether, moreLikeThis = [] }: FeaturedGameProps) {
   const { t } = useTranslation();
+  const videoRef = useRef<HTMLVideoElement>(null);
+  const [previewPlaying, setPreviewPlaying] = useState(false);
   const screenshots = entry.media?.screenshots ?? [];
   const selected = screenshots[defaultScreenshotIndex(screenshots)];
   const posterUrl = selected ? catalogMediaUrl(entry.slug, selected.file, 960) : undefined;
+  const videoUrl = entry.media?.video ? catalogMediaUrl(entry.slug, entry.media.video) : null;
+
+  // Tap-to-play, not autoplay — this is the page's heaviest asset.
+  useEffect(() => setPreviewPlaying(false), [entry.slug]);
+
+  function togglePreview() {
+    if (!videoUrl) return;
+    if (previewPlaying) {
+      videoRef.current?.pause();
+      setPreviewPlaying(false);
+      return;
+    }
+    setPreviewPlaying(true);
+    void Promise.resolve(videoRef.current?.play()).catch(() => setPreviewPlaying(false));
+  }
 
   return (
     <article className="featured-game">
@@ -264,7 +281,34 @@ export function FeaturedGame({ entry, onPlayGame, onPlayTogether, moreLikeThis =
           href={`${gamePath(gamePageHandle(entry), entry.slug)}?via=featured`}
           aria-label={`${entry.title} — ${t('catalog.openGame')}`}
         />
-        {posterUrl ? <img src={posterUrl} alt="" loading="eager" decoding="async" /> : null}
+        {previewPlaying && videoUrl ? (
+          <video
+            ref={videoRef}
+            className="featured-game-preview"
+            src={videoUrl}
+            poster={posterUrl}
+            muted
+            loop
+            playsInline
+            preload="auto"
+            aria-label={t('catalog.previewVideo', { title: entry.title })}
+            onPlay={() => setPreviewPlaying(true)}
+            onPause={() => setPreviewPlaying(false)}
+          />
+        ) : posterUrl ? (
+          <img src={posterUrl} alt="" loading="eager" decoding="async" />
+        ) : null}
+        {videoUrl && (
+          <button
+            type="button"
+            className={`featured-game-preview-toggle${previewPlaying ? ' is-playing' : ''}`}
+            aria-pressed={previewPlaying}
+            aria-label={previewPlaying ? t('catalog.pausePreview') : t('catalog.watchPreview')}
+            onClick={togglePreview}
+          >
+            <PixelIcon name={previewPlaying ? 'pause' : 'play'} size={previewPlaying ? 14 : 22} />
+          </button>
+        )}
       </div>
       <div className="featured-game-body">
         <span className="featured-game-kicker">

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -281,6 +281,11 @@
     "about": "About",
     "withContributions": "with contributions from"
   },
+  "bottomCta": {
+    "headline": "Have your own idea?",
+    "sub": "Describe it above and an AI agent builds it for real — live for everyone to play.",
+    "action": "Describe your idea"
+  },
   "recommendations": {
     "reasonContinue": "Continue playing",
     "reasonForYou": "Matches what you play",

--- a/apps/web/src/i18n/locales/pl.json
+++ b/apps/web/src/i18n/locales/pl.json
@@ -281,6 +281,11 @@
     "about": "O grze",
     "withContributions": "ze zmianami od"
   },
+  "bottomCta": {
+    "headline": "Masz własny pomysł?",
+    "sub": "Opisz go powyżej, a agent AI zbuduje go naprawdę — gotowego do gry dla wszystkich.",
+    "action": "Opisz swój pomysł"
+  },
   "recommendations": {
     "reasonContinue": "Kontynuuj grę",
     "reasonForYou": "Pasuje do Twoich gier",

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -1193,7 +1193,8 @@ button:disabled {
   overflow: hidden;
 }
 
-.featured-game-media img {
+.featured-game-media img,
+.featured-game-media video {
   width: 100%;
   height: 100%;
   object-fit: cover;
@@ -1209,6 +1210,42 @@ button:disabled {
 .featured-game-hit-area:focus-visible {
   outline: 3px solid var(--turquoise);
   outline-offset: -3px;
+}
+
+/* Idle: a big centered affordance over the poster, same shape a video thumbnail
+   uses everywhere else. Playing: shrinks to a small corner pause control so it
+   stops competing with the trailer it is now sitting on top of. */
+.featured-game-preview-toggle {
+  position: absolute;
+  z-index: 1;
+  display: grid;
+  place-items: center;
+  border: 1px solid rgba(255, 255, 255, 0.35);
+  border-radius: 999px;
+  color: #fff;
+  background: rgba(6, 10, 14, 0.72);
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.4);
+  cursor: pointer;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 64px;
+  height: 64px;
+}
+
+.featured-game-preview-toggle:hover,
+.featured-game-preview-toggle:focus-visible {
+  border-color: var(--turquoise);
+  color: var(--turquoise);
+}
+
+.featured-game-preview-toggle.is-playing {
+  top: 12px;
+  left: 12px;
+  transform: none;
+  width: 36px;
+  height: 36px;
+  background: rgba(6, 10, 14, 0.92);
 }
 
 .featured-game-body {
@@ -1512,6 +1549,43 @@ button:disabled {
   .rail-card {
     flex-basis: 156px;
   }
+}
+
+/* Fills the gap the sticky footer leaves above it when a page's real content
+   runs shorter than the viewport — see App.tsx for where this mounts. */
+.bottom-cta {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 20px;
+  margin-top: 48px;
+  padding: 28px 32px;
+  border: 1px solid var(--panel-border);
+  border-radius: 16px;
+  background: linear-gradient(135deg, rgba(0, 228, 172, 0.08) 0%, var(--panel-card) 100%);
+}
+
+.bottom-cta-copy {
+  min-width: 0;
+}
+
+.bottom-cta-headline {
+  margin: 0 0 4px;
+  font-size: 1.1rem;
+  font-weight: 700;
+  color: var(--text);
+}
+
+.bottom-cta-sub {
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.9rem;
+  max-width: 46ch;
+}
+
+.bottom-cta-action {
+  flex: none;
 }
 
 /* UNBOXED ARCADE CATALOG */


### PR DESCRIPTION
## Summary

Follow-up to #868 — the two items still open from live feedback:

- **Featured hero video**: it was a static poster only. Adds a tap-to-play toggle — a big centered button while idle, shrinking to a small corner pause control while playing — reusing the same `media.video` field `CatalogCard`/`RailCard` already play. Every catalog entry already has a video, so this is pure frontend wiring, no new data. Never autoplays (it's the page's heaviest single asset).
- **Bottom CTA on home and `/create`**: both pages' real content can run shorter than the viewport, and the sticky-footer layout (`.app { min-height: 100vh; display: flex; flex-direction: column }`) was leaving a bare gap above the footer as a result — confirmed live at 248px on home and 128px on `/create`. Fills it with a slim band nudging back to the composer (`#hero-prompt`) instead of leaving it empty.

## Test plan
- [x] `npm run type-check`, `eslint` on touched files, `npm run comment-prose`, full `npm test` all green (177 files / 1530 tests)
- [x] New unit tests: `FeaturedGame`'s preview toggle (poster ↔ video, pause reverts, no toggle without video) and `BottomCta` (scrolls to composer, no-op if it's not mounted)
- [x] Live Playwright verification: hero toggle screenshots (idle + playing), bottom CTA renders and its "Describe your idea" button scrolls back to the composer, on both home and `/create`

---
_Generated by [Claude Code](https://claude.ai/code/session_011NBEzZgRhyHfgBwXd8UzWm)_