### PR TITLE
polish: promote Play Together as the primary rail-card action

### DIFF
--- a/apps/web/src/CatalogRail.tsx
+++ b/apps/web/src/CatalogRail.tsx
@@ -182,13 +182,19 @@ function RailCard({
       <div className="rail-card-body">
         <h4 className="rail-card-title">{entry.title}</h4>
         <div className="rail-card-actions">
-          <button type="button" className="primary-btn rail-card-play" onClick={() => onPlayGame(entry, via)}>
+          <button
+            type="button"
+            className={
+              entry.multiplayer && onPlayTogether ? 'secondary-btn rail-card-play' : 'primary-btn rail-card-play'
+            }
+            onClick={() => onPlayGame(entry, via)}
+          >
             <PixelIcon name="play" size={12} /> {t('catalog.play')}
           </button>
           {entry.multiplayer && onPlayTogether && (
             <button
               type="button"
-              className="secondary-btn rail-card-party"
+              className="primary-btn rail-card-party"
               onClick={() => onPlayTogether(entry, via)}
               aria-label={t('party.playTogether')}
               title={t('party.playTogether')}

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -1183,7 +1183,7 @@
     "pageHeadline": "One screen, everyone's phone",
     "pageSubhead": "Pick a game, share the code, and every phone in the room becomes a controller — no app to install, no account to make.",
     "diagramAlt": "Three phones, each a different color, each moving its own matching-colored character on the shared screen.",
-    "diagramCaption": "Each phone only moves its own character — same color, same button, same direction.",
+    "diagramCaption": "Each phone only moves its own character — same color, button, direction.",
     "diagramPhonesLabel": "Your phones",
     "howHeading": "How it works",
     "step1Title": "Open a game",

--- a/apps/web/src/i18n/locales/pl.json
+++ b/apps/web/src/i18n/locales/pl.json
@@ -1195,7 +1195,7 @@
     "pageHeadline": "Jeden ekran, telefon każdego gracza",
     "pageSubhead": "Wybierz grę, udostępnij kod, a każdy telefon w pokoju staje się kontrolerem — bez instalowania aplikacji, bez zakładania konta.",
     "diagramAlt": "Trzy telefony, każdy w innym kolorze, każdy porusza swoją postacią w tym samym kolorze na wspólnym ekranie.",
-    "diagramCaption": "Każdy telefon porusza tylko swoją postacią — ten sam kolor, ten sam przycisk, ten sam kierunek.",
+    "diagramCaption": "Każdy telefon porusza tylko swoją postacią — ten sam kolor, przycisk, kierunek.",
     "diagramPhonesLabel": "Wasze telefony",
     "howHeading": "Jak to działa",
     "step1Title": "Otwórz grę",


### PR DESCRIPTION
## Summary

- On any catalog rail card that offers both actions, the multiplayer "Play together" button is now the prominent `primary-btn` and solo "Play" becomes the outlined `secondary-btn` — matches the site's emphasis on party mode over solo play for these games.
- Trims the `/party` diagram caption (English and Polish) by a couple of words so it fits on one line at narrow mobile widths instead of wrapping.

## Test plan

- [x] `npx tsc --noEmit -p .` — clean
- [x] `npx eslint src/CatalogRail.tsx --max-warnings 0` — clean
- [x] `npx vitest run src/CatalogRail.test.tsx src/ArcadeCatalog.test.tsx src/PartyPage.test.tsx` — 33 tests pass
- [x] Verified visually with Playwright screenshots (desktop rail cards, mobile `/party` diagram caption)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BamcxDavd42EQLFTg2H8m9)_