### PR TITLE
fix(continue_draft): honor builder: self on a round that never delivered

### DIFF
--- a/.claude/skills/byoca-mcp/SKILL.md
+++ b/.claude/skills/byoca-mcp/SKILL.md
@@ -879,6 +879,34 @@ has no cancel endpoint. Do not auto-dispatch platform from an ordinary `end`.
 `no_agent_yet` is a handoff without an agent to acknowledge it, so Studio can dispatch
 the selected replacement immediately.
 
+### A platform→self request on a never-dispatched round has no agent to ack
+
+`status.builder` is only echoed to the browser when `record.builder` is explicitly set
+(`submissions.ts` `nativeJobStatus`) — a round with none yet (e.g. opened via
+`code_surface_opened`, before any dispatch) reports it `undefined`. The Studio control that
+offers the switch-to-self badge used to require `status.builder === 'platform'` exactly,
+which hid it on every such round even though it resolves to `platform` by default
+(`canOfferSelfHandoff`, `apps/web/src/SubmissionStatusView.tsx`, now excludes only `'self'`).
+
+Exposing the control there surfaced a second bug: `POST /handoff`'s `awaitsAgentAck`
+(submissions.ts) waited for an agent to acknowledge a stop even when nothing was ever
+dispatched — there is no agent to ack, so the round sat `pending` until the 10-minute
+stale-handoff sweep force-acked it. `awaitsAgentAck` now also resolves immediately
+when `record.dispatch` has no refs, the same way it already skips waiting for an
+already-`ended` agent.
+
+### `continue_draft` must not silently reopen a self request as platform
+
+`continueDraftRound` always passes `builder: 'self'` to `resumeBuild` — MCP `continue_draft`
+is only ever called by a self/BYOCA agent's own creator key. But `resumeBuild` discards
+`input.builder` whenever it treats the round as `undelivered` (same-round retry semantics),
+and that flag used to key off `record.deliveredVersion` — a field only MCP `submit_sources`
+ever sets. A platform (managed) round reaches `ready_for_review` through its own completion
+path and never sets it, so every `continue_draft` on a job a platform agent last touched kept
+silently reopening it on `platform` regardless of what was asked. `undelivered` now keys off
+`record.dispatch?.refs?.length` instead — a round nothing was ever dispatched to is the one
+genuinely "undelivered" case the flag exists for; a round that ran to completion is not.
+
 ### The platform→self control must not require the agent to still be working
 
 The server-side gate for a creator-requested platform→self handoff

--- a/apps/api/src/mcp-continue-draft.test.ts
+++ b/apps/api/src/mcp-continue-draft.test.ts
@@ -157,6 +157,38 @@ describe('MCP continue_draft', () => {
     expect(started.structured).toMatchObject({ jobId: DRAFT_ISSUE, slug: SLUG });
   });
 
+  it('reopens as self even when the closed round was platform-built and never set deliveredVersion', async () => {
+    // A platform round reaches ready_for_review without ever setting deliveredVersion.
+    const store = new InMemoryStore();
+    await store.createSubmission(DRAFT_ISSUE, OWNER, 'Pong Draft');
+    await store.setSubmissionSlug(DRAFT_ISSUE, SLUG);
+    await store.recordDispatch(DRAFT_ISSUE, { backend: 'managed:openai', ref: 'resp_1' });
+    await store.recordJobTransition(DRAFT_ISSUE, {
+      to: 'ready_for_review',
+      at: '2026-08-01T12:00:00.000Z',
+      by: 'reconciler',
+      reason: 'task_completed',
+    });
+    await store.ensureGameAgentKey(SLUG, OWNER, '2026-08-01T12:00:00.000Z');
+    const headers = await creatorHeaders(store);
+    app = await createApp(store);
+
+    const { isError } = await callTool(
+      app,
+      'continue_draft',
+      { slug: SLUG, feedback: 'Switch this to my own agent.' },
+      headers,
+    );
+    expect(isError).toBe(false);
+
+    const job = await store.getSubmission(DRAFT_ISSUE);
+    expect(job?.builder).toBe('self');
+    expect(job?.state).toBe('dispatched');
+
+    const started = await callTool(app, 'start', { slug: SLUG }, headers);
+    expect(started.isError).toBe(false);
+  });
+
   it('records the relayed feedback as the agent’s words, not the creator’s', async () => {
     // The agent writes this sentence; the creator said something else, somewhere else.
     // Studio shows it on the creator's side of the thread, so it has to carry who typed
@@ -233,12 +265,7 @@ describe('MCP continue_draft', () => {
     const headers = await creatorHeaders(store);
     app = await createApp(store, undefined, translator);
 
-    const res = await callTool(
-      app,
-      'continue_draft',
-      { slug: SLUG, feedback: 'Make the paddle wider.' },
-      headers,
-    );
+    const res = await callTool(app, 'continue_draft', { slug: SLUG, feedback: 'Make the paddle wider.' }, headers);
 
     expect((res.structured as { error?: string }).error).toBeUndefined();
     const messages = await store.listCreatorMessages(DRAFT_ISSUE);

--- a/apps/api/src/submissions.ts
+++ b/apps/api/src/submissions.ts
@@ -1931,7 +1931,8 @@ export async function registerSubmissionRoutes(
       feedback: input.feedback,
       locale: input.locale,
       log: input.log,
-      ...(record.deliveredVersion ? {} : { undelivered: true }),
+      // deliveredVersion misses platform rounds; dispatch presence is the real "never ran" signal.
+      ...(record.dispatch?.refs?.length ? {} : { undelivered: true }),
       builder: 'self',
       transition: {
         by: input.openedBy === 'agent' ? 'agent' : 'creator',

--- a/apps/web/src/SubmissionStatusView.tsx
+++ b/apps/web/src/SubmissionStatusView.tsx
@@ -116,12 +116,6 @@ function isAgentWorkActive(status: SubmissionStatus | null | undefined): boolean
 }
 
 // True even once the agent has ended.
-// `status.builder` is only echoed when the record has committed to one (submissions.ts
-// `nativeJobStatus`) — a fresh round that has not dispatched yet reports it `undefined`,
-// which still resolves to `platform` server-side (`builderOf()`'s fallback). Treating
-// `undefined` as "not platform" hid this control on every such round: a queued round
-// opened via `code_surface_opened` had no `builder`/`defaultBuilder` field, `canChooseBuilder`
-// also excludes `queued`, so the creator had no path at all to pick `self` for it.
 function canOfferSelfHandoff(status: SubmissionStatus | null | undefined): boolean {
   if (!status || status.builder === 'self') return false;
   if (status.status === 'publishing') return false;

--- a/apps/web/src/SubmissionStatusView.tsx
+++ b/apps/web/src/SubmissionStatusView.tsx
@@ -116,6 +116,12 @@ function isAgentWorkActive(status: SubmissionStatus | null | undefined): boolean
 }
 
 // True even once the agent has ended.
+// `status.builder` is only echoed when the record has committed to one (submissions.ts
+// `nativeJobStatus`) — a fresh round that has not dispatched yet reports it `undefined`,
+// which still resolves to `platform` server-side (`builderOf()`'s fallback). Treating
+// `undefined` as "not platform" hid this control on every such round: a queued round
+// opened via `code_surface_opened` had no `builder`/`defaultBuilder` field, `canChooseBuilder`
+// also excludes `queued`, so the creator had no path at all to pick `self` for it.
 function canOfferSelfHandoff(status: SubmissionStatus | null | undefined): boolean {
   if (!status || status.builder === 'self') return false;
   if (status.status === 'publishing') return false;


### PR DESCRIPTION
## Summary
Follow-up to #890. That PR made the switch-to-self control visible and fixed the handoff-ack race, but a live incident on `transport-tycoon-remake` (job 1000081, `bot:grok`) showed a third, deeper bug on the same code path:

- `continueDraftRound` (the handler behind MCP `continue_draft`, which is **only ever called by a self/BYOCA agent's own creator key**) always passes `builder: 'self'` to `resumeBuild`.
- `resumeBuild` silently discards `input.builder` whenever it treats the round as `undelivered` — a flag that used to key off `record.deliveredVersion`.
- `deliveredVersion` is only ever set by MCP `submit_sources`. A platform (managed) round reaches `ready_for_review` through its own completion path and never sets it.
- Net effect: every `continue_draft` call on a job a platform agent last touched kept **silently reopening it on `platform`**, no matter what the BYOCA agent asked for — confirmed live via MCP transcript (`start` refused with "platform-agent build, can't join" right after `continue_draft` had just run).

Fix: gate `undelivered` on `record.dispatch?.refs?.length` instead — a round nothing was ever dispatched to is the one genuinely "undelivered" case the flag exists for (matches its own doc comment: "same round continuing — the agent never uploaded"); a round that ran to completion (platform or self) is not.

Also updates the `byoca-mcp` skill doc with all three fixes from this incident (mandatory per the skill's own "keep current" note).

## Test plan
- [x] New regression test in `mcp-continue-draft.test.ts`: seeds a `ready_for_review` round with a platform dispatch and no `deliveredVersion`, calls `continue_draft`, asserts `builder` becomes `self` and `start()` succeeds. Fails without the fix (old code errors outright — no platform backend configured in this harness, confirming it tried to route to `platform`).
- [x] `npx vitest run apps/api/src/submissions.test.ts apps/api/src/mcp-continue-draft.test.ts apps/api/src/mcp-open-round.test.ts apps/api/src/mcp-server.test.ts apps/api/src/job-state.test.ts apps/api/src/mcp-presence.test.ts` — 360/360 pass
- [x] `npm run lint` — clean
- [ ] Verify in prod: reopen `transport-tycoon-remake`'s draft via MCP `continue_draft` and confirm it lands on `self`, not `platform`

🤖 Generated with [Claude Code](https://claude.com/claude-code)