### PR TITLE
legal: disclose Meta as a round-0 seeding recipient in the privacy policy

### DIFF
--- a/apps/web/src/legal/privacy.en.ts
+++ b/apps/web/src/legal/privacy.en.ts
@@ -247,6 +247,11 @@ export const privacyEn: LegalDocument = {
               'Moderating and refining your game description; suggesting code completions in the Code editor',
               'USA / global — Standard Contractual Clauses',
             ],
+            [
+              'Meta (Muse Spark, Meta Model API)',
+              'Generating a starting draft of your game from your description, before the coding agent begins',
+              'USA — Standard Contractual Clauses',
+            ],
             ['GitHub (Microsoft)', 'Games repository and coding agent', 'USA — Data Privacy Framework'],
             ['Resend', 'Sending email', 'USA — Standard Contractual Clauses'],
             [

--- a/apps/web/src/legal/privacy.pl.ts
+++ b/apps/web/src/legal/privacy.pl.ts
@@ -257,6 +257,11 @@ export const privacyPl: LegalDocument = {
               'Moderacja i doprecyzowanie opisu gry; podpowiedzi uzupełnień kodu w edytorze kodu',
               'USA / globalnie — standardowe klauzule umowne',
             ],
+            [
+              'Meta (Muse Spark, Meta Model API)',
+              'Wygenerowanie wstępnego szkicu gry na podstawie Twojego opisu, zanim zajmie się nią agent kodujący',
+              'USA — standardowe klauzule umowne',
+            ],
             ['GitHub (Microsoft)', 'Repozytorium gier i agent kodujący', 'USA — Data Privacy Framework'],
             ['Resend', 'Wysyłka wiadomości e-mail', 'USA — standardowe klauzule umowne'],
             [


### PR DESCRIPTION
## Summary

Adds Meta (Muse Spark, Meta Model API) to the privacy policy's recipients table (`apps/web/src/legal/privacy.en.ts` / `privacy.pl.ts`), ahead of it becoming a live round-0 seed provider (ops: `seed-provider-selection-plan.md`, `legal-compliance-plan.md`).

| Provider | Role | Where |
| --- | --- | --- |
| Meta (Muse Spark, Meta Model API) | Generating a starting draft of your game from your description, before the coding agent begins | USA — Standard Contractual Clauses |

## Why this transfer basis

Meta's own EU Data Transfer Addendum documents processor-to-processor Standard Contractual Clauses (module 3, EC decision 2021/914) as their transfer mechanism — same claim class as the existing Vertex and Resend rows, not invented for this PR.

The account this was tested against is **not** on Meta's training/contributor tier (confirmed with the owner), so this is a standard processing disclosure, not a training-data one. Meta's Model API offers a separate, much cheaper tier in exchange for training on prompts/completions — if that tier is ever used instead, this row and disclosure would need to change.

## Sequencing

This is safe to merge on its own — it only adds a disclosure, no code changes. But real creator specs must not reach Meta before this lands: production round-0 seeding stays Vertex-only until `meta-api-key` is actually provisioned in Secret Manager (still gated on the wave-3 items in `legal-compliance-plan.md`).

## Test plan

- [x] `apps/web/src/legal/legal.test.ts` — PL/EN table row-count parity passes
- [x] `apps/web/src/legal/` full suite passes
- [x] `tsc -p apps/web --noEmit` clean
- [x] `npm run lint` (ESLint + comment-prose) clean

https://claude.ai/code/session_017aN2YwzNuF9d8so8gfWuWz

---
_Generated by [Claude Code](https://claude.ai/code/session_017aN2YwzNuF9d8so8gfWuWz)_