### PR TITLE
Fix hero video timing, catalog-loading flash, scroll target, rail buttons, mobile logo clip

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1297,8 +1297,10 @@ export function App() {
             )}
 
             {/* Both pages' real content can run shorter than the viewport, leaving a
-                bare gap above the sticky footer — fill it with a reason to scroll back up. */}
-            {(route.view === 'home' || route.view === 'create') && <BottomCta />}
+                bare gap above the sticky footer — fill it with a reason to scroll back up.
+                Gated on the catalog for home: before it's ready, the nudge would sit right
+                under the composer with nothing in between but a loading spinner. */}
+            {(route.view === 'create' || (route.view === 'home' && catalogStatus === 'ready')) && <BottomCta />}
           </>
         )}
       </main>

--- a/apps/web/src/CatalogRail.test.tsx
+++ b/apps/web/src/CatalogRail.test.tsx
@@ -141,6 +141,8 @@ describe('FeaturedGame hero preview', () => {
   }
 
   it('starts on the poster and swaps in the trailer on tap, without autoplaying', () => {
+    // Regression guard: play must fire from an effect, after the video mounts.
+    const play = vi.spyOn(HTMLMediaElement.prototype, 'play').mockResolvedValue(undefined);
     renderHero(withVideo);
 
     expect(container.querySelector('img')).not.toBeNull();
@@ -157,6 +159,7 @@ describe('FeaturedGame hero preview', () => {
     expect(container.querySelector('img')).toBeNull();
     expect(container.querySelector('.featured-game-preview-toggle')?.getAttribute('aria-pressed')).toBe('true');
     expect(container.querySelector('.featured-game-preview-toggle')?.classList.contains('is-playing')).toBe(true);
+    expect(play).toHaveBeenCalled();
   });
 
   it('pauses back to the poster on a second tap', () => {

--- a/apps/web/src/CatalogRail.tsx
+++ b/apps/web/src/CatalogRail.tsx
@@ -165,8 +165,14 @@ function RailCard({
             <PixelIcon name="play" size={12} /> {t('catalog.play')}
           </button>
           {entry.multiplayer && onPlayTogether && (
-            <button type="button" className="secondary-btn rail-card-party" onClick={() => onPlayTogether(entry, via)}>
-              <PixelIcon name="phone" size={12} /> {t('party.playTogether')}
+            <button
+              type="button"
+              className="secondary-btn rail-card-party"
+              onClick={() => onPlayTogether(entry, via)}
+              aria-label={t('party.playTogether')}
+              title={t('party.playTogether')}
+            >
+              <PixelIcon name="phone" size={13} />
             </button>
           )}
         </div>
@@ -262,6 +268,12 @@ export function FeaturedGame({ entry, onPlayGame, onPlayTogether, moreLikeThis =
   // Tap-to-play, not autoplay — this is the page's heaviest asset.
   useEffect(() => setPreviewPlaying(false), [entry.slug]);
 
+  // The video only mounts once playing flips true — wait for that first.
+  useEffect(() => {
+    if (!previewPlaying) return;
+    void Promise.resolve(videoRef.current?.play()).catch(() => setPreviewPlaying(false));
+  }, [previewPlaying]);
+
   function togglePreview() {
     if (!videoUrl) return;
     if (previewPlaying) {
@@ -270,7 +282,6 @@ export function FeaturedGame({ entry, onPlayGame, onPlayTogether, moreLikeThis =
       return;
     }
     setPreviewPlaying(true);
-    void Promise.resolve(videoRef.current?.play()).catch(() => setPreviewPlaying(false));
   }
 
   return (

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -1413,6 +1413,11 @@ button:disabled {
   scroll-margin-top: 88px;
 }
 
+#hero-prompt {
+  /* Same reasoning — the composer headline was landing right under the header. */
+  scroll-margin-top: 88px;
+}
+
 .catalog-rail-track {
   display: flex;
   gap: 14px;
@@ -1532,16 +1537,34 @@ button:disabled {
 
 .rail-card-actions {
   display: flex;
-  flex-wrap: wrap;
+  align-items: center;
   gap: 6px;
 }
 
-.rail-card-play,
-.rail-card-party {
+.rail-card-play {
+  flex: 1 1 auto;
+  min-width: 0;
   border-radius: 8px;
   padding: 6px 14px;
   font-size: 0.75rem;
   font-weight: 700;
+  cursor: pointer;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* Icon-only: the card is too narrow (200px) to fit both labels on one row
+   without clipping one, so the accessible name lives in aria-label/title. */
+.rail-card-party {
+  flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 30px;
+  height: 30px;
+  padding: 0;
+  border-radius: 8px;
   cursor: pointer;
 }
 
@@ -3716,11 +3739,9 @@ body.player-open {
     text-overflow: ellipsis;
   }
 
-  .app-header .logo img {
+  .app-header .logo img,
+  .app-header .logo .mascot {
     flex: 0 0 auto;
-  }
-
-  .app-header .logo img {
     width: 28px;
     height: 28px;
     margin-right: 8px;
@@ -4042,7 +4063,8 @@ body.player-open {
     font-size: 1.2em;
   }
 
-  .app-header .logo img {
+  .app-header .logo img,
+  .app-header .logo .mascot {
     width: 24px;
     height: 24px;
     margin-right: 6px;


### PR DESCRIPTION
## Summary

Follow-up to #871 — five issues found on the deployed build:

- **Hero video never actually played.** `FeaturedGame`'s `togglePreview` called `videoRef.current?.play()` inline in the click handler, but the `<video>` element only mounts on the *next* render (once `previewPlaying` flips true) — so the ref was still `null` from the pre-toggle render and the call silently no-op'd. Moved the `play()` call into a `useEffect` keyed on `previewPlaying`, matching the pattern `RailCard`/`CatalogCard` already use. Verified the file itself is a well-formed, complete H.264 MP4 (walked the `moov`/`mdat` boxes byte-by-byte) — this was purely a React ref-timing bug, not a bad asset.
- **Flash of composer + CTA with no catalog between them.** `BottomCta` on home now waits for `catalogStatus === 'ready'` — previously it rendered unconditionally and could appear directly under the composer while the catalog was still showing its loading spinner.
- **Scroll target landing under the sticky header.** `#hero-prompt` (the composer, `scrollIntoView`'d by `BottomCta`'s "Describe your idea" and Studio's retry-concept flow) had no `scroll-margin-top`, so its top edge landed exactly at the header's bottom edge, and the headline was clipped underneath it. Added the same `scroll-margin-top: 88px` other jump targets already use.
- **Rail card "Zagraj"/"Zagrajcie razem" still not on one row.** The main catalog grid was fixed in #868, but `.rail-card-actions` was never touched — at the rail card's fixed 200px width, neither shrinking nor wrapping can fit both full labels without clipping one (confirmed: content alone needs ~225px against ~176px available). Made the secondary Play Together button icon-only there, with the label preserved via `aria-label`/`title` — the same trade-off `.preview-toggle` already makes at narrow widths elsewhere in this codebase.
- **Mobile header logo clipping without an ellipsis.** The two narrow-viewport rules meant to shrink the header mascot (`≤768px` and `≤360px`) targeted `.app-header .logo img` — but the mascot renders as an inline `<svg class="mascot">`, not an `<img>`, so neither rule ever matched. The icon stayed at full desktop size, eating space the wordmark needed and clipping "gamedev.pl" to "gamedev.p" with no visible ellipsis (confirmed via `scrollWidth` vs `clientWidth`). Fixed both selectors to also match `.mascot`.

## Test plan
- [x] `npm run type-check`, `eslint` on touched files, `npm run comment-prose`, full `npm test` all green (177 files / 1530 tests)
- [x] New regression test: spies on `HTMLMediaElement.prototype.play` to assert the hero toggle actually calls it (would have failed against the old inline-in-click-handler code)
- [x] Live Playwright verification of all five fixes against a local build: catalog-loading gate confirmed (0 `.bottom-cta` before ready, 1 after), scroll landing 30px clear of the header, rail card buttons on the same row, mobile logo `scrollWidth === clientWidth` (was overflowing by 14px)

---
_Generated by [Claude Code](https://claude.ai/code/session_011NBEzZgRhyHfgBwXd8UzWm)_