### PR TITLE
Fix title crushed to one letter while playtest is active

### DIFF
--- a/apps/web/src/StudioStrip.tsx
+++ b/apps/web/src/StudioStrip.tsx
@@ -212,6 +212,7 @@ export function StudioStrip({
           type="button"
           className={`studio-head-action is-primary is-play${posture === 'play' ? ' is-active' : ''}`}
           aria-pressed={posture === 'play'}
+          aria-label={posture === 'play' ? t('studioPanel.stage.stopPlaying') : undefined}
           disabled={posture === 'watch' && stageEmpty}
           onClick={() => onPostureChange(posture === 'play' ? 'watch' : 'play')}
         >

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -7437,6 +7437,22 @@ a.user-name--profile:focus-visible {
     border: 0;
   }
 
+  /* Play keeps its word, but "Stop playing" (Polish: "Zakończ granie") is a
+     different, much longer word — long enough to crush the title down to a
+     single letter. The X icon already says "stop" on its own; only the label
+     goes, and only in this active state. */
+  .app:has(.studio-layout.is-game-open) .studio-head-action.is-primary.is-active .studio-head-action-label {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+  }
+
   /* 126px of page padding — 60 on the content, 48 on the panel, 18 on the detail — was
      what put the composer that far above the bottom of the screen with nothing under it.
      Right for a section of a document, wrong for the bottom edge of an app. */


### PR DESCRIPTION
## Summary

Play's label swaps to "Stop playing" (Polish: "Zakończ granie") once `posture === 'play'` — much longer than "Play"/"Zagraj", and long enough on its own to eat nearly all of the mobile Studio strip's flexible space, crushing the game title down to a single letter (e.g. "D…") on real titles.

The X icon on that button already communicates "stop" on its own, so this hides the text label in just that active state (mobile only) — the same way every other non-primary button's label is already hidden — and adds an `aria-label` so the accessible name survives losing the visible text.

## Verification

- Local dev server (proxying `/api` to production), signed in as `bot:e2e`: clicking Play now shows a compact icon-only stop control and the title reads "OpenAI Luna Prob…" instead of "D…", coexisting correctly with the existing back-arrow/`onExit` control.
- Full `apps/web` lint, typecheck, and test suite (180 files, 1549 tests) pass.

https://claude.ai/code/session_01CsrN3bXVyLDTi4BuCovRni

---
_Generated by [Claude Code](https://claude.ai/code/session_01CsrN3bXVyLDTi4BuCovRni)_