### PR TITLE
Show live build checklist on the Studio welcome/draft-ready screen

### DIFF
--- a/apps/web/src/StudioDetailsBuildProgress.tsx
+++ b/apps/web/src/StudioDetailsBuildProgress.tsx
@@ -7,46 +7,26 @@ import { getSubmissionStatus, type BuildEvent, type BuildProgress } from './subm
 const DETAILS_POLL_MS = 10_000;
 
 /**
- * Checklist + fraction for the Details rail — the progress that used to sit in the
- * thread foot. Kept out of the composer strip so the conversation stays Claude-quiet;
- * open Details when you want the count.
+ * Pure checklist + progress-bar rendering, driven entirely by props. Callers that
+ * already poll `SubmissionStatus` themselves (e.g. the Studio welcome screen) should
+ * pass that data straight through instead of mounting a second poller against the
+ * same endpoint — `StudioDetailsBuildProgress` below is the self-fetching wrapper for
+ * callers that don't have a status poll of their own.
  */
-export function StudioDetailsBuildProgress({
-  token,
+export function BuildProgressChecklist({
+  progress,
+  events,
+  loaded,
   emptyLabel,
 }: {
-  token: string;
+  progress: BuildProgress | null;
+  events: BuildEvent[];
+  /** Whether the first fetch has completed — controls the empty-state message. */
+  loaded: boolean;
   /** When set, an empty checklist renders this instead of nothing. */
   emptyLabel?: string;
 }) {
-  const { t, i18n } = useTranslation();
-  const [progress, setProgress] = useState<BuildProgress | null>(null);
-  const [events, setEvents] = useState<BuildEvent[]>([]);
-  const [loaded, setLoaded] = useState(false);
-
-  useEffect(() => {
-    let cancelled = false;
-
-    const load = async () => {
-      try {
-        const status = await getSubmissionStatus(token, i18n.language);
-        if (cancelled) return;
-        setProgress(status.progress ?? null);
-        setEvents(status.events ?? []);
-      } catch {
-        // Secondary chrome — a failed poll must not toast over the thread.
-      } finally {
-        if (!cancelled) setLoaded(true);
-      }
-    };
-
-    void load();
-    const timer = window.setInterval(() => void load(), DETAILS_POLL_MS);
-    return () => {
-      cancelled = true;
-      window.clearInterval(timer);
-    };
-  }, [token, i18n.language]);
+  const { t } = useTranslation();
 
   const checklist = progress?.checklist ?? [];
   const reported = events.find((event) => event.progress)?.progress;
@@ -106,4 +86,50 @@ export function StudioDetailsBuildProgress({
       ) : null}
     </div>
   );
+}
+
+/**
+ * Checklist + fraction for the Details rail — the progress that used to sit in the
+ * thread foot. Kept out of the composer strip so the conversation stays Claude-quiet;
+ * open Details when you want the count. Self-fetches on its own timer — only use this
+ * for callers that don't already poll `SubmissionStatus`.
+ */
+export function StudioDetailsBuildProgress({
+  token,
+  emptyLabel,
+}: {
+  token: string;
+  /** When set, an empty checklist renders this instead of nothing. */
+  emptyLabel?: string;
+}) {
+  const { i18n } = useTranslation();
+  const [progress, setProgress] = useState<BuildProgress | null>(null);
+  const [events, setEvents] = useState<BuildEvent[]>([]);
+  const [loaded, setLoaded] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const load = async () => {
+      try {
+        const status = await getSubmissionStatus(token, i18n.language);
+        if (cancelled) return;
+        setProgress(status.progress ?? null);
+        setEvents(status.events ?? []);
+      } catch {
+        // Secondary chrome — a failed poll must not toast over the thread.
+      } finally {
+        if (!cancelled) setLoaded(true);
+      }
+    };
+
+    void load();
+    const timer = window.setInterval(() => void load(), DETAILS_POLL_MS);
+    return () => {
+      cancelled = true;
+      window.clearInterval(timer);
+    };
+  }, [token, i18n.language]);
+
+  return <BuildProgressChecklist progress={progress} events={events} loaded={loaded} emptyLabel={emptyLabel} />;
 }

--- a/apps/web/src/StudioDetailsBuildProgress.tsx
+++ b/apps/web/src/StudioDetailsBuildProgress.tsx
@@ -3,16 +3,10 @@ import { useTranslation } from 'react-i18next';
 import { PixelIcon } from './PixelIcon.js';
 import { getSubmissionStatus, type BuildEvent, type BuildProgress } from './submissionApi.js';
 
-/** Details refreshes slower than the thread — the thread already owns the live pulse. */
+// Details refreshes slower than the thread's own live pulse.
 const DETAILS_POLL_MS = 10_000;
 
-/**
- * Pure checklist + progress-bar rendering, driven entirely by props. Callers that
- * already poll `SubmissionStatus` themselves (e.g. the Studio welcome screen) should
- * pass that data straight through instead of mounting a second poller against the
- * same endpoint — `StudioDetailsBuildProgress` below is the self-fetching wrapper for
- * callers that don't have a status poll of their own.
- */
+// Props-driven; callers with their own status poll should feed it in, not refetch.
 export function BuildProgressChecklist({
   progress,
   events,
@@ -21,9 +15,9 @@ export function BuildProgressChecklist({
 }: {
   progress: BuildProgress | null;
   events: BuildEvent[];
-  /** Whether the first fetch has completed — controls the empty-state message. */
+  // Whether the first fetch has completed.
   loaded: boolean;
-  /** When set, an empty checklist renders this instead of nothing. */
+  // Empty-state label shown when the checklist is empty.
   emptyLabel?: string;
 }) {
   const { t } = useTranslation();
@@ -88,18 +82,13 @@ export function BuildProgressChecklist({
   );
 }
 
-/**
- * Checklist + fraction for the Details rail — the progress that used to sit in the
- * thread foot. Kept out of the composer strip so the conversation stays Claude-quiet;
- * open Details when you want the count. Self-fetches on its own timer — only use this
- * for callers that don't already poll `SubmissionStatus`.
- */
+// Self-fetching wrapper for callers with no status poll of their own.
 export function StudioDetailsBuildProgress({
   token,
   emptyLabel,
 }: {
   token: string;
-  /** When set, an empty checklist renders this instead of nothing. */
+  // Empty-state label shown when the checklist is empty.
   emptyLabel?: string;
 }) {
   const { i18n } = useTranslation();

--- a/apps/web/src/StudioWelcomeView.tsx
+++ b/apps/web/src/StudioWelcomeView.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from 'react-i18next';
 import { InteractiveMascot, type MascotEmotion } from './Mascot.js';
 import { PixelIcon } from './PixelIcon.js';
 import { studioPath } from './router.js';
+import { StudioDetailsBuildProgress } from './StudioDetailsBuildProgress.js';
 import { isStudioOnboarded, markStudioOnboarded, resolveWelcomeToken } from './studioWelcome.js';
 import { pollDelayMs } from './studioStatusPoll.js';
 import { getSubmissionStatus, type SubmissionStatus } from './submissionApi.js';
@@ -333,6 +334,11 @@ export function StudioWelcomeView({ game, onOpenStudio }: StudioWelcomeViewProps
             <p className="studio-welcome-progress-message" role="status" aria-live="polite">
               {progress}
             </p>
+            {isRunning && token ? (
+              <div className="studio-welcome-checklist">
+                <StudioDetailsBuildProgress token={token} />
+              </div>
+            ) : null}
             {isReady ? (
               <button type="button" className="studio-welcome-ready-callout" onClick={openStudio}>
                 <p className="studio-welcome-ready-title">

--- a/apps/web/src/StudioWelcomeView.tsx
+++ b/apps/web/src/StudioWelcomeView.tsx
@@ -4,7 +4,7 @@ import { useTranslation } from 'react-i18next';
 import { InteractiveMascot, type MascotEmotion } from './Mascot.js';
 import { PixelIcon } from './PixelIcon.js';
 import { studioPath } from './router.js';
-import { StudioDetailsBuildProgress } from './StudioDetailsBuildProgress.js';
+import { BuildProgressChecklist } from './StudioDetailsBuildProgress.js';
 import { isStudioOnboarded, markStudioOnboarded, resolveWelcomeToken } from './studioWelcome.js';
 import { pollDelayMs } from './studioStatusPoll.js';
 import { getSubmissionStatus, type SubmissionStatus } from './submissionApi.js';
@@ -336,7 +336,11 @@ export function StudioWelcomeView({ game, onOpenStudio }: StudioWelcomeViewProps
             </p>
             {isRunning && token ? (
               <div className="studio-welcome-checklist">
-                <StudioDetailsBuildProgress token={token} />
+                <BuildProgressChecklist
+                  progress={status?.progress ?? null}
+                  events={status?.events ?? []}
+                  loaded={status != null}
+                />
               </div>
             ) : null}
             {isReady ? (

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -8916,6 +8916,13 @@ button.builder-mode-selector:disabled {
   color: var(--text, #e2e8f0);
 }
 
+/* Live "what's happening behind the scenes" checklist while the build runs. */
+.studio-welcome-checklist {
+  margin-top: 14px;
+  padding-top: 14px;
+  border-top: 1px solid rgba(148, 163, 184, 0.15);
+}
+
 .studio-welcome-primer {
   margin: 0 0 20px;
 }


### PR DESCRIPTION
While a draft is still building, surface the same "what the agent is
doing" checklist/progress bar used elsewhere in Studio, so the queued
handoff screen reflects the behind-the-scenes work instead of a single
static status line.