### PR TITLE
Hide handoff buttons while sending message in compact mode

### DIFF
--- a/apps/web/src/SubmissionStatusView.tsx
+++ b/apps/web/src/SubmissionStatusView.tsx
@@ -1701,9 +1701,7 @@ function FeedbackPanel({
   if (compact) {
     const sending = state === 'sending';
     const empty = text.length === 0;
-    // Hide the handoff switch button while a message is sending: it sits right above
-    // the "Wysyłanie…" status line, and showing it there reads as if switching builders
-    // — not the unrelated send — is what's in flight.
+    // Hidden while sending: it sat right above the unrelated status line.
     const compactBuilderControls = (
       <div className="builder-mode-controls">
         {builderSelector}

--- a/apps/web/src/SubmissionStatusView.tsx
+++ b/apps/web/src/SubmissionStatusView.tsx
@@ -1701,14 +1701,6 @@ function FeedbackPanel({
   if (compact) {
     const sending = state === 'sending';
     const empty = text.length === 0;
-    // Hidden while sending: it sat right above the unrelated status line.
-    const compactBuilderControls = (
-      <div className="builder-mode-controls">
-        {builderSelector}
-        {sending ? null : activeSelfHandoff}
-        {sending ? null : activePlatformHandoff}
-      </div>
-    );
     return (
       <div
         className={`status-feedback status-composer is-compact${empty ? ' is-empty' : ''}${sending ? ' is-sending' : ''}`}
@@ -1758,7 +1750,7 @@ function FeedbackPanel({
           disabled={sending}
         />
         <div className="status-composer-toolbar">
-          <div className="status-composer-toolbar-left">{compactBuilderControls}</div>
+          <div className="status-composer-toolbar-left">{builderControls}</div>
           <div className="status-composer-toolbar-right">
             {showStop ? (
               <button
@@ -1792,11 +1784,11 @@ function FeedbackPanel({
             ask the creator to wait or act. A plain Sent receipt does not: the thread
             already shows the message the moment send succeeds. */}
         {error || sending || notice ? (
-          <div className="status-feedback-actions">
+          <div className={`status-feedback-actions${sending ? ' status-feedback-actions-end' : ''}`}>
             {error ? (
               <p className="error">{error}</p>
             ) : sending ? (
-              // The send button already animates its own spinner — one is enough.
+              // Right-aligned under Send, not the switch-builder button.
               <span className="status-feedback-sending" role="status">
                 {t('statusView.feedback.sending')}
               </span>

--- a/apps/web/src/SubmissionStatusView.tsx
+++ b/apps/web/src/SubmissionStatusView.tsx
@@ -1701,6 +1701,16 @@ function FeedbackPanel({
   if (compact) {
     const sending = state === 'sending';
     const empty = text.length === 0;
+    // Hide the handoff switch button while a message is sending: it sits right above
+    // the "Wysyłanie…" status line, and showing it there reads as if switching builders
+    // — not the unrelated send — is what's in flight.
+    const compactBuilderControls = (
+      <div className="builder-mode-controls">
+        {builderSelector}
+        {sending ? null : activeSelfHandoff}
+        {sending ? null : activePlatformHandoff}
+      </div>
+    );
     return (
       <div
         className={`status-feedback status-composer is-compact${empty ? ' is-empty' : ''}${sending ? ' is-sending' : ''}`}
@@ -1750,7 +1760,7 @@ function FeedbackPanel({
           disabled={sending}
         />
         <div className="status-composer-toolbar">
-          <div className="status-composer-toolbar-left">{builderControls}</div>
+          <div className="status-composer-toolbar-left">{compactBuilderControls}</div>
           <div className="status-composer-toolbar-right">
             {showStop ? (
               <button

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -7069,6 +7069,11 @@ a.user-name--profile:focus-visible {
   margin: 0;
 }
 
+/* Sending pairs with Send on the right, not the switch-builder button on the left. */
+.status-composer.is-compact .status-feedback-actions-end {
+  justify-content: flex-end;
+}
+
 /* THE STUDIO THREAD AS AN APP SCREEN — the part that is true at every width.
    Below this, two media blocks give the shell its shape: edge-to-edge on a phone at
    800px and under, a shelf rail and a capped reading column above that. What lives here


### PR DESCRIPTION
## Summary
Updated the feedback panel to hide the handoff switch buttons while a message is being sent in compact mode, improving UX clarity by preventing visual confusion about what action is in flight.

## Key Changes
- Created a new `compactBuilderControls` variable that conditionally renders the handoff buttons (`activeSelfHandoff` and `activePlatformHandoff`) only when not sending
- Updated the toolbar to use `compactBuilderControls` instead of the previous `builderControls`
- Added explanatory comment clarifying that hiding these buttons prevents misinterpretation of the "Wysyłanie…" (Sending...) status line

## Implementation Details
The handoff buttons are now hidden during the sending state by conditionally rendering them as `null` when `sending` is true. This prevents the buttons from appearing directly above the sending status indicator, which could mislead users into thinking the builder switch action is what's being processed rather than the message send operation.

https://claude.ai/code/session_01AQLad88EWFgjnJXtbKNbDg