### PR TITLE
Fix account settings modal layout and tab ordering

### DIFF
--- a/apps/web/src/AccountSettingsModal.test.tsx
+++ b/apps/web/src/AccountSettingsModal.test.tsx
@@ -86,6 +86,19 @@ describe('AccountSettingsModal', () => {
   const panel = (section: string) =>
     document.body.querySelector(`.account-settings-panel[data-section="${section}"]`) as HTMLElement | undefined;
 
+  it('lists Account before Credentials, but still opens on Credentials', async () => {
+    await act(async () => {
+      root.render(createElement(AccountSettingsModal, { isOpen: true, onClose: () => {} }));
+      await flush();
+    });
+
+    const order = [...document.body.querySelectorAll('.account-settings-nav-item')].map((el) =>
+      el.getAttribute('data-section'),
+    );
+    expect(order).toEqual(['account', 'credentials']);
+    expect(panel('credentials')?.hidden).toBe(false);
+  });
+
   it('switches to the Account section and hides — but keeps — the credentials panel', async () => {
     await act(async () => {
       root.render(createElement(AccountSettingsModal, { isOpen: true, onClose: () => {} }));

--- a/apps/web/src/AccountSettingsModal.tsx
+++ b/apps/web/src/AccountSettingsModal.tsx
@@ -40,8 +40,8 @@ export function AccountSettingsModal({ isOpen, onClose }: { isOpen: boolean; onC
   if (!isOpen) return null;
 
   const sections: { id: AccountSettingsSection; icon: 'lock' | 'user'; label: string }[] = [
-    { id: 'credentials', icon: 'lock', label: t('creatorProfile.accountNavCredentials') },
     { id: 'account', icon: 'user', label: t('creatorProfile.accountNavAccount') },
+    { id: 'credentials', icon: 'lock', label: t('creatorProfile.accountNavCredentials') },
   ];
 
   return createPortal(

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -19255,24 +19255,40 @@ body.remix-entry-open {
   opacity: 1;
 }
 
+/* Fixed height, own scroll: switching tabs must not resize or jump the modal. */
 .account-settings-modal-card {
+  display: flex;
   max-width: 700px;
   width: min(94vw, 700px);
+  height: min(85dvh, 640px);
+  max-height: min(85dvh, 640px);
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.account-settings-modal-card .claim-handle-modal-head {
+  flex: 0 0 auto;
 }
 
 .account-settings-body {
   display: flex;
+  min-height: 0;
+  flex: 1 1 auto;
   flex-direction: column;
-  gap: 0.75rem;
+  gap: 0.5rem;
   margin-top: 1rem;
 }
 
+/* Always visible: never scrolls out of reach on mobile. */
 .account-settings-nav {
   display: flex;
+  flex: 0 0 auto;
   flex-direction: row;
   gap: 4px;
   overflow-x: auto;
-  padding-bottom: 4px;
+  -webkit-overflow-scrolling: touch;
+  padding-bottom: 8px;
+  border-bottom: 1px solid var(--panel-border);
 }
 
 .account-settings-nav-item {
@@ -19280,6 +19296,7 @@ body.remix-entry-open {
   flex: 0 0 auto;
   align-items: center;
   gap: 8px;
+  min-height: 40px;
   padding: 8px 12px;
   border: 0;
   border-radius: 8px;
@@ -19301,9 +19318,15 @@ body.remix-entry-open {
   color: var(--text-heading, #fff);
 }
 
+/* The one scrolling region — nav and header stay put while this moves. */
 .account-settings-panel {
   min-width: 0;
-  padding-top: 0.25rem;
+  min-height: 0;
+  flex: 1 1 auto;
+  padding-top: 0.75rem;
+  padding-right: 2px;
+  overflow-y: auto;
+  -webkit-overflow-scrolling: touch;
 }
 
 .account-settings-panel[hidden] {
@@ -19319,20 +19342,18 @@ body.remix-entry-open {
 @media (min-width: 640px) {
   .account-settings-body {
     flex-direction: row;
-    align-items: flex-start;
     gap: 1.25rem;
   }
 
   .account-settings-nav {
-    position: sticky;
-    top: 0;
-    flex-direction: column;
     flex: 0 0 168px;
+    flex-direction: column;
     gap: 2px;
     overflow-x: visible;
     padding-right: 0.75rem;
     padding-bottom: 0;
     border-right: 1px solid var(--panel-border);
+    border-bottom: 0;
   }
 
   .account-settings-nav-item {
@@ -19340,8 +19361,8 @@ body.remix-entry-open {
   }
 
   .account-settings-panel {
-    flex: 1 1 auto;
     padding-top: 0;
+    padding-left: 2px;
   }
 }
 


### PR DESCRIPTION
## Summary
Refactored the account settings modal to use a proper flexbox layout with fixed dimensions and independent scroll regions, while also reordering the navigation tabs to show Account before Credentials.

## Key Changes

**Layout & Scrolling:**
- Converted `.account-settings-modal-card` to a flex container with fixed height (`min(85dvh, 640px)`) to prevent resizing when switching tabs
- Made `.account-settings-panel` the sole scrolling region with `overflow-y: auto`, while keeping the navigation and header fixed
- Added `min-height: 0` to flex children to enable proper scroll behavior
- Improved mobile scrolling with `-webkit-overflow-scrolling: touch` on scrollable elements
- Adjusted padding and gaps for better visual hierarchy

**Navigation Styling:**
- Added visual separator with `border-bottom` on mobile and `border-right` on desktop
- Set minimum height of 40px for nav items for better touch targets
- Removed `position: sticky` from nav (no longer needed with new layout)
- Adjusted padding and spacing for consistency

**Tab Ordering:**
- Reordered sections array to show "Account" tab before "Credentials" tab
- Updated test to verify the new ordering while ensuring Credentials panel still opens correctly

## Implementation Details
- The modal now maintains a stable height regardless of content changes, preventing layout jumps
- Only the content panel scrolls; navigation and header remain visible at all times
- Desktop layout uses a sidebar navigation (168px fixed width) while mobile uses horizontal scrolling tabs
- Proper flex sizing ensures the layout adapts correctly between mobile and desktop breakpoints

https://claude.ai/code/session_01MLYE2oU9EzwuwBMAebRrfW