### PR TITLE
Studio composer: fix attach-menu overflow, hide switcher while sending, support paste

### DIFF
--- a/apps/web/src/HeroPromptSection.test.tsx
+++ b/apps/web/src/HeroPromptSection.test.tsx
@@ -254,6 +254,47 @@ describe('HeroPromptSection', () => {
     await act(async () => root.unmount());
   });
 
+  it('attaches an image pasted into the prompt field', async () => {
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    await i18n.changeLanguage('en');
+
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(
+        createElement(HeroPromptSection, {
+          initialPrompt: '',
+          catalogEntries: [],
+          submissionStatus: 'idle',
+          submissionError: null,
+          onSubmitSpec: vi.fn(),
+          mockStatus: 'idle',
+          mockError: null,
+          onGenerateMock: vi.fn(),
+        }),
+      );
+      await flushEffects();
+    });
+
+    const input = container.querySelector('.big-prompt-input')!;
+    const file = new File(['fake'], 'sprite.png', { type: 'image/png' });
+    await act(async () => {
+      const paste = new Event('paste', { bubbles: true, cancelable: true }) as ClipboardEvent;
+      Object.defineProperty(paste, 'clipboardData', {
+        value: { items: [{ type: 'image/png', getAsFile: () => file }] },
+      });
+      input.dispatchEvent(paste);
+      // FileReader resolves on a real macrotask in jsdom, not a microtask.
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    });
+    expect(container.querySelector('.attachments-list')).not.toBeNull();
+    expect(container.querySelector('.attachment-thumb')?.getAttribute('alt')).toBe('sprite.png');
+
+    await act(async () => root.unmount());
+  });
+
   it('opens sketch modal from the attach menu', async () => {
     (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
     await i18n.changeLanguage('en');

--- a/apps/web/src/HeroPromptSection.test.tsx
+++ b/apps/web/src/HeroPromptSection.test.tsx
@@ -295,6 +295,61 @@ describe('HeroPromptSection', () => {
     await act(async () => root.unmount());
   });
 
+  it('blocks submit until a pasted image finishes loading', async () => {
+    // Codex #887: a same-tick submit after paste raced the FileReader.
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    await i18n.changeLanguage('en');
+    const onSubmitSpec = vi.fn();
+
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(
+        createElement(HeroPromptSection, {
+          initialPrompt: 'a quiet garden game',
+          catalogEntries: [],
+          submissionStatus: 'idle',
+          submissionError: null,
+          onSubmitSpec,
+          mockStatus: 'idle',
+          mockError: null,
+          onGenerateMock: vi.fn(),
+        }),
+      );
+      await flushEffects();
+    });
+
+    const input = container.querySelector('.big-prompt-input')!;
+    const file = new File(['fake'], 'sprite.png', { type: 'image/png' });
+    await act(async () => {
+      const paste = new Event('paste', { bubbles: true, cancelable: true }) as ClipboardEvent;
+      Object.defineProperty(paste, 'clipboardData', {
+        value: { items: [{ type: 'image/png', getAsFile: () => file }] },
+      });
+      input.dispatchEvent(paste);
+      // Deliberately not awaiting the FileReader's macrotask.
+      await flushEffects();
+    });
+
+    expect(container.querySelector<HTMLButtonElement>('.build-btn')?.disabled).toBe(true);
+    await act(async () => {
+      container
+        .querySelector('.prompt-box-form')
+        ?.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }));
+      await flushEffects();
+    });
+    expect(onSubmitSpec).not.toHaveBeenCalled();
+
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    });
+    expect(container.querySelector<HTMLButtonElement>('.build-btn')?.disabled).toBe(false);
+
+    await act(async () => root.unmount());
+  });
+
   it('opens sketch modal from the attach menu', async () => {
     (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
     await i18n.changeLanguage('en');

--- a/apps/web/src/HeroPromptSection.tsx
+++ b/apps/web/src/HeroPromptSection.tsx
@@ -6,6 +6,7 @@ import { SketchModal } from './SketchModal.js';
 import { PixelIcon } from './PixelIcon.js';
 import { getQuota, type PlatformBuilderAvailability } from './submissionApi.js';
 import { toBase64PngList } from './attachmentImages.js';
+import { useClampToViewport } from './useClampToViewport.js';
 
 // Mirrors MAX_REFERENCE_IMAGES in submissions.ts.
 const MAX_ATTACHMENTS = 4;
@@ -136,6 +137,7 @@ export function HeroPromptSection({
 
   const fileInputRef = useRef<HTMLInputElement | null>(null);
   const attachMenuRef = useRef<HTMLDivElement | null>(null);
+  const attachPanelRef = useClampToViewport<HTMLDivElement>(attachMenuOpen);
 
   // Show quota before a 429 after they finish typing.
   const [quota, setQuota] = useState<{ used: number; limit: number | null } | null>(null);
@@ -381,7 +383,7 @@ export function HeroPromptSection({
                 <PixelIcon name="plus" size={18} />
               </button>
               {attachMenuOpen && !isBusy ? (
-                <div className="prompt-attach-menu" role="menu" aria-label={t('hero.attachMenu')}>
+                <div className="prompt-attach-menu" role="menu" aria-label={t('hero.attachMenu')} ref={attachPanelRef}>
                   <button
                     type="button"
                     className="prompt-attach-item"
@@ -430,6 +432,13 @@ export function HeroPromptSection({
               enterKeyHint="go"
               autoComplete="off"
               disabled={isBusy}
+              onPaste={(e) => {
+                const pastedImages = Array.from(e.clipboardData?.items ?? [])
+                  .filter((item) => item.type.startsWith('image/'))
+                  .map((item) => item.getAsFile())
+                  .filter((file): file is File => file !== null);
+                if (pastedImages.length > 0) handleFiles(pastedImages);
+              }}
             />
 
             <div className="prompt-bar-actions">

--- a/apps/web/src/HeroPromptSection.tsx
+++ b/apps/web/src/HeroPromptSection.tsx
@@ -129,6 +129,8 @@ export function HeroPromptSection({
   const shouldAutoFocusPrompt = typeof matchMedia !== 'function' || !matchMedia('(max-width: 768px)').matches;
   const [promptText, setPromptText] = useState(initialPrompt);
   const [attachments, setAttachments] = useState<VisualAttachment[]>([]);
+  // FileReader work not yet landed in attachments.
+  const [pendingAttachmentReads, setPendingAttachmentReads] = useState(0);
   const [isSketchOpen, setIsSketchOpen] = useState(false);
   const [isDragging, setIsDragging] = useState(false);
   const [isListening, setIsListening] = useState(false);
@@ -257,7 +259,9 @@ export function HeroPromptSection({
     if (submissionStatus !== 'idle' || mockStatus === 'loading') return;
     Array.from(files).forEach((file) => {
       if (!file.type.startsWith('image/')) return;
+      setPendingAttachmentReads((count) => count + 1);
       const reader = new FileReader();
+      const done = () => setPendingAttachmentReads((count) => count - 1);
       reader.onload = (e) => {
         const dataUrl = e.target?.result as string;
         if (dataUrl) {
@@ -270,7 +274,9 @@ export function HeroPromptSection({
             },
           ]);
         }
+        done();
       };
+      reader.onerror = done;
       reader.readAsDataURL(file);
     });
   };
@@ -338,7 +344,7 @@ export function HeroPromptSection({
 
   const handlePrimarySubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    if (isBusy) return;
+    if (isBusy || pendingAttachmentReads > 0) return;
     const trimmed = promptText.trim();
     if (!trimmed && attachments.length === 0) return;
 
@@ -460,7 +466,7 @@ export function HeroPromptSection({
               className={`primary-btn build-btn${isBusy ? ' is-busy' : ''}`}
               title={busyLabel ?? t('hero.buildGameButton')}
               aria-label={busyLabel ?? t('hero.buildGameButton')}
-              disabled={isBusy || (!promptText.trim() && attachments.length === 0)}
+              disabled={isBusy || pendingAttachmentReads > 0 || (!promptText.trim() && attachments.length === 0)}
             >
               {isBusy ? <span className="build-btn-spinner" aria-hidden="true" /> : <PixelIcon name="send" size={16} />}
               {/* refining ≠ submitting; phone shows label, desktop clips to icon */}

--- a/apps/web/src/SubmissionStatusView.test.ts
+++ b/apps/web/src/SubmissionStatusView.test.ts
@@ -1890,6 +1890,82 @@ describe('SubmissionStatusView', () => {
     });
   });
 
+  it('blocks send until a pasted image finishes loading, so it never ships without it', async () => {
+    // Codex #887: a same-tick send after paste could beat the FileReader.
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    mockedGetSubmissionStatus.mockResolvedValue({
+      status: 'needs_changes',
+      preview: { slug: 'space-runner' },
+      progress: { headSha: 'sha-1', commits: [], checklist: [] },
+    });
+    mockedGetSubmissionPreview.mockResolvedValue({
+      slug: 'space-runner',
+      title: 'Space Runner',
+      html: '<canvas></canvas>',
+    });
+    mockedSubmitFeedback.mockResolvedValue({ ok: true, target: 'pull_request' });
+    await i18n.changeLanguage('en');
+    window.history.pushState(null, '', '/studio/feedback-token/thread');
+
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(createElement(SubmissionStatusView, { token: 'feedback-token', embedded: true }));
+      await flushEffects();
+      await flushEffects();
+    });
+
+    const textarea = container.querySelector<HTMLTextAreaElement>('.status-feedback-input');
+    await act(async () => {
+      if (textarea) {
+        const setter = Object.getOwnPropertyDescriptor(HTMLTextAreaElement.prototype, 'value')?.set;
+        setter?.call(textarea, 'Match the sketch I just pasted please.');
+        textarea.dispatchEvent(new Event('input', { bubbles: true }));
+      }
+      await flushEffects();
+    });
+
+    const file = new File(['fake'], 'sprite.png', { type: 'image/png' });
+    await act(async () => {
+      const paste = new Event('paste', { bubbles: true, cancelable: true }) as ClipboardEvent;
+      Object.defineProperty(paste, 'clipboardData', {
+        value: { items: [{ type: 'image/png', getAsFile: () => file }] },
+      });
+      textarea?.dispatchEvent(paste);
+      // Deliberately not awaiting the FileReader's macrotask here.
+      await flushEffects();
+    });
+
+    const sendButton = container.querySelector<HTMLButtonElement>('.status-composer-send');
+    expect(sendButton?.disabled).toBe(true);
+    await act(async () => {
+      sendButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      await flushEffects();
+    });
+    expect(mockedSubmitFeedback).not.toHaveBeenCalled();
+
+    await act(async () => {
+      // Let the FileReader resolve.
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    });
+    expect(container.querySelector<HTMLButtonElement>('.status-composer-send')?.disabled).toBe(false);
+
+    await act(async () => {
+      container
+        .querySelector<HTMLButtonElement>('.status-composer-send')
+        ?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      await flushEffects();
+    });
+    expect(mockedSubmitFeedback).toHaveBeenCalledTimes(1);
+    expect(mockedSubmitFeedback.mock.calls[0][2]).toMatchObject({ referenceImages: [expect.any(String)] });
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
+
   it('sends from the compact composer on Enter and focuses the field from card chrome', async () => {
     (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
     mockedGetSubmissionStatus.mockResolvedValue({

--- a/apps/web/src/SubmissionStatusView.test.ts
+++ b/apps/web/src/SubmissionStatusView.test.ts
@@ -1036,6 +1036,69 @@ describe('SubmissionStatusView', () => {
     }
   });
 
+  it('hides the switch-builder control while a message is sending, not just while the agent is live', async () => {
+    // Regression: the handoff button had no "sending" gate at all.
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    mockedGetSubmissionStatus.mockResolvedValue({
+      status: 'building',
+      phase: 'building',
+      builder: 'platform',
+      stall: 'ended',
+      agentEndedAt: '2026-08-12T20:00:00.000Z',
+      events: [],
+    });
+    let resolveSend!: (value: { ok: boolean; target: string }) => void;
+    mockedSubmitFeedback.mockReturnValue(
+      new Promise((resolve) => {
+        resolveSend = resolve;
+      }),
+    );
+    await i18n.changeLanguage('en');
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    try {
+      await act(async () => {
+        root.render(createElement(SubmissionStatusView, { token: 'ended-platform-token', embedded: true }));
+        await flushEffects();
+        await flushEffects();
+      });
+
+      expect(container.querySelector('[data-testid="active-switch-builder-self"]')).not.toBeNull();
+
+      const textarea = container.querySelector<HTMLTextAreaElement>('.status-feedback-input');
+      await act(async () => {
+        if (textarea) {
+          const setter = Object.getOwnPropertyDescriptor(HTMLTextAreaElement.prototype, 'value')?.set;
+          setter?.call(textarea, 'Please make the car faster and add a boost pad.');
+          textarea.dispatchEvent(new Event('input', { bubbles: true }));
+        }
+        await flushEffects();
+      });
+      await act(async () => {
+        container
+          .querySelector<HTMLButtonElement>('.status-composer-send')
+          ?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+        await flushEffects();
+      });
+
+      expect(container.querySelector('.status-composer.is-sending')).not.toBeNull();
+      expect(container.querySelector('[data-testid="active-switch-builder-self"]')).toBeNull();
+      // Sending sits inline next to Send now, not a row below.
+      expect(container.querySelector('.status-composer-toolbar-right .status-feedback-sending')).not.toBeNull();
+
+      await act(async () => {
+        resolveSend({ ok: true, target: 'ended-platform-token' });
+        await flushEffects();
+      });
+    } finally {
+      await act(async () => {
+        root.unmount();
+      });
+    }
+  });
+
   it('keeps the live builder handoff in the composer, not the transcript', async () => {
     (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
     mockedGetSubmissionStatus.mockResolvedValue({
@@ -1776,6 +1839,51 @@ describe('SubmissionStatusView', () => {
     expect(container.querySelector('.status-feedback-receipt')).toBeNull();
     expect(container.querySelector('.status-feedback-actions')).toBeNull();
     expect(container.textContent).toContain('Please make the car faster and add a boost pad.');
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
+
+  it('attaches an image pasted into the compact composer', async () => {
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    mockedGetSubmissionStatus.mockResolvedValue({
+      status: 'needs_changes',
+      preview: { slug: 'space-runner' },
+      progress: { headSha: 'sha-1', commits: [], checklist: [] },
+    });
+    mockedGetSubmissionPreview.mockResolvedValue({
+      slug: 'space-runner',
+      title: 'Space Runner',
+      html: '<canvas></canvas>',
+    });
+    await i18n.changeLanguage('en');
+    window.history.pushState(null, '', '/studio/feedback-token/thread');
+
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(createElement(SubmissionStatusView, { token: 'feedback-token', embedded: true }));
+      await flushEffects();
+      await flushEffects();
+    });
+
+    const textarea = container.querySelector<HTMLTextAreaElement>('.status-feedback-input');
+    const file = new File(['fake'], 'sprite.png', { type: 'image/png' });
+    await act(async () => {
+      const paste = new Event('paste', { bubbles: true, cancelable: true }) as ClipboardEvent;
+      Object.defineProperty(paste, 'clipboardData', {
+        value: { items: [{ type: 'image/png', getAsFile: () => file }] },
+      });
+      textarea?.dispatchEvent(paste);
+      // FileReader resolves on a real macrotask in jsdom, not a microtask.
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    });
+
+    expect(container.querySelector('.status-composer-attachment-chip')).not.toBeNull();
+    expect(container.querySelector('.status-composer-attachment-thumb')?.getAttribute('alt')).toBe('sprite.png');
 
     await act(async () => {
       root.unmount();

--- a/apps/web/src/SubmissionStatusView.tsx
+++ b/apps/web/src/SubmissionStatusView.tsx
@@ -1454,6 +1454,8 @@ function FeedbackPanel({
   const [builder, setBuilder] = useState<BuilderKind>(initialBuilder);
   const inputRef = useRef<HTMLTextAreaElement | null>(null);
   const [attachments, setAttachments] = useState<ComposerAttachment[]>([]);
+  // FileReader work not yet landed in attachments — Send waits for it.
+  const [pendingAttachmentReads, setPendingAttachmentReads] = useState(0);
   const [attachMenuOpen, setAttachMenuOpen] = useState(false);
   const [isSketchOpen, setIsSketchOpen] = useState(false);
   const fileInputRef = useRef<HTMLInputElement | null>(null);
@@ -1557,19 +1559,24 @@ function FeedbackPanel({
     if (state === 'sending') return;
     Array.from(files).forEach((file) => {
       if (!file.type.startsWith('image/')) return;
+      setPendingAttachmentReads((count) => count + 1);
       const reader = new FileReader();
+      const done = () => setPendingAttachmentReads((count) => count - 1);
       reader.onload = (e) => {
         const dataUrl = e.target?.result as string;
-        if (!dataUrl) return;
-        setAttachments((prev) =>
-          prev.length >= MAX_COMPOSER_ATTACHMENTS
-            ? prev
-            : [
-                ...prev,
-                { id: `file-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`, name: file.name, dataUrl },
-              ],
-        );
+        if (dataUrl) {
+          setAttachments((prev) =>
+            prev.length >= MAX_COMPOSER_ATTACHMENTS
+              ? prev
+              : [
+                  ...prev,
+                  { id: `file-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`, name: file.name, dataUrl },
+                ],
+          );
+        }
+        done();
       };
+      reader.onerror = done;
       reader.readAsDataURL(file);
     });
   };
@@ -1588,7 +1595,7 @@ function FeedbackPanel({
 
   const send = async (requestedText: string = trimmed) => {
     const message = requestedText.trim();
-    if (message.length < 10 || state === 'sending') return;
+    if (message.length < 10 || state === 'sending' || pendingAttachmentReads > 0) return;
     setState('sending');
     setError(null);
     setNotice(null);
@@ -1927,7 +1934,7 @@ function FeedbackPanel({
                 type="button"
                 className="primary-btn status-composer-send"
                 onClick={() => void send()}
-                disabled={sending || trimmed.length < 10}
+                disabled={sending || trimmed.length < 10 || pendingAttachmentReads > 0}
                 aria-label={sending ? t('statusView.feedback.sending') : t('statusView.feedback.submit')}
                 title={sending ? t('statusView.feedback.sending') : t('statusView.feedback.submit')}
               >

--- a/apps/web/src/SubmissionStatusView.tsx
+++ b/apps/web/src/SubmissionStatusView.tsx
@@ -35,6 +35,7 @@ import { studioThreadContentScrollTop, studioThreadNearContentEnd } from './stud
 import { recordStudioStep, type StudioStepDetail } from './visitTelemetry.js';
 import { toBase64PngList } from './attachmentImages.js';
 import { SketchModal } from './SketchModal.js';
+import { useClampToViewport } from './useClampToViewport.js';
 
 type BuilderHandoffHandler = () => Promise<void | { pending?: boolean }> | void | { pending?: boolean };
 
@@ -1457,6 +1458,7 @@ function FeedbackPanel({
   const [isSketchOpen, setIsSketchOpen] = useState(false);
   const fileInputRef = useRef<HTMLInputElement | null>(null);
   const attachMenuRef = useRef<HTMLDivElement | null>(null);
+  const attachPanelRef = useClampToViewport<HTMLDivElement>(attachMenuOpen);
 
   useEffect(() => {
     if (!attachMenuOpen) return;
@@ -1711,7 +1713,7 @@ function FeedbackPanel({
     />
   ) : null;
   const activeSelfHandoff =
-    !chooseBuilder && effectiveBuilder === 'self' && onSwitchToPlatform ? (
+    !chooseBuilder && effectiveBuilder === 'self' && onSwitchToPlatform && state !== 'sending' ? (
       <SwitchToPlatformControl
         compact
         active
@@ -1724,7 +1726,7 @@ function FeedbackPanel({
     !chooseBuilder && agentWorking && effectiveBuilder === 'platform' && Boolean(onSwitchToSelf) && !stopRequested;
   // Hide the switch-to-self badge while STOP covers the same action.
   const activePlatformHandoff =
-    !chooseBuilder && effectiveBuilder === 'platform' && onSwitchToSelf && !showStop ? (
+    !chooseBuilder && effectiveBuilder === 'platform' && onSwitchToSelf && !showStop && state !== 'sending' ? (
       <SwitchToSelfControl compact active onSwitchToSelf={onSwitchToSelf} pending={stopRequested} />
     ) : null;
   const stopAndSwitchToSelf = async () => {
@@ -1816,6 +1818,13 @@ function FeedbackPanel({
             event.preventDefault();
             void send();
           }}
+          onPaste={(event) => {
+            const pastedImages = Array.from(event.clipboardData?.items ?? [])
+              .filter((item) => item.type.startsWith('image/'))
+              .map((item) => item.getAsFile())
+              .filter((file): file is File => file !== null);
+            if (pastedImages.length > 0) handleAttachFiles(pastedImages);
+          }}
           placeholder={t(composerHintKey)}
           aria-label={t(titleKey)}
           rows={1}
@@ -1856,7 +1865,7 @@ function FeedbackPanel({
                 <PixelIcon name="plus" size={15} />
               </button>
               {attachMenuOpen && !sending ? (
-                <div className="prompt-attach-menu" role="menu" aria-label={t('hero.attachMenu')}>
+                <div className="prompt-attach-menu" role="menu" aria-label={t('hero.attachMenu')} ref={attachPanelRef}>
                   <button
                     type="button"
                     className="prompt-attach-item"
@@ -1898,6 +1907,11 @@ function FeedbackPanel({
             {builderControls}
           </div>
           <div className="status-composer-toolbar-right">
+            {sending && !showStop ? (
+              <span className="status-feedback-sending" role="status">
+                {t('statusView.feedback.sending')}
+              </span>
+            ) : null}
             {showStop ? (
               <button
                 type="button"
@@ -1926,21 +1940,10 @@ function FeedbackPanel({
             )}
           </div>
         </div>
-        {/* Failures, in-flight, and "kept but nothing started" still need a row — they
-            ask the creator to wait or act. A plain Sent receipt does not: the thread
-            already shows the message the moment send succeeds. */}
-        {error || sending || notice ? (
-          <div className={`status-feedback-actions${sending ? ' status-feedback-actions-end' : ''}`}>
-            {error ? (
-              <p className="error">{error}</p>
-            ) : sending ? (
-              // Right-aligned under Send, not the switch-builder button.
-              <span className="status-feedback-sending" role="status">
-                {t('statusView.feedback.sending')}
-              </span>
-            ) : (
-              <p className="status-feedback-notice">{notice}</p>
-            )}
+        {/* Sending's indicator now sits inline next to Send, above */}
+        {error || notice ? (
+          <div className="status-feedback-actions">
+            {error ? <p className="error">{error}</p> : <p className="status-feedback-notice">{notice}</p>}
           </div>
         ) : null}
         <SketchModal isOpen={isSketchOpen} onClose={() => setIsSketchOpen(false)} onSaveSketch={handleSaveSketch} />

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -7166,11 +7166,6 @@ a.user-name--profile:focus-visible {
   margin: 0;
 }
 
-/* Sending pairs with Send on the right, not the switch-builder button on the left. */
-.status-composer.is-compact .status-feedback-actions-end {
-  justify-content: flex-end;
-}
-
 /* THE STUDIO THREAD AS AN APP SCREEN — the part that is true at every width.
    Below this, two media blocks give the shell its shape: edge-to-edge on a phone at
    800px and under, a shelf rail and a capped reading column above that. What lives here

--- a/apps/web/src/useClampToViewport.test.ts
+++ b/apps/web/src/useClampToViewport.test.ts
@@ -1,0 +1,67 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from 'react';
+import { createRoot } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useClampToViewport } from './useClampToViewport.js';
+
+function Probe({ active }: { active: boolean }) {
+  const ref = useClampToViewport<HTMLDivElement>(active);
+  return createElement('div', { ref, 'data-testid': 'panel' });
+}
+
+async function mountProbe(active: boolean) {
+  (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  await act(async () => {
+    root.render(createElement(Probe, { active }));
+  });
+  const panel = container.querySelector<HTMLDivElement>('[data-testid="panel"]');
+  return { container, root, panel };
+}
+
+describe('useClampToViewport', () => {
+  beforeEach(() => {
+    Object.defineProperty(window, 'innerWidth', { configurable: true, writable: true, value: 400 });
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = '';
+    vi.restoreAllMocks();
+  });
+
+  it('shifts a panel left when its natural position overflows the right edge', async () => {
+    const { container, panel } = await mountProbe(true);
+    panel!.getBoundingClientRect = () =>
+      ({ left: 264, right: 444, width: 180, top: 0, bottom: 0, height: 0, x: 264, y: 0, toJSON() {} }) as DOMRect;
+    await act(async () => {
+      window.dispatchEvent(new Event('resize'));
+    });
+    expect(panel!.style.transform).toBe('translateX(-56px)');
+    container.remove();
+  });
+
+  it('leaves an in-bounds panel untouched', async () => {
+    const { container, panel } = await mountProbe(true);
+    panel!.getBoundingClientRect = () =>
+      ({ left: 100, right: 280, width: 180, top: 0, bottom: 0, height: 0, x: 100, y: 0, toJSON() {} }) as DOMRect;
+    await act(async () => {
+      window.dispatchEvent(new Event('resize'));
+    });
+    expect(panel!.style.transform).toBe('');
+    container.remove();
+  });
+
+  it('does nothing while inactive', async () => {
+    const { container, panel } = await mountProbe(false);
+    panel!.getBoundingClientRect = () =>
+      ({ left: 264, right: 444, width: 180, top: 0, bottom: 0, height: 0, x: 264, y: 0, toJSON() {} }) as DOMRect;
+    await act(async () => {
+      window.dispatchEvent(new Event('resize'));
+    });
+    expect(panel!.style.transform).toBe('');
+    container.remove();
+  });
+});

--- a/apps/web/src/useClampToViewport.ts
+++ b/apps/web/src/useClampToViewport.ts
@@ -1,0 +1,27 @@
+import { useLayoutEffect, useRef, type RefObject } from 'react';
+import { notificationPanelShiftX } from './notificationPanelPosition.js';
+
+// Keeps a left-anchored popover from overflowing the viewport's right edge.
+export function useClampToViewport<T extends HTMLElement>(active: boolean): RefObject<T> {
+  const ref = useRef<T>(null);
+
+  useLayoutEffect(() => {
+    const panel = ref.current;
+    if (!active || !panel) return;
+
+    const place = () => {
+      panel.style.transform = '';
+      const shift = notificationPanelShiftX(panel.getBoundingClientRect(), window.innerWidth);
+      panel.style.transform = shift === 0 ? '' : `translateX(${shift}px)`;
+    };
+
+    place();
+    window.addEventListener('resize', place);
+    return () => {
+      window.removeEventListener('resize', place);
+      panel.style.transform = '';
+    };
+  }, [active]);
+
+  return ref as RefObject<T>;
+}


### PR DESCRIPTION
## Summary

Three creator-reported bugs in the attach/send flow, live-reproduced against production (bot:e2e's real submissions) before fixing.

**1. Attach menu overflow off the right edge of the viewport**

"Upload Image"/"Draw Sketch" text was cut off on mobile. Live-reproduced: the "+" button renders at x:264 on a 390px viewport, and the menu's fixed 180px min-width, anchored unconditionally at `left:0`, pushed its right edge to x:444 — 54px past the edge. Fixed by reusing `NotificationBell`'s existing viewport-clamp pattern (`notificationPanelShiftX`), generalized into a new `useClampToViewport` hook shared by both composers that render this menu (`SubmissionStatusView.tsx` and `HeroPromptSection.tsx`).

**2. "Switch to your agent" stayed clickable-looking while sending**

The handoff control had no gate on the composer's `sending` state at all — despite PR #881's title ("Hide handoff buttons while sending message in compact mode") implying this was already handled; its actual diff only right-aligned the "Sending…" text, never touched the handoff button. Hid `activeSelfHandoff`/`activePlatformHandoff` while sending, and moved the "Sending…" indicator inline next to Send instead of a separate row below (per creator feedback: "Sending... needs fix to be on the left from button").

**3. No clipboard paste support**

Only the file picker and drag-and-drop worked; `Ctrl+V` did nothing. Added `onPaste` to both composers, reusing the existing image-attach pipeline (`handleAttachFiles`/`handleFiles`).

**Also answered** (no code change): does pausing the game preview to annotate pass a screenshot + state to the agent? Yes — it passes a PNG screenshot plus instrumentation (play time, last-alive frame count, errors, progress notes) through the same `context` mechanism as manual attach, so it's subject to the same chat-agent silent-drop gap flagged separately (not part of this PR).

## Test plan

- [x] `npx tsc --noEmit` (apps/web) — clean
- [x] `npm run lint` — clean, comment-prose at/under baseline
- [x] `apps/web` test suite — 181 files / 1555 tests passing, including 3 new test files/additions (`useClampToViewport.test.ts`, a paste-to-attach test in each composer, a sending-hides-handoff regression test)
- [x] Live-reproduced the attach-menu overflow against a real production submission (bot:e2e, mobile viewport) before fixing — screenshot-matched the exact reported bug
- [x] Verified the fix via computed bounding-box checks: menu clamps to stay within the viewport in the overflow case, stays untouched when already in bounds

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01QKoPG5i8SSWLxSDtXs8oAf

---
_Generated by [Claude Code](https://claude.ai/code/session_01QKoPG5i8SSWLxSDtXs8oAf)_