### PR TITLE
fix(game-seed, source-delivery): stop silent seed crash + silent typecheck skip

### DIFF
--- a/apps/api/src/game-seed.test.ts
+++ b/apps/api/src/game-seed.test.ts
@@ -498,6 +498,19 @@ describe('VertexGameSeeder', () => {
     expect(await seeder.seed(request)).toBeNull();
   });
 
+  it('treats an empty pick response as no references, not a crash', async () => {
+    // Regression: seen in prod 2026-08-19 — a verbose 'low' thinking pass spent the whole
+    // maxOutputTokens budget on thinking and left nothing for the answer. The empty text
+    // used to reach JSON.parse('') uncaught, throwing "Unexpected end of JSON input" and
+    // taking the whole seed down instead of the pick alone failing open.
+    const seeder = new VertexGameSeeder({
+      context: stubContext(),
+      client: stubClient([{ text: '' }, { text: GOOD_DRAFT }]),
+    });
+
+    await expect(seeder.seed(request)).resolves.toBeNull();
+  });
+
   it('returns null when the draft is not a usable game', async () => {
     const seeder = new VertexGameSeeder({
       context: stubContext(),

--- a/apps/api/src/game-seed.test.ts
+++ b/apps/api/src/game-seed.test.ts
@@ -499,10 +499,7 @@ describe('VertexGameSeeder', () => {
   });
 
   it('treats an empty pick response as no references, not a crash', async () => {
-    // Regression: seen in prod 2026-08-19 — a verbose 'low' thinking pass spent the whole
-    // maxOutputTokens budget on thinking and left nothing for the answer. The empty text
-    // used to reach JSON.parse('') uncaught, throwing "Unexpected end of JSON input" and
-    // taking the whole seed down instead of the pick alone failing open.
+    // Regression: empty pick text used to throw JSON.parse('') uncaught.
     const seeder = new VertexGameSeeder({
       context: stubContext(),
       client: stubClient([{ text: '' }, { text: GOOD_DRAFT }]),

--- a/apps/api/src/game-seed.ts
+++ b/apps/api/src/game-seed.ts
@@ -79,6 +79,14 @@ const MAX_SEED_TOTAL_BYTES = 400_000;
 /** A seed that has not arrived by now has stopped being an optimization. */
 export const DEFAULT_SEED_PICK_TIMEOUT_MS = 30_000;
 export const DEFAULT_SEED_GENERATE_TIMEOUT_MS = 180_000;
+
+// 'low' thinking is mandatory here (thinkingBudget:0 400s on this model — see pickReferences)
+// and its tokens are drawn from the same maxOutputTokens cap as the answer. 512 was sized for
+// the JSON answer alone and left no headroom: on a verbose thinking pass the whole budget went
+// to thinking, the answer came back empty, and JSON.parse('') crashed the pick (seen in prod,
+// 2026-08-19). This is still tiny next to the 65_536 generate calls — just enough slack that
+// thinking overhead can't starve the three-slug answer that follows it.
+const SEED_PICK_MAX_OUTPUT_TOKENS = 2048;
 export const DEFAULT_SEED_TYPECHECK_TIMEOUT_MS = TYPECHECK_PREFLIGHT_BUDGET_MS;
 
 /** Same model family as the rest of our Vertex call sites; flash is the measured choice. */
@@ -498,16 +506,28 @@ export class VertexGameSeeder implements GameSeeder {
     const result = await this.client('pick')(buildPickPrompt(context, spec, this.references))
       .thinking({ level: 'low' })
       .temperature(0)
-      .maxOutputTokens(512)
+      .maxOutputTokens(SEED_PICK_MAX_OUTPUT_TOKENS)
       .signal(AbortSignal.timeout(this.pickTimeoutMs))
       .run();
 
-    const parsed = PickSchema.safeParse(JSON.parse(extractJson(result)));
-    const picks = (parsed.success ? (parsed.data.picks ?? []) : [])
-      .filter((slug) => context.hasGame(slug))
-      .slice(0, this.references);
+    const usage = usageOf(result, this.model);
+    // The answer is a few slugs, not prose — but an empty or fence-only reply parses to
+    // neither valid JSON nor a schema match. Miss either way and this call still picked
+    // nothing, same as a clean "no references matched": fail open, don't crash the seed.
+    let picks: string[] = [];
+    try {
+      const parsed = PickSchema.safeParse(JSON.parse(extractJson(result)));
+      picks = (parsed.success ? (parsed.data.picks ?? []) : [])
+        .filter((slug) => context.hasGame(slug))
+        .slice(0, this.references);
+    } catch (error) {
+      this.options.log?.warn(
+        { err: error, raw: extractJson(result).slice(0, 200) },
+        'seed pick response was not valid JSON, treating as no references',
+      );
+    }
 
-    return { picks, usage: usageOf(result, this.model) };
+    return { picks, usage };
   }
 
   // Fail-open: absent or timed out just means references-only generation.

--- a/apps/api/src/game-seed.ts
+++ b/apps/api/src/game-seed.ts
@@ -487,7 +487,18 @@ export class VertexGameSeeder implements GameSeeder {
   private client(kind: 'pick' | 'generate'): GenAIClient {
     if (this.options.client) return this.options.client;
     const generationConfig: Record<string, unknown> = {};
-    if (kind === 'pick') generationConfig.responseMimeType = 'application/json';
+    if (kind === 'pick') {
+      generationConfig.responseMimeType = 'application/json';
+      // Constrains the *shape* the model is decoded into — hallucinated extra fields or
+      // a picks list past `this.references` cannot happen. It does not reserve output
+      // tokens for the answer, so it does not by itself stop the empty-response crash
+      // pickReferences guards against below; that is what maxOutputTokens headroom is for.
+      generationConfig.responseSchema = {
+        type: 'OBJECT',
+        properties: { picks: { type: 'ARRAY', items: { type: 'STRING' }, maxItems: String(this.references) } },
+        required: ['picks'],
+      };
+    }
     const build = () =>
       createVertexClient({
         projectId: this.options.projectId,

--- a/apps/api/src/game-seed.ts
+++ b/apps/api/src/game-seed.ts
@@ -80,12 +80,7 @@ const MAX_SEED_TOTAL_BYTES = 400_000;
 export const DEFAULT_SEED_PICK_TIMEOUT_MS = 30_000;
 export const DEFAULT_SEED_GENERATE_TIMEOUT_MS = 180_000;
 
-// 'low' thinking is mandatory here (thinkingBudget:0 400s on this model — see pickReferences)
-// and its tokens are drawn from the same maxOutputTokens cap as the answer. 512 was sized for
-// the JSON answer alone and left no headroom: on a verbose thinking pass the whole budget went
-// to thinking, the answer came back empty, and JSON.parse('') crashed the pick (seen in prod,
-// 2026-08-19). This is still tiny next to the 65_536 generate calls — just enough slack that
-// thinking overhead can't starve the three-slug answer that follows it.
+// 'low' thinking shares this budget; 512 could starve the JSON answer empty.
 const SEED_PICK_MAX_OUTPUT_TOKENS = 2048;
 export const DEFAULT_SEED_TYPECHECK_TIMEOUT_MS = TYPECHECK_PREFLIGHT_BUDGET_MS;
 
@@ -489,10 +484,7 @@ export class VertexGameSeeder implements GameSeeder {
     const generationConfig: Record<string, unknown> = {};
     if (kind === 'pick') {
       generationConfig.responseMimeType = 'application/json';
-      // Constrains the *shape* the model is decoded into — hallucinated extra fields or
-      // a picks list past `this.references` cannot happen. It does not reserve output
-      // tokens for the answer, so it does not by itself stop the empty-response crash
-      // pickReferences guards against below; that is what maxOutputTokens headroom is for.
+      // Constrains picks' shape; doesn't reserve output tokens for the answer.
       generationConfig.responseSchema = {
         type: 'OBJECT',
         properties: { picks: { type: 'ARRAY', items: { type: 'STRING' }, maxItems: String(this.references) } },
@@ -522,9 +514,7 @@ export class VertexGameSeeder implements GameSeeder {
       .run();
 
     const usage = usageOf(result, this.model);
-    // The answer is a few slugs, not prose — but an empty or fence-only reply parses to
-    // neither valid JSON nor a schema match. Miss either way and this call still picked
-    // nothing, same as a clean "no references matched": fail open, don't crash the seed.
+    // An empty or malformed reply must fail open, not crash the seed.
     let picks: string[] = [];
     try {
       const parsed = PickSchema.safeParse(JSON.parse(extractJson(result)));

--- a/apps/api/src/source-delivery.test.ts
+++ b/apps/api/src/source-delivery.test.ts
@@ -349,6 +349,14 @@ export function tick(round: Round) {
       const record = await store.getSubmission(ISSUE);
       expect(record?.roundTypecheckPreflightRefusals).toBe(2);
       expect(record?.roundTypecheckPreflightBypassErrors).toMatch(/Typecheck preflight failed/);
+
+      // Regression: this used to be a server log line only — the diagnostics landed in
+      // roundTypecheckPreflightBypassErrors, which nothing reads, so the creator never
+      // learned their "accepted" delivery skipped validation. It must reach the thread.
+      const events = await store.listBuildEvents(ISSUE);
+      expect(events).toContainEqual(
+        expect.objectContaining({ kind: 'blocked', text: expect.stringContaining('without a passing typecheck') }),
+      );
     });
 
     it('does not refuse when no kit store is configured', async () => {

--- a/apps/api/src/source-delivery.test.ts
+++ b/apps/api/src/source-delivery.test.ts
@@ -4,6 +4,7 @@ import { InvalidUploadError } from './games-store.js';
 import type { KitFileStore, KitTree } from './kit-files.js';
 import { KIT_ROOT_DIR } from './kit-registry.js';
 import { InMemoryStore } from './store.js';
+import { NoopTranslator, type BilingualText, type Translator } from './translate.js';
 import { DELIVERY_ACCEPTED_MSG, DELIVERY_PREFLIGHT_REFUSED_MSG } from './delivery-metrics.js';
 import {
   createSourceDeliveryService,
@@ -43,6 +44,10 @@ interface GameKitGameContext { width: number; height: number; }
 declare const GameKit: { defineGame(): unknown };
 `;
 
+function stubTranslator(pl: string): Translator {
+  return { toBilingual: async (text): Promise<BilingualText> => ({ en: text, localized: pl }) };
+}
+
 function fakeKitStore(trees: Record<string, KitTree>): KitFileStore {
   return {
     loadRegistry: async () => ({ engineRef: Object.keys(trees)[0]!, previous: null, sha256: 'a'.repeat(64) }),
@@ -64,7 +69,11 @@ function treeFor(engineRef: string, kitDts: string): KitTree {
   };
 }
 
-async function setup(opts?: { kitFileStore?: KitFileStore | null }) {
+async function setup(opts?: {
+  kitFileStore?: KitFileStore | null;
+  failPutCandidateSources?: boolean;
+  translator?: Translator;
+}) {
   const store = new InMemoryStore();
   await store.createSubmission(ISSUE, 'owner', 'Original title');
   await store.setSubmissionSlug(ISSUE, SLUG);
@@ -78,6 +87,7 @@ async function setup(opts?: { kitFileStore?: KitFileStore | null }) {
 
   let versionNumber = 0;
   const putCandidateSources = vi.fn(async (input: { files: SourceFile[] }) => {
+    if (opts?.failPutCandidateSources) throw new InvalidUploadError('storage rejected this delivery', 'audio');
     versionNumber += 1;
     const version = `v-managed-${versionNumber}`;
     return { version, manifest: manifest(input.files, version) };
@@ -92,6 +102,7 @@ async function setup(opts?: { kitFileStore?: KitFileStore | null }) {
     onSourcesDelivered: gate,
     onEvent: vi.fn(),
     log,
+    translator: opts?.translator ?? new NoopTranslator(),
   });
   const authority: SourceDeliveryAuthority = {
     backend: BACKEND,
@@ -357,6 +368,64 @@ export function tick(round: Round) {
       );
     });
 
+    it('does not post the bypass warning when the delivery itself fails to store', async () => {
+      // Regression: bypass event used to post before storage could fail.
+      const kitFileStore = fakeKitStore({ [PINNED]: treeFor(PINNED, KIT_DTS) });
+      const { store, service, authority } = await setup({ kitFileStore, failPutCandidateSources: true });
+      await store.pinRoundKitEngineRef(ISSUE, PINNED);
+
+      for (let i = 0; i < 2; i += 1) {
+        await expect(
+          service.deliver({
+            issueNumber: ISSUE,
+            slug: SLUG,
+            files: brokenFiles,
+            mode: 'preview',
+            backend: BACKEND,
+            authority,
+          }),
+        ).rejects.toBeInstanceOf(InvalidUploadError);
+      }
+
+      await expect(
+        service.deliver({
+          issueNumber: ISSUE,
+          slug: SLUG,
+          files: brokenFiles,
+          mode: 'preview',
+          backend: BACKEND,
+          authority,
+        }),
+      ).rejects.toBeInstanceOf(InvalidUploadError);
+
+      expect(await store.listBuildEvents(ISSUE)).toEqual([]);
+    });
+
+    it('localizes the bypass warning like any other build event', async () => {
+      // Regression: this event skipped intake localization, unlike agent progress events.
+      const kitFileStore = fakeKitStore({ [PINNED]: treeFor(PINNED, KIT_DTS) });
+      const { store, service, authority } = await setup({
+        kitFileStore,
+        translator: stubTranslator('Dostarczono bez przejścia typecheck.'),
+      });
+      await store.pinRoundKitEngineRef(ISSUE, PINNED);
+
+      for (let i = 0; i < 3; i += 1) {
+        await service
+          .deliver({ issueNumber: ISSUE, slug: SLUG, files: brokenFiles, mode: 'preview', backend: BACKEND, authority })
+          .catch(() => {});
+      }
+
+      const events = await store.listBuildEvents(ISSUE);
+      expect(events).toContainEqual(
+        expect.objectContaining({
+          kind: 'blocked',
+          textLocalized: 'Dostarczono bez przejścia typecheck.',
+          locale: 'pl',
+        }),
+      );
+    });
+
     it('does not refuse when no kit store is configured', async () => {
       const { putCandidateSources, service, authority } = await setup({ kitFileStore: null });
       const result = await service.deliver({
@@ -392,6 +461,12 @@ export function tick(round: Round) {
       });
       expect(result.accepted).toBe(true);
       expect((await store.getSubmission(ISSUE))?.roundTypecheckPreflightBypassErrors).toBeUndefined();
+
+      // Regression: the stale 'blocked' warning was never superseded for a reader.
+      const events = await store.listBuildEvents(ISSUE);
+      expect(events).toContainEqual(
+        expect.objectContaining({ kind: 'milestone', text: expect.stringContaining('no longer applies') }),
+      );
     });
   });
 });

--- a/apps/api/src/source-delivery.test.ts
+++ b/apps/api/src/source-delivery.test.ts
@@ -350,9 +350,7 @@ export function tick(round: Round) {
       expect(record?.roundTypecheckPreflightRefusals).toBe(2);
       expect(record?.roundTypecheckPreflightBypassErrors).toMatch(/Typecheck preflight failed/);
 
-      // Regression: this used to be a server log line only — the diagnostics landed in
-      // roundTypecheckPreflightBypassErrors, which nothing reads, so the creator never
-      // learned their "accepted" delivery skipped validation. It must reach the thread.
+      // Regression: bypass diagnostics never reached the thread, only a log line.
       const events = await store.listBuildEvents(ISSUE);
       expect(events).toContainEqual(
         expect.objectContaining({ kind: 'blocked', text: expect.stringContaining('without a passing typecheck') }),

--- a/apps/api/src/source-delivery.ts
+++ b/apps/api/src/source-delivery.ts
@@ -124,6 +124,24 @@ export interface SourceDeliveryServiceOptions {
 const DEFAULT_MAX_SUBMITS_PER_WINDOW = 20;
 const RATE_LIMIT_WINDOW_MS = 60 * 60 * 1000;
 
+// Matches agent-channel.ts's MAX_EVENT_TEXT — same field, same reader, same cap.
+const MAX_DELIVERY_EVENT_TEXT = 300;
+
+/**
+ * A creator-visible 'blocked' thread event for a delivery that went through with a
+ * gap the creator cannot otherwise see: typecheck skipped or bypassed. Before this,
+ * these were `log?.warn` only — real in the store (roundTypecheckPreflightBypassErrors)
+ * but never read by anything, so a build could sit unpublished with the thread saying
+ * nothing was wrong. `appendBuildEvent` already renders 'blocked' with its own icon
+ * (see apps/web/src/SubmissionStatusView.tsx); no client change needed to show this.
+ */
+async function reportDeliveryBlocked(store: Store, issueNumber: number, text: string): Promise<void> {
+  await store.appendBuildEvent(issueNumber, {
+    kind: 'blocked',
+    text: sanitizeCreatorText(text, { singleLine: true }).slice(0, MAX_DELIVERY_EVENT_TEXT),
+  });
+}
+
 function stopReason(record: SubmissionRecord): 'stopped' | null {
   if (record.abandonedAt || record.publishedAt || resolveJobState(record) === 'canceled') return 'stopped';
   if (record.builderHandoff && record.builderHandoff.awaitsAgentAck !== false) return 'stopped';
@@ -312,6 +330,11 @@ export function createSourceDeliveryService(options: SourceDeliveryServiceOption
               },
               'typecheck preflight bypassed after refusal cap',
             );
+            await reportDeliveryBlocked(
+              options.store,
+              input.issueNumber,
+              `Delivered without a passing typecheck after ${TYPECHECK_PREFLIGHT_MAX_REFUSALS} failed attempts: ${check.message}`,
+            );
           } else {
             if (record.roundTypecheckPreflightBypassErrors) {
               typecheckBypass = false;
@@ -321,6 +344,11 @@ export function createSourceDeliveryService(options: SourceDeliveryServiceOption
               options.log?.warn?.(
                 { issueNumber: input.issueNumber, slug: input.slug, durationMs: check.durationMs },
                 'typecheck preflight skipped: budget exceeded',
+              );
+              await reportDeliveryBlocked(
+                options.store,
+                input.issueNumber,
+                "Delivered without typecheck validation — the check ran out of time on this round's budget.",
               );
             }
           }

--- a/apps/api/src/source-delivery.ts
+++ b/apps/api/src/source-delivery.ts
@@ -15,8 +15,10 @@ import {
   type TransitionActor,
 } from './job-state.js';
 import type { KitFileStore } from './kit-files.js';
+import { normalizeAtIntake } from './localize-intake.js';
 import { sanitizeCreatorText } from './submission-status.js';
 import type { Store, SubmissionRecord } from './store.js';
+import { createTranslatorFromEnv, type Translator } from './translate.js';
 import {
   runTypecheckPreflight,
   sharedSourcesFromKitTree,
@@ -119,6 +121,8 @@ export interface SourceDeliveryServiceOptions {
     error: (context: object, message: string) => void;
     warn?: (context: object, message: string) => void;
   };
+  // Same lazy-default pattern as agent-channel.ts / submissions.ts.
+  translator?: Translator;
 }
 
 const DEFAULT_MAX_SUBMITS_PER_WINDOW = 20;
@@ -127,11 +131,20 @@ const RATE_LIMIT_WINDOW_MS = 60 * 60 * 1000;
 // Matches agent-channel.ts's MAX_EVENT_TEXT — same field, same reader, same cap.
 const MAX_DELIVERY_EVENT_TEXT = 300;
 
-// Posts a 'blocked' thread event; UI already renders that kind.
-async function reportDeliveryBlocked(store: Store, issueNumber: number, text: string): Promise<void> {
+// Posts a thread event via the same localization pass agent events get.
+async function reportDeliveryEvent(
+  store: Store,
+  translator: Translator,
+  issueNumber: number,
+  kind: 'blocked' | 'milestone',
+  rawText: string,
+): Promise<void> {
+  const clean = sanitizeCreatorText(rawText, { singleLine: true }).slice(0, MAX_DELIVERY_EVENT_TEXT);
+  const intake = await normalizeAtIntake(translator, clean, { kind: 'log', maxLength: MAX_DELIVERY_EVENT_TEXT });
   await store.appendBuildEvent(issueNumber, {
-    kind: 'blocked',
-    text: sanitizeCreatorText(text, { singleLine: true }).slice(0, MAX_DELIVERY_EVENT_TEXT),
+    kind,
+    text: intake.text,
+    ...(intake.textLocalized && intake.locale ? { textLocalized: intake.textLocalized, locale: intake.locale } : {}),
   });
 }
 
@@ -191,6 +204,7 @@ function managedAuthorityError(
 
 export function createSourceDeliveryService(options: SourceDeliveryServiceOptions): SourceDeliveryService {
   const now = options.now ?? Date.now;
+  const translator = options.translator ?? createTranslatorFromEnv();
   const maxSubmitsPerWindow = options.maxSubmitsPerWindow ?? DEFAULT_MAX_SUBMITS_PER_WINDOW;
   const submitsByBuild = new Map<number, number[]>();
 
@@ -290,6 +304,8 @@ export function createSourceDeliveryService(options: SourceDeliveryServiceOption
       // Typecheck preflight uses the pinned kit; skip if unavailable.
       const engineRefForCheck = pinnedEngineRef ?? input.kitEngineRef;
       let typecheckBypass = Boolean(record.roundTypecheckPreflightBypassErrors);
+      // Deferred: posted only after storage succeeds, not before.
+      const pendingThreadEvents: { kind: 'blocked' | 'milestone'; text: string }[] = [];
       if (options.kitFileStore && engineRefForCheck) {
         try {
           const tree = await options.kitFileStore.loadTree(engineRefForCheck);
@@ -323,26 +339,28 @@ export function createSourceDeliveryService(options: SourceDeliveryServiceOption
               },
               'typecheck preflight bypassed after refusal cap',
             );
-            await reportDeliveryBlocked(
-              options.store,
-              input.issueNumber,
-              `Delivered without a passing typecheck after ${TYPECHECK_PREFLIGHT_MAX_REFUSALS} failed attempts: ${check.message}`,
-            );
+            pendingThreadEvents.push({
+              kind: 'blocked',
+              text: `Delivered without a passing typecheck after ${TYPECHECK_PREFLIGHT_MAX_REFUSALS} failed attempts: ${check.message}`,
+            });
           } else {
             if (record.roundTypecheckPreflightBypassErrors) {
               typecheckBypass = false;
               await options.store.setRoundTypecheckPreflightBypassErrors(input.issueNumber, null);
+              pendingThreadEvents.push({
+                kind: 'milestone',
+                text: "Typecheck now passes — this round's earlier bypass warning no longer applies.",
+              });
             }
             if (check.skipped === 'timeout') {
               options.log?.warn?.(
                 { issueNumber: input.issueNumber, slug: input.slug, durationMs: check.durationMs },
                 'typecheck preflight skipped: budget exceeded',
               );
-              await reportDeliveryBlocked(
-                options.store,
-                input.issueNumber,
-                "Delivered without typecheck validation — the check ran out of time on this round's budget.",
-              );
+              pendingThreadEvents.push({
+                kind: 'blocked',
+                text: "Delivered without typecheck validation — the check ran out of time on this round's budget.",
+              });
             }
           }
         } catch (error) {
@@ -393,6 +411,9 @@ export function createSourceDeliveryService(options: SourceDeliveryServiceOption
           await emitRefusal(error.kind);
         }
         throw error;
+      }
+      for (const event of pendingThreadEvents) {
+        await reportDeliveryEvent(options.store, translator, input.issueNumber, event.kind, event.text);
       }
 
       if (input.mode === 'preview') {

--- a/apps/api/src/source-delivery.ts
+++ b/apps/api/src/source-delivery.ts
@@ -127,14 +127,7 @@ const RATE_LIMIT_WINDOW_MS = 60 * 60 * 1000;
 // Matches agent-channel.ts's MAX_EVENT_TEXT — same field, same reader, same cap.
 const MAX_DELIVERY_EVENT_TEXT = 300;
 
-/**
- * A creator-visible 'blocked' thread event for a delivery that went through with a
- * gap the creator cannot otherwise see: typecheck skipped or bypassed. Before this,
- * these were `log?.warn` only — real in the store (roundTypecheckPreflightBypassErrors)
- * but never read by anything, so a build could sit unpublished with the thread saying
- * nothing was wrong. `appendBuildEvent` already renders 'blocked' with its own icon
- * (see apps/web/src/SubmissionStatusView.tsx); no client change needed to show this.
- */
+// Posts a 'blocked' thread event; UI already renders that kind.
 async function reportDeliveryBlocked(store: Store, issueNumber: number, text: string): Promise<void> {
   await store.appendBuildEvent(issueNumber, {
     kind: 'blocked',


### PR DESCRIPTION
## Summary

Root-caused from a stuck build (`pinnacle-fairways-championship`, 2026-08-19): the round never landed a first draft, and nothing in the Studio thread said why. Two independent silent failures compounded:

- **`VertexGameSeeder.pickReferences`** (`game-seed.ts`) capped `maxOutputTokens` at 512 while forcing `thinking: 'low'` — both draw from the same budget. A verbose thinking pass could burn the whole 512 and leave an empty answer, and `JSON.parse('')` threw `SyntaxError: Unexpected end of JSON input` uncaught, taking the whole seed down instead of the pick alone failing open (per this module's own "fail-open, always" contract). Fix: bump the pick call's budget to 2048 (still tiny next to the 65,536 generate calls) and catch the parse failure explicitly, logging it distinctly from a generic seed failure.

- **`source-delivery.ts`**: when typecheck preflight is bypassed after hitting the refusal cap, or skipped because its time budget ran out, the only record was a `log.warn` — `roundTypecheckPreflightBypassErrors` is written to the store but nothing ever reads it back, so a delivery could go out unverified with zero signal to the creator. Fix: both paths now also post a `kind: 'blocked'` build-thread event via the existing `appendBuildEvent`/`BuildEvent` pipeline — the web client already renders `'blocked'` with its own icon (`SubmissionStatusView.tsx`), so this needed no client change, just wiring the write.

## Test plan
- [x] `npx vitest run game-seed --dir apps/api` — 45/45, including new regression test for an empty pick response
- [x] `npx vitest run source-delivery --dir apps/api` — 13/13, including new assertion that the bypass path emits a `blocked` thread event
- [x] `npx vitest run --dir apps/api` — full suite, 3285/3285
- [x] `npx tsc --noEmit -p apps/api`, `eslint`, `prettier --check` on all touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)