### PR TITLE
Gate BottomCta on catalog readiness for /create too, not just home

### DIFF
--- a/apps/web/src/App.bottomCta.test.ts
+++ b/apps/web/src/App.bottomCta.test.ts
@@ -1,0 +1,101 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from 'react';
+import { createRoot } from 'react-dom/client';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { App } from './App.js';
+import { AuthProvider } from './AuthContext.js';
+import i18n from './i18n/index.js';
+
+// BottomCta must wait for the catalog, on home and /create alike.
+
+async function flushEffects() {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((r) => (resolve = r));
+  return { promise, resolve };
+}
+
+async function renderApp() {
+  (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  await i18n.changeLanguage('en');
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  await act(async () => {
+    root.render(createElement(AuthProvider, null, createElement(App)));
+    await flushEffects();
+  });
+  return { container, root };
+}
+
+describe('BottomCta gated on catalog readiness', () => {
+  afterEach(() => {
+    document.body.innerHTML = '';
+    localStorage.clear();
+    window.history.pushState(null, '', '/');
+    vi.restoreAllMocks();
+  });
+
+  function mockApiWithDeferredCatalog() {
+    const catalogGate = deferred<Response>();
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async (input) => {
+      const url = String(input);
+      if (url.endsWith('/api/auth/me')) {
+        return new Response(JSON.stringify({ user: null }), { status: 401 });
+      }
+      if (url.endsWith('/api/health')) {
+        return new Response(JSON.stringify({ status: 'ok', provider: 'mock', privateBeta: false }));
+      }
+      if (url.endsWith('/api/catalog')) {
+        return catalogGate.promise;
+      }
+      if (url.includes('/api/recommendations')) {
+        return new Response(JSON.stringify({ items: [] }));
+      }
+      return new Response(JSON.stringify({}), { status: 404 });
+    });
+    return catalogGate;
+  }
+
+  it('waits for the catalog on home', async () => {
+    const catalogGate = mockApiWithDeferredCatalog();
+    const { container, root } = await renderApp();
+
+    expect(container.querySelector('#hero-prompt')).not.toBeNull();
+    expect(container.querySelector('.bottom-cta')).toBeNull();
+
+    await act(async () => {
+      catalogGate.resolve(new Response(JSON.stringify([])));
+      await flushEffects();
+      await flushEffects();
+    });
+
+    expect(container.querySelector('.bottom-cta')).not.toBeNull();
+
+    await act(async () => root.unmount());
+  });
+
+  it('waits for the catalog on /create too', async () => {
+    const catalogGate = mockApiWithDeferredCatalog();
+    window.history.pushState(null, '', '/create');
+    const { container, root } = await renderApp();
+
+    expect(container.querySelector('#hero-prompt')).not.toBeNull();
+    expect(container.querySelector('.bottom-cta')).toBeNull();
+
+    await act(async () => {
+      catalogGate.resolve(new Response(JSON.stringify([])));
+      await flushEffects();
+      await flushEffects();
+    });
+
+    expect(container.querySelector('.bottom-cta')).not.toBeNull();
+
+    await act(async () => root.unmount());
+  });
+});

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1298,9 +1298,8 @@ export function App() {
 
             {/* Both pages' real content can run shorter than the viewport, leaving a
                 bare gap above the sticky footer — fill it with a reason to scroll back up.
-                Gated on the catalog for home: before it's ready, the nudge would sit right
-                under the composer with nothing in between but a loading spinner. */}
-            {(route.view === 'create' || (route.view === 'home' && catalogStatus === 'ready')) && <BottomCta />}
+                Gated on the catalog on both: /create's showcase rail is catalog data too. */}
+            {(route.view === 'home' || route.view === 'create') && catalogStatus === 'ready' && <BottomCta />}
           </>
         )}
       </main>


### PR DESCRIPTION
## Summary

Follow-up nit: #872 fixed the composer→CTA→footer flash on home by waiting for `catalogStatus === 'ready'` before rendering `BottomCta`, but left `/create` unconditional. `/create`'s own showcase rail (`CatalogRail` fed by `catalogEntries`) is catalog data too — before that fetch resolves it renders nothing, so the same flash was still there: the CTA band and footer briefly appearing right under the composer with no showcase content between them.

Now `BottomCta` waits for the catalog on both routes:
```tsx
{(route.view === 'home' || route.view === 'create') && catalogStatus === 'ready' && <BottomCta />}
```

## Test plan
- [x] `npm run type-check`, `eslint`, `npm run comment-prose`, full `npm test` all green (178 files / 1534 tests)
- [x] New test file `App.bottomCta.test.ts`: deferred `/api/catalog` response, asserts `.bottom-cta` is absent while pending and appears once resolved — on both home and `/create`

---
_Generated by [Claude Code](https://claude.ai/code/session_011NBEzZgRhyHfgBwXd8UzWm)_