### PR TITLE
feat(github-client): allow game TypeScript to import shared sim code from shared/sim

### DIFF
--- a/apps/api/src/github-client.test.ts
+++ b/apps/api/src/github-client.test.ts
@@ -1407,6 +1407,34 @@ describe('getGameSources', () => {
     expect(() => new Function(sources?.gameJs ?? '')).not.toThrow();
   });
 
+  it('allows importing shared sim code from shared/sim', async () => {
+    const files = new Map<string, string | Uint8Array>([
+      ['games/sim-game/index.html', '<canvas id="game"></canvas>'],
+      ['games/sim-game/game.ts', "import { createWorld } from '../../shared/sim/box-world.ts'; createWorld();"],
+      ['shared/sim/box-world.ts', 'export function createWorld(): void { GameKit.mount({ ok: true }); }'],
+      ['games/sim-game/style.css', '.game { color: gold; }'],
+      ['games/sim-game/SPEC.md', specMd({ title: 'Sim Game' })],
+      ['games/sim-game/GAME.json', JSON.stringify({ engine: { modules: [] } })],
+      ['shared/game-shell.css', '.shell { display: grid; }'],
+      ['shared/modules/core.ts', 'window.GameKit = { mount() {} };'],
+    ]);
+    const fetchImpl = vi.fn(async (input: RequestInfo | URL) => {
+      const pathname = new URL(String(input)).pathname;
+      const marker = '/contents/';
+      const requestedPath = decodeURIComponent(pathname.slice(pathname.indexOf(marker) + marker.length));
+      const value = files.get(requestedPath);
+      return value === undefined ? new Response('not found', { status: 404 }) : new Response(value, { status: 200 });
+    }) as unknown as typeof fetch;
+    const client = createGitHubClient({ token: 'test-token', repo, fetchImpl });
+
+    const sources = await client.getGameSources('main', 'sim-game');
+    expect(sources?.gameJs).toContain('ok: true');
+    expect(() => new Function(sources?.gameJs ?? '')).not.toThrow();
+
+    const sourceMap = await client.getGameSourceMap('main', 'sim-game');
+    expect(Object.keys(sourceMap ?? {})).toEqual(['game.ts']);
+  });
+
   it.each([
     ["import '../other-game/runtime.ts';", 'game imports must be TypeScript files inside'],
     ["import 'some-package';", 'game runtime dependency is forbidden'],

--- a/apps/api/src/github-client.ts
+++ b/apps/api/src/github-client.ts
@@ -906,6 +906,8 @@ export function createGitHubClient(options: GitHubClientOptions): GitHubClient {
     return (await response.json()) as T;
   }
 
+  const SHARED_SIM_ROOT = '/shared/sim';
+
   async function bundleTypeScriptGraph(
     entrySource: string,
     ref: string,
@@ -946,7 +948,11 @@ export function createGitHubClient(options: GitHubClientOptions): GitHubClient {
               // onto a path under the source root before the sandbox check; anything
               // that escapes that root is rejected.
               const sourcePath = resolveGameTypeScriptPath(args.resolveDir, args.path);
-              if (!sourcePath || !sourcePath.startsWith(`${sourceRoot}/`)) {
+              const isAllowed =
+                sourcePath &&
+                (sourcePath.startsWith(`${sourceRoot}/`) ||
+                  (sourceKind === 'game' && sourcePath.startsWith(`${SHARED_SIM_ROOT}/`)));
+              if (!isAllowed) {
                 return {
                   errors: [{ text: `${sourceKind} imports must be TypeScript files inside ${sourceRoot}` }],
                 };
@@ -973,7 +979,10 @@ export function createGitHubClient(options: GitHubClientOptions): GitHubClient {
               let source = overrideOf(loadedPath) ?? (await readRawFile(loadedPath.slice(1), ref));
               if (source === null && loadedPath.endsWith('.ts')) {
                 const indexPath = `${loadedPath.slice(0, -'.ts'.length)}/index.ts`;
-                if (indexPath.startsWith(`${sourceRoot}/`)) {
+                const isAllowedIndex =
+                  indexPath.startsWith(`${sourceRoot}/`) ||
+                  (sourceKind === 'game' && indexPath.startsWith(`${SHARED_SIM_ROOT}/`));
+                if (isAllowedIndex) {
                   const indexSource = overrideOf(indexPath) ?? (await readRawFile(indexPath.slice(1), ref));
                   if (indexSource !== null) {
                     loadedPath = indexPath;
@@ -984,7 +993,9 @@ export function createGitHubClient(options: GitHubClientOptions): GitHubClient {
               if (source === null) {
                 return { errors: [{ text: `${sourceKind} module not found: ${args.path}` }] };
               }
-              collect?.set(loadedPath.slice(sourceRoot.length + 1), source);
+              if (loadedPath.startsWith(`${sourceRoot}/`)) {
+                collect?.set(loadedPath.slice(sourceRoot.length + 1), source);
+              }
               if (!loadedPaths.has(loadedPath)) {
                 if (loadedPaths.size >= MAX_SOURCE_GRAPH_MODULES) {
                   return {

--- a/apps/api/src/typecheck-preflight.test.ts
+++ b/apps/api/src/typecheck-preflight.test.ts
@@ -29,11 +29,16 @@ describe('typecheck preflight', () => {
       kitTree({
         'shared/game-kit.d.ts': KIT_DTS,
         'shared/modules/core.ts': 'export const core = 1;\n',
+        'shared/sim/box-world.ts': 'export const boxWorld = 1;\n',
         'SKILL.md': '# ignore\n',
         'shared/audio/beep.wav': 'not-text',
       }),
     );
-    expect(Object.keys(shared).sort()).toEqual(['shared/game-kit.d.ts', 'shared/modules/core.ts']);
+    expect(Object.keys(shared).sort()).toEqual([
+      'shared/game-kit.d.ts',
+      'shared/modules/core.ts',
+      'shared/sim/box-world.ts',
+    ]);
   });
 
   it('refuses the Round-field transcript failure with one grouped line', () => {

--- a/apps/api/src/typecheck-preflight.ts
+++ b/apps/api/src/typecheck-preflight.ts
@@ -48,7 +48,8 @@ export function sharedSourcesFromKitTree(tree: KitTree): Record<string, string> 
     const isKitDts = rel === 'shared/game-kit.d.ts';
     const isModule = rel.startsWith('shared/modules/') && rel.endsWith('.ts');
     const isVertical = rel.startsWith('shared/verticals/') && rel.endsWith('.ts');
-    if (isKitDts || isModule || isVertical) {
+    const isSharedSim = rel.startsWith('shared/sim/') && rel.endsWith('.ts');
+    if (isKitDts || isModule || isVertical || isSharedSim) {
       out[rel] = buf.toString('utf8');
     }
   }

--- a/apps/web/src/StudioStage.tsx
+++ b/apps/web/src/StudioStage.tsx
@@ -150,7 +150,16 @@ export function StudioStage({
 
   const [idle, setIdle] = useState(false);
   const idleTimerRef = useRef<number | null>(null);
+  const shimmerTimeoutRef = useRef<number | null>(null);
   const swapWatchRef = useRef<{ stop: () => void } | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (shimmerTimeoutRef.current !== null) {
+        window.clearTimeout(shimmerTimeoutRef.current);
+      }
+    };
+  }, []);
 
   const reducedMotion =
     typeof window.matchMedia === 'function' && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
@@ -214,7 +223,13 @@ export function StudioStage({
     setStatusAndReport(next ? { kind: 'ready' } : { kind: 'empty' });
     if (next) watchSwappedDocument(next, origin);
     if (showShimmer) {
-      window.setTimeout(() => setShimmer(false), 400);
+      if (shimmerTimeoutRef.current !== null) {
+        window.clearTimeout(shimmerTimeoutRef.current);
+      }
+      shimmerTimeoutRef.current = window.setTimeout(() => {
+        setShimmer(false);
+        shimmerTimeoutRef.current = null;
+      }, 400);
     }
   }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary of Changes

Enables game TypeScript bundling on the website (`apps/api`) to import shared sim code from `/shared/sim/` (introduced by games-repo PR #820).

1. **`github-client.ts`**:
   - In `bundleTypeScriptGraph`'s `github-typescript-modules` plugin, allow relative imports resolving under `/shared/sim/` when bundling `sourceKind === 'game'`.
   - In `onLoad`, handle `/shared/sim/` index file fallbacks and avoid slicing off-root paths when collecting module maps.
2. **`typecheck-preflight.ts`**:
   - Include `shared/sim/*.ts` in `sharedSourcesFromKitTree` so preflight `tsc` checks can resolve shared sim modules.
3. **`StudioStage.tsx`**:
   - Track and clear `shimmer` timeout on unmount/re-trigger to eliminate unhandled timer errors during component teardown in tests.

## Verification
- Unit and integration tests added for `shared/sim` game imports in `github-client.test.ts` and `typecheck-preflight.test.ts`.
- Full green gate (`npm run type-check && npm run lint && npm run test && npm run build`) passes cleanly across all workspaces.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-14557200-22d7-403a-af71-e027aed6fbc0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-14557200-22d7-403a-af71-e027aed6fbc0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

