### PR TITLE
Record two verification misses from games-repo PR 807

### DIFF
--- a/.claude/skills/verify-agent-work/SKILL.md
+++ b/.claude/skills/verify-agent-work/SKILL.md
@@ -198,6 +198,21 @@ Two concrete instances of that (observed 2026-07-23):
   what the scan used to tolerate. Enumerate the states the discarded records could be
   in (abandoned, canceled, superseded, owned-by-someone-else) and test the newest
   record in each, not just the one from the bug report.
+- **A follow-up that claims "all review findings fixed" can drop items that lived
+  only in an issue comment.** Observed (www.gamedev.pl-games#807, 2026-08-19): the
+  first pass posted 32 inline findings plus a separate issue comment for two
+  `zone.ts` defects that were not in the diff (restart slot stranding, host-disconnect
+  zombie actors). The later "all 32 findings fixed" body was true of the *threads*;
+  the issue-comment item (host close leaves remotes latched and farmable) was still
+  on HEAD. When verifying a "we fixed the review" push, re-probe every promised
+  fix — including ones that could not be inlined — and do not treat resolved-thread
+  count as the checklist.
+- **A whole-action cap check can still leak through a multi-count loop.** Same PR:
+  `launch()` started returning before spending ammo when `projectiles.length >= MAX`,
+  which fixes the single-rocket case; Feather Flurry still spends one ammo unit and
+  then `addProjectile` silently drops the remaining pellets once the cap is hit
+  mid-volley (probe: 78/80, ammo 10→9, added 2 of 7). When a fix adds an early
+  return at the cap, walk every caller that loops `count` times.
 - **Run your probe against the PRE-fix branch too.** A probe that only fails on the
   candidate proves a defect exists; running the identical probe on the base proves
   whether the PR _introduced_ it or merely failed to fix it. Those are different


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

Adds two observed failure modes to the verify-agent-work playbook, found while independently reviewing [www.gamedev.pl-games#807](https://github.com/gamedevpl/www.gamedev.pl-games/pull/807):

1. A follow-up that claims "all review findings fixed" can drop items that lived only in an issue comment (not an inline thread).
2. A whole-action cap check can still leak through a multi-count loop.

## Why

The playbook's self-improvement clause: if verification surfaces a way to look fixed without being fixed, record it in the same session.

## Player impact

None. Internal agent playbook only.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d92b182c-f3af-442f-92f7-a739ae6a4f86?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d92b182c-f3af-442f-92f7-a739ae6a4f86&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

