### PR TITLE
Add compact mode with overflow menu for mobile Studio strip

### DIFF
--- a/apps/web/src/CreatorStudioView.tsx
+++ b/apps/web/src/CreatorStudioView.tsx
@@ -951,6 +951,7 @@ export function CreatorStudioView({
                         onClaim={() => setClaimOpen(true)}
                         shareSlot={shareSlot}
                         onOpenTheater={() => setTheaterOpen(true)}
+                        isCompact={shelfIsDrawer}
                       />
 
                       {theaterOpen ? (
@@ -998,7 +999,8 @@ export function CreatorStudioView({
                           onImproved={(newToken) => setHandoffToken(newToken)}
                           onDisplayedOriginChange={setDisplayedOrigin}
                           editorPushRef={editorPushRef}
-                           onEditorControllerChange={setEditorController}                        />
+                          onEditorControllerChange={setEditorController}
+                        />
 
                         {stageStatus.kind === 'empty' &&
                         !stageSource.html &&

--- a/apps/web/src/CreatorStudioView.tsx
+++ b/apps/web/src/CreatorStudioView.tsx
@@ -96,9 +96,10 @@ const WINDOWS = [1, 7, 30];
  */
 const SHEET_MAX_WIDTH = 1099;
 const SHEET_QUERY = `(max-width: ${SHEET_MAX_WIDTH}px)`;
-/** Matches the phone drawer breakpoint in styles.css — shelf off-canvas when a game is open. */
+// Matches styles.css. Height too: a landscape phone clears the width alone.
 const SHELF_DRAWER_MAX_WIDTH = 800;
-const SHELF_DRAWER_QUERY = `(max-width: ${SHELF_DRAWER_MAX_WIDTH}px)`;
+const SHELF_DRAWER_MAX_HEIGHT = 500;
+const SHELF_DRAWER_QUERY = `(max-width: ${SHELF_DRAWER_MAX_WIDTH}px), (max-height: ${SHELF_DRAWER_MAX_HEIGHT}px)`;
 
 type NavigateOptions = { replace?: boolean };
 
@@ -536,7 +537,12 @@ export function CreatorStudioView({
 
   useEffect(() => {
     const query = typeof window.matchMedia === 'function' ? window.matchMedia(SHELF_DRAWER_QUERY) : null;
-    const sync = () => setShelfIsDrawer(query ? query.matches : window.innerWidth <= SHELF_DRAWER_MAX_WIDTH);
+    const sync = () =>
+      setShelfIsDrawer(
+        query
+          ? query.matches
+          : window.innerWidth <= SHELF_DRAWER_MAX_WIDTH || window.innerHeight <= SHELF_DRAWER_MAX_HEIGHT,
+      );
     sync();
     query?.addEventListener('change', sync);
     window.addEventListener('resize', sync);
@@ -952,6 +958,7 @@ export function CreatorStudioView({
                         shareSlot={shareSlot}
                         onOpenTheater={() => setTheaterOpen(true)}
                         isCompact={shelfIsDrawer}
+                        onExit={() => onNavigate('/')}
                       />
 
                       {theaterOpen ? (

--- a/apps/web/src/StudioStrip.tsx
+++ b/apps/web/src/StudioStrip.tsx
@@ -58,6 +58,8 @@ export type StudioStripProps = {
   onOpenTheater?: () => void;
   // ≤800px (shelfIsDrawer): fold secondary actions behind a ⋯ menu.
   isCompact?: boolean;
+  // Replaces the global header's back arrow, hidden below 800px.
+  onExit?: () => void;
 };
 
 export function StudioStrip({
@@ -86,6 +88,7 @@ export function StudioStrip({
   shareSlot,
   onOpenTheater,
   isCompact = false,
+  onExit,
 }: StudioStripProps) {
   const { t, i18n } = useTranslation();
   const [overflowOpen, setOverflowOpen] = useState(false);
@@ -134,6 +137,12 @@ export function StudioStrip({
 
   return (
     <header className="studio-strip">
+      {isCompact && onExit ? (
+        <button type="button" className="studio-strip-exit" onClick={onExit} aria-label={t('studioPanel.strip.exit')}>
+          <PixelIcon name="arrowLeft" size={16} />
+        </button>
+      ) : null}
+
       <button
         type="button"
         className="studio-shelf-open"

--- a/apps/web/src/StudioStrip.tsx
+++ b/apps/web/src/StudioStrip.tsx
@@ -1,4 +1,4 @@
-import { useEffect, type ReactNode, type RefObject } from 'react';
+import { useEffect, useRef, useState, type ReactNode, type RefObject } from 'react';
 import { useTranslation } from 'react-i18next';
 import { PixelIcon } from './PixelIcon.js';
 import { formatRelativeTime } from './relativeTime.js';
@@ -56,6 +56,8 @@ export type StudioStripProps = {
    * studio-game-first-implementation-plan.md's follow-up: the stage's own play posture
    * is Studio's lighter theater, and this is the way to the site's fuller one. */
   onOpenTheater?: () => void;
+  // ≤800px (shelfIsDrawer): fold secondary actions behind a ⋯ menu.
+  isCompact?: boolean;
 };
 
 export function StudioStrip({
@@ -83,8 +85,12 @@ export function StudioStrip({
   onClaim,
   shareSlot,
   onOpenTheater,
+  isCompact = false,
 }: StudioStripProps) {
   const { t, i18n } = useTranslation();
+  const [overflowOpen, setOverflowOpen] = useState(false);
+  const overflowRef = useRef<HTMLDivElement>(null);
+  const overflowTriggerRef = useRef<HTMLButtonElement>(null);
 
   // The D.15 denominator (CE-01): recorded where the door itself renders, not where
   // the surface behind it mounts — otherwise "offered" only ever fires alongside
@@ -92,6 +98,31 @@ export function StudioStrip({
   useEffect(() => {
     if (codeAvailable) recordCodeStep('offered');
   }, [codeAvailable]);
+
+  useEffect(() => {
+    if (!isCompact) setOverflowOpen(false);
+  }, [isCompact]);
+
+  useEffect(() => {
+    if (!overflowOpen) return;
+    const onKey = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        setOverflowOpen(false);
+        overflowTriggerRef.current?.focus();
+      }
+    };
+    // Same idiom as the share popover: outside tap closes it.
+    const onPointerDown = (event: PointerEvent) => {
+      if (overflowRef.current?.contains(event.target as Node)) return;
+      setOverflowOpen(false);
+    };
+    window.addEventListener('keydown', onKey);
+    document.addEventListener('pointerdown', onPointerDown);
+    return () => {
+      window.removeEventListener('keydown', onKey);
+      document.removeEventListener('pointerdown', onPointerDown);
+    };
+  }, [overflowOpen]);
 
   const heartbeatAt = latestAgentActivityAt(status);
   const showPhasePill = Boolean(status && HEARTBEAT_STATES.has(status.status));
@@ -129,7 +160,7 @@ export function StudioStrip({
       <div className="studio-strip-spacer" />
 
       <div className="studio-strip-actions">
-        {editAvailable ? (
+        {editAvailable && !isCompact ? (
           <button
             type="button"
             className={`studio-head-action is-icon-only${editActive ? ' is-active' : ''}`}
@@ -156,7 +187,7 @@ export function StudioStrip({
           </button>
         ) : null}
 
-        {canClaim ? (
+        {canClaim && !isCompact ? (
           <button
             type="button"
             className="studio-head-action is-icon-only studio-head-action--claim"
@@ -181,7 +212,7 @@ export function StudioStrip({
           </span>
         </button>
 
-        {onOpenTheater ? (
+        {onOpenTheater && !isCompact ? (
           <button
             type="button"
             className="studio-head-action is-icon-only"
@@ -195,35 +226,141 @@ export function StudioStrip({
           </button>
         ) : null}
 
-        {shareSlot}
+        {!isCompact ? shareSlot : null}
 
-        <button
-          type="button"
-          className={`studio-head-action is-icon-only${detailsActive ? ' is-active' : ''}`}
-          aria-pressed={detailsActive}
-          aria-label={t('studioPanel.tabs.details')}
-          onClick={onToggleDetails}
-        >
-          <PixelIcon name="panel" size={12} />{' '}
-          <span className="studio-head-action-label">{t('studioPanel.tabs.details')}</span>
-        </button>
+        {!isCompact ? (
+          <button
+            type="button"
+            className={`studio-head-action is-icon-only${detailsActive ? ' is-active' : ''}`}
+            aria-pressed={detailsActive}
+            aria-label={t('studioPanel.tabs.details')}
+            onClick={onToggleDetails}
+          >
+            <PixelIcon name="panel" size={12} />{' '}
+            <span className="studio-head-action-label">{t('studioPanel.tabs.details')}</span>
+          </button>
+        ) : null}
 
-        <button
-          type="button"
-          className={`studio-head-action studio-head-action--chat${threadOpen ? ' is-active' : ''}`}
-          aria-pressed={threadOpen}
-          aria-label={t(threadOpen ? 'studioPanel.rail.closeThread' : 'studioPanel.rail.openThread')}
-          title={t(threadOpen ? 'studioPanel.rail.closeThread' : 'studioPanel.rail.openThread')}
-          onClick={onToggleThread}
-        >
-          <PixelIcon name="chat" size={12} />
-          <span className="studio-head-action-label">{t('studioPanel.rail.chat')}</span>
-          {threadUnreadCount > 0 ? (
-            <span className="studio-chat-unread-badge" aria-hidden="true">
-              {threadUnreadCount > 99 ? '99+' : threadUnreadCount}
-            </span>
-          ) : null}
-        </button>
+        {!isCompact ? (
+          <button
+            type="button"
+            className={`studio-head-action studio-head-action--chat${threadOpen ? ' is-active' : ''}`}
+            aria-pressed={threadOpen}
+            aria-label={t(threadOpen ? 'studioPanel.rail.closeThread' : 'studioPanel.rail.openThread')}
+            title={t(threadOpen ? 'studioPanel.rail.closeThread' : 'studioPanel.rail.openThread')}
+            onClick={onToggleThread}
+          >
+            <PixelIcon name="chat" size={12} />
+            <span className="studio-head-action-label">{t('studioPanel.rail.chat')}</span>
+            {threadUnreadCount > 0 ? (
+              <span className="studio-chat-unread-badge" aria-hidden="true">
+                {threadUnreadCount > 99 ? '99+' : threadUnreadCount}
+              </span>
+            ) : null}
+          </button>
+        ) : null}
+
+        {isCompact ? (
+          <div className="studio-head-menu" ref={overflowRef}>
+            <button
+              type="button"
+              ref={overflowTriggerRef}
+              className={`studio-head-action is-icon-only${overflowOpen ? ' is-active' : ''}`}
+              aria-haspopup="menu"
+              aria-expanded={overflowOpen}
+              aria-label={t('studioPanel.strip.moreActions')}
+              onClick={() => setOverflowOpen((open) => !open)}
+            >
+              <PixelIcon name="menu" size={12} />{' '}
+              <span className="studio-head-action-label">{t('studioPanel.strip.moreActions')}</span>
+            </button>
+            {overflowOpen ? (
+              <div className="studio-head-menu-popover" role="menu" aria-label={t('studioPanel.strip.moreActions')}>
+                {editAvailable ? (
+                  <button
+                    type="button"
+                    role="menuitem"
+                    className={`studio-head-menu-item${editActive ? ' is-active' : ''}`}
+                    aria-pressed={editActive}
+                    onClick={() => {
+                      setOverflowOpen(false);
+                      onToggleEdit();
+                    }}
+                  >
+                    <PixelIcon name="pencil" size={14} />
+                    <span>{t('studioPanel.tabs.edit')}</span>
+                  </button>
+                ) : null}
+
+                {canClaim ? (
+                  <button
+                    type="button"
+                    role="menuitem"
+                    className="studio-head-menu-item"
+                    onClick={() => {
+                      setOverflowOpen(false);
+                      onClaim();
+                    }}
+                  >
+                    <PixelIcon name="sparkle" size={14} />
+                    <span>{t('creatorProfile.publishGateTitle')}</span>
+                  </button>
+                ) : null}
+
+                {onOpenTheater ? (
+                  <button
+                    type="button"
+                    role="menuitem"
+                    className="studio-head-menu-item"
+                    disabled={stageEmpty}
+                    onClick={() => {
+                      setOverflowOpen(false);
+                      onOpenTheater();
+                    }}
+                  >
+                    <PixelIcon name="gamepad" size={14} />
+                    <span>{t('studioPanel.stage.openTheater')}</span>
+                  </button>
+                ) : null}
+
+                {shareSlot}
+
+                <button
+                  type="button"
+                  role="menuitem"
+                  className={`studio-head-menu-item${detailsActive ? ' is-active' : ''}`}
+                  aria-pressed={detailsActive}
+                  onClick={() => {
+                    setOverflowOpen(false);
+                    onToggleDetails();
+                  }}
+                >
+                  <PixelIcon name="panel" size={14} />
+                  <span>{t('studioPanel.tabs.details')}</span>
+                </button>
+
+                <button
+                  type="button"
+                  role="menuitem"
+                  className={`studio-head-menu-item${threadOpen ? ' is-active' : ''}`}
+                  aria-pressed={threadOpen}
+                  onClick={() => {
+                    setOverflowOpen(false);
+                    onToggleThread();
+                  }}
+                >
+                  <PixelIcon name="chat" size={14} />
+                  <span>{t('studioPanel.rail.chat')}</span>
+                  {threadUnreadCount > 0 ? (
+                    <span className="studio-chat-unread-badge" aria-hidden="true">
+                      {threadUnreadCount > 99 ? '99+' : threadUnreadCount}
+                    </span>
+                  ) : null}
+                </button>
+              </div>
+            ) : null}
+          </div>
+        ) : null}
       </div>
     </header>
   );

--- a/apps/web/src/StudioStrip.tsx
+++ b/apps/web/src/StudioStrip.tsx
@@ -173,7 +173,7 @@ export function StudioStrip({
           </button>
         ) : null}
 
-        {codeAvailable ? (
+        {codeAvailable && !isCompact ? (
           // Visible label like Play's: the bare glyph read as decoration.
           <button
             type="button"
@@ -276,6 +276,22 @@ export function StudioStrip({
             </button>
             {overflowOpen ? (
               <div className="studio-head-menu-popover" role="menu" aria-label={t('studioPanel.strip.moreActions')}>
+                {codeAvailable ? (
+                  <button
+                    type="button"
+                    role="menuitem"
+                    className={`studio-head-menu-item${codeActive ? ' is-active' : ''}`}
+                    aria-pressed={codeActive}
+                    onClick={() => {
+                      setOverflowOpen(false);
+                      onToggleCode();
+                    }}
+                  >
+                    <PixelIcon name="code" size={14} />
+                    <span>{t('studioPanel.tabs.code')}</span>
+                  </button>
+                ) : null}
+
                 {editAvailable ? (
                   <button
                     type="button"

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -345,6 +345,9 @@
       "edit": "Edit",
       "code": "Code"
     },
+    "strip": {
+      "moreActions": "More"
+    },
     "code": {
       "back": "Thread",
       "filePicker": "Choose file",

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -346,7 +346,8 @@
       "code": "Code"
     },
     "strip": {
-      "moreActions": "More"
+      "moreActions": "More",
+      "exit": "Leave Studio"
     },
     "code": {
       "back": "Thread",

--- a/apps/web/src/i18n/locales/pl.json
+++ b/apps/web/src/i18n/locales/pl.json
@@ -348,7 +348,8 @@
       "code": "Kod"
     },
     "strip": {
-      "moreActions": "Więcej"
+      "moreActions": "Więcej",
+      "exit": "Opuść Studio"
     },
     "code": {
       "back": "Wątek",

--- a/apps/web/src/i18n/locales/pl.json
+++ b/apps/web/src/i18n/locales/pl.json
@@ -347,6 +347,9 @@
       "edit": "Edytuj",
       "code": "Kod"
     },
+    "strip": {
+      "moreActions": "Więcej"
+    },
     "code": {
       "back": "Wątek",
       "filePicker": "Wybierz plik",

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -7181,8 +7181,14 @@ a.user-name--profile:focus-visible {
 
    800px, not 900, because that is where the studio itself changes shape: below it the
    shelf becomes a drawer and the open-shelf control joins the title row. Between 801 and
-   900 the shelf is still a column beside the thread. */
-@media (max-width: 800px) {
+   900 the shelf is still a column beside the thread.
+
+   Height joins width for the same reason a landscape phone joins portrait: 844×390 clears
+   800px but has no more room than 390×844 turned sideways — the desktop shell (sidebar +
+   inline strip) doesn't fit either way and just wraps everywhere instead. The min-width
+   companion block below stays the exact complement (801px AND 501px) so the two can never
+   both match the same viewport. */
+@media (max-width: 800px), (max-height: 500px) {
   /* Every wrapper between the shell and the transcript has to give up its height, or the
      scroller at the bottom of the chain has nothing to measure itself against. */
   .app:has(.studio-layout.is-game-open) .studio-panel,
@@ -7377,8 +7383,12 @@ a.user-name--profile:focus-visible {
    scroller, composer pinned above the bottom. Turn prose keeps its own 68ch measure.
 
    The shell itself — the window-owning, footer-hiding, banner-reflowing part — is
-   above, outside any media query, and shared with the phone. */
-@media (min-width: 801px) {
+   above, outside any media query, and shared with the phone.
+
+   min-height 501px joins min-width 801px so this stays the exact complement of the
+   phone block's `(max-width: 800px), (max-height: 500px)` — a short landscape phone
+   must never match both. */
+@media (min-width: 801px) and (min-height: 501px) {
   .app:has(.studio-layout.is-game-open) > .content {
     max-width: none;
     padding: 0;
@@ -14445,6 +14455,34 @@ button.builder-mode-selector:disabled {
   font-weight: 700;
 }
 
+/* The strip's own back arrow — only rendered (see StudioStrip.tsx) once the
+   global header's is hidden below 800px/500px, so there is no toggle to pair
+   with a shown/hidden state here, just a fixed-size peer for the folder icon. */
+.studio-strip-exit {
+  display: inline-flex;
+  flex: none;
+  align-items: center;
+  justify-content: center;
+  width: 44px;
+  height: 44px;
+  padding: 0;
+  border: none;
+  border-radius: 10px;
+  background: transparent;
+  color: var(--text);
+  cursor: pointer;
+}
+
+.studio-strip-exit:hover {
+  color: var(--turquoise);
+  background: rgba(0, 228, 172, 0.08);
+}
+
+.studio-strip-exit:focus-visible {
+  outline: 2px solid var(--turquoise);
+  outline-offset: 2px;
+}
+
 /* Expand/collapse on the shelf itself (desktop rail ↔ full list, phone drawer close). */
 .studio-shelf-edge-toggle {
   display: none;
@@ -14511,27 +14549,31 @@ button.builder-mode-selector:disabled {
   box-shadow: 0 0 0 2px var(--panel);
 }
 
-/* A game open in Studio on a phone already has its own back-arrow-equivalent
-   (the strip's folder button, for switching games) and its own action row —
-   the site chrome above it was a second, redundant nav bar competing for the
-   same few hundred px. Collapse it to just the "leave Studio" back arrow;
-   logo, nav links, avatar, bell, and hamburger all wait behind that tap. */
-@media (max-width: 800px) {
+/* A game open in Studio on a phone already has its own back-arrow-equivalent —
+   the strip's folder button opens the same shelf `navUpTarget` sends "Up" to for
+   a selected game (see router.ts), just as an in-page drawer instead of a URL
+   change. The site chrome above it was a second, fully redundant nav bar eating
+   a whole row for a control the strip already offers. Drop the bar entirely
+   rather than shrink it to a lone arrow — a one-row header beats a two-row one
+   with an empty second row. The strip picks up the safe-area inset this bar
+   used to pay. */
+@media (max-width: 800px), (max-height: 500px) {
   .app:has(.studio-layout.is-game-open) .app-header {
-    gap: 0;
+    display: none;
   }
 
-  .app:has(.studio-layout.is-game-open) .app-header .logo,
-  .app:has(.studio-layout.is-game-open) .app-header .header-nav,
-  .app:has(.studio-layout.is-game-open) .app-header .header-actions {
-    display: none;
+  .app:has(.studio-layout.is-game-open) .studio-strip {
+    padding-top: max(8px, env(safe-area-inset-top));
   }
 }
 
 /* 5+ games on a desktop: collapse to a left-edge folder+badge after selection.
    Width matches the header mascot column, so the rail and the logo share one vertical
-   band instead of a skinny strip floating left of the face. */
-@media (min-width: 801px) {
+   band instead of a skinny strip floating left of the face. min-height 501px keeps
+   this the exact complement of the phone/landscape-phone block above — otherwise a
+   short-but-wide viewport gets this collapsed-rail grid *and* the drawer grid from
+   the shelf-becomes-drawer block below, fighting over the same grid-template-columns. */
+@media (min-width: 801px) and (min-height: 501px) {
   /* Variable on `.app` (ancestor of both header and shelf) — children inherit it. */
   .app:has(.studio-layout.is-game-open.is-compact-shelf:not(.is-shelf-open)) {
     --studio-shelf-collapsed-width: 80px;
@@ -15411,14 +15453,15 @@ button.builder-mode-selector:disabled {
   font-size: 0.8rem;
 }
 
-@media (max-width: 800px) {
+@media (max-width: 800px), (max-height: 500px) {
   .studio-layout {
     grid-template-columns: 1fr;
   }
 
   /* Phone + game open: the shelf is a drawer, never a permanent column. Closed it sits
      off the left edge; open it covers ~90% of the width over a backdrop — the usual
-     mobile nav pattern, not a second page of cards above the thread. */
+     mobile nav pattern, not a second page of cards above the thread. Height joins
+     width here too — see the matching note on the shell's own phone block above. */
   .studio-layout.is-game-open > .studio-shelf {
     position: fixed;
     top: 0;

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -7208,25 +7208,29 @@ a.user-name--profile:focus-visible {
     max-width: 100%;
   }
 
+  /* One row, not two: nowrap, not wrap. Every child below is sized so the
+     title — the one thing with no natural minimum — is the sole part that
+     shrinks; everything else (folder, Code, Play, ⋯) keeps its intrinsic
+     width and the title's own ellipsis absorbs whatever room is left. */
   .app:has(.studio-layout.is-game-open) .studio-strip {
     min-width: 0;
     max-width: 100%;
     gap: 8px;
-    flex-wrap: wrap;
+    flex-wrap: nowrap;
   }
 
   /* flex-basis 0, not the base rule's auto: `auto` sizes this by its unwrapped
      content (title + pill), and that content is routinely just wide enough to
      push the whole block, folder button included, onto its own line. A 0 basis
-     makes it a true flexible child that shares row 1 and lets the title's own
-     ellipsis absorb the shortfall instead. */
+     makes it a true flexible child that shares the row instead. */
   .app:has(.studio-layout.is-game-open) .studio-strip-title-block {
     flex: 1 1 0%;
     min-width: 0;
+    flex-wrap: nowrap;
   }
 
   /* Same fix, one level deeper: the title's own auto basis was pushing the
-     phase pill beside it onto its own line too. */
+     phase pill beside it out of the row entirely. */
   .app:has(.studio-layout.is-game-open) .studio-strip-title {
     flex: 1 1 0%;
     min-width: 0;
@@ -7237,41 +7241,42 @@ a.user-name--profile:focus-visible {
     display: none;
   }
 
-  /* Actions already move to their own full-width row below (flex-basis 100%),
-     so this desktop-only right-pusher has nothing left to push — left alone
-     it was still claiming half of every pixel the title tried to grow into. */
+  /* The pill's own text can't shrink, so on the narrowest phones (portrait,
+     not the wider end of this band a landscape phone lands in) it's the one
+     thing this row drops rather than squeezing the title to a few letters. */
+  @media (max-width: 460px) {
+    .app:has(.studio-layout.is-game-open) .studio-strip-phase-pill {
+      display: none;
+    }
+  }
+
+  /* The action row no longer claims its own line below (see .studio-strip-
+     actions right after), so this desktop-only right-pusher has nothing left
+     to push — left alone it was still claiming half of every pixel the title
+     tried to grow into. */
   .app:has(.studio-layout.is-game-open) .studio-strip-spacer {
     display: none;
   }
 
-  /* Flex, not the old 4-col grid: the ⋯ overflow menu folds Edit/Claim/Theater/
-     Share/Details/Chat away, so this row only ever holds Code (optional), Play,
-     and the menu trigger — a fixed column count stopped fitting the item count. */
+  /* Inline on the title's row now, not a forced second line: the ⋯ overflow
+     menu folds Edit/Claim/Theater/Share/Details/Chat away, so this only ever
+     holds Code (optional), Play, and the menu trigger — three intrinsic-width
+     controls the title-block's own shrink already makes room for. */
   .app:has(.studio-layout.is-game-open) .studio-strip-actions {
     display: flex;
-    width: 100%;
-    flex: 1 0 100%;
+    flex: 0 0 auto;
     gap: 8px;
   }
 
   .app:has(.studio-layout.is-game-open) .studio-strip-actions > *,
   .app:has(.studio-layout.is-game-open) .studio-strip-actions .studio-head-action,
   .app:has(.studio-layout.is-game-open) .studio-head-menu {
-    min-width: 0;
-    flex: 1;
+    flex: 0 0 auto;
     justify-content: center;
-  }
-
-  .app:has(.studio-layout.is-game-open) .studio-strip-actions .studio-head-action.is-primary {
-    flex: 2;
   }
 
   .app:has(.studio-layout.is-game-open) .studio-head-menu {
     display: flex;
-  }
-
-  .app:has(.studio-layout.is-game-open) .studio-head-menu .studio-head-action {
-    width: 100%;
   }
 
   /* 24px tall icon pills read as cramped and undershoot the ~44px touch target

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -7293,6 +7293,13 @@ a.user-name--profile:focus-visible {
     min-height: 44px;
   }
 
+  /* Same 44px box as its neighbors, but the desktop glow (halo radius 14px)
+     read as taller/heavier than the flat icon pills beside it in this tight
+     row — trimmed, not removed, so Play still reads as the filled CTA. */
+  .app:has(.studio-layout.is-game-open) .studio-head-action.is-primary.is-play {
+    box-shadow: 0 0 6px var(--turquoise-glow);
+  }
+
   /* Icon-only peers in the title row — Share / Details / Edit / Claim were enough to
      shove the trailing control past the right edge on a 390px phone with a long title.
      Play keeps its word: clipping it made the primary CTA a tiny icon twin of Details. */

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -6150,6 +6150,93 @@ a.user-name--profile:focus-visible {
   box-shadow: 0 12px 32px rgba(0, 0, 0, 0.45);
 }
 
+/* The ⋯ overflow trigger on phones — same anchored-popover shape as Share. */
+.studio-head-menu {
+  position: relative;
+}
+
+.studio-head-menu-popover {
+  position: absolute;
+  top: calc(100% + 8px);
+  right: 0;
+  z-index: 40;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  width: min(280px, calc(100vw - 24px));
+  padding: 6px;
+  border-radius: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  background: var(--panel-bg, #0c1218);
+  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.45);
+}
+
+.studio-head-menu-item {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  width: 100%;
+  min-height: 44px;
+  padding: 8px 10px;
+  border: 0;
+  border-radius: 8px;
+  background: transparent;
+  color: var(--text);
+  font: inherit;
+  font-size: 0.86rem;
+  text-align: left;
+  cursor: pointer;
+  position: relative;
+}
+
+.studio-head-menu-item:hover,
+.studio-head-menu-item:focus-visible {
+  background: rgba(0, 228, 172, 0.1);
+}
+
+.studio-head-menu-item.is-active {
+  color: var(--turquoise);
+}
+
+/* Share drops into the ⋯ menu as-is (CreatorStudioView owns its state) — restyled
+   here to read as a menu row instead of the icon-only pill it is everywhere else. */
+.studio-head-menu-popover .studio-head-share {
+  display: flex;
+}
+
+.studio-head-menu-popover .studio-head-share > .studio-head-action {
+  width: 100%;
+  min-height: 44px;
+  padding: 8px 10px;
+  border: 0;
+  border-radius: 8px;
+  background: transparent;
+  justify-content: flex-start;
+}
+
+/* !important: the phone-strip rule that visually-hides non-primary labels
+   (specificity 0,6,0, `:not(.is-primary) .studio-head-action-label`) outranks
+   a same-shape override here — this un-hides Share's label inside the menu. */
+.studio-head-menu-popover .studio-head-share > .studio-head-action .studio-head-action-label {
+  position: static !important;
+  width: auto !important;
+  height: auto !important;
+  margin: 0 !important;
+  overflow: visible !important;
+  clip: auto !important;
+  white-space: normal !important;
+  font-size: 0.86rem;
+}
+
+/* Anchoring to its own trigger's box would push Share's dialog off past the
+   menu's right edge, so it drops in-flow under the trigger instead. */
+.studio-head-menu-popover .studio-head-share-popover {
+  position: static;
+  width: auto;
+  margin-top: 6px;
+  box-shadow: none;
+}
+
 .studio-head-action--claim {
   border-color: rgba(0, 228, 172, 0.45);
   color: #c8f5da;
@@ -7141,23 +7228,34 @@ a.user-name--profile:focus-visible {
     display: none;
   }
 
+  /* Flex, not the old 4-col grid: the ⋯ overflow menu folds Edit/Claim/Theater/
+     Share/Details/Chat away, so this row only ever holds Code (optional), Play,
+     and the menu trigger — a fixed column count stopped fitting the item count. */
   .app:has(.studio-layout.is-game-open) .studio-strip-actions {
-    display: grid;
-    grid-template-columns: repeat(4, minmax(0, 1fr));
+    display: flex;
     width: 100%;
     flex: 1 0 100%;
     gap: 8px;
   }
 
   .app:has(.studio-layout.is-game-open) .studio-strip-actions > *,
-  .app:has(.studio-layout.is-game-open) .studio-strip-actions .studio-head-action {
+  .app:has(.studio-layout.is-game-open) .studio-strip-actions .studio-head-action,
+  .app:has(.studio-layout.is-game-open) .studio-head-menu {
     min-width: 0;
-    width: 100%;
+    flex: 1;
     justify-content: center;
   }
 
   .app:has(.studio-layout.is-game-open) .studio-strip-actions .studio-head-action.is-primary {
-    grid-column: span 2;
+    flex: 2;
+  }
+
+  .app:has(.studio-layout.is-game-open) .studio-head-menu {
+    display: flex;
+  }
+
+  .app:has(.studio-layout.is-game-open) .studio-head-menu .studio-head-action {
+    width: 100%;
   }
 
   /* 24px tall icon pills read as cramped and undershoot the ~44px touch target
@@ -12166,6 +12264,11 @@ button.builder-mode-selector:disabled {
   border: 1px solid var(--panel-border);
   background: rgba(10, 14, 20, 0.72);
   backdrop-filter: blur(10px);
+  /* backdrop-filter makes this its own stacking context; without a z-index of
+     its own, that context sank below the stage's z-index:30 crash card and
+     swallowed any popover anchored here (Share, now ⋯). */
+  position: relative;
+  z-index: 35;
 }
 
 .studio-strip-title-block {

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -7215,16 +7215,32 @@ a.user-name--profile:focus-visible {
     flex-wrap: wrap;
   }
 
+  /* flex-basis 0, not the base rule's auto: `auto` sizes this by its unwrapped
+     content (title + pill), and that content is routinely just wide enough to
+     push the whole block, folder button included, onto its own line. A 0 basis
+     makes it a true flexible child that shares row 1 and lets the title's own
+     ellipsis absorb the shortfall instead. */
   .app:has(.studio-layout.is-game-open) .studio-strip-title-block {
+    flex: 1 1 0%;
     min-width: 0;
   }
 
+  /* Same fix, one level deeper: the title's own auto basis was pushing the
+     phase pill beside it onto its own line too. */
   .app:has(.studio-layout.is-game-open) .studio-strip-title {
+    flex: 1 1 0%;
     min-width: 0;
   }
 
   .app:has(.studio-layout.is-game-open) .studio-strip .studio-slug,
   .app:has(.studio-layout.is-game-open) .studio-strip-heartbeat {
+    display: none;
+  }
+
+  /* Actions already move to their own full-width row below (flex-basis 100%),
+     so this desktop-only right-pusher has nothing left to push — left alone
+     it was still claiming half of every pixel the title tried to grow into. */
+  .app:has(.studio-layout.is-game-open) .studio-strip-spacer {
     display: none;
   }
 

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -14511,6 +14511,23 @@ button.builder-mode-selector:disabled {
   box-shadow: 0 0 0 2px var(--panel);
 }
 
+/* A game open in Studio on a phone already has its own back-arrow-equivalent
+   (the strip's folder button, for switching games) and its own action row —
+   the site chrome above it was a second, redundant nav bar competing for the
+   same few hundred px. Collapse it to just the "leave Studio" back arrow;
+   logo, nav links, avatar, bell, and hamburger all wait behind that tap. */
+@media (max-width: 800px) {
+  .app:has(.studio-layout.is-game-open) .app-header {
+    gap: 0;
+  }
+
+  .app:has(.studio-layout.is-game-open) .app-header .logo,
+  .app:has(.studio-layout.is-game-open) .app-header .header-nav,
+  .app:has(.studio-layout.is-game-open) .app-header .header-actions {
+    display: none;
+  }
+}
+
 /* 5+ games on a desktop: collapse to a left-edge folder+badge after selection.
    Width matches the header mascot column, so the rail and the logo share one vertical
    band instead of a skinny strip floating left of the face. */

--- a/apps/web/src/styles.studioShell.test.ts
+++ b/apps/web/src/styles.studioShell.test.ts
@@ -23,15 +23,23 @@ describe('studio shell claim selectors', () => {
     );
   });
 
-  it('gives the complete phone action set a full-width row', () => {
+  it('keeps the whole phone strip — folder, title, actions — on one row', () => {
     expect(css).toMatch(
-      /@media \(max-width: 800px\)[\s\S]*?\.app:has\(\.studio-layout\.is-game-open\) \.studio-strip\s*\{[\s\S]*?flex-wrap:\s*wrap;/,
+      /@media \(max-width: 800px\), \(max-height: 500px\)[\s\S]*?\.app:has\(\.studio-layout\.is-game-open\) \.studio-strip\s*\{[\s\S]*?flex-wrap:\s*nowrap;/,
     );
+    // Inline after the title, not forced onto its own full-width line.
     expect(css).toMatch(
-      /\.app:has\(\.studio-layout\.is-game-open\) \.studio-strip-actions\s*\{[\s\S]*?grid-template-columns:\s*repeat\(4, minmax\(0, 1fr\)\);[\s\S]*?width:\s*100%;/,
+      /\.app:has\(\.studio-layout\.is-game-open\) \.studio-strip-actions\s*\{[\s\S]*?flex:\s*0 0 auto;/,
     );
+    // Folder/Code/Play/⋯ stay fixed size; only the title shrinks.
     expect(css).toMatch(
-      /\.app:has\(\.studio-layout\.is-game-open\) \.studio-strip-actions \.studio-head-action\.is-primary\s*\{[\s\S]*?grid-column:\s*span 2;/,
+      /\.app:has\(\.studio-layout\.is-game-open\) \.studio-strip-actions > \*,[\s\S]*?flex:\s*0 0 auto;/,
+    );
+  });
+
+  it('hides the redundant global topbar once a game is open on a phone', () => {
+    expect(css).toMatch(
+      /@media \(max-width: 800px\), \(max-height: 500px\)[\s\S]*?\.app:has\(\.studio-layout\.is-game-open\) \.app-header\s*\{[\s\S]*?display:\s*none;/,
     );
   });
 


### PR DESCRIPTION
## Summary
Implements a responsive compact mode for the Studio strip component that collapses secondary actions into an overflow menu on narrow viewports (≤800px), improving mobile usability by reducing visual clutter and maintaining touch-friendly interaction targets.

## Key Changes

- **New `isCompact` prop** on `StudioStrip` component to conditionally render compact layout
- **Overflow menu implementation** with keyboard (Escape) and outside-click dismissal patterns
- **Conditional action rendering**: Edit, Code, Claim, Theater, Share, Details, and Chat actions are hidden in compact mode and moved into a collapsible "More" (⋯) menu
- **Menu styling** with proper accessibility attributes (`role="menu"`, `aria-haspopup`, `aria-expanded`)
- **Responsive layout fixes**:
  - Changed `.studio-strip` from `flex-wrap: wrap` to `nowrap` to keep title and actions on one line
  - Updated `.studio-strip-actions` from grid layout to flex with `flex: 0 0 auto` to prevent forced wrapping
  - Added phase pill hiding at ≤460px to preserve title space on narrowest phones
  - Hid spacer element that was claiming unnecessary space
- **Header chrome collapse** at ≤800px when game is open: hides logo, nav links, and header actions, leaving only the back arrow
- **Z-index fix** for `.studio-strip` to ensure popovers (Share, overflow menu) render above stage crash cards
- **Internationalization**: Added "More" translation key for English and Polish

## Implementation Details

- Uses `useRef` and `useState` hooks to manage overflow menu open state and DOM references
- Event listeners for keyboard and pointer events follow the same pattern as existing Share popover
- Share slot is rendered inside the overflow menu with custom styling to match menu item appearance
- Menu items close the overflow menu on click and restore focus to the trigger button
- All menu items maintain their original functionality (toggle states, callbacks) when moved to compact layout

https://claude.ai/code/session_01CsrN3bXVyLDTi4BuCovRni