### PR TITLE
Add targeted re-review workflow for game assessments

### DIFF
--- a/apps/api/src/review.test.ts
+++ b/apps/api/src/review.test.ts
@@ -629,12 +629,11 @@ describe('targeted re-review', () => {
       gameVersion: 'v1',
     });
 
-    // Once assessed, the slug is gone from this reviewer's queue — the permanent
-    // exclusion the games-repo skill flags as the gap.
+    // Once assessed, the slug drops out of this reviewer's queue.
     const gone = await app.inject({ method: 'GET', url: '/api/review/queue', headers: { cookie: reviewer } });
     expect(JSON.parse(gone.body).items.map((i: { slug: string }) => i.slug)).not.toContain('sky-dodge');
 
-    // Close out the sweep so only the targeted request drives what shows up next.
+    // Close out the sweep so only the targeted request drives the queue.
     await app.inject({
       method: 'POST',
       url: '/api/admin/review-sweeps/swp-first',
@@ -642,8 +641,7 @@ describe('targeted re-review', () => {
       payload: { status: 'completed' },
     });
 
-    // A fix lands; an operator asks this specific reviewer to look again, with an
-    // explicit slug and reviewer uid (not a sweep), naming the fixed version.
+    // A fix lands; requeue that one slug for that one reviewer.
     const requeue = await app.inject({
       method: 'POST',
       url: '/api/admin/review-requeue',
@@ -662,8 +660,7 @@ describe('targeted re-review', () => {
       expect.objectContaining({ slug: 'sky-dodge', reviewerUid: 'dev:reviewer', status: 'open' }),
     ]);
 
-    // The targeted reviewer sees it again, flagged as a re-review — even with no active
-    // sweep at all.
+    // The targeted reviewer sees it again, flagged as a re-review.
     const targetedQueue = await app.inject({ method: 'GET', url: '/api/review/queue', headers: { cookie: reviewer } });
     const targetedBody = JSON.parse(targetedQueue.body) as {
       items: Array<{ slug: string; reReview: { reason: string | null; gameVersion: string | null } | null }>;
@@ -679,8 +676,7 @@ describe('targeted re-review', () => {
     const otherQueue = await app.inject({ method: 'GET', url: '/api/review/queue', headers: { cookie: second } });
     expect(JSON.parse(otherQueue.body).items).toEqual([]);
 
-    // The targeted reviewer re-assesses; the original verdict is preserved as history,
-    // not overwritten silently, and the new row carries the version it judged.
+    // Re-assessing archives the original verdict instead of overwriting it.
     const second_assessment = await assess(app, reviewer, {
       slug: 'sky-dodge',
       source: 'catalog',

--- a/apps/api/src/review.test.ts
+++ b/apps/api/src/review.test.ts
@@ -775,4 +775,40 @@ describe('targeted re-review', () => {
     });
     expect(asReviewer.statusCode).toBe(404);
   });
+
+  it('counts a targeted re-review in the nav badge with no active sweep', async () => {
+    const { app } = await makeApp();
+    const reviewer = await sessionCookie(app, 'reviewer');
+    const boss = await sessionCookie(app, 'boss');
+
+    const idle = await app.inject({ method: 'GET', url: '/api/review/status', headers: { cookie: reviewer } });
+    expect(JSON.parse(idle.body)).toEqual({ remaining: 0, sweep: null });
+
+    await app.inject({
+      method: 'POST',
+      url: '/api/admin/review-requeue',
+      headers: { cookie: boss },
+      payload: { slugs: ['sky-dodge'], reviewerUids: ['dev:reviewer'], notify: false },
+    });
+
+    const targeted = await app.inject({ method: 'GET', url: '/api/review/status', headers: { cookie: reviewer } });
+    expect(JSON.parse(targeted.body).remaining).toBe(1);
+  });
+
+  it('rejects a slug that is neither in the catalog nor a reviewable draft', async () => {
+    const { app } = await makeApp();
+    const boss = await sessionCookie(app, 'boss');
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/admin/review-requeue',
+      headers: { cookie: boss },
+      payload: { slugs: ['does-not-exist'], reviewerUids: ['dev:reviewer'], notify: false },
+    });
+    expect(res.statusCode).toBe(400);
+
+    // No phantom request was left behind for the valid slug either.
+    const list = await app.inject({ method: 'GET', url: '/api/admin/review-requeue', headers: { cookie: boss } });
+    expect(JSON.parse(list.body).requests).toEqual([]);
+  });
 });

--- a/apps/api/src/review.test.ts
+++ b/apps/api/src/review.test.ts
@@ -549,3 +549,234 @@ describe('reviewer assessment desk', () => {
     expect(body.recent.length).toBeLessThanOrEqual(40);
   });
 });
+
+describe('targeted re-review', () => {
+  const apps: Array<Awaited<ReturnType<typeof buildApp>>> = [];
+
+  afterEach(async () => {
+    while (apps.length) {
+      await apps.pop()!.close();
+    }
+  });
+
+  const catalog = [
+    {
+      slug: 'sky-dodge',
+      title: 'Sky Dodge',
+      creatorHandle: null as string | null,
+      genre: 'arcade',
+      media: { screenshots: [], video: null as string | null },
+    },
+    {
+      slug: 'neon-courier',
+      title: 'Neon Courier',
+      creatorHandle: 'ada' as string | null,
+      genre: 'racing',
+      media: { screenshots: [], video: null as string | null },
+    },
+  ];
+
+  async function makeApp() {
+    const store = new InMemoryStore();
+    const app = await buildApp({
+      store,
+      contentChecker: allowAll,
+      reviewerUids: 'dev:reviewer,dev:second',
+      adminUids: 'dev:boss',
+      reviewRoutes: {
+        listCatalog: async () => catalog,
+      },
+    });
+    apps.push(app);
+    return { app, store };
+  }
+
+  async function assess(app: Awaited<ReturnType<typeof buildApp>>, cookie: string, payload: Record<string, unknown>) {
+    const res = await app.inject({ method: 'POST', url: '/api/review/assessments', headers: { cookie }, payload });
+    expect(res.statusCode).toBe(200);
+    return JSON.parse(res.body).assessment;
+  }
+
+  it('re-surfaces an already-assessed slug only for the targeted reviewer, and resolves once re-assessed', async () => {
+    const { app, store } = await makeApp();
+    const reviewer = await sessionCookie(app, 'reviewer');
+    const second = await sessionCookie(app, 'second');
+    const boss = await sessionCookie(app, 'boss');
+
+    // First pass, via a normal sweep.
+    await store.createReviewSweep({
+      id: 'swp-first',
+      status: 'active',
+      source: 'catalog',
+      slugs: ['sky-dodge'],
+      releasedCount: 1,
+      releasePerDay: null,
+      startedAt: new Date().toISOString(),
+      note: null,
+      createdAt: new Date().toISOString(),
+      createdBy: 'dev:boss',
+      updatedAt: new Date().toISOString(),
+      updatedBy: 'dev:boss',
+      notifiedAt: null,
+      notifiedCount: 0,
+    });
+    await assess(app, reviewer, {
+      slug: 'sky-dodge',
+      source: 'catalog',
+      verdict: 'cut',
+      note: 'Controls are broken.',
+      checklist: sampleChecklist,
+      gameVersion: 'v1',
+    });
+
+    // Once assessed, the slug is gone from this reviewer's queue — the permanent
+    // exclusion the games-repo skill flags as the gap.
+    const gone = await app.inject({ method: 'GET', url: '/api/review/queue', headers: { cookie: reviewer } });
+    expect(JSON.parse(gone.body).items.map((i: { slug: string }) => i.slug)).not.toContain('sky-dodge');
+
+    // Close out the sweep so only the targeted request drives what shows up next.
+    await app.inject({
+      method: 'POST',
+      url: '/api/admin/review-sweeps/swp-first',
+      headers: { cookie: boss },
+      payload: { status: 'completed' },
+    });
+
+    // A fix lands; an operator asks this specific reviewer to look again, with an
+    // explicit slug and reviewer uid (not a sweep), naming the fixed version.
+    const requeue = await app.inject({
+      method: 'POST',
+      url: '/api/admin/review-requeue',
+      headers: { cookie: boss },
+      payload: {
+        slugs: ['sky-dodge'],
+        reviewerUids: ['dev:reviewer'],
+        gameVersion: 'v2',
+        reason: 'Controls fix shipped.',
+        notify: false,
+      },
+    });
+    expect(requeue.statusCode).toBe(200);
+    const requeueBody = JSON.parse(requeue.body) as { requests: Array<{ slug: string; reviewerUid: string }> };
+    expect(requeueBody.requests).toEqual([
+      expect.objectContaining({ slug: 'sky-dodge', reviewerUid: 'dev:reviewer', status: 'open' }),
+    ]);
+
+    // The targeted reviewer sees it again, flagged as a re-review — even with no active
+    // sweep at all.
+    const targetedQueue = await app.inject({ method: 'GET', url: '/api/review/queue', headers: { cookie: reviewer } });
+    const targetedBody = JSON.parse(targetedQueue.body) as {
+      items: Array<{ slug: string; reReview: { reason: string | null; gameVersion: string | null } | null }>;
+    };
+    expect(targetedBody.items).toEqual([
+      expect.objectContaining({
+        slug: 'sky-dodge',
+        reReview: expect.objectContaining({ reason: 'Controls fix shipped.', gameVersion: 'v2' }),
+      }),
+    ]);
+
+    // A different reviewer, not named in the request, does not see it.
+    const otherQueue = await app.inject({ method: 'GET', url: '/api/review/queue', headers: { cookie: second } });
+    expect(JSON.parse(otherQueue.body).items).toEqual([]);
+
+    // The targeted reviewer re-assesses; the original verdict is preserved as history,
+    // not overwritten silently, and the new row carries the version it judged.
+    const second_assessment = await assess(app, reviewer, {
+      slug: 'sky-dodge',
+      source: 'catalog',
+      verdict: 'keep',
+      note: 'Controls feel great now.',
+      checklist: sampleChecklist,
+    });
+    expect(second_assessment.verdict).toBe('keep');
+    expect(second_assessment.gameVersion).toBe('v2'); // inherited from the re-review request
+
+    const history = await app.inject({
+      method: 'GET',
+      url: '/api/admin/assessments/history?slug=sky-dodge&reviewerUid=dev:reviewer',
+      headers: { cookie: boss },
+    });
+    expect(history.statusCode).toBe(200);
+    const historyBody = JSON.parse(history.body) as {
+      current: { verdict: string };
+      history: Array<{ verdict: string; note: string; gameVersion: string | null }>;
+    };
+    expect(historyBody.current.verdict).toBe('keep');
+    expect(historyBody.history).toEqual([
+      expect.objectContaining({ verdict: 'cut', note: 'Controls are broken.', gameVersion: 'v1' }),
+    ]);
+
+    // Resolved: it drops back out of the queue.
+    const resolved = await app.inject({ method: 'GET', url: '/api/review/queue', headers: { cookie: reviewer } });
+    expect(JSON.parse(resolved.body).items).toEqual([]);
+  });
+
+  it('lets an explicit gameVersion on the submission override the re-review request default', async () => {
+    const { app, store } = await makeApp();
+    const reviewer = await sessionCookie(app, 'reviewer');
+    const boss = await sessionCookie(app, 'boss');
+    await store.upsertGameAssessment({
+      slug: 'neon-courier',
+      title: 'Neon Courier',
+      source: 'catalog',
+      creatorHandle: 'ada',
+      reviewerUid: 'dev:reviewer',
+      verdict: 'cut',
+      note: 'first pass',
+      noteOrigin: 'text',
+      checklist: sampleChecklist,
+      clientContext: null,
+      gameVersion: 'v1',
+    });
+    await app.inject({
+      method: 'POST',
+      url: '/api/admin/review-requeue',
+      headers: { cookie: boss },
+      payload: { slugs: ['neon-courier'], reviewerUids: ['dev:reviewer'], gameVersion: 'v2', notify: false },
+    });
+    const assessment = await assess(app, reviewer, {
+      slug: 'neon-courier',
+      source: 'catalog',
+      verdict: 'keep',
+      note: 'Better now.',
+      checklist: sampleChecklist,
+      gameVersion: 'v3',
+    });
+    expect(assessment.gameVersion).toBe('v3');
+  });
+
+  it('rejects a requeue naming a uid that is not a reviewer, and caps slug x reviewer pairs', async () => {
+    const { app } = await makeApp();
+    const boss = await sessionCookie(app, 'boss');
+
+    const badReviewer = await app.inject({
+      method: 'POST',
+      url: '/api/admin/review-requeue',
+      headers: { cookie: boss },
+      payload: { slugs: ['sky-dodge'], reviewerUids: ['dev:stranger'], notify: false },
+    });
+    expect(badReviewer.statusCode).toBe(400);
+
+    const tooManyPairs = await app.inject({
+      method: 'POST',
+      url: '/api/admin/review-requeue',
+      headers: { cookie: boss },
+      payload: {
+        slugs: Array.from({ length: 41 }, (_, i) => `game-${i}`),
+        reviewerUids: ['dev:reviewer', 'dev:second', 'dev:boss', 'dev:boss', 'dev:boss'],
+        notify: false,
+      },
+    });
+    expect(tooManyPairs.statusCode).toBe(400);
+
+    // Only admins can requeue.
+    const reviewer = await sessionCookie(app, 'reviewer');
+    const asReviewer = await app.inject({
+      method: 'POST',
+      url: '/api/admin/review-requeue',
+      headers: { cookie: reviewer },
+      payload: { slugs: ['sky-dodge'], reviewerUids: ['dev:reviewer'], notify: false },
+    });
+    expect(asReviewer.statusCode).toBe(404);
+  });
+});

--- a/apps/api/src/review.ts
+++ b/apps/api/src/review.ts
@@ -227,27 +227,38 @@ export async function registerReviewRoutes(app: FastifyInstance, options: Review
     return items;
   }
 
-  // Single-slug lookup for a targeted re-review, outside any sweep pool.
-  async function findQueueItem(slug: string): Promise<ReviewQueueItem | null> {
+  interface ReviewPools {
+    catalog: ReviewCatalogEntry[];
+    delivered: SubmissionRecord[];
+  }
+
+  // Loaded once per request, not once per targeted slug.
+  async function loadReviewPools(): Promise<ReviewPools> {
+    let catalog: ReviewCatalogEntry[];
     try {
-      const catalog = await listCatalog();
-      const entry = catalog.find((row) => row.slug === slug);
-      if (entry) {
-        return {
-          slug: entry.slug,
-          title: entry.title || entry.slug,
-          source: 'catalog',
-          creatorHandle: entry.creatorHandle,
-          genre: entry.genre ?? null,
-          issueNumber: null,
-          media: entry.media ?? null,
-        };
-      }
+      catalog = await listCatalog();
     } catch {
-      // Fall through to creator drafts.
+      catalog = [];
     }
     const delivered = await store.listSubmissionsWithDelivery();
-    const record = delivered.find((row) => row.slug === slug && isReviewableCreatorDraft(row));
+    return { catalog, delivered };
+  }
+
+  // Single-slug lookup for a targeted re-review, against already-loaded pools.
+  async function findQueueItem(slug: string, pools: ReviewPools): Promise<ReviewQueueItem | null> {
+    const entry = pools.catalog.find((row) => row.slug === slug);
+    if (entry) {
+      return {
+        slug: entry.slug,
+        title: entry.title || entry.slug,
+        source: 'catalog',
+        creatorHandle: entry.creatorHandle,
+        genre: entry.genre ?? null,
+        issueNumber: null,
+        media: entry.media ?? null,
+      };
+    }
+    const record = pools.delivered.find((row) => row.slug === slug && isReviewableCreatorDraft(row));
     if (!record) return null;
     let creatorHandle: string | null = null;
     try {
@@ -274,9 +285,11 @@ export async function registerReviewRoutes(app: FastifyInstance, options: Review
     requests: ReReviewRequest[];
   }> {
     const requests = await store.listOpenReReviewRequestsForReviewer(reviewerUid);
+    if (requests.length === 0) return { items: [], requests };
+    const pools = await loadReviewPools();
     const items: ReviewQueueItem[] = [];
     for (const req of requests) {
-      const item = await findQueueItem(req.slug);
+      const item = await findQueueItem(req.slug, pools);
       if (!item) continue;
       if (sourceFilter !== 'all' && item.source !== sourceFilter) continue;
       items.push({
@@ -384,10 +397,12 @@ export async function registerReviewRoutes(app: FastifyInstance, options: Review
     const refused = refuseUnlessReviewer(request, reply);
     if (refused) return refused;
     const uid = request.user!.uid;
+    const { items: targeted } = await targetedQueueItems(uid, 'all');
+    const targetedSlugs = new Set(targeted.map((item) => item.slug));
     const open = await store.getOpenReviewSweep();
     if (!open || open.status !== 'active') {
       return {
-        remaining: 0,
+        remaining: targetedSlugs.size,
         sweep: open
           ? {
               id: open.id,
@@ -401,9 +416,9 @@ export async function registerReviewRoutes(app: FastifyInstance, options: Review
     const mine = await store.listGameAssessmentsByReviewer(uid);
     const done = new Set(mine.map((row) => row.slug));
     const unlocked = releasedSlugs(open, now());
-    const remaining = unlocked.reduce((count, slug) => count + (done.has(slug) ? 0 : 1), 0);
+    const sweepRemaining = unlocked.filter((slug) => !done.has(slug) && !targetedSlugs.has(slug)).length;
     return {
-      remaining,
+      remaining: sweepRemaining + targetedSlugs.size,
       sweep: {
         id: open.id,
         status: open.status,
@@ -752,6 +767,14 @@ export async function registerReviewRoutes(app: FastifyInstance, options: Review
     const unknownReviewer = body.data.reviewerUids.find((uid) => !audience.has(uid));
     if (unknownReviewer) {
       return reply.status(400).send({ error: `${unknownReviewer} is not a reviewer` });
+    }
+
+    // Refuse a phantom request the reviewer could never see or resolve.
+    const pools = await loadReviewPools();
+    for (const slug of body.data.slugs) {
+      if (!(await findQueueItem(slug, pools))) {
+        return reply.status(400).send({ error: `${slug} is not a published or reviewable slug` });
+      }
     }
 
     const gameVersion = body.data.gameVersion ?? null;

--- a/apps/api/src/review.ts
+++ b/apps/api/src/review.ts
@@ -65,11 +65,7 @@ export interface ReviewQueueItem {
   genre: string | null;
   issueNumber: number | null;
   media: ReviewCatalogMedia | null;
-  /**
-   * Present when this slug is queued via an operator's targeted re-review request
-   * rather than (or in addition to) the general sweep — meaning this reviewer has
-   * already assessed it once and an operator is explicitly asking for another look.
-   */
+  // Set when an operator targeted this slug for re-review.
   reReview?: { reason: string | null; gameVersion: string | null; requestedAt: string } | null;
 }
 
@@ -110,7 +106,7 @@ const AssessmentBodySchema = z.object({
   noteOrigin: z.enum(['text', 'speech']).optional(),
   checklist: ChecklistSchema,
   clientContext: ClientContextSchema.optional(),
-  // The deployed game version this verdict judges (e.g. a shared draft's deliveredVersion).
+  // The deployed game version this verdict judges.
   gameVersion: z.string().trim().min(1).max(80).nullable().optional(),
 });
 
@@ -231,9 +227,7 @@ export async function registerReviewRoutes(app: FastifyInstance, options: Review
     return items;
   }
 
-  // Single-slug lookup for a targeted re-review, independent of any sweep — a slug an
-  // operator wants a specific reviewer to look at again is not necessarily in the
-  // currently open sweep's pool at all.
+  // Single-slug lookup for a targeted re-review, outside any sweep pool.
   async function findQueueItem(slug: string): Promise<ReviewQueueItem | null> {
     try {
       const catalog = await listCatalog();
@@ -363,8 +357,7 @@ export async function registerReviewRoutes(app: FastifyInstance, options: Review
       seen.add(slug);
       if (items.length >= MAX_QUEUE) break;
     }
-    // Targeted re-review slugs surface even though the reviewer already assessed them —
-    // that is the whole point of a targeted request — and even outside the sweep's pool.
+    // Targeted slugs surface even if already assessed or outside the pool.
     for (const item of targeted) {
       if (seen.has(item.slug) || items.length >= MAX_QUEUE) continue;
       items.push(item);
@@ -460,8 +453,7 @@ export async function registerReviewRoutes(app: FastifyInstance, options: Review
     const creatorHandle = body.data.creatorHandle === undefined ? null : body.data.creatorHandle;
     const reviewerUid = request.user!.uid;
 
-    // New rows need an active released slug or an operator's targeted re-review request;
-    // re-edits are always ok.
+    // New rows need a released slug or an open re-review request.
     const prior = await store.getGameAssessment(body.data.slug, reviewerUid);
     const reReviewRequest = await store.getReReviewRequest(body.data.slug, reviewerUid);
     const targeted = reReviewRequest?.status === 'open';
@@ -711,8 +703,7 @@ export async function registerReviewRoutes(app: FastifyInstance, options: Review
     };
   });
 
-  // Superseded rows for one reviewer's one game — the record a plain re-edit would
-  // otherwise have overwritten silently.
+  // Superseded rows a plain re-edit would otherwise overwrite silently.
   const HistoryQuerySchema = z.object({
     slug: z.string().trim().min(1).max(80).regex(SLUG_PATTERN, 'invalid slug'),
     reviewerUid: z.string().trim().min(1).max(120),
@@ -742,9 +733,7 @@ export async function registerReviewRoutes(app: FastifyInstance, options: Review
     notify: z.boolean().optional(),
   });
 
-  // Explicit slugs × explicit reviewers, independent of any sweep — "reviewer X, look at
-  // slug Y again" for a fix that landed after a cut (docs/game-assessment-plan.md
-  // follow-up: re-queue a game after a major revision).
+  // Explicit slugs x explicit reviewers, outside any sweep.
   app.post('/api/admin/review-requeue', async (request, reply) => {
     if (!isAdminSession(request, adminUids)) {
       return reply.status(404).send({ error: 'not found' });

--- a/apps/api/src/review.ts
+++ b/apps/api/src/review.ts
@@ -19,6 +19,7 @@ import type {
   AssessmentSource,
   AssessmentVerdict,
   GameAssessment,
+  ReReviewRequest,
   ReviewSweep,
   ReviewSweepSource,
   Store,
@@ -28,6 +29,9 @@ import type {
 const SLUG_PATTERN = /^[a-z0-9][a-z0-9-]*$/;
 const MAX_NOTE = 2000;
 const MAX_ADMIN_ROWS = 200;
+const MAX_REQUEUE_SLUGS = 50;
+const MAX_REQUEUE_REVIEWERS = 50;
+const MAX_REQUEUE_PAIRS = 200;
 const ChecklistMarkSchema = z.enum(['ok', 'weak', 'bad']);
 const ChecklistSchema = z
   .object({
@@ -61,6 +65,12 @@ export interface ReviewQueueItem {
   genre: string | null;
   issueNumber: number | null;
   media: ReviewCatalogMedia | null;
+  /**
+   * Present when this slug is queued via an operator's targeted re-review request
+   * rather than (or in addition to) the general sweep — meaning this reviewer has
+   * already assessed it once and an operator is explicitly asking for another look.
+   */
+  reReview?: { reason: string | null; gameVersion: string | null; requestedAt: string } | null;
 }
 
 export interface ReviewRoutesOptions {
@@ -100,6 +110,8 @@ const AssessmentBodySchema = z.object({
   noteOrigin: z.enum(['text', 'speech']).optional(),
   checklist: ChecklistSchema,
   clientContext: ClientContextSchema.optional(),
+  // The deployed game version this verdict judges (e.g. a shared draft's deliveredVersion).
+  gameVersion: z.string().trim().min(1).max(80).nullable().optional(),
 });
 
 function normalizeClientContext(raw: z.infer<typeof ClientContextSchema> | undefined): AssessmentClientContext | null {
@@ -219,6 +231,68 @@ export async function registerReviewRoutes(app: FastifyInstance, options: Review
     return items;
   }
 
+  // Single-slug lookup for a targeted re-review, independent of any sweep — a slug an
+  // operator wants a specific reviewer to look at again is not necessarily in the
+  // currently open sweep's pool at all.
+  async function findQueueItem(slug: string): Promise<ReviewQueueItem | null> {
+    try {
+      const catalog = await listCatalog();
+      const entry = catalog.find((row) => row.slug === slug);
+      if (entry) {
+        return {
+          slug: entry.slug,
+          title: entry.title || entry.slug,
+          source: 'catalog',
+          creatorHandle: entry.creatorHandle,
+          genre: entry.genre ?? null,
+          issueNumber: null,
+          media: entry.media ?? null,
+        };
+      }
+    } catch {
+      // Fall through to creator drafts.
+    }
+    const delivered = await store.listSubmissionsWithDelivery();
+    const record = delivered.find((row) => row.slug === slug && isReviewableCreatorDraft(row));
+    if (!record) return null;
+    let creatorHandle: string | null = null;
+    try {
+      creatorHandle = (await store.getUser(record.ownerUid))?.handle ?? null;
+    } catch {
+      // best-effort
+    }
+    return {
+      slug,
+      title: titleFromSubmission(record),
+      source: 'creator',
+      creatorHandle,
+      genre: null,
+      issueNumber: record.issueNumber,
+      media: null,
+    };
+  }
+
+  async function targetedQueueItems(
+    reviewerUid: string,
+    sourceFilter: 'catalog' | 'creator' | 'all',
+  ): Promise<{
+    items: ReviewQueueItem[];
+    requests: ReReviewRequest[];
+  }> {
+    const requests = await store.listOpenReReviewRequestsForReviewer(reviewerUid);
+    const items: ReviewQueueItem[] = [];
+    for (const req of requests) {
+      const item = await findQueueItem(req.slug);
+      if (!item) continue;
+      if (sourceFilter !== 'all' && item.source !== sourceFilter) continue;
+      items.push({
+        ...item,
+        reReview: { reason: req.reason, gameVersion: req.gameVersion, requestedAt: req.createdAt },
+      });
+    }
+    return { items, requests };
+  }
+
   async function notifySweep(sweep: ReviewSweep, notificationId: string): Promise<number> {
     if (!options.emitDeps) return 0;
     const audience = reviewerAudience(reviewerUids, adminUids);
@@ -251,14 +325,16 @@ export async function registerReviewRoutes(app: FastifyInstance, options: Review
     }
     const sourceFilter = query.data.source ?? 'all';
     const uid = request.user!.uid;
+    const mine = await store.listGameAssessmentsByReviewer(uid);
+    const { items: targeted } = await targetedQueueItems(uid, sourceFilter);
 
     const open = await store.getOpenReviewSweep();
     if (!open || open.status === 'paused') {
       return {
         source: sourceFilter,
-        remaining: 0,
-        assessed: (await store.listGameAssessmentsByReviewer(uid)).length,
-        items: [] as ReviewQueueItem[],
+        remaining: targeted.length,
+        assessed: mine.length,
+        items: targeted,
         sweep: open
           ? {
               id: open.id,
@@ -267,24 +343,32 @@ export async function registerReviewRoutes(app: FastifyInstance, options: Review
               released: effectiveReleasedCount(open, now()),
             }
           : null,
-        emptyReason: open ? ('sweep_paused' as const) : ('no_active_sweep' as const),
+        emptyReason: targeted.length > 0 ? null : open ? ('sweep_paused' as const) : ('no_active_sweep' as const),
       };
     }
 
-    const mine = await store.listGameAssessmentsByReviewer(uid);
     const done = new Set(mine.map((row) => row.slug));
     const unlocked = new Set(releasedSlugs(open, now()));
     const pool = await collectPool(open.source);
     const bySlug = new Map(pool.map((item) => [item.slug, item]));
 
     const items: ReviewQueueItem[] = [];
+    const seen = new Set<string>();
     for (const slug of open.slugs) {
       if (!unlocked.has(slug) || done.has(slug)) continue;
       const item = bySlug.get(slug);
       if (!item) continue;
       if (sourceFilter !== 'all' && item.source !== sourceFilter) continue;
       items.push(item);
+      seen.add(slug);
       if (items.length >= MAX_QUEUE) break;
+    }
+    // Targeted re-review slugs surface even though the reviewer already assessed them —
+    // that is the whole point of a targeted request — and even outside the sweep's pool.
+    for (const item of targeted) {
+      if (seen.has(item.slug) || items.length >= MAX_QUEUE) continue;
+      items.push(item);
+      seen.add(item.slug);
     }
 
     return {
@@ -376,9 +460,12 @@ export async function registerReviewRoutes(app: FastifyInstance, options: Review
     const creatorHandle = body.data.creatorHandle === undefined ? null : body.data.creatorHandle;
     const reviewerUid = request.user!.uid;
 
-    // New rows need an active released slug; re-edits ok.
+    // New rows need an active released slug or an operator's targeted re-review request;
+    // re-edits are always ok.
     const prior = await store.getGameAssessment(body.data.slug, reviewerUid);
-    if (!prior) {
+    const reReviewRequest = await store.getReReviewRequest(body.data.slug, reviewerUid);
+    const targeted = reReviewRequest?.status === 'open';
+    if (!prior && !targeted) {
       const open = await store.getOpenReviewSweep();
       if (!open || open.status !== 'active') {
         return reply.status(409).send({ error: 'no_active_sweep' });
@@ -387,6 +474,9 @@ export async function registerReviewRoutes(app: FastifyInstance, options: Review
         return reply.status(409).send({ error: 'slug_not_in_sweep' });
       }
     }
+
+    const gameVersion =
+      body.data.gameVersion === undefined ? (reReviewRequest?.gameVersion ?? null) : body.data.gameVersion;
 
     const assessment: GameAssessment = await store.upsertGameAssessment({
       slug: body.data.slug,
@@ -399,7 +489,12 @@ export async function registerReviewRoutes(app: FastifyInstance, options: Review
       noteOrigin,
       checklist,
       clientContext: normalizeClientContext(body.data.clientContext),
+      gameVersion,
     });
+
+    if (targeted) {
+      await store.resolveReReviewRequest(body.data.slug, reviewerUid);
+    }
 
     return { assessment };
   });
@@ -614,5 +709,92 @@ export async function registerReviewRoutes(app: FastifyInstance, options: Review
       },
       notified,
     };
+  });
+
+  // Superseded rows for one reviewer's one game — the record a plain re-edit would
+  // otherwise have overwritten silently.
+  const HistoryQuerySchema = z.object({
+    slug: z.string().trim().min(1).max(80).regex(SLUG_PATTERN, 'invalid slug'),
+    reviewerUid: z.string().trim().min(1).max(120),
+  });
+
+  app.get('/api/admin/assessments/history', async (request, reply) => {
+    if (!isAdminSession(request, adminUids)) {
+      return reply.status(404).send({ error: 'not found' });
+    }
+    const query = HistoryQuerySchema.safeParse(request.query);
+    if (!query.success) {
+      return reply.status(400).send({ error: query.error.issues[0]?.message ?? 'invalid query' });
+    }
+    const [current, history] = await Promise.all([
+      store.getGameAssessment(query.data.slug, query.data.reviewerUid),
+      store.listGameAssessmentHistory(query.data.slug, query.data.reviewerUid),
+    ]);
+    return { current, history };
+  });
+
+  const RequeueSchema = z.object({
+    slugs: z.array(z.string().trim().min(1).max(80).regex(SLUG_PATTERN, 'invalid slug')).min(1).max(MAX_REQUEUE_SLUGS),
+    reviewerUids: z.array(z.string().trim().min(1).max(120)).min(1).max(MAX_REQUEUE_REVIEWERS),
+    // Deployed version the requeued fix is expected to be judged against; informational.
+    gameVersion: z.string().trim().min(1).max(80).nullable().optional(),
+    reason: z.string().trim().max(280).nullable().optional(),
+    notify: z.boolean().optional(),
+  });
+
+  // Explicit slugs × explicit reviewers, independent of any sweep — "reviewer X, look at
+  // slug Y again" for a fix that landed after a cut (docs/game-assessment-plan.md
+  // follow-up: re-queue a game after a major revision).
+  app.post('/api/admin/review-requeue', async (request, reply) => {
+    if (!isAdminSession(request, adminUids)) {
+      return reply.status(404).send({ error: 'not found' });
+    }
+    const body = RequeueSchema.safeParse(request.body ?? {});
+    if (!body.success) {
+      return reply.status(400).send({ error: body.error.issues[0]?.message ?? 'invalid request' });
+    }
+
+    const pairCount = body.data.slugs.length * body.data.reviewerUids.length;
+    if (pairCount > MAX_REQUEUE_PAIRS) {
+      return reply.status(400).send({ error: `too many slug × reviewer pairs (max ${MAX_REQUEUE_PAIRS})` });
+    }
+
+    const audience = reviewerAudience(reviewerUids, adminUids);
+    const unknownReviewer = body.data.reviewerUids.find((uid) => !audience.has(uid));
+    if (unknownReviewer) {
+      return reply.status(400).send({ error: `${unknownReviewer} is not a reviewer` });
+    }
+
+    const gameVersion = body.data.gameVersion ?? null;
+    const reason = body.data.reason ?? null;
+    const createdBy = request.user!.uid;
+    const requests = body.data.slugs.flatMap((slug) =>
+      body.data.reviewerUids.map((reviewerUid) => ({ slug, reviewerUid, gameVersion, reason, createdBy })),
+    );
+    const created = await store.upsertReReviewRequests(requests);
+
+    let notified = 0;
+    if (body.data.notify !== false && options.emitDeps) {
+      const targetedReviewers = new Set(body.data.reviewerUids);
+      const { created: n } = await emitReviewSweep(
+        { ...options.emitDeps, reviewerUids: targetedReviewers, now },
+        {
+          notificationId: `review-requeue-${now().toString(36)}`,
+          title: `Targeted re-review · ${body.data.slugs.length} game${body.data.slugs.length === 1 ? '' : 's'}`,
+          detail: reason ?? undefined,
+        },
+      );
+      notified = n;
+    }
+
+    return { requests: created, notified };
+  });
+
+  app.get('/api/admin/review-requeue', async (request, reply) => {
+    if (!isAdminSession(request, adminUids)) {
+      return reply.status(404).send({ error: 'not found' });
+    }
+    const requests = await store.listReReviewRequests({ limit: MAX_ADMIN_ROWS });
+    return { requests };
   });
 }

--- a/apps/api/src/store-firestore.test.ts
+++ b/apps/api/src/store-firestore.test.ts
@@ -140,8 +140,9 @@ function fakeFirestore() {
     return query;
   };
 
+  let autoIdCounter = 0;
   const makeCollection = (path: string) => ({
-    doc: (id: string) => makeRef(path, id),
+    doc: (id?: string) => makeRef(path, id ?? `auto-${(autoIdCounter += 1)}`),
     listDocuments: async () => idsUnder(path).map((id) => makeRef(path, id)),
     where: (field: string, op: string, value: unknown) => makeQuery([path], null).where(field, op, value),
     count: () => makeQuery([path], null).count(),
@@ -162,6 +163,11 @@ function fakeFirestore() {
     batch: () => {
       const staged: Array<() => void> = [];
       return {
+        set: (ref: ReturnType<typeof makeRef>, data: Record<string, unknown>, options?: { merge?: boolean }) => {
+          rejectUndefined(data);
+          rejectNestedArrays(data);
+          staged.push(() => void ref.set(data, options));
+        },
         delete: (ref: { id: string; delete: () => Promise<void> }) => {
           staged.push(() => void ref.delete());
         },
@@ -402,6 +408,49 @@ describe('FirestoreStore game saves', () => {
 
     expect(await store.getGameSave('g:alice', 'crypt-delver')).toBeNull();
     expect(await store.getGameSave('g:alice', 'brick-storm')).not.toBeNull();
+  });
+});
+
+describe('FirestoreStore game assessments', () => {
+  const checklist = { graphics: 'ok', gameplay: 'ok', fun: 'ok', sound: 'ok', controls: 'ok' } as const;
+
+  it('archives the superseded row in the same batch as the replacement', async () => {
+    const { db } = fakeFirestore();
+    const store = new FirestoreStore(db);
+
+    await store.upsertGameAssessment({
+      slug: 'sky-dodge',
+      title: 'Sky Dodge',
+      source: 'catalog',
+      creatorHandle: null,
+      reviewerUid: 'g:alice',
+      verdict: 'cut',
+      note: 'Controls are broken.',
+      noteOrigin: 'text',
+      checklist: { ...checklist },
+      clientContext: null,
+      gameVersion: 'v1',
+    });
+    await store.upsertGameAssessment({
+      slug: 'sky-dodge',
+      title: 'Sky Dodge',
+      source: 'catalog',
+      creatorHandle: null,
+      reviewerUid: 'g:alice',
+      verdict: 'keep',
+      note: 'Controls feel great now.',
+      noteOrigin: 'text',
+      checklist: { ...checklist },
+      clientContext: null,
+      gameVersion: 'v2',
+    });
+
+    const current = await store.getGameAssessment('sky-dodge', 'g:alice');
+    expect(current?.verdict).toBe('keep');
+    expect(current?.gameVersion).toBe('v2');
+
+    const history = await store.listGameAssessmentHistory('sky-dodge', 'g:alice');
+    expect(history).toEqual([expect.objectContaining({ verdict: 'cut', gameVersion: 'v1' })]);
   });
 });
 

--- a/apps/api/src/store.ts
+++ b/apps/api/src/store.ts
@@ -1227,6 +1227,13 @@ export interface GameAssessment {
   // Null on rows written before checklist / clientContext shipped.
   checklist: AssessmentChecklist | null;
   clientContext: AssessmentClientContext | null;
+  /**
+   * The deployed game version this verdict judged — `deliveredVersion` for a shared
+   * creator draft, or null when the source (e.g. the catalog today) does not carry a
+   * per-game version yet. Lets a targeted re-review tell "already judged this exact
+   * build" apart from "judged an older one" instead of only "already judged".
+   */
+  gameVersion: string | null;
   createdAt: string;
   updatedAt: string;
 }
@@ -1238,14 +1245,56 @@ export function gameAssessmentId(slug: string, reviewerUid: string): string {
   return `${slug}:${reviewerUid}`;
 }
 
-// Missing checklist / clientContext become null, not undefined.
+// Missing checklist / clientContext / gameVersion become null, not undefined.
 export function hydrateGameAssessment(id: string, data: Omit<GameAssessment, 'id'>): GameAssessment {
   return {
     ...data,
     id,
     checklist: data.checklist ?? null,
     clientContext: data.clientContext ?? null,
+    gameVersion: data.gameVersion ?? null,
   };
+}
+
+/**
+ * A superseded assessment row, archived the moment a reviewer's second pass would
+ * otherwise overwrite it. Preserves the original judgment (docs/game-assessment-plan.md
+ * follow-up: "re-queue a game after a major revision") so a targeted re-review can be
+ * compared against what was said before, not just replace it silently.
+ */
+export interface GameAssessmentHistoryEntry extends Omit<GameAssessment, 'id'> {
+  id: string;
+  supersededAt: string;
+}
+
+export const GAME_ASSESSMENT_HISTORY_COLLECTION = 'gameAssessmentHistory';
+
+export type ReReviewRequestStatus = 'open' | 'resolved' | 'cancelled';
+
+/**
+ * An operator's explicit ask: "reviewer X, look at slug Y again" — independent of a
+ * general sweep. Exists because `/api/review/queue` otherwise excludes a slug a reviewer
+ * has already assessed permanently, which is fine for a first pass but wrong once a fix
+ * has landed and the same reviewer (who has the original context) needs a re-look.
+ */
+export interface ReReviewRequest {
+  id: string;
+  slug: string;
+  reviewerUid: string;
+  status: ReReviewRequestStatus;
+  // Deployed version the fix is expected to be judged against; informational only, not
+  // enforced — a reviewer can still submit before it lands.
+  gameVersion: string | null;
+  reason: string | null;
+  createdAt: string;
+  createdBy: string;
+  resolvedAt: string | null;
+}
+
+export const RE_REVIEW_REQUESTS_COLLECTION = 'reviewReRequests';
+
+export function reReviewRequestId(slug: string, reviewerUid: string): string {
+  return `${slug}:${reviewerUid}`;
 }
 
 /**
@@ -2445,7 +2494,10 @@ export interface Store {
   countPlayerFeedback(slug: string): Promise<number>;
   // Upsert reviewer verdict; second pass overwrites in place.
   upsertGameAssessment(
-    input: Omit<GameAssessment, 'id' | 'createdAt' | 'updatedAt'> & { createdAt?: string },
+    input: Omit<GameAssessment, 'id' | 'createdAt' | 'updatedAt' | 'gameVersion'> & {
+      createdAt?: string;
+      gameVersion?: string | null;
+    },
   ): Promise<GameAssessment>;
   getGameAssessment(slug: string, reviewerUid: string): Promise<GameAssessment | null>;
   listGameAssessmentsByReviewer(reviewerUid: string): Promise<GameAssessment[]>;
@@ -2454,6 +2506,17 @@ export interface Store {
   listGameAssessmentsBySource(source: AssessmentSource): Promise<GameAssessment[]>;
   countGameAssessmentsByUid(uid: string): Promise<number>;
   deleteGameAssessmentsByUid(uid: string): Promise<number>;
+  // Superseded rows for one reviewer's one game, newest first; empty before a second pass.
+  listGameAssessmentHistory(slug: string, reviewerUid: string): Promise<GameAssessmentHistoryEntry[]>;
+  // Opens (or re-opens) one targeted re-review request per (slug, reviewerUid) pair.
+  upsertReReviewRequests(
+    requests: Array<Pick<ReReviewRequest, 'slug' | 'reviewerUid' | 'gameVersion' | 'reason' | 'createdBy'>>,
+  ): Promise<ReReviewRequest[]>;
+  getReReviewRequest(slug: string, reviewerUid: string): Promise<ReReviewRequest | null>;
+  listOpenReReviewRequestsForReviewer(reviewerUid: string): Promise<ReReviewRequest[]>;
+  // Recent targeted requests across reviewers; bounded operator page.
+  listReReviewRequests(opts?: { limit?: number }): Promise<ReReviewRequest[]>;
+  resolveReReviewRequest(slug: string, reviewerUid: string): Promise<ReReviewRequest | null>;
   getOpenReviewSweep(): Promise<ReviewSweep | null>;
   getReviewSweep(id: string): Promise<ReviewSweep | null>;
   listReviewSweeps(opts?: { limit?: number }): Promise<ReviewSweep[]>;
@@ -2822,6 +2885,9 @@ export class InMemoryStore implements Store {
   // slug -> feedback rows, newest last (reversed on read)
   private playerFeedback = new Map<string, PlayerFeedbackRecord[]>();
   private gameAssessments = new Map<string, GameAssessment>();
+  // gameAssessmentId -> superseded rows, oldest first.
+  private gameAssessmentHistory = new Map<string, GameAssessmentHistoryEntry[]>();
+  private reReviewRequests = new Map<string, ReReviewRequest>();
   private reviewSweeps = new Map<string, ReviewSweep>();
   // uid -> (slug -> saved progress)
   private gameSaves = new Map<string, Map<string, GameSaveRecord>>();
@@ -4567,11 +4633,19 @@ export class InMemoryStore implements Store {
   }
 
   async upsertGameAssessment(
-    input: Omit<GameAssessment, 'id' | 'createdAt' | 'updatedAt'> & { createdAt?: string },
+    input: Omit<GameAssessment, 'id' | 'createdAt' | 'updatedAt' | 'gameVersion'> & {
+      createdAt?: string;
+      gameVersion?: string | null;
+    },
   ): Promise<GameAssessment> {
     const id = gameAssessmentId(input.slug, input.reviewerUid);
     const existing = this.gameAssessments.get(id);
     const now = new Date().toISOString();
+    if (existing) {
+      const history = this.gameAssessmentHistory.get(id) ?? [];
+      history.push({ ...existing, supersededAt: now });
+      this.gameAssessmentHistory.set(id, history);
+    }
     const record: GameAssessment = {
       id,
       slug: input.slug,
@@ -4584,11 +4658,72 @@ export class InMemoryStore implements Store {
       noteOrigin: input.noteOrigin,
       checklist: input.checklist ?? null,
       clientContext: input.clientContext ?? null,
+      gameVersion: input.gameVersion ?? null,
       createdAt: existing?.createdAt ?? input.createdAt ?? now,
       updatedAt: now,
     };
     this.gameAssessments.set(id, record);
     return { ...record };
+  }
+
+  async listGameAssessmentHistory(slug: string, reviewerUid: string): Promise<GameAssessmentHistoryEntry[]> {
+    const id = gameAssessmentId(slug, reviewerUid);
+    return [...(this.gameAssessmentHistory.get(id) ?? [])]
+      .sort((a, b) => b.supersededAt.localeCompare(a.supersededAt))
+      .map((row) => ({ ...row }));
+  }
+
+  async upsertReReviewRequests(
+    requests: Array<Pick<ReReviewRequest, 'slug' | 'reviewerUid' | 'gameVersion' | 'reason' | 'createdBy'>>,
+  ): Promise<ReReviewRequest[]> {
+    const now = new Date().toISOString();
+    const out: ReReviewRequest[] = [];
+    for (const req of requests) {
+      const id = reReviewRequestId(req.slug, req.reviewerUid);
+      const record: ReReviewRequest = {
+        id,
+        slug: req.slug,
+        reviewerUid: req.reviewerUid,
+        status: 'open',
+        gameVersion: req.gameVersion,
+        reason: req.reason,
+        createdAt: now,
+        createdBy: req.createdBy,
+        resolvedAt: null,
+      };
+      this.reReviewRequests.set(id, record);
+      out.push({ ...record });
+    }
+    return out;
+  }
+
+  async getReReviewRequest(slug: string, reviewerUid: string): Promise<ReReviewRequest | null> {
+    const record = this.reReviewRequests.get(reReviewRequestId(slug, reviewerUid));
+    return record ? { ...record } : null;
+  }
+
+  async listOpenReReviewRequestsForReviewer(reviewerUid: string): Promise<ReReviewRequest[]> {
+    return Array.from(this.reReviewRequests.values())
+      .filter((row) => row.reviewerUid === reviewerUid && row.status === 'open')
+      .sort((a, b) => b.createdAt.localeCompare(a.createdAt))
+      .map((row) => ({ ...row }));
+  }
+
+  async listReReviewRequests(opts?: { limit?: number }): Promise<ReReviewRequest[]> {
+    const sorted = Array.from(this.reReviewRequests.values())
+      .sort((a, b) => b.createdAt.localeCompare(a.createdAt))
+      .map((row) => ({ ...row }));
+    return opts?.limit !== undefined ? sorted.slice(0, opts.limit) : sorted;
+  }
+
+  async resolveReReviewRequest(slug: string, reviewerUid: string): Promise<ReReviewRequest | null> {
+    const id = reReviewRequestId(slug, reviewerUid);
+    const existing = this.reReviewRequests.get(id);
+    if (!existing) return null;
+    if (existing.status !== 'open') return { ...existing };
+    const updated: ReReviewRequest = { ...existing, status: 'resolved', resolvedAt: new Date().toISOString() };
+    this.reReviewRequests.set(id, updated);
+    return { ...updated };
   }
 
   async getGameAssessment(slug: string, reviewerUid: string): Promise<GameAssessment | null> {
@@ -4630,8 +4765,12 @@ export class InMemoryStore implements Store {
     for (const [id, row] of this.gameAssessments) {
       if (row.reviewerUid === uid) {
         this.gameAssessments.delete(id);
+        this.gameAssessmentHistory.delete(id);
         deleted += 1;
       }
+    }
+    for (const [id, row] of this.reReviewRequests) {
+      if (row.reviewerUid === uid) this.reReviewRequests.delete(id);
     }
     return deleted;
   }
@@ -7647,7 +7786,10 @@ export class FirestoreStore implements Store {
   }
 
   async upsertGameAssessment(
-    input: Omit<GameAssessment, 'id' | 'createdAt' | 'updatedAt'> & { createdAt?: string },
+    input: Omit<GameAssessment, 'id' | 'createdAt' | 'updatedAt' | 'gameVersion'> & {
+      createdAt?: string;
+      gameVersion?: string | null;
+    },
   ): Promise<GameAssessment> {
     const id = gameAssessmentId(input.slug, input.reviewerUid);
     const ref = this.gameAssessmentsCollection().doc(id);
@@ -7657,6 +7799,15 @@ export class FirestoreStore implements Store {
       existing.exists && typeof existing.data()?.createdAt === 'string'
         ? (existing.data()!.createdAt as string)
         : (input.createdAt ?? now);
+    if (existing.exists) {
+      const prior = hydrateGameAssessment(id, existing.data() as Omit<GameAssessment, 'id'>);
+      const { id: priorId, ...priorBody } = prior;
+      await this.gameAssessmentHistoryCollection().add({
+        ...priorBody,
+        assessmentId: priorId,
+        supersededAt: now,
+      });
+    }
     const record: GameAssessment = {
       id,
       slug: input.slug,
@@ -7669,6 +7820,7 @@ export class FirestoreStore implements Store {
       noteOrigin: input.noteOrigin,
       checklist: input.checklist ?? null,
       clientContext: input.clientContext ?? null,
+      gameVersion: input.gameVersion ?? null,
       createdAt,
       updatedAt: now,
     };
@@ -7683,10 +7835,110 @@ export class FirestoreStore implements Store {
       noteOrigin: record.noteOrigin,
       checklist: record.checklist,
       clientContext: record.clientContext,
+      gameVersion: record.gameVersion,
       createdAt: record.createdAt,
       updatedAt: record.updatedAt,
     });
     return record;
+  }
+
+  private gameAssessmentHistoryCollection() {
+    return this.db.collection(GAME_ASSESSMENT_HISTORY_COLLECTION);
+  }
+
+  async listGameAssessmentHistory(slug: string, reviewerUid: string): Promise<GameAssessmentHistoryEntry[]> {
+    const id = gameAssessmentId(slug, reviewerUid);
+    // Equality query only; sort in memory, same shape as the assessments themselves.
+    const snap = await this.gameAssessmentHistoryCollection().where('assessmentId', '==', id).get();
+    return snap.docs
+      .map((d) => {
+        const { assessmentId, ...rest } = d.data() as Omit<GameAssessmentHistoryEntry, 'id'> & {
+          assessmentId: string;
+        };
+        return { ...rest, id: d.id, checklist: rest.checklist ?? null, clientContext: rest.clientContext ?? null };
+      })
+      .sort((a, b) => b.supersededAt.localeCompare(a.supersededAt));
+  }
+
+  private reReviewRequestsCollection() {
+    return this.db.collection(RE_REVIEW_REQUESTS_COLLECTION);
+  }
+
+  private hydrateReReviewRequest(id: string, data: Omit<ReReviewRequest, 'id'>): ReReviewRequest {
+    return {
+      ...data,
+      id,
+      gameVersion: data.gameVersion ?? null,
+      reason: data.reason ?? null,
+      resolvedAt: data.resolvedAt ?? null,
+    };
+  }
+
+  async upsertReReviewRequests(
+    requests: Array<Pick<ReReviewRequest, 'slug' | 'reviewerUid' | 'gameVersion' | 'reason' | 'createdBy'>>,
+  ): Promise<ReReviewRequest[]> {
+    const now = new Date().toISOString();
+    const out: ReReviewRequest[] = [];
+    for (let index = 0; index < requests.length; index += 400) {
+      const batch = this.db.batch();
+      const chunk = requests.slice(index, index + 400);
+      const records = chunk.map((req) => {
+        const id = reReviewRequestId(req.slug, req.reviewerUid);
+        const record: ReReviewRequest = {
+          id,
+          slug: req.slug,
+          reviewerUid: req.reviewerUid,
+          status: 'open',
+          gameVersion: req.gameVersion,
+          reason: req.reason,
+          createdAt: now,
+          createdBy: req.createdBy,
+          resolvedAt: null,
+        };
+        const { id: recordId, ...body } = record;
+        batch.set(this.reReviewRequestsCollection().doc(recordId), body);
+        return record;
+      });
+      await batch.commit();
+      out.push(...records);
+    }
+    return out;
+  }
+
+  async getReReviewRequest(slug: string, reviewerUid: string): Promise<ReReviewRequest | null> {
+    const id = reReviewRequestId(slug, reviewerUid);
+    const snap = await this.reReviewRequestsCollection().doc(id).get();
+    if (!snap.exists) return null;
+    return this.hydrateReReviewRequest(id, snap.data() as Omit<ReReviewRequest, 'id'>);
+  }
+
+  async listOpenReReviewRequestsForReviewer(reviewerUid: string): Promise<ReReviewRequest[]> {
+    // Equality only — no orderBy / composite index.
+    const snap = await this.reReviewRequestsCollection()
+      .where('reviewerUid', '==', reviewerUid)
+      .where('status', '==', 'open')
+      .get();
+    return snap.docs
+      .map((d) => this.hydrateReReviewRequest(d.id, d.data() as Omit<ReReviewRequest, 'id'>))
+      .sort((a, b) => b.createdAt.localeCompare(a.createdAt));
+  }
+
+  async listReReviewRequests(opts?: { limit?: number }): Promise<ReReviewRequest[]> {
+    const ordered = this.reReviewRequestsCollection().orderBy('createdAt', 'desc');
+    const snap = await (opts?.limit === undefined ? ordered : ordered.limit(opts.limit)).get();
+    return snap.docs.map((d) => this.hydrateReReviewRequest(d.id, d.data() as Omit<ReReviewRequest, 'id'>));
+  }
+
+  async resolveReReviewRequest(slug: string, reviewerUid: string): Promise<ReReviewRequest | null> {
+    const id = reReviewRequestId(slug, reviewerUid);
+    const ref = this.reReviewRequestsCollection().doc(id);
+    const snap = await ref.get();
+    if (!snap.exists) return null;
+    const existing = this.hydrateReReviewRequest(id, snap.data() as Omit<ReReviewRequest, 'id'>);
+    if (existing.status !== 'open') return existing;
+    const resolvedAt = new Date().toISOString();
+    await ref.set({ status: 'resolved', resolvedAt }, { merge: true });
+    return { ...existing, status: 'resolved', resolvedAt };
   }
 
   async getGameAssessment(slug: string, reviewerUid: string): Promise<GameAssessment | null> {
@@ -7724,13 +7976,18 @@ export class FirestoreStore implements Store {
   }
 
   async deleteGameAssessmentsByUid(uid: string): Promise<number> {
-    const snap = await this.gameAssessmentsCollection().where('reviewerUid', '==', uid).get();
-    for (let index = 0; index < snap.docs.length; index += 400) {
+    const [assessments, history, reReviews] = await Promise.all([
+      this.gameAssessmentsCollection().where('reviewerUid', '==', uid).get(),
+      this.gameAssessmentHistoryCollection().where('reviewerUid', '==', uid).get(),
+      this.reReviewRequestsCollection().where('reviewerUid', '==', uid).get(),
+    ]);
+    const refs = [...assessments.docs, ...history.docs, ...reReviews.docs].map((d) => d.ref);
+    for (let index = 0; index < refs.length; index += 400) {
       const batch = this.db.batch();
-      for (const doc of snap.docs.slice(index, index + 400)) batch.delete(doc.ref);
+      for (const ref of refs.slice(index, index + 400)) batch.delete(ref);
       await batch.commit();
     }
-    return snap.docs.length;
+    return assessments.docs.length;
   }
 
   private reviewSweepsCollection() {

--- a/apps/api/src/store.ts
+++ b/apps/api/src/store.ts
@@ -1227,12 +1227,7 @@ export interface GameAssessment {
   // Null on rows written before checklist / clientContext shipped.
   checklist: AssessmentChecklist | null;
   clientContext: AssessmentClientContext | null;
-  /**
-   * The deployed game version this verdict judged — `deliveredVersion` for a shared
-   * creator draft, or null when the source (e.g. the catalog today) does not carry a
-   * per-game version yet. Lets a targeted re-review tell "already judged this exact
-   * build" apart from "judged an older one" instead of only "already judged".
-   */
+  // The deployed game version this verdict judged; null when unknown.
   gameVersion: string | null;
   createdAt: string;
   updatedAt: string;
@@ -1256,12 +1251,7 @@ export function hydrateGameAssessment(id: string, data: Omit<GameAssessment, 'id
   };
 }
 
-/**
- * A superseded assessment row, archived the moment a reviewer's second pass would
- * otherwise overwrite it. Preserves the original judgment (docs/game-assessment-plan.md
- * follow-up: "re-queue a game after a major revision") so a targeted re-review can be
- * compared against what was said before, not just replace it silently.
- */
+// A superseded assessment row, archived before the next pass overwrites it.
 export interface GameAssessmentHistoryEntry extends Omit<GameAssessment, 'id'> {
   id: string;
   supersededAt: string;
@@ -1271,19 +1261,13 @@ export const GAME_ASSESSMENT_HISTORY_COLLECTION = 'gameAssessmentHistory';
 
 export type ReReviewRequestStatus = 'open' | 'resolved' | 'cancelled';
 
-/**
- * An operator's explicit ask: "reviewer X, look at slug Y again" — independent of a
- * general sweep. Exists because `/api/review/queue` otherwise excludes a slug a reviewer
- * has already assessed permanently, which is fine for a first pass but wrong once a fix
- * has landed and the same reviewer (who has the original context) needs a re-look.
- */
+// An operator asking one reviewer to look at one slug again.
 export interface ReReviewRequest {
   id: string;
   slug: string;
   reviewerUid: string;
   status: ReReviewRequestStatus;
-  // Deployed version the fix is expected to be judged against; informational only, not
-  // enforced — a reviewer can still submit before it lands.
+  // Version the fix is expected to be judged against; informational only.
   gameVersion: string | null;
   reason: string | null;
   createdAt: string;
@@ -2506,9 +2490,9 @@ export interface Store {
   listGameAssessmentsBySource(source: AssessmentSource): Promise<GameAssessment[]>;
   countGameAssessmentsByUid(uid: string): Promise<number>;
   deleteGameAssessmentsByUid(uid: string): Promise<number>;
-  // Superseded rows for one reviewer's one game, newest first; empty before a second pass.
+  // Superseded rows for one reviewer's one game, newest first.
   listGameAssessmentHistory(slug: string, reviewerUid: string): Promise<GameAssessmentHistoryEntry[]>;
-  // Opens (or re-opens) one targeted re-review request per (slug, reviewerUid) pair.
+  // Opens or re-opens one re-review request per (slug, reviewerUid) pair.
   upsertReReviewRequests(
     requests: Array<Pick<ReReviewRequest, 'slug' | 'reviewerUid' | 'gameVersion' | 'reason' | 'createdBy'>>,
   ): Promise<ReReviewRequest[]>;

--- a/apps/api/src/store.ts
+++ b/apps/api/src/store.ts
@@ -7783,15 +7783,6 @@ export class FirestoreStore implements Store {
       existing.exists && typeof existing.data()?.createdAt === 'string'
         ? (existing.data()!.createdAt as string)
         : (input.createdAt ?? now);
-    if (existing.exists) {
-      const prior = hydrateGameAssessment(id, existing.data() as Omit<GameAssessment, 'id'>);
-      const { id: priorId, ...priorBody } = prior;
-      await this.gameAssessmentHistoryCollection().add({
-        ...priorBody,
-        assessmentId: priorId,
-        supersededAt: now,
-      });
-    }
     const record: GameAssessment = {
       id,
       slug: input.slug,
@@ -7808,7 +7799,18 @@ export class FirestoreStore implements Store {
       createdAt,
       updatedAt: now,
     };
-    await ref.set({
+    // One batch: the archive and the replacement land together, or neither does.
+    const batch = this.db.batch();
+    if (existing.exists) {
+      const prior = hydrateGameAssessment(id, existing.data() as Omit<GameAssessment, 'id'>);
+      const { id: priorId, ...priorBody } = prior;
+      batch.set(this.gameAssessmentHistoryCollection().doc(), {
+        ...priorBody,
+        assessmentId: priorId,
+        supersededAt: now,
+      });
+    }
+    batch.set(ref, {
       slug: record.slug,
       title: record.title,
       source: record.source,
@@ -7823,6 +7825,7 @@ export class FirestoreStore implements Store {
       createdAt: record.createdAt,
       updatedAt: record.updatedAt,
     });
+    await batch.commit();
     return record;
   }
 

--- a/apps/web/src/ReviewDesk.test.tsx
+++ b/apps/web/src/ReviewDesk.test.tsx
@@ -247,4 +247,33 @@ describe('ReviewDesk', () => {
       }),
     );
   });
+
+  it('flags a slug an operator explicitly requeued for re-review', async () => {
+    reviewApi.fetchReviewQueue.mockResolvedValue({
+      source: 'all',
+      remaining: 1,
+      assessed: 1,
+      items: [
+        {
+          slug: 'sky-dodge',
+          title: 'Sky Dodge',
+          source: 'catalog',
+          creatorHandle: 'sky-pilot',
+          genre: 'arcade',
+          issueNumber: null,
+          media: { screenshots: [], video: null },
+          reReview: { reason: 'Controls fix shipped.', gameVersion: 'v2', requestedAt: '2026-08-06T00:00:00.000Z' },
+        },
+      ],
+    });
+
+    root = createRoot(container);
+    await act(async () => {
+      root!.render(<ReviewDesk />);
+    });
+    await flush();
+
+    expect(container.textContent).toContain('Re-review requested');
+    expect(container.textContent).toContain('Controls fix shipped.');
+  });
 });

--- a/apps/web/src/ReviewDesk.tsx
+++ b/apps/web/src/ReviewDesk.tsx
@@ -420,6 +420,14 @@ export function ReviewDesk() {
                   {current.creatorHandle ? <span> · @{current.creatorHandle}</span> : null}
                   <span> · {t(`review.source.${current.source}`)}</span>
                 </p>
+                {current.reReview ? (
+                  <p className="review-card-rereview">
+                    {t('review.reReviewBadge')}
+                    {current.reReview.reason
+                      ? ` — ${t('review.reReviewReason', { reason: current.reReview.reason })}`
+                      : ''}
+                  </p>
+                ) : null}
               </div>
 
               <div className="review-card-stage">

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -1296,6 +1296,8 @@
     "loading": "Loading the queue…",
     "denied": "This desk is only for reviewers.",
     "loadError": "Could not load the review queue. Try again.",
+    "reReviewBadge": "Re-review requested",
+    "reReviewReason": "Why: {{reason}}",
     "empty": "Queue clear — nothing left to assess in this filter.",
     "emptyNoSweep": "No active review sweep. An operator opens one from the Assessments console.",
     "emptyPaused": "The current review sweep is paused. Check back when it resumes.",

--- a/apps/web/src/i18n/locales/pl.json
+++ b/apps/web/src/i18n/locales/pl.json
@@ -1308,6 +1308,8 @@
     "loading": "Ładowanie kolejki…",
     "denied": "To biurko jest tylko dla recenzentów.",
     "loadError": "Nie udało się wczytać kolejki ocen. Spróbuj ponownie.",
+    "reReviewBadge": "Poproszono o ponowną ocenę",
+    "reReviewReason": "Powód: {{reason}}",
     "empty": "Kolejka pusta — nic więcej do oceny w tym filtrze.",
     "emptyNoSweep": "Brak aktywnego przeglądu. Operator uruchamia go w konsoli Ocen.",
     "emptyPaused": "Bieżący przegląd jest wstrzymany. Wróć, gdy zostanie wznowiony.",

--- a/apps/web/src/reviewApi.ts
+++ b/apps/web/src/reviewApi.ts
@@ -21,6 +21,9 @@ export interface ReviewQueueItem {
   genre: string | null;
   issueNumber: number | null;
   media: ReviewQueueMedia | null;
+  // Present when an operator explicitly asked this reviewer to look at this slug again
+  // (a fix landed after an earlier verdict), not a first pass through a sweep.
+  reReview?: { reason: string | null; gameVersion: string | null; requestedAt: string } | null;
 }
 
 export interface ReviewQueueSweepHint {
@@ -51,6 +54,9 @@ export interface GameAssessment {
   noteOrigin: AssessmentNoteOrigin;
   checklist: AssessmentChecklist | null;
   clientContext: AssessmentClientContext | null;
+  // The deployed game version this verdict judged, or null when the source does not
+  // carry a per-game version (today: the catalog).
+  gameVersion: string | null;
   createdAt: string;
   updatedAt: string;
 }
@@ -65,6 +71,7 @@ export interface SubmitAssessmentInput {
   noteOrigin?: Exclude<AssessmentNoteOrigin, 'none'>;
   checklist: AssessmentChecklist;
   clientContext?: AssessmentClientContext | null;
+  gameVersion?: string | null;
 }
 
 export interface AdminAssessmentsResponse {
@@ -142,5 +149,61 @@ export async function fetchMyAssessments(): Promise<GameAssessment[]> {
 
 export async function fetchAdminAssessments(): Promise<AdminAssessmentsResponse> {
   const res = await fetch(`${API_BASE}/api/admin/assessments`, { credentials: 'include' });
+  return readJson(res);
+}
+
+export type ReReviewRequestStatus = 'open' | 'resolved' | 'cancelled';
+
+export interface ReReviewRequest {
+  id: string;
+  slug: string;
+  reviewerUid: string;
+  status: ReReviewRequestStatus;
+  gameVersion: string | null;
+  reason: string | null;
+  createdAt: string;
+  createdBy: string;
+  resolvedAt: string | null;
+}
+
+export interface RequeueForReReviewInput {
+  slugs: string[];
+  reviewerUids: string[];
+  gameVersion?: string | null;
+  reason?: string | null;
+  notify?: boolean;
+}
+
+// Explicit slugs x explicit reviewers, independent of any sweep — asks a specific
+// reviewer to look at a specific game again after a fix (docs/game-assessment-plan.md
+// follow-up: re-queue a game after a major revision).
+export async function requeueForReReview(
+  input: RequeueForReReviewInput,
+): Promise<{ requests: ReReviewRequest[]; notified: number }> {
+  const res = await fetch(`${API_BASE}/api/admin/review-requeue`, {
+    method: 'POST',
+    credentials: 'include',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(input),
+  });
+  return readJson(res);
+}
+
+export async function fetchReReviewRequests(): Promise<{ requests: ReReviewRequest[] }> {
+  const res = await fetch(`${API_BASE}/api/admin/review-requeue`, { credentials: 'include' });
+  return readJson(res);
+}
+
+export interface AssessmentHistoryResponse {
+  current: GameAssessment | null;
+  history: GameAssessment[];
+}
+
+// The rows a plain re-edit would otherwise have overwritten silently.
+export async function fetchAssessmentHistory(slug: string, reviewerUid: string): Promise<AssessmentHistoryResponse> {
+  const params = new URLSearchParams({ slug, reviewerUid });
+  const res = await fetch(`${API_BASE}/api/admin/assessments/history?${params.toString()}`, {
+    credentials: 'include',
+  });
   return readJson(res);
 }

--- a/apps/web/src/reviewApi.ts
+++ b/apps/web/src/reviewApi.ts
@@ -21,8 +21,7 @@ export interface ReviewQueueItem {
   genre: string | null;
   issueNumber: number | null;
   media: ReviewQueueMedia | null;
-  // Present when an operator explicitly asked this reviewer to look at this slug again
-  // (a fix landed after an earlier verdict), not a first pass through a sweep.
+  // Set when an operator targeted this slug for re-review.
   reReview?: { reason: string | null; gameVersion: string | null; requestedAt: string } | null;
 }
 
@@ -54,8 +53,7 @@ export interface GameAssessment {
   noteOrigin: AssessmentNoteOrigin;
   checklist: AssessmentChecklist | null;
   clientContext: AssessmentClientContext | null;
-  // The deployed game version this verdict judged, or null when the source does not
-  // carry a per-game version (today: the catalog).
+  // The deployed game version this verdict judged.
   gameVersion: string | null;
   createdAt: string;
   updatedAt: string;
@@ -174,9 +172,7 @@ export interface RequeueForReReviewInput {
   notify?: boolean;
 }
 
-// Explicit slugs x explicit reviewers, independent of any sweep — asks a specific
-// reviewer to look at a specific game again after a fix (docs/game-assessment-plan.md
-// follow-up: re-queue a game after a major revision).
+// Explicit slugs x explicit reviewers, outside any sweep.
 export async function requeueForReReview(
   input: RequeueForReReviewInput,
 ): Promise<{ requests: ReReviewRequest[]; notified: number }> {

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -20115,6 +20115,13 @@ body.remix-entry-open {
   font-size: 0.8rem;
 }
 
+.review-card-rereview {
+  margin: 0.35rem 0 0;
+  color: var(--warning, #f5a623);
+  font-size: 0.78rem;
+  font-weight: 600;
+}
+
 .review-card-stage {
   position: relative;
   aspect-ratio: 16 / 10;

--- a/docs/game-assessment-plan.md
+++ b/docs/game-assessment-plan.md
@@ -13,21 +13,22 @@ judgment_ from someone who knows what the shelf should feel like.
 
 ## Shape
 
-| Piece         | Choice                                                                                                                                                                 |
-| ------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Role          | Env allowlist `REVIEWER_UIDS` (comma UIDs). Admins are reviewers too. Session-only, same posture as `ADMIN_UIDS` — PATs never count.                                   |
-| Surface       | Unlisted `/review`. 404 to everyone else (API answers 404, not 403).                                                                                                   |
-| Queue         | **Catalog** (published) and **Creator** (delivered, shared drafts that are not yet published). Private unshared drafts stay private.                                   |
-| Gesture       | Swipe right = keep, left = cut, down/button = skip. Keyboard: `→` / `←` / `↓`.                                                                                         |
-| Preview       | Catalog **MP4 + screenshots** first (gate media). Optional **Try play** opens full-screen theater (no play telemetry, no remix).                                       |
-| Mobile dock   | Note + Cut/Skip/Keep sit in a **bottom dock** (thumb zone). The desk owns the window like Studio; install/update banners join the column instead of covering the game. |
-| Rationale     | **Required** free text and/or speech-to-text (same Web Speech API as the hero mic). Transcript only — no audio upload.                                                 |
-| Checklist     | Required marks for **graphics / gameplay / fun / sound / controls** — each `ok` · `weak` · `bad`.                                                                      |
-| Client env    | Viewport, screen size, DPR, input method (`touch`/`mouse`/`mixed`), platform, lang, truncated UA — stored on the row at commit time.                                   |
-| Storage       | `gameAssessments/{slug}:{reviewerUid}` — one row per reviewer per game; a second pass overwrites.                                                                      |
-| Operator read | `/admin/assessments` — **review sweeps** (dispatch / rate / pause / notify) plus keep/cut aggregates and recent notes.                                                 |
-| Sweeps        | Operator opens a bounded pass; desk shows only the released prefix. `releasePerDay` drips by 24h from `startedAt`; manual Release.                                     |
-| Notify        | Starting or re-notifying a sweep fans out `operator.review_sweep` to `REVIEWER_UIDS` ∪ admins (in-app + email + push).                                                 |
+| Piece              | Choice                                                                                                                                                                 |
+| ------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Role               | Env allowlist `REVIEWER_UIDS` (comma UIDs). Admins are reviewers too. Session-only, same posture as `ADMIN_UIDS` — PATs never count.                                   |
+| Surface            | Unlisted `/review`. 404 to everyone else (API answers 404, not 403).                                                                                                   |
+| Queue              | **Catalog** (published) and **Creator** (delivered, shared drafts that are not yet published). Private unshared drafts stay private.                                   |
+| Gesture            | Swipe right = keep, left = cut, down/button = skip. Keyboard: `→` / `←` / `↓`.                                                                                         |
+| Preview            | Catalog **MP4 + screenshots** first (gate media). Optional **Try play** opens full-screen theater (no play telemetry, no remix).                                       |
+| Mobile dock        | Note + Cut/Skip/Keep sit in a **bottom dock** (thumb zone). The desk owns the window like Studio; install/update banners join the column instead of covering the game. |
+| Rationale          | **Required** free text and/or speech-to-text (same Web Speech API as the hero mic). Transcript only — no audio upload.                                                 |
+| Checklist          | Required marks for **graphics / gameplay / fun / sound / controls** — each `ok` · `weak` · `bad`.                                                                      |
+| Client env         | Viewport, screen size, DPR, input method (`touch`/`mouse`/`mixed`), platform, lang, truncated UA — stored on the row at commit time.                                   |
+| Storage            | `gameAssessments/{slug}:{reviewerUid}` — one row per reviewer per game; a second pass archives the prior row to `gameAssessmentHistory` before overwriting.            |
+| Operator read      | `/admin/assessments` — **review sweeps** (dispatch / rate / pause / notify) plus keep/cut aggregates and recent notes.                                                 |
+| Sweeps             | Operator opens a bounded pass; desk shows only the released prefix. `releasePerDay` drips by 24h from `startedAt`; manual Release.                                     |
+| Targeted re-review | Operator picks explicit `slugs` × `reviewerUids` (`reviewReRequests/{slug}:{reviewerUid}`) to re-surface a slug for one reviewer outside any sweep — see below.        |
+| Notify             | Starting or re-notifying a sweep, or a targeted re-review, fans out `operator.review_sweep` to the intended reviewers (in-app + email + push).                         |
 
 ## Non-goals (this steel thread)
 
@@ -82,22 +83,44 @@ Unset / empty means nobody extra is a reviewer. Locally: `REVIEWER_UIDS=dev:loca
 
 ## API
 
-| Method | Path                                             | Who      | Body / query                                                                                      |
-| ------ | ------------------------------------------------ | -------- | ------------------------------------------------------------------------------------------------- |
-| `GET`  | `/api/review/queue?source=catalog\|creator\|all` | reviewer | Queue of games not yet assessed by this reviewer                                                  |
-| `POST` | `/api/review/assessments`                        | reviewer | `{ slug, source, title?, creatorHandle?, verdict, note, checklist, noteOrigin?, clientContext? }` |
-| `GET`  | `/api/review/assessments/mine`                   | reviewer | This reviewer's rows (progress / re-edit)                                                         |
-| `GET`  | `/api/admin/assessments`                         | admin    | Aggregate + recent rows for the operator tab                                                      |
-| `GET`  | `/api/admin/review-sweeps`                       | admin    | Open sweep + progress + recent history                                                            |
-| `POST` | `/api/admin/review-sweeps`                       | admin    | Start a sweep (`source`, `maxGames`, `releasePerDay?`, `note?`, `notify?`)                        |
-| `POST` | `/api/admin/review-sweeps/:id`                   | admin    | Pause / resume / complete / cancel, release more/all, change rate, notify again                   |
+| Method | Path                                                | Who      | Body / query                                                                                                                   |
+| ------ | --------------------------------------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| `GET`  | `/api/review/queue?source=catalog\|creator\|all`    | reviewer | Queue of games not yet assessed by this reviewer, plus any slug an operator has targeted for this reviewer to re-review        |
+| `POST` | `/api/review/assessments`                           | reviewer | `{ slug, source, title?, creatorHandle?, verdict, note, checklist, noteOrigin?, clientContext?, gameVersion? }`                |
+| `GET`  | `/api/review/assessments/mine`                      | reviewer | This reviewer's rows (progress / re-edit)                                                                                      |
+| `GET`  | `/api/admin/assessments`                            | admin    | Aggregate + recent rows for the operator tab                                                                                   |
+| `GET`  | `/api/admin/assessments/history?slug=&reviewerUid=` | admin    | The superseded rows a re-assessment would otherwise have overwritten silently                                                  |
+| `GET`  | `/api/admin/review-sweeps`                          | admin    | Open sweep + progress + recent history                                                                                         |
+| `POST` | `/api/admin/review-sweeps`                          | admin    | Start a sweep (`source`, `maxGames`, `releasePerDay?`, `note?`, `notify?`)                                                     |
+| `POST` | `/api/admin/review-sweeps/:id`                      | admin    | Pause / resume / complete / cancel, release more/all, change rate, notify again                                                |
+| `POST` | `/api/admin/review-requeue`                         | admin    | `{ slugs[], reviewerUids[], gameVersion?, reason?, notify? }` — target explicit games at explicit reviewers, outside any sweep |
+| `GET`  | `/api/admin/review-requeue`                         | admin    | Recent targeted re-review requests                                                                                             |
 
-The desk queue is **empty until an operator opens a sweep**. Released games unlock by
-`releasePerDay` (elapsed 24h windows from `startedAt`) and/or manual Release controls.
-Every **new** verdict must target a slug in the active released prefix (re-edits of an
-existing assessment are allowed). Every verdict (including `skip`) needs a **non-empty
-note** and a complete checklist (`graphics` / `gameplay` / `fun` / `sound` / `controls`,
-each `ok|weak|bad`). Notes are moderated and sanitized.
+The desk queue is **empty until an operator opens a sweep**, except for slugs an operator
+explicitly targeted (see below), which surface regardless of any sweep. Released games
+unlock by `releasePerDay` (elapsed 24h windows from `startedAt`) and/or manual Release
+controls. Every **new** verdict must target a slug in the active released prefix, or one
+of this reviewer's open targeted re-review requests (re-edits of an existing assessment
+are always allowed). Every verdict (including `skip`) needs a **non-empty note** and a
+complete checklist (`graphics` / `gameplay` / `fun` / `sound` / `controls`, each
+`ok|weak|bad`). Notes are moderated and sanitized.
+
+### Targeted re-review
+
+`POST /api/admin/review-requeue` closes the gap the games-repo `catalog-feedback-loop`
+skill used to call out: `/api/review/queue` excludes a slug a reviewer has already
+assessed **permanently**, which is fine for a first pass but wrong once a fix has landed.
+An operator names explicit `slugs` × explicit `reviewerUids` (bounded to 200 pairs) and
+optionally the `gameVersion` the fix is expected to be judged against and a `reason`; each
+pair opens (or re-opens) a `ReReviewRequest`. Only that reviewer sees that slug surface
+again — the general sweep pool and every other reviewer are unaffected. The reviewer's
+next verdict on that slug resolves the request and stamps the assessment's `gameVersion`
+(from the submission if given, else the request's) so a later look can tell "judged this
+exact build" apart from "judged an older one." The **previous** assessment is archived,
+not overwritten — `GET /api/admin/assessments/history` reads it back — so the record of
+what a reviewer said the first time survives a second pass. `gameVersion` is informational
+only for the catalog (not tracked per-commit today); creator drafts pass their
+`deliveredVersion`.
 
 ## Instrumentation
 
@@ -108,8 +131,11 @@ into the existing `health` bucket (same unlisted-console posture as `/admin`).
 
 ## Follow-ups (not blocking)
 
-- Re-queue a game after a major revision (invalidate assessments when `publishedAt` or
-  delivered version advances).
+- ✅ **Targeted re-review** — `POST /api/admin/review-requeue` re-queues explicit slugs for
+  explicit reviewers after a fix, independent of the general sweep exclusion. See "Targeted
+  re-review" above. Still open: nothing _automatically_ invalidates an assessment when
+  `publishedAt` or `deliveredVersion` advances — an operator (or a script driving the API)
+  decides when a fix is worth a re-look and requeues it deliberately.
 - Optional CSV for offline curation — **Copy JSON** on Admin → Assessments is enough for
   agent paste handoff ([`ingest-desk-reviews`](../.claude/skills/ingest-desk-reviews/SKILL.md)).
 - ✅ **Editorial signal class** — creator-source cut consensus (≥2 reviewers, cut ≥ keep)


### PR DESCRIPTION
## Summary

Implements a targeted re-review system that allows operators to explicitly request specific reviewers to re-assess games after fixes have landed, independent of general review sweeps. This addresses the gap where reviewers are permanently excluded from reassessing games they've already judged, even when significant changes warrant a fresh look.

## Key Changes

- **New data models**: Added `GameAssessmentHistoryEntry` and `ReReviewRequest` interfaces to track superseded assessments and explicit re-review requests
- **Assessment versioning**: Added `gameVersion` field to `GameAssessment` to distinguish between different deployed versions of a game, enabling comparison of "already judged this exact build" vs "judged an older one"
- **History preservation**: When a reviewer submits a second assessment, the prior verdict is archived to `gameAssessmentHistory` collection with a `supersededAt` timestamp, preventing silent overwrites
- **Re-review queue**: Implemented `ReReViewRequest` collection with status tracking (`open`/`resolved`/`cancelled`) to manage operator-initiated re-review requests
- **Queue integration**: Modified `/api/review/queue` to surface targeted re-review items even for already-assessed games, with metadata about the request (reason, expected version, request timestamp)
- **Admin endpoints**:
  - `POST /api/admin/review-requeue`: Create targeted re-review requests for specific slug × reviewer pairs
  - `GET /api/admin/assessments/history`: Retrieve superseded assessments for comparison
  - `GET /api/admin/review-requeue`: List recent re-review requests
- **UI updates**: Added re-review badge and reason display in ReviewDesk to surface targeted requests to reviewers
- **Validation**: Enforced limits on requeue operations (50 slugs, 50 reviewers, 200 total pairs) and verified reviewer UIDs

## Implementation Details

- Game version can be inherited from the re-review request or explicitly overridden in the assessment submission
- History entries are sorted newest-first for easy comparison of progression
- Both InMemoryStore and FirestoreStore implementations provided with proper batch handling for Firestore
- Targeted items appear in the queue regardless of sweep status or release schedule
- Re-review requests are automatically resolved when a reviewer submits an assessment for that slug
- Comprehensive test coverage including validation, permission checks, and end-to-end workflows

https://claude.ai/code/session_01CCdbZKSixN8GLtGr7G51AE