### PR TITLE
Trim games-repo-contract.ts comments under the prose baseline

### DIFF
--- a/apps/api/src/games-repo-contract.ts
+++ b/apps/api/src/games-repo-contract.ts
@@ -92,13 +92,7 @@ export const GAME_KIT_MODULES = [
 
 export type GameKitModuleName = (typeof GAME_KIT_MODULES)[number];
 
-/**
- * Author-facing budget — games-repo Check 4 `GAME_BUDGET_BYTES`.
- *
- * 252 → 624 KiB for transport-tycoon-remake, an OpenTTD-scale sim whose assembled
- * project (694_419 bytes) blew the prior 668_048 total cap by ~26 KiB even with a
- * lean platform half.
- */
+// Author-facing budget — games-repo Check 4 `GAME_BUDGET_BYTES`. 252 → 624 KiB.
 export const GAME_BUDGET_BYTES = 624 * 1024;
 
 /**
@@ -110,8 +104,7 @@ export const GAME_BUDGET_BYTES = 624 * 1024;
  * under the author budget while comments and types push the `.ts` tree higher. Moved
  * 200 → 300 KiB when carjack-city (~247 KiB source) stranded every snapshot publish;
  * 300 → 336 KiB for the same game's island coastline, on-foot car collision and
- * mission-ladder work — 335_142 raw bytes carrying 252_340 assembled ones. 336 → 708 KiB
- * to keep clearing the 624 KiB author budget when it moved for transport-tycoon-remake.
+ * mission-ladder work — 335_142 raw bytes carrying 252_340 assembled ones. 336 → 708 KiB.
  */
 export const SOURCE_GRAPH_BUDGET_BYTES = 708 * 1024;
 


### PR DESCRIPTION
Master's own CI (`50c082d`, "Raise games serve cap to ~1MB") is currently red — the comment-prose ratchet failed at 2152 words against a 2105 baseline for this file. That commit added rationale prose to two budget comments (`GAME_BUDGET_BYTES`, `SOURCE_GRAPH_BUDGET_BYTES`) explaining the transport-tycoon-remake bump; the explanation is also in the commit message and already covered by the surrounding block comment on `SOURCE_GRAPH_BUDGET_BYTES`, so it's redundant in two places, not one.

Trimmed both to the changed numbers only — no rationale text, no behavior change:

- `GAME_BUDGET_BYTES`: kept `252 → 624 KiB`, dropped the transport-tycoon-remake explanation
- `SOURCE_GRAPH_BUDGET_BYTES`: kept `336 → 708 KiB`, dropped the "to keep clearing the author budget" clause

Values (`624 * 1024`, `708 * 1024`) are untouched.

## Verification

`npm run comment-prose`, `npm run lint`, `npm run type-check` — clean. `games-repo-contract.test.ts` (32 tests) still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AqzyGhjv7Ktb8xLEVmH4tG

---
_Generated by [Claude Code](https://claude.ai/code/session_01AqzyGhjv7Ktb8xLEVmH4tG)_