### PR TITLE
docs(verify-agent-work): record training-closer capture miss

### DIFF
--- a/.claude/skills/verify-agent-work/SKILL.md
+++ b/.claude/skills/verify-agent-work/SKILL.md
@@ -229,6 +229,13 @@ Two concrete instances of that (observed 2026-07-23):
   skip. For puzzle games, import the pure model in a throwaway clone and prove a
   no-mechanic control *fails* (walk-only into the door, jump-over) in the same session as
   the intended solve.
+- **A training-lab / per-mode closer can be TRACE-green on one happy path.** Observed
+  (mexico-86 / www.gamedev.pl-games#811, 2026-08-19): SPEC promised every drill ends in a
+  pass/fail verdict; CAPTURE only `waitFor`s `trainingOutcome` after short-pass key 4.
+  Isolated `check:game` was green. Walking the other labs showed set-piece choice and STOP
+  leave `trainingOutcome=none` with `trainingActed` already true, so the idle closer never
+  fires. When a PR adds a per-mode closer, probe each mode (or at least the one that does
+  not go through `finishAction`), not only the capture drill.
 - **Two writers of one knob, tested in isolation, is not a composition test.** Observed
   (games-repo gfx scale, 2026-08-12, [www.gamedev.pl-games#692](https://github.com/gamedevpl/www.gamedev.pl-games/pull/692)):
   a frame governor stepped the backing-store scale down when fill was slow, and a


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Follow-up from reviewing [www.gamedev.pl-games#811](https://github.com/gamedevpl/www.gamedev.pl-games/pull/811).

`check:game` was green because CAPTURE only waits for a short-pass `trainingOutcome`. Walking the other Training Ground labs showed set-piece choice and STOP leaving `trainingOutcome=none` with `trainingActed` already true, so the idle closer never fires.

This adds that failure mode to the verify-agent-work playbook: when a PR adds a per-mode closer, probe each mode (or at least the one that does not go through `finishAction`), not only the capture drill.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-53714ff0-8c45-4ba7-9237-5815fd0c55ce?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-53714ff0-8c45-4ba7-9237-5815fd0c55ce&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

