### PR TITLE
Code surface: keep watching a self-build round, whose agent never dispatches

### DIFF
--- a/apps/api/src/code-surface.ts
+++ b/apps/api/src/code-surface.ts
@@ -39,3 +39,30 @@ export function isLiveAgentRound(record: {
   if (!isActiveBuildRound({ state, transitions: record.transitions })) return false;
   return (record.dispatch?.refs?.length ?? 0) > 0;
 }
+
+/**
+ * Whether an agent *could* be writing to this round's buffer.
+ *
+ * Deliberately weaker than `isLiveAgentRound`, and the difference is the whole
+ * point: that one additionally requires `dispatch.refs`, which only a
+ * platform-dispatched round has. A self-build round — the creator's own agent
+ * staging over MCP — never has one, so it read as "no agent here" everywhere the
+ * live test was used.
+ *
+ * Two questions were being answered by one predicate, and only one of them is
+ * about dispatch. *Should the owner be locked out* is: the platform round owns
+ * the buffer while its agent holds it. *Should the view keep refreshing* is not
+ * — files land in the staging buffer the same way whoever staged them, and an
+ * editor that stops watching shows a stale game with no sign it is stale. This
+ * answers the second; `isLiveAgentRound` still answers the first.
+ */
+export function isOpenAgentRound(record: {
+  state?: JobState;
+  lastStatus?: Parameters<typeof resolveJobState>[0]['lastStatus'];
+  transitions?: JobTransition[];
+  agentEndedAt?: string;
+}): boolean {
+  if (record.agentEndedAt) return false;
+  const state = resolveJobState(record) ?? 'queued';
+  return isActiveBuildRound({ state, transitions: record.transitions });
+}

--- a/apps/api/src/code-surface.ts
+++ b/apps/api/src/code-surface.ts
@@ -40,22 +40,7 @@ export function isLiveAgentRound(record: {
   return (record.dispatch?.refs?.length ?? 0) > 0;
 }
 
-/**
- * Whether an agent *could* be writing to this round's buffer.
- *
- * Deliberately weaker than `isLiveAgentRound`, and the difference is the whole
- * point: that one additionally requires `dispatch.refs`, which only a
- * platform-dispatched round has. A self-build round — the creator's own agent
- * staging over MCP — never has one, so it read as "no agent here" everywhere the
- * live test was used.
- *
- * Two questions were being answered by one predicate, and only one of them is
- * about dispatch. *Should the owner be locked out* is: the platform round owns
- * the buffer while its agent holds it. *Should the view keep refreshing* is not
- * — files land in the staging buffer the same way whoever staged them, and an
- * editor that stops watching shows a stale game with no sign it is stale. This
- * answers the second; `isLiveAgentRound` still answers the first.
- */
+// Could an agent be writing? No dispatch.refs needed, unlike isLiveAgentRound.
 export function isOpenAgentRound(record: {
   state?: JobState;
   lastStatus?: Parameters<typeof resolveJobState>[0]['lastStatus'];

--- a/apps/api/src/code-surface.ts
+++ b/apps/api/src/code-surface.ts
@@ -41,13 +41,14 @@ export function isLiveAgentRound(record: {
 }
 
 // Could an agent be writing? No dispatch.refs needed, unlike isLiveAgentRound.
+// agentEndedAt is deliberately ignored: it is an optimistic handoff marker that
+// any later stage or patch deletes, so a resumed agent would never be watched.
+// The job state already bounds this — submitted, gating and gate-red all stay true.
 export function isOpenAgentRound(record: {
   state?: JobState;
   lastStatus?: Parameters<typeof resolveJobState>[0]['lastStatus'];
   transitions?: JobTransition[];
-  agentEndedAt?: string;
 }): boolean {
-  if (record.agentEndedAt) return false;
   const state = resolveJobState(record) ?? 'queued';
   return isActiveBuildRound({ state, transitions: record.transitions });
 }

--- a/apps/api/src/code-surface.ts
+++ b/apps/api/src/code-surface.ts
@@ -40,10 +40,7 @@ export function isLiveAgentRound(record: {
   return (record.dispatch?.refs?.length ?? 0) > 0;
 }
 
-// Could an agent be writing? No dispatch.refs needed, unlike isLiveAgentRound.
-// agentEndedAt is deliberately ignored: it is an optimistic handoff marker that
-// any later stage or patch deletes, so a resumed agent would never be watched.
-// The job state already bounds this — submitted, gating and gate-red all stay true.
+// Could an agent write? No dispatch.refs; agentEndedAt self-clears.
 export function isOpenAgentRound(record: {
   state?: JobState;
   lastStatus?: Parameters<typeof resolveJobState>[0]['lastStatus'];

--- a/apps/api/src/creator-code.test.ts
+++ b/apps/api/src/creator-code.test.ts
@@ -247,9 +247,7 @@ describe('the Code surface routes (creator-code.ts)', () => {
 
     it('keeps watching across the submit handoff, which any later stage undoes', async () =>
       withApp(async (app) => {
-        // agentEndedAt is optimistic: touchLastAgentSignalAt deletes it on the next
-        // stage or patch. Gating on it stopped the only interval at submit, so an
-        // agent resuming after a red gate wrote into a view that had stopped looking.
+        // agentEndedAt is self-clearing: the next stage call deletes it.
         await store.markAgentEnded(10);
         const res = await app.inject({
           method: 'GET',

--- a/apps/api/src/creator-code.test.ts
+++ b/apps/api/src/creator-code.test.ts
@@ -230,6 +230,24 @@ describe('the Code surface routes (creator-code.ts)', () => {
         expect(body.readOnly).toBe(true);
         expect(body.reason).toBe('agent_round');
       }));
+
+    it('marks a self-build round as watchable even though it is never read-only', async () =>
+      withApp(async (app) => {
+        // The bug this pins: `readOnly` requires `dispatch.refs`, which only a
+        // platform-dispatched round has. A creator's own agent staging over MCP
+        // has none, so the Code surface read it as "no agent here" and stopped
+        // polling — the files landed in the staging buffer and the editor never
+        // asked again. Locked and worth-watching are different questions.
+        const res = await app.inject({
+          method: 'GET',
+          url: '/api/me/studio/games/sky-dodge/sources',
+          headers: authHeaders('g:creator'),
+        });
+        expect(res.statusCode).toBe(200);
+        const body = res.json() as { readOnly: boolean; agentRound: boolean };
+        expect(body.readOnly).toBe(false);
+        expect(body.agentRound).toBe(true);
+      }));
   });
 
   describe('PUT /api/me/studio/games/:slug/sources/stage', () => {

--- a/apps/api/src/creator-code.test.ts
+++ b/apps/api/src/creator-code.test.ts
@@ -233,11 +233,7 @@ describe('the Code surface routes (creator-code.ts)', () => {
 
     it('marks a self-build round as watchable even though it is never read-only', async () =>
       withApp(async (app) => {
-        // The bug this pins: `readOnly` requires `dispatch.refs`, which only a
-        // platform-dispatched round has. A creator's own agent staging over MCP
-        // has none, so the Code surface read it as "no agent here" and stopped
-        // polling — the files landed in the staging buffer and the editor never
-        // asked again. Locked and worth-watching are different questions.
+        // readOnly needs dispatch.refs; a self-build MCP round has none.
         const res = await app.inject({
           method: 'GET',
           url: '/api/me/studio/games/sky-dodge/sources',

--- a/apps/api/src/creator-code.test.ts
+++ b/apps/api/src/creator-code.test.ts
@@ -244,6 +244,21 @@ describe('the Code surface routes (creator-code.ts)', () => {
         expect(body.readOnly).toBe(false);
         expect(body.agentRound).toBe(true);
       }));
+
+    it('keeps watching across the submit handoff, which any later stage undoes', async () =>
+      withApp(async (app) => {
+        // agentEndedAt is optimistic: touchLastAgentSignalAt deletes it on the next
+        // stage or patch. Gating on it stopped the only interval at submit, so an
+        // agent resuming after a red gate wrote into a view that had stopped looking.
+        await store.markAgentEnded(10);
+        const res = await app.inject({
+          method: 'GET',
+          url: '/api/me/studio/games/sky-dodge/sources',
+          headers: authHeaders('g:creator'),
+        });
+        expect(res.statusCode).toBe(200);
+        expect((res.json() as { agentRound: boolean }).agentRound).toBe(true);
+      }));
   });
 
   describe('PUT /api/me/studio/games/:slug/sources/stage', () => {

--- a/apps/api/src/creator-code.ts
+++ b/apps/api/src/creator-code.ts
@@ -322,13 +322,7 @@ export async function registerCreatorCodeRoutes(
         deleted,
         readOnly: liveAgent,
         ...(liveAgent ? { reason: 'agent_round' as const } : {}),
-        /**
-         * The round is open to agent writes, so this response can go stale under
-         * the reader. Separate from `readOnly` because a self-build round has an
-         * agent staging over MCP and no dispatch — locked and worth-watching are
-         * different questions, and answering both with the live test left the
-         * Code surface not refreshing at all for exactly those rounds.
-         */
+        // Round is open to agent writes, so this snapshot can go stale.
         agentRound: isOpenAgentRound(record),
         staged: {
           totalBytes: stagedSummary.totalBytes,

--- a/apps/api/src/creator-code.ts
+++ b/apps/api/src/creator-code.ts
@@ -2,7 +2,7 @@ import type { FastifyInstance } from 'fastify';
 import { z } from 'zod';
 import { assembleGameHtml, CredentialLeakError, EmptyProjectError, ProjectTooLargeError } from './assemble.js';
 import { isActiveBuildRound } from './builder.js';
-import { codeSurfaceEnabled, isLiveAgentRound } from './code-surface.js';
+import { codeSurfaceEnabled, isLiveAgentRound, isOpenAgentRound } from './code-surface.js';
 import type { GcsObjectStore } from './gcs-sign.js';
 import {
   InvalidUploadError,
@@ -322,6 +322,14 @@ export async function registerCreatorCodeRoutes(
         deleted,
         readOnly: liveAgent,
         ...(liveAgent ? { reason: 'agent_round' as const } : {}),
+        /**
+         * The round is open to agent writes, so this response can go stale under
+         * the reader. Separate from `readOnly` because a self-build round has an
+         * agent staging over MCP and no dispatch — locked and worth-watching are
+         * different questions, and answering both with the live test left the
+         * Code surface not refreshing at all for exactly those rounds.
+         */
+        agentRound: isOpenAgentRound(record),
         staged: {
           totalBytes: stagedSummary.totalBytes,
           maxBytes: stagedSummary.maxBytes,

--- a/apps/web/src/CodeSurface.test.tsx
+++ b/apps/web/src/CodeSurface.test.tsx
@@ -164,6 +164,46 @@ describe('CodeSurface', () => {
     expect(container.textContent).toContain('export const boot');
   });
 
+  it('keeps watching a self-build round, which is never read-only', async () => {
+    // The gap this closes: polling was gated on `readOnly`, which needs a
+    // platform dispatch. A creator's own agent staging over MCP produces no
+    // dispatch, so the editor stopped asking and showed a snapshot from before
+    // the agent wrote anything — with nothing on screen to say it was stale.
+    vi.useFakeTimers();
+    try {
+      mocked.fetchCodeSurfaceSources.mockResolvedValue(sourcesFor({ readOnly: false, agentRound: true }));
+      await render();
+      const initial = mocked.fetchCodeSurfaceSources.mock.calls.length;
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(4_100);
+      });
+
+      expect(mocked.fetchCodeSurfaceSources.mock.calls.length).toBeGreaterThan(initial);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('stops watching once the round is neither live nor open to an agent', async () => {
+    vi.useFakeTimers();
+    try {
+      mocked.fetchCodeSurfaceSources.mockResolvedValue(sourcesFor({ readOnly: false, agentRound: false }));
+      await render();
+      const initial = mocked.fetchCodeSurfaceSources.mock.calls.length;
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(4_100);
+      });
+
+      // A closed round cannot gain files under the reader; polling it forever
+      // would be a request every four seconds for the life of the tab.
+      expect(mocked.fetchCodeSurfaceSources.mock.calls.length).toBe(initial);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('opens on game.ts, not whatever sorts first — the manifest listing leads with GAME.json', async () => {
     mocked.fetchCodeSurfaceSources.mockResolvedValue(
       sourcesFor({

--- a/apps/web/src/CodeSurface.test.tsx
+++ b/apps/web/src/CodeSurface.test.tsx
@@ -165,10 +165,7 @@ describe('CodeSurface', () => {
   });
 
   it('keeps watching a self-build round, which is never read-only', async () => {
-    // The gap this closes: polling was gated on `readOnly`, which needs a
-    // platform dispatch. A creator's own agent staging over MCP produces no
-    // dispatch, so the editor stopped asking and showed a snapshot from before
-    // the agent wrote anything — with nothing on screen to say it was stale.
+    // Polling was gated on readOnly, which a self-build round never sets.
     vi.useFakeTimers();
     try {
       mocked.fetchCodeSurfaceSources.mockResolvedValue(sourcesFor({ readOnly: false, agentRound: true }));
@@ -196,8 +193,7 @@ describe('CodeSurface', () => {
         await vi.advanceTimersByTimeAsync(4_100);
       });
 
-      // A closed round cannot gain files under the reader; polling it forever
-      // would be a request every four seconds for the life of the tab.
+      // A closed round cannot gain files; do not poll it forever.
       expect(mocked.fetchCodeSurfaceSources.mock.calls.length).toBe(initial);
     } finally {
       vi.useRealTimers();

--- a/apps/web/src/CodeSurface.tsx
+++ b/apps/web/src/CodeSurface.tsx
@@ -312,19 +312,8 @@ export function CodeSurface({
     load(true);
   }, [load]);
 
-  /*
-   * Watching an agent's files land, for as long as one could be staging them.
-   *
-   * This used to poll only while `readOnly` — a platform round holding the
-   * buffer. A self-build round has the creator's own agent staging over MCP and
-   * no dispatch, so it is never read-only, so this never armed: the agent's
-   * files reached the staging buffer, the API merged them on request, and the
-   * editor never asked again. The files were live; the view was not, with
-   * nothing on screen to say so.
-   *
-   * `agentRound` is the wider question — is the round open to agent writes —
-   * and `readOnly` still answers the narrower one about who owns the buffer.
-   */
+  // Poll while an agent could be staging. Was gated on readOnly, which needs
+  // a dispatch a self-build round never has — so it never armed there.
   const watching = Boolean(sources?.readOnly || sources?.agentRound);
   useEffect(() => {
     if (!watching) return undefined;

--- a/apps/web/src/CodeSurface.tsx
+++ b/apps/web/src/CodeSurface.tsx
@@ -312,13 +312,25 @@ export function CodeSurface({
     load(true);
   }, [load]);
 
-  // Watching an agent's files land live, while the buffer is locked (CE-08) — the same
-  // polling cadence the read-only banner needs to stay current without a page reload.
+  /*
+   * Watching an agent's files land, for as long as one could be staging them.
+   *
+   * This used to poll only while `readOnly` — a platform round holding the
+   * buffer. A self-build round has the creator's own agent staging over MCP and
+   * no dispatch, so it is never read-only, so this never armed: the agent's
+   * files reached the staging buffer, the API merged them on request, and the
+   * editor never asked again. The files were live; the view was not, with
+   * nothing on screen to say so.
+   *
+   * `agentRound` is the wider question — is the round open to agent writes —
+   * and `readOnly` still answers the narrower one about who owns the buffer.
+   */
+  const watching = Boolean(sources?.readOnly || sources?.agentRound);
   useEffect(() => {
-    if (!sources?.readOnly) return undefined;
+    if (!watching) return undefined;
     const id = window.setInterval(() => load(false), 4_000);
     return () => window.clearInterval(id);
-  }, [sources?.readOnly, load]);
+  }, [watching, load]);
 
   useEffect(() => {
     setCodeSurfaceSessionState(slug, {
@@ -815,8 +827,8 @@ export function CodeSurface({
       const base = liveContentRef.current ?? fetched;
       if (!base) return;
       const prevParams = base.params;
-       const params: Record<string, EditorParamValue> =
-         prevParams && !Array.isArray(prevParams) ? { ...(prevParams as Record<string, EditorParamValue>) } : {};
+      const params: Record<string, EditorParamValue> =
+        prevParams && !Array.isArray(prevParams) ? { ...(prevParams as Record<string, EditorParamValue>) } : {};
       for (const change of changes) params[change.key] = change.value as EditorParamValue;
       const merged: EditorContentDoc = { ...base, params };
       liveContentRef.current = merged;

--- a/apps/web/src/codeSurfaceApi.ts
+++ b/apps/web/src/codeSurfaceApi.ts
@@ -50,6 +50,13 @@ export type CodeSurfaceSources = {
   deleted: string[];
   readOnly: boolean;
   reason?: 'agent_round';
+  /**
+   * The round is open to agent writes, so this snapshot can go stale under the
+   * reader. Wider than `readOnly`: a self-build round has an agent staging over
+   * MCP and no platform dispatch, so it is never read-only and its files were
+   * landing into a view that had stopped watching. Absent from an older server.
+   */
+  agentRound?: boolean;
   staged: CodeSurfaceStagingSummary;
 };
 

--- a/apps/web/src/codeSurfaceApi.ts
+++ b/apps/web/src/codeSurfaceApi.ts
@@ -50,12 +50,7 @@ export type CodeSurfaceSources = {
   deleted: string[];
   readOnly: boolean;
   reason?: 'agent_round';
-  /**
-   * The round is open to agent writes, so this snapshot can go stale under the
-   * reader. Wider than `readOnly`: a self-build round has an agent staging over
-   * MCP and no platform dispatch, so it is never read-only and its files were
-   * landing into a view that had stopped watching. Absent from an older server.
-   */
+  // Wider than readOnly; absent on older servers.
   agentRound?: boolean;
   staged: CodeSurfaceStagingSummary;
 };


### PR DESCRIPTION
Reported from use: MCP-staged sources should reach the editor and the preview immediately, and the editor never showed them.

## The API was right the whole time

`GET /api/me/studio/games/:slug/sources` merges the staging overlay on **every** request, so an agent's file is in the response the moment it is staged. The client just stopped asking.

Polling was gated on `readOnly`, and `readOnly` is `isLiveAgentRound`, which requires `dispatch.refs.length > 0`. Only a **platform-dispatched** round has those. A creator's own agent staging over MCP has no dispatch at all — so a self-build round reads as "no agent here", the interval never armed, and the editor sat on a snapshot taken before the agent wrote anything. Nothing on screen said it was stale. The files were live; the view was not.

## One predicate was answering two questions

They are not the same question, and only one of them is about dispatch:

| question | answer | why |
|---|---|---|
| Should the owner be locked out? | `isLiveAgentRound` — **unchanged** | the platform round owns the buffer while its agent holds it |
| Should the view keep refreshing? | `isOpenAgentRound` — **new** | files land in the staging buffer the same way whoever staged them |

So `readOnly` keeps its exact meaning and locking semantics are untouched; the response gains `agentRound`, and the client polls on `readOnly || agentRound`.

Polling still stops on a closed round. One that cannot gain files does not deserve a request every four seconds for the life of the tab.

## Preview: already wired, deliberately not instant

Worth stating since the ask covers it. Staging fires `onSourcesStaged` from all four agent-channel write paths, which schedules a staged preview — but through `STAGED_PREVIEW_DEBOUNCE_MS = 6_000`. That debounce is doing a real job: an agent staging a dozen files in a burst should produce one assemble, not twelve. So the preview does update from MCP staging, ~6s after the last write rather than on the first.

If "immediately" should mean the preview too, that is a separate change with a real trade-off to make (shorten the debounce, or serve staged content to the preview without waiting for an assemble) — flagging it rather than deciding it here.

## Verification

`npm run lint`, `npm run type-check`, `npm run test` — clean; **394 test files** pass. Three new tests: the API reports `agentRound` for a round with no dispatch, the editor keeps polling when `readOnly: false, agentRound: true` (this one fails on the old code — no interval was armed at all), and it stops polling once the round is closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AqzyGhjv7Ktb8xLEVmH4tG

---
_Generated by [Claude Code](https://claude.ai/code/session_01AqzyGhjv7Ktb8xLEVmH4tG)_