### PR TITLE
Bring trailer preview to touch: grid cards and rail cards, matching the hero

### DIFF
--- a/apps/web/src/ArcadeCatalog.test.tsx
+++ b/apps/web/src/ArcadeCatalog.test.tsx
@@ -187,6 +187,9 @@ describe('ArcadeCatalog lazy media', () => {
     expect(poster?.getAttribute('src')).toBe('/api/games/above-fold/media/mid.png?w=640');
     expect(container.querySelectorAll('.catalog-moment')).toHaveLength(0);
 
+    // The modifier the coarse-pointer CSS keeps visible for a tap.
+    expect(container.querySelector('.preview-toggle')?.classList.contains('preview-toggle--video')).toBe(true);
+
     await act(async () => {
       container.querySelector<HTMLButtonElement>('.preview-toggle')?.click();
       await flushEffects();

--- a/apps/web/src/ArcadeCatalog.tsx
+++ b/apps/web/src/ArcadeCatalog.tsx
@@ -330,7 +330,7 @@ function CatalogCard({
           {hasVideo && (
             <button
               type="button"
-              className="preview-toggle"
+              className="preview-toggle preview-toggle--video"
               aria-pressed={isPreviewPlaying}
               aria-label={isPreviewPlaying ? t('catalog.pausePreview') : t('catalog.watchPreview')}
               disabled={!inView}

--- a/apps/web/src/CatalogRail.test.tsx
+++ b/apps/web/src/CatalogRail.test.tsx
@@ -124,6 +124,27 @@ describe('RailCard hover video preview', () => {
     });
     expect(container.querySelector('video')).toBeNull();
   });
+
+  it('arms and disarms the trailer from the tap-only toggle, bypassing the dwell timer', () => {
+    render([withVideo]);
+
+    const toggle = () => container.querySelector<HTMLButtonElement>('.rail-card-preview-toggle')!;
+    expect(toggle()).not.toBeNull();
+    expect(container.querySelector('video')).toBeNull();
+
+    act(() => toggle().click());
+    expect(container.querySelector('video')).not.toBeNull();
+    expect(toggle().getAttribute('aria-pressed')).toBe('true');
+
+    act(() => toggle().click());
+    expect(container.querySelector('video')).toBeNull();
+    expect(toggle().getAttribute('aria-pressed')).toBe('false');
+  });
+
+  it('has no tap toggle for a card with no video', () => {
+    render([withoutVideo]);
+    expect(container.querySelector('.rail-card-preview-toggle')).toBeNull();
+  });
 });
 
 describe('FeaturedGame hero preview', () => {

--- a/apps/web/src/CatalogRail.tsx
+++ b/apps/web/src/CatalogRail.tsx
@@ -109,6 +109,16 @@ function RailCard({
     }
   }
 
+  // Touch-only tap target (CSS-gated) — hover never fires on a finger.
+  function toggleTap() {
+    if (previewArmed) {
+      disarm();
+      return;
+    }
+    clearHoverIntent();
+    setPreviewArmed(true);
+  }
+
   return (
     <article className="rail-card">
       <div
@@ -156,6 +166,17 @@ function RailCard({
           <span className="rail-card-party-badge">
             <PixelIcon name="phone" size={11} /> {t('party.playersBadge', { max: entry.multiplayer.maxPlayers })}
           </span>
+        )}
+        {hasVideo && (
+          <button
+            type="button"
+            className="rail-card-preview-toggle"
+            aria-pressed={previewArmed}
+            aria-label={previewArmed ? t('catalog.pausePreview') : t('catalog.watchPreview')}
+            onClick={toggleTap}
+          >
+            <PixelIcon name={previewArmed ? 'pause' : 'play'} size={12} />
+          </button>
         )}
       </div>
       <div className="rail-card-body">

--- a/apps/web/src/styles.catalogGrid.test.ts
+++ b/apps/web/src/styles.catalogGrid.test.ts
@@ -29,8 +29,8 @@ describe('catalog grid layout', () => {
     expect(ruleBody('.catalog-media')).toMatch(/aspect-ratio:\s*16\s*\/\s*9/);
   });
 
-  it('hides trailer/moment chrome on coarse pointers so cards keep one Play CTA', () => {
-    const rule = css.match(/\.preview-toggle\s*,\s*\.catalog-moments\s*\{([\s\S]*?)\}/);
+  it('hides the moments-only toggle on coarse pointers, but keeps the video one tappable', () => {
+    const rule = css.match(/\.preview-toggle:not\(\.preview-toggle--video\)\s*,\s*\.catalog-moments\s*\{([\s\S]*?)\}/);
     expect(rule, 'missing combined preview-toggle/catalog-moments hide rule').not.toBeNull();
     expect(rule![1]).toMatch(/display:\s*none/);
     // Same rule lives under the coarse/phone media query (look behind a short window).

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -1518,6 +1518,32 @@ button:disabled {
   white-space: nowrap;
 }
 
+/* Hidden by default — hover already arms the preview on a mouse. Shown only
+   where hover never fires, same reasoning as .preview-toggle on the grid. */
+.rail-card-preview-toggle {
+  display: none;
+}
+
+@media (pointer: coarse), (max-width: 768px) {
+  .rail-card-preview-toggle {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    position: absolute;
+    z-index: 1;
+    bottom: 8px;
+    right: 8px;
+    width: 28px;
+    height: 28px;
+    padding: 0;
+    border: 1px solid rgba(255, 255, 255, 0.3);
+    border-radius: 999px;
+    color: #fff;
+    background: rgba(6, 10, 14, 0.92);
+    cursor: pointer;
+  }
+}
+
 .rail-card-body {
   display: flex;
   flex-direction: column;
@@ -2136,12 +2162,12 @@ button:disabled {
   text-transform: uppercase;
 }
 
-/* Phone / coarse pointer: the card already has a primary Zagraj CTA. A second 44px
-   play circle for trailer preview (plus moment thumbs) stacked the AI disclosure over
-   gameplay HUDs and read as two competing Play affordances. Hover-to-preview is a
-   mouse behaviour — on a finger, leave the art alone and keep only the disclosures. */
+/* Phone / coarse pointer: hover-to-preview is a mouse behaviour, so a finger gets an
+   explicit tap target instead — the hero's single tap-to-play button, reused here.
+   The moments-only toggle stays hidden: that is the second, lower-value affordance
+   that used to stack with the video one and read as competing Play buttons. */
 @media (pointer: coarse), (max-width: 768px) {
-  .preview-toggle,
+  .preview-toggle:not(.preview-toggle--video),
   .catalog-moments {
     display: none;
   }


### PR DESCRIPTION
## Summary

Nit from live feedback on #872: the hero's tap-to-play video works on mobile, but grid and rail cards' trailer previews don't — hover never fires on a finger, and the existing coarse-pointer rule hid the whole `.preview-toggle` (video + moments-only variants together) to avoid two competing Play buttons stacking on one card. Now that the hero has proven a single, unambiguous tap-to-play button works cleanly, extends the same idea to both card types instead of leaving touch with no trailer preview at all.

- **Grid cards (`CatalogCard`)**: the video toggle now carries a `preview-toggle--video` modifier and stays visible on coarse pointers. Only the moments-only toggle — the second, lower-value affordance that caused the original stacking problem — stays hidden there.
- **Rail cards (`RailCard`)**: had no touch affordance at all before (mouse hover + keyboard focus only). Adds a small icon-only tap toggle, shown only on coarse pointers, that arms/disarms the trailer immediately — no dwell timer, since an explicit tap isn't incidental hover the way a finger resting on a scrolling rail can be.

## Test plan
- [x] `npm run type-check`, `eslint` on touched files, `npm run comment-prose`, full `npm test` all green (177 files / 1532 tests)
- [x] Updated the existing coarse-pointer CSS regression test for the new selector, and added new tests: grid toggle carries the `--video` modifier, rail card's tap toggle arms/disarms and is absent without video
- [x] Live Playwright verification with a real touch-emulated mobile context (390×844, `hasTouch`/`isMobile`): grid toggle visible and tappable (video mounts after tap), moments-only toggle stays hidden (0 visible), rail card's tap toggle visible and tappable (video mounts after tap)

---
_Generated by [Claude Code](https://claude.ai/code/session_011NBEzZgRhyHfgBwXd8UzWm)_