### PR TITLE
Fix footer flash during catalog loading

### DIFF
--- a/apps/web/src/ArcadeCatalog.test.tsx
+++ b/apps/web/src/ArcadeCatalog.test.tsx
@@ -390,6 +390,7 @@ describe('ArcadeCatalog lazy media', () => {
 
     expect(container.querySelectorAll('.catalog-card')).toHaveLength(0);
     expect(container.querySelector('.catalog-state')?.textContent).toMatch(/Loading/i);
+    expect(container.querySelector('.arcade-section')?.classList.contains('is-pending')).toBe(true);
 
     await act(async () => {
       resolveSignals?.(
@@ -402,6 +403,7 @@ describe('ArcadeCatalog lazy media', () => {
     });
 
     expect(container.querySelectorAll('.catalog-card')).toHaveLength(2);
+    expect(container.querySelector('.arcade-section')?.classList.contains('is-pending')).toBe(false);
 
     await act(async () => {
       root.unmount();

--- a/apps/web/src/ArcadeCatalog.tsx
+++ b/apps/web/src/ArcadeCatalog.tsx
@@ -707,6 +707,7 @@ export function ArcadeCatalog({
     catalogStatus === 'ready' && catalogEntries.length > 0 && catalogSortNeedsSignals(sortMode) && !signalsReady;
   // Hold the grid while auth is unknown, and while a signed-in shelf is still loading.
   const awaitingCreatorShelf = authLoading || (Boolean(viewerUid) && !creatorGamesReady);
+  const catalogPending = catalogStatus === 'loading' || awaitingSignals || awaitingCreatorShelf || !featuredPoolReady;
   const layoutReady = catalogStatus === 'ready' && !awaitingSignals && !awaitingCreatorShelf;
 
   // Curated surfaces above the grid, gated on layoutReady like the grid.
@@ -936,7 +937,7 @@ export function ArcadeCatalog({
           ))}
         </>
       )}
-      <section id="arcade" className="arcade-section">
+      <section id="arcade" className={`arcade-section${catalogPending ? ' is-pending' : ''}`}>
         <div id="browse-everything" className="arcade-header">
           <div className="arcade-title-row">
             <h2 className="arcade-title">{t('catalog.browseEverything')}</h2>
@@ -1020,7 +1021,7 @@ export function ArcadeCatalog({
           </div>
         ) : null}
 
-        {catalogStatus === 'loading' || awaitingSignals || awaitingCreatorShelf || !featuredPoolReady ? (
+        {catalogPending ? (
           <MascotMoment className="catalog-state" emotion="busy" size={56} title={t('mascot.busyAlt')}>
             <p>{t('catalog.loading')}</p>
           </MascotMoment>

--- a/apps/web/src/styles.catalogGrid.test.ts
+++ b/apps/web/src/styles.catalogGrid.test.ts
@@ -29,6 +29,12 @@ describe('catalog grid layout', () => {
     expect(ruleBody('.catalog-media')).toMatch(/aspect-ratio:\s*16\s*\/\s*9/);
   });
 
+  it('keeps the footer below the fold while the catalog settles', () => {
+    const rule = ruleBody('.arcade-section.is-pending');
+    expect(rule).toMatch(/min-height:\s*100vh/);
+    expect(rule).toMatch(/min-height:\s*100dvh/);
+  });
+
   it('hides the moments-only toggle on coarse pointers, but keeps the video one tappable', () => {
     const rule = css.match(/\.preview-toggle:not\(\.preview-toggle--video\)\s*,\s*\.catalog-moments\s*\{([\s\S]*?)\}/);
     expect(rule, 'missing combined preview-toggle/catalog-moments hide rule').not.toBeNull();

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -1644,6 +1644,12 @@ button:disabled {
   margin-bottom: 60px;
 }
 
+/* Keep the footer below the fold while the catalog settles. */
+.arcade-section.is-pending {
+  min-height: 100vh;
+  min-height: 100dvh;
+}
+
 .arcade-header {
   margin-bottom: 16px;
   display: flex;


### PR DESCRIPTION
## What changed

Keep the home page footer below the fold while the catalog is settling, including the recommendation, featured-pool, auth, and creator-shelf loading gates.

## Why

The footer mounted immediately while the home catalog only contained its small loading state, so it briefly appeared in the viewport before catalog cards arrived and pushed it down.

The catalog now applies a pending layout class and reserves one viewport of height during those states. The reservation is released as soon as the grid is ready.

## Validation

- `npm run type-check`
- `npm run lint`
- `npm run test`
- `npm run build`
- Browser verification at 1440×900 and 390×844, including no horizontal overflow on mobile
