### PR TITLE
Fix Studio share popover hidden under the play canvas

### DIFF
--- a/apps/web/src/CreatorStudioView.tsx
+++ b/apps/web/src/CreatorStudioView.tsx
@@ -427,9 +427,7 @@ export function CreatorStudioView({
     return () => document.body.classList.remove('player-open');
   }, [theaterOpen]);
 
-  // The theater's fixed full-viewport surface sits above the strip (z-index 1000 vs.
-  // the popover's 40) — an open share popover would be pinned underneath it, present
-  // but unreachable. Close it rather than chase the theater's stacking context.
+  // Theater z-index (1000) buries the popover (40) — close it instead.
   useEffect(() => {
     if (theaterOpen) setShareMenuOpen(false);
   }, [theaterOpen]);

--- a/apps/web/src/CreatorStudioView.tsx
+++ b/apps/web/src/CreatorStudioView.tsx
@@ -427,6 +427,13 @@ export function CreatorStudioView({
     return () => document.body.classList.remove('player-open');
   }, [theaterOpen]);
 
+  // The theater's fixed full-viewport surface sits above the strip (z-index 1000 vs.
+  // the popover's 40) — an open share popover would be pinned underneath it, present
+  // but unreachable. Close it rather than chase the theater's stacking context.
+  useEffect(() => {
+    if (theaterOpen) setShareMenuOpen(false);
+  }, [theaterOpen]);
+
   // A game switch starts every per-game bit of stage state fresh. The very first
   // resolution applies the deep link's posture (if any); every later switch — the
   // creator picking a different game — always starts back in watch.
@@ -998,7 +1005,8 @@ export function CreatorStudioView({
                           onImproved={(newToken) => setHandoffToken(newToken)}
                           onDisplayedOriginChange={setDisplayedOrigin}
                           editorPushRef={editorPushRef}
-                           onEditorControllerChange={setEditorController}                        />
+                          onEditorControllerChange={setEditorController}
+                        />
 
                         {stageStatus.kind === 'empty' &&
                         !stageSource.html &&


### PR DESCRIPTION
## Summary
- The Studio header's share popover (`.studio-head-share-popover`, `z-index: 40`) shares a stacking context with the game theater. When the theater opens (`.stage.is-playing-full-viewport`, `position: fixed; z-index: 1000`), it painted over the popover — leaving it mounted but visually buried under the play canvas, matching the reported screenshots.
- Close the share popover whenever the theater opens, since an open share dropdown behind a fullscreen game player isn't reachable or meaningful anyway.

## Test plan
- [x] `vitest run CreatorStudioView.test` — all 54 tests pass
- [x] Manual code trace confirming `.studio-head-share-popover` (z-index 40) vs. `.stage.is-playing-full-viewport` (z-index 1000) stacking conflict

---
_Generated by [Claude Code](https://claude.ai/code/session_01KCYPVyqXCEFAuF3bqAe8yf)_