### PR TITLE
Redesign account settings modal with tabbed navigation

### DIFF
--- a/apps/web/src/AccountSettingsModal.test.tsx
+++ b/apps/web/src/AccountSettingsModal.test.tsx
@@ -80,27 +80,69 @@ describe('AccountSettingsModal', () => {
     expect(card?.textContent).toContain('Connection 111111');
   });
 
-  it('switches to the Account tab and hides the credentials panel', async () => {
+  const navItem = (section: string) =>
+    document.body.querySelector(`.account-settings-nav-item[data-section="${section}"]`) as
+      HTMLButtonElement | undefined;
+  const panel = (section: string) =>
+    document.body.querySelector(`.account-settings-panel[data-section="${section}"]`) as HTMLElement | undefined;
+
+  it('switches to the Account section and hides — but keeps — the credentials panel', async () => {
     await act(async () => {
       root.render(createElement(AccountSettingsModal, { isOpen: true, onClose: () => {} }));
       await flush();
     });
 
-    const card = document.body.querySelector('.account-settings-modal-card');
-    const accountTab = [...(card?.querySelectorAll('[role="tab"]') ?? [])].find(
-      (tab) => tab.textContent === 'Account',
-    ) as HTMLButtonElement | undefined;
-    expect(accountTab).toBeDefined();
-
     await act(async () => {
-      accountTab?.click();
+      navItem('account')?.click();
       await flush();
     });
 
-    expect(card?.querySelector('[data-testid="creator-key-masked"]')).toBeNull();
-    expect(card?.querySelectorAll('.studio-oauth-client-row')).toHaveLength(0);
-    expect(card?.textContent).toContain('Schedule account deletion');
-    expect(accountTab?.getAttribute('aria-selected')).toBe('true');
+    expect(panel('credentials')?.hidden).toBe(true);
+    expect(panel('account')?.hidden).toBe(false);
+    expect(panel('account')?.textContent).toContain('Schedule account deletion');
+    expect(navItem('account')?.getAttribute('aria-current')).toBe('true');
+    expect(navItem('credentials')?.getAttribute('aria-current')).toBeNull();
+  });
+
+  it('does not refetch credentials when the creator switches back', async () => {
+    await act(async () => {
+      root.render(createElement(AccountSettingsModal, { isOpen: true, onClose: () => {} }));
+      await flush();
+    });
+    expect(connectApi.getCreatorAgentKey).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      navItem('account')?.click();
+      await flush();
+    });
+    await act(async () => {
+      navItem('credentials')?.click();
+      await flush();
+    });
+
+    expect(connectApi.getCreatorAgentKey).toHaveBeenCalledTimes(1);
+    expect(connectApi.listOAuthGrants).toHaveBeenCalledTimes(1);
+  });
+
+  it('reopens on Credentials even after closing on Account', async () => {
+    const render = (isOpen: boolean) =>
+      act(async () => {
+        root.render(createElement(AccountSettingsModal, { isOpen, onClose: () => {} }));
+        await flush();
+      });
+
+    await render(true);
+    await act(async () => {
+      navItem('account')?.click();
+      await flush();
+    });
+    expect(panel('account')?.hidden).toBe(false);
+
+    await render(false);
+    await render(true);
+
+    expect(panel('credentials')?.hidden).toBe(false);
+    expect(panel('account')?.hidden).toBe(true);
   });
 
   it('renders nothing — and asks for no credentials — while closed', async () => {

--- a/apps/web/src/AccountSettingsModal.test.tsx
+++ b/apps/web/src/AccountSettingsModal.test.tsx
@@ -80,6 +80,29 @@ describe('AccountSettingsModal', () => {
     expect(card?.textContent).toContain('Connection 111111');
   });
 
+  it('switches to the Account tab and hides the credentials panel', async () => {
+    await act(async () => {
+      root.render(createElement(AccountSettingsModal, { isOpen: true, onClose: () => {} }));
+      await flush();
+    });
+
+    const card = document.body.querySelector('.account-settings-modal-card');
+    const accountTab = [...(card?.querySelectorAll('[role="tab"]') ?? [])].find(
+      (tab) => tab.textContent === 'Account',
+    ) as HTMLButtonElement | undefined;
+    expect(accountTab).toBeDefined();
+
+    await act(async () => {
+      accountTab?.click();
+      await flush();
+    });
+
+    expect(card?.querySelector('[data-testid="creator-key-masked"]')).toBeNull();
+    expect(card?.querySelectorAll('.studio-oauth-client-row')).toHaveLength(0);
+    expect(card?.textContent).toContain('Schedule account deletion');
+    expect(accountTab?.getAttribute('aria-selected')).toBe('true');
+  });
+
   it('renders nothing — and asks for no credentials — while closed', async () => {
     await act(async () => {
       root.render(createElement(AccountSettingsModal, { isOpen: false, onClose: () => {} }));

--- a/apps/web/src/AccountSettingsModal.tsx
+++ b/apps/web/src/AccountSettingsModal.tsx
@@ -17,6 +17,12 @@ export function AccountSettingsModal({ isOpen, onClose }: { isOpen: boolean; onC
   onCloseRef.current = onClose;
   const [section, setSection] = useState<AccountSettingsSection>('credentials');
 
+  // The modal stays mounted between openings, so without this a creator who left
+  // on Account reopens staring at the deletion pane.
+  useEffect(() => {
+    if (isOpen) setSection('credentials');
+  }, [isOpen]);
+
   useEffect(() => {
     if (!isOpen) return;
     const previouslyFocused = document.activeElement instanceof HTMLElement ? document.activeElement : null;
@@ -35,8 +41,10 @@ export function AccountSettingsModal({ isOpen, onClose }: { isOpen: boolean; onC
 
   if (!isOpen) return null;
 
-  const credentialsPanelId = `${headingId}-panel-credentials`;
-  const accountPanelId = `${headingId}-panel-account`;
+  const sections: { id: AccountSettingsSection; icon: 'lock' | 'user'; label: string }[] = [
+    { id: 'credentials', icon: 'lock', label: t('creatorProfile.accountNavCredentials') },
+    { id: 'account', icon: 'user', label: t('creatorProfile.accountNavAccount') },
+  ];
 
   return createPortal(
     <div className="modal-backdrop claim-handle-modal-backdrop" role="presentation" onClick={onClose}>
@@ -56,56 +64,36 @@ export function AccountSettingsModal({ isOpen, onClose }: { isOpen: boolean; onC
         </header>
 
         <div className="account-settings-body">
-          <nav className="account-settings-nav" aria-orientation="vertical">
-            <button
-              type="button"
-              role="tab"
-              id={`${headingId}-tab-credentials`}
-              className={`account-settings-nav-item${section === 'credentials' ? ' is-active' : ''}`}
-              aria-selected={section === 'credentials'}
-              aria-controls={credentialsPanelId}
-              onClick={() => setSection('credentials')}
-            >
-              <PixelIcon name="lock" size={14} />
-              {t('creatorProfile.accountNavCredentials')}
-            </button>
-            <button
-              type="button"
-              role="tab"
-              id={`${headingId}-tab-account`}
-              className={`account-settings-nav-item${section === 'account' ? ' is-active' : ''}`}
-              aria-selected={section === 'account'}
-              aria-controls={accountPanelId}
-              onClick={() => setSection('account')}
-            >
-              <PixelIcon name="trash" size={14} />
-              {t('creatorProfile.accountNavAccount')}
-            </button>
+          {/* Plain nav rather than a tablist: two buttons do not earn the roving-focus contract. */}
+          <nav className="account-settings-nav" aria-label={t('creatorProfile.accountSettings')}>
+            {sections.map((entry) => (
+              <button
+                key={entry.id}
+                type="button"
+                className={`account-settings-nav-item${section === entry.id ? ' is-active' : ''}`}
+                aria-current={section === entry.id ? 'true' : undefined}
+                data-section={entry.id}
+                onClick={() => setSection(entry.id)}
+              >
+                <PixelIcon name={entry.icon} size={14} />
+                {entry.label}
+              </button>
+            ))}
           </nav>
 
-          {section === 'credentials' ? (
-            <div
-              className="account-settings-panel"
-              role="tabpanel"
-              id={credentialsPanelId}
-              aria-labelledby={`${headingId}-tab-credentials`}
-            >
-              <p className="studio-rail-credentials-hint">{t('studioPanel.rail.credentialsHint')}</p>
-              <div className="studio-rail-credentials-body">
-                <StudioCreatorAgentKeyPanel />
-                <StudioOAuthClientsPanel />
-              </div>
+          {/* Both panels stay mounted so switching away never refetches the key or
+              discards a confirmation the creator already armed. */}
+          <div className="account-settings-panel" data-section="credentials" hidden={section !== 'credentials'}>
+            <p className="studio-rail-credentials-hint">{t('studioPanel.rail.credentialsHint')}</p>
+            <div className="studio-rail-credentials-body">
+              <StudioCreatorAgentKeyPanel />
+              <StudioOAuthClientsPanel />
             </div>
-          ) : (
-            <div
-              className="account-settings-panel"
-              role="tabpanel"
-              id={accountPanelId}
-              aria-labelledby={`${headingId}-tab-account`}
-            >
-              <AccountDeletionControl labelledBy={`${headingId}-danger`} />
-            </div>
-          )}
+          </div>
+
+          <div className="account-settings-panel" data-section="account" hidden={section !== 'account'}>
+            <AccountDeletionControl labelledBy={`${headingId}-danger`} />
+          </div>
         </div>
       </div>
     </div>,

--- a/apps/web/src/AccountSettingsModal.tsx
+++ b/apps/web/src/AccountSettingsModal.tsx
@@ -17,8 +17,7 @@ export function AccountSettingsModal({ isOpen, onClose }: { isOpen: boolean; onC
   onCloseRef.current = onClose;
   const [section, setSection] = useState<AccountSettingsSection>('credentials');
 
-  // The modal stays mounted between openings, so without this a creator who left
-  // on Account reopens staring at the deletion pane.
+  // Modal stays mounted between openings; reset the tab on each open.
   useEffect(() => {
     if (isOpen) setSection('credentials');
   }, [isOpen]);
@@ -64,7 +63,7 @@ export function AccountSettingsModal({ isOpen, onClose }: { isOpen: boolean; onC
         </header>
 
         <div className="account-settings-body">
-          {/* Plain nav rather than a tablist: two buttons do not earn the roving-focus contract. */}
+          {/* Plain nav, not a tablist: too few tabs for roving focus. */}
           <nav className="account-settings-nav" aria-label={t('creatorProfile.accountSettings')}>
             {sections.map((entry) => (
               <button
@@ -81,8 +80,7 @@ export function AccountSettingsModal({ isOpen, onClose }: { isOpen: boolean; onC
             ))}
           </nav>
 
-          {/* Both panels stay mounted so switching away never refetches the key or
-              discards a confirmation the creator already armed. */}
+          {/* Stays mounted so switching tabs keeps state and skips a refetch. */}
           <div className="account-settings-panel" data-section="credentials" hidden={section !== 'credentials'}>
             <p className="studio-rail-credentials-hint">{t('studioPanel.rail.credentialsHint')}</p>
             <div className="studio-rail-credentials-body">

--- a/apps/web/src/AccountSettingsModal.tsx
+++ b/apps/web/src/AccountSettingsModal.tsx
@@ -17,7 +17,6 @@ export function AccountSettingsModal({ isOpen, onClose }: { isOpen: boolean; onC
   onCloseRef.current = onClose;
   const [section, setSection] = useState<AccountSettingsSection>('credentials');
 
-  // Modal stays mounted between openings; reset the tab on each open.
   useEffect(() => {
     if (isOpen) setSection('credentials');
   }, [isOpen]);
@@ -63,7 +62,6 @@ export function AccountSettingsModal({ isOpen, onClose }: { isOpen: boolean; onC
         </header>
 
         <div className="account-settings-body">
-          {/* Plain nav, not a tablist: too few tabs for roving focus. */}
           <nav className="account-settings-nav" aria-label={t('creatorProfile.accountSettings')}>
             {sections.map((entry) => (
               <button
@@ -80,7 +78,6 @@ export function AccountSettingsModal({ isOpen, onClose }: { isOpen: boolean; onC
             ))}
           </nav>
 
-          {/* Stays mounted so switching tabs keeps state and skips a refetch. */}
           <div className="account-settings-panel" data-section="credentials" hidden={section !== 'credentials'}>
             <p className="studio-rail-credentials-hint">{t('studioPanel.rail.credentialsHint')}</p>
             <div className="studio-rail-credentials-body">

--- a/apps/web/src/AccountSettingsModal.tsx
+++ b/apps/web/src/AccountSettingsModal.tsx
@@ -1,9 +1,12 @@
-import { useEffect, useId, useRef } from 'react';
+import { useEffect, useId, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { useTranslation } from 'react-i18next';
 import { AccountDeletionControl } from './AccountDeletionControl.js';
+import { PixelIcon } from './PixelIcon.js';
 import { StudioCreatorAgentKeyPanel } from './StudioCreatorAgentKeyPanel.js';
 import { StudioOAuthClientsPanel } from './StudioOAuthClientsPanel.js';
+
+type AccountSettingsSection = 'credentials' | 'account';
 
 /** Account settings remain reachable even before a creator claims a public handle. */
 export function AccountSettingsModal({ isOpen, onClose }: { isOpen: boolean; onClose: () => void }) {
@@ -12,6 +15,7 @@ export function AccountSettingsModal({ isOpen, onClose }: { isOpen: boolean; onC
   const cardRef = useRef<HTMLDivElement>(null);
   const onCloseRef = useRef(onClose);
   onCloseRef.current = onClose;
+  const [section, setSection] = useState<AccountSettingsSection>('credentials');
 
   useEffect(() => {
     if (!isOpen) return;
@@ -31,6 +35,9 @@ export function AccountSettingsModal({ isOpen, onClose }: { isOpen: boolean; onC
 
   if (!isOpen) return null;
 
+  const credentialsPanelId = `${headingId}-panel-credentials`;
+  const accountPanelId = `${headingId}-panel-account`;
+
   return createPortal(
     <div className="modal-backdrop claim-handle-modal-backdrop" role="presentation" onClick={onClose}>
       <div
@@ -47,18 +54,59 @@ export function AccountSettingsModal({ isOpen, onClose }: { isOpen: boolean; onC
         <header className="claim-handle-modal-head">
           <h2 id={headingId}>{t('creatorProfile.accountSettings')}</h2>
         </header>
-        <section className="account-settings-credentials" aria-labelledby={`${headingId}-credentials`}>
-          <h3 id={`${headingId}-credentials`} className="account-settings-section-title">
-            {t('creatorProfile.accountCredentials')}
-          </h3>
-          <p className="studio-rail-credentials-hint">{t('studioPanel.rail.credentialsHint')}</p>
-          <div className="studio-rail-credentials-body">
-            <StudioCreatorAgentKeyPanel />
-            <StudioOAuthClientsPanel />
-          </div>
-        </section>
 
-        <AccountDeletionControl labelledBy={`${headingId}-danger`} />
+        <div className="account-settings-body">
+          <nav className="account-settings-nav" aria-orientation="vertical">
+            <button
+              type="button"
+              role="tab"
+              id={`${headingId}-tab-credentials`}
+              className={`account-settings-nav-item${section === 'credentials' ? ' is-active' : ''}`}
+              aria-selected={section === 'credentials'}
+              aria-controls={credentialsPanelId}
+              onClick={() => setSection('credentials')}
+            >
+              <PixelIcon name="lock" size={14} />
+              {t('creatorProfile.accountNavCredentials')}
+            </button>
+            <button
+              type="button"
+              role="tab"
+              id={`${headingId}-tab-account`}
+              className={`account-settings-nav-item${section === 'account' ? ' is-active' : ''}`}
+              aria-selected={section === 'account'}
+              aria-controls={accountPanelId}
+              onClick={() => setSection('account')}
+            >
+              <PixelIcon name="trash" size={14} />
+              {t('creatorProfile.accountNavAccount')}
+            </button>
+          </nav>
+
+          {section === 'credentials' ? (
+            <div
+              className="account-settings-panel"
+              role="tabpanel"
+              id={credentialsPanelId}
+              aria-labelledby={`${headingId}-tab-credentials`}
+            >
+              <p className="studio-rail-credentials-hint">{t('studioPanel.rail.credentialsHint')}</p>
+              <div className="studio-rail-credentials-body">
+                <StudioCreatorAgentKeyPanel />
+                <StudioOAuthClientsPanel />
+              </div>
+            </div>
+          ) : (
+            <div
+              className="account-settings-panel"
+              role="tabpanel"
+              id={accountPanelId}
+              aria-labelledby={`${headingId}-tab-account`}
+            >
+              <AccountDeletionControl labelledBy={`${headingId}-danger`} />
+            </div>
+          )}
+        </div>
       </div>
     </div>,
     document.body,

--- a/apps/web/src/StudioOAuthClientsPanel.tsx
+++ b/apps/web/src/StudioOAuthClientsPanel.tsx
@@ -71,37 +71,31 @@ export function StudioOAuthClientsPanel() {
         <ul className="studio-oauth-client-list">
           {grants.map((grant) => (
             <li key={grant.grantId} className="studio-oauth-client-row">
-              <div className="studio-oauth-client-meta">
+              <div className="studio-oauth-client-summary">
                 <div className="studio-oauth-client-name">
                   <strong>{grant.clientLabel}</strong>
-                  <span>{t('oauthClients.connectionId', { id: grant.grantId.slice(-6).toUpperCase() })}</span>
                 </div>
-                <dl className="studio-oauth-client-dates">
-                  <div>
-                    <dt>{t('oauthClients.connectedLabel')}</dt>
-                    <dd>
-                      <time dateTime={grant.createdAt} title={formatExact(grant.createdAt)}>
-                        {formatRelativeTime(grant.createdAt, i18n.language)}
-                      </time>
-                    </dd>
-                  </div>
-                  <div>
-                    <dt>{t('oauthClients.lastUsedLabel')}</dt>
-                    <dd>
-                      {grant.lastUsedAt ? (
-                        <time dateTime={grant.lastUsedAt} title={formatExact(grant.lastUsedAt)}>
-                          {formatRelativeTime(grant.lastUsedAt, i18n.language)}
-                        </time>
-                      ) : (
-                        t('oauthClients.neverUsed')
-                      )}
-                    </dd>
-                  </div>
-                </dl>
+                <p className="studio-oauth-client-meta">
+                  {t('oauthClients.connectionId', { id: grant.grantId.slice(-6).toUpperCase() })}
+                  {' · '}
+                  {t('oauthClients.connectedLabel')}{' '}
+                  <time dateTime={grant.createdAt} title={formatExact(grant.createdAt)}>
+                    {formatRelativeTime(grant.createdAt, i18n.language)}
+                  </time>
+                  {' · '}
+                  {t('oauthClients.lastUsedLabel')}{' '}
+                  {grant.lastUsedAt ? (
+                    <time dateTime={grant.lastUsedAt} title={formatExact(grant.lastUsedAt)}>
+                      {formatRelativeTime(grant.lastUsedAt, i18n.language)}
+                    </time>
+                  ) : (
+                    t('oauthClients.neverUsed')
+                  )}
+                </p>
               </div>
 
               {confirmingId === grant.grantId ? (
-                <div className="studio-credential-confirm is-danger" role="alert">
+                <div className="studio-credential-confirm is-danger is-compact" role="alert">
                   <p>{t('oauthClients.confirm', { client: grant.clientLabel })}</p>
                   <div className="studio-credential-actions">
                     <button
@@ -126,7 +120,7 @@ export function StudioOAuthClientsPanel() {
               ) : (
                 <button
                   type="button"
-                  className="studio-credential-action is-danger"
+                  className="studio-oauth-client-revoke"
                   disabled={revokingId !== null}
                   onClick={() => setConfirmingId(grant.grantId)}
                 >

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -1391,7 +1391,9 @@
       "cooldown": "You renamed recently — try again after the cooldown.",
       "unchanged": "That is already your handle.",
       "unknown": "Could not update the profile."
-    }
+    },
+    "accountNavCredentials": "Credentials",
+    "accountNavAccount": "Account"
   },
   "pwa": {
     "ariaLabel": "Install this app",

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -1371,7 +1371,6 @@
     "available": "Available",
     "accountHeading": "Account",
     "accountSettings": "Account settings",
-    "accountCredentials": "Keys and connected agents",
     "deleteAccountSummary": "Schedule your account and personal data for deletion after a 14-day recovery window.",
     "deleteAccount": "Schedule account deletion",
     "deleteDialogTitle": "Schedule account deletion?",

--- a/apps/web/src/i18n/locales/pl.json
+++ b/apps/web/src/i18n/locales/pl.json
@@ -1403,7 +1403,9 @@
       "cooldown": "Niedawno zmieniałeś handle — spróbuj ponownie po okresie oczekiwania.",
       "unchanged": "To już jest Twój handle.",
       "unknown": "Nie udało się zaktualizować profilu."
-    }
+    },
+    "accountNavCredentials": "Dane dostępowe",
+    "accountNavAccount": "Konto"
   },
   "pwa": {
     "ariaLabel": "Zainstaluj tę aplikację",

--- a/apps/web/src/i18n/locales/pl.json
+++ b/apps/web/src/i18n/locales/pl.json
@@ -1383,7 +1383,6 @@
     "available": "Dostępny",
     "accountHeading": "Konto",
     "accountSettings": "Ustawienia konta",
-    "accountCredentials": "Klucze i połączone agenty",
     "deleteAccountSummary": "Zaplanuj usunięcie konta i danych osobowych po 14-dniowym okresie na zmianę decyzji.",
     "deleteAccount": "Zaplanuj usunięcie konta",
     "deleteDialogTitle": "Zaplanować usunięcie konta?",

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -19255,16 +19255,86 @@ body.remix-entry-open {
 }
 
 .account-settings-modal-card {
-  width: min(92vw, 520px);
+  width: min(94vw, 700px);
 }
 
-.account-settings-credentials {
-  margin-top: 0.75rem;
+.account-settings-body {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  margin-top: 1rem;
 }
 
-.account-settings-section-title {
-  margin: 0 0 0.35rem;
-  font-size: 0.9rem;
+.account-settings-nav {
+  display: flex;
+  flex-direction: row;
+  gap: 4px;
+  overflow-x: auto;
+  padding-bottom: 4px;
+}
+
+.account-settings-nav-item {
+  display: flex;
+  flex: 0 0 auto;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 12px;
+  border: 0;
+  border-radius: 8px;
+  background: transparent;
+  color: var(--muted, #94a3b8);
+  font-size: 0.85rem;
+  font-weight: 600;
+  white-space: nowrap;
+  cursor: pointer;
+}
+
+.account-settings-nav-item:hover {
+  background: color-mix(in srgb, var(--panel-card) 70%, transparent);
+  color: var(--text, #e2e8f0);
+}
+
+.account-settings-nav-item.is-active {
+  background: color-mix(in srgb, var(--panel-card) 90%, transparent);
+  color: var(--text-heading, #fff);
+}
+
+.account-settings-panel {
+  min-width: 0;
+  padding-top: 0.25rem;
+}
+
+.account-settings-panel .creator-profile-danger {
+  margin-top: 0;
+  padding-top: 0;
+  border-top: 0;
+}
+
+@media (min-width: 640px) {
+  .account-settings-body {
+    flex-direction: row;
+    align-items: flex-start;
+    gap: 1.25rem;
+  }
+
+  .account-settings-nav {
+    flex-direction: column;
+    flex: 0 0 168px;
+    gap: 2px;
+    overflow-x: visible;
+    padding-right: 0.75rem;
+    padding-bottom: 0;
+    border-right: 1px solid var(--panel-border);
+  }
+
+  .account-settings-nav-item {
+    width: 100%;
+  }
+
+  .account-settings-panel {
+    flex: 1 1 auto;
+    padding-top: 0;
+  }
 }
 
 .creator-profile-danger {

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -15423,6 +15423,7 @@ button.builder-mode-selector:disabled {
 .studio-oauth-client-summary {
   display: flex;
   min-width: 0;
+  flex: 1 1 0;
   flex-direction: column;
   gap: 2px;
 }
@@ -19305,6 +19306,10 @@ body.remix-entry-open {
   padding-top: 0.25rem;
 }
 
+.account-settings-panel[hidden] {
+  display: none;
+}
+
 .account-settings-panel .creator-profile-danger {
   margin-top: 0;
   padding-top: 0;
@@ -19319,6 +19324,8 @@ body.remix-entry-open {
   }
 
   .account-settings-nav {
+    position: sticky;
+    top: 0;
     flex-direction: column;
     flex: 0 0 168px;
     gap: 2px;

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -19255,6 +19255,7 @@ body.remix-entry-open {
 }
 
 .account-settings-modal-card {
+  max-width: 700px;
   width: min(94vw, 700px);
 }
 

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -15395,7 +15395,6 @@ button.builder-mode-selector:disabled {
 .studio-oauth-client-list {
   display: flex;
   flex-direction: column;
-  gap: 10px;
   margin: 2px 0 0;
   padding: 0;
   list-style: none;
@@ -15403,69 +15402,69 @@ button.builder-mode-selector:disabled {
 
 .studio-oauth-client-row {
   display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 6px 12px;
+  padding: 10px 0;
+  border-bottom: 1px solid var(--panel-border);
+}
+
+.studio-oauth-client-row:last-child {
+  border-bottom: 0;
+  padding-bottom: 0;
+}
+
+.studio-oauth-client-row:has(.studio-credential-confirm) {
   flex-direction: column;
-  align-items: flex-start;
-  gap: 12px;
-  padding: 12px;
-  border: 1px solid var(--panel-border);
-  border-radius: 10px;
-  background: color-mix(in srgb, var(--panel-card) 70%, transparent);
+  align-items: stretch;
 }
 
-.studio-oauth-client-meta {
-  display: flex;
-  min-width: 0;
-  width: 100%;
-  flex-direction: column;
-  gap: 10px;
-}
-
-.studio-oauth-client-name {
-  gap: 6px 10px;
-}
-
-.studio-oauth-client-name strong {
-  min-width: 0;
-  overflow-wrap: anywhere;
-  color: var(--text-heading, #fff);
-  font-size: 0.92rem;
-}
-
-.studio-oauth-client-name span {
-  color: var(--muted, #94a3b8);
-  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
-  font-size: 0.68rem;
-  letter-spacing: 0.04em;
-  text-transform: uppercase;
-}
-
-.studio-oauth-client-dates {
-  display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 8px;
-  margin: 0;
-}
-
-.studio-oauth-client-dates div {
+.studio-oauth-client-summary {
   display: flex;
   min-width: 0;
   flex-direction: column;
   gap: 2px;
 }
 
-.studio-oauth-client-dates dt {
-  color: var(--muted, #94a3b8);
-  font-size: 0.68rem;
-  font-weight: 700;
-  letter-spacing: 0.04em;
-  text-transform: uppercase;
+.studio-oauth-client-name strong {
+  min-width: 0;
+  overflow-wrap: anywhere;
+  color: var(--text-heading, #fff);
+  font-size: 0.9rem;
+  font-weight: 600;
 }
 
-.studio-oauth-client-dates dd {
+.studio-oauth-client-meta {
   margin: 0;
-  color: var(--text, #e2e8f0);
-  font-size: 0.8rem;
-  line-height: 1.35;
+  color: var(--muted, #94a3b8);
+  font-size: 0.75rem;
+  line-height: 1.4;
+}
+
+.studio-oauth-client-revoke {
+  flex: 0 0 auto;
+  padding: 4px 2px;
+  border: 0;
+  background: transparent;
+  color: var(--danger, #f87171);
+  font-size: 0.78rem;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.studio-oauth-client-revoke:hover:not(:disabled) {
+  text-decoration: underline;
+}
+
+.studio-oauth-client-revoke:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+
+.studio-credential-confirm.is-compact {
+  margin: 8px 0 12px;
+  padding: 10px 12px;
 }
 
 @media (max-width: 520px) {
@@ -15473,13 +15472,10 @@ button.builder-mode-selector:disabled {
   .studio-credential-action {
     width: 100%;
   }
-
-  .studio-oauth-client-dates {
-    grid-template-columns: 1fr;
-  }
 }
 
 /* Panel density: install chrome without the thread's title/lead/waiting stack. */
+
 .studio-connect.is-panel {
   gap: 12px;
   margin: 0;

--- a/eslint-rules/comment-prose-baseline.json
+++ b/eslint-rules/comment-prose-baseline.json
@@ -334,7 +334,7 @@
     "apps/web/src/AccessTokensPanel.test.tsx": 75,
     "apps/web/src/AccessTokensPanel.tsx": 185,
     "apps/web/src/AccountDeletionControl.tsx": 40,
-    "apps/web/src/AccountSettingsModal.tsx": 34,
+    "apps/web/src/AccountSettingsModal.tsx": 12,
     "apps/web/src/activeBuilds.test.ts": 47,
     "apps/web/src/activeBuilds.ts": 255,
     "apps/web/src/adminApi.ts": 223,

--- a/eslint-rules/comment-prose-baseline.json
+++ b/eslint-rules/comment-prose-baseline.json
@@ -334,7 +334,7 @@
     "apps/web/src/AccessTokensPanel.test.tsx": 75,
     "apps/web/src/AccessTokensPanel.tsx": 185,
     "apps/web/src/AccountDeletionControl.tsx": 40,
-    "apps/web/src/AccountSettingsModal.tsx": 12,
+    "apps/web/src/AccountSettingsModal.tsx": 34,
     "apps/web/src/activeBuilds.test.ts": 47,
     "apps/web/src/activeBuilds.ts": 255,
     "apps/web/src/adminApi.ts": 223,


### PR DESCRIPTION
## Summary
Restructured the account settings modal to use a tabbed navigation interface, separating credentials management from account deletion controls into distinct panels. This improves organization and UX by allowing users to focus on one task at a time.

## Key Changes

- **Added tabbed navigation** to the account settings modal with two sections:
  - Credentials (keys and OAuth clients)
  - Account (deletion controls)
  - Navigation uses icon + label buttons with active state styling

- **Refactored OAuth client list styling**:
  - Changed from card-based layout (bordered boxes) to a cleaner list with dividers
  - Condensed metadata display into a single line (connection ID, connected date, last used)
  - Simplified revoke button styling as a text button instead of action button
  - Improved responsive layout with flexbox wrapping

- **Improved modal behavior**:
  - Both panels remain mounted to preserve state (prevents refetching credentials or losing confirmation dialogs when switching tabs)
  - Modal resets to credentials tab when reopened
  - Panels use `hidden` attribute for visibility control

- **Enhanced responsive design**:
  - Mobile: horizontal scrolling nav with stacked layout
  - Desktop (640px+): sticky vertical sidebar navigation with main content area
  - Adjusted modal width from 520px to 700px max-width

- **Updated translations**:
  - Removed "accountCredentials" label (now implicit in tab)
  - Added "accountNavCredentials" and "accountNavAccount" for tab labels

## Implementation Details

- Navigation uses semantic `<nav>` with plain buttons (not tablist) since two buttons don't require roving-focus keyboard pattern
- `aria-current="true"` indicates active tab for accessibility
- CSS uses `:has()` selector to adjust layout when confirmation dialog is present
- OAuth client metadata now uses semantic `<p>` instead of `<dl>` for simpler inline display

https://claude.ai/code/session_01MLYE2oU9EzwuwBMAebRrfW