### PR TITLE
Let a creator or operator delete a published game

### DIFF
--- a/apps/api/src/creator-studio.test.ts
+++ b/apps/api/src/creator-studio.test.ts
@@ -68,6 +68,44 @@ describe('GET /api/me/studio', () => {
     await app.close();
   });
 
+  it('reports a deleted game as not live while keeping its publish history', async () => {
+    await store.createSubmission(20, 'g:creator', 'Comet Courier');
+    await store.setSubmissionSlug(20, 'comet-courier');
+    await store.setSubmissionPublishedAt(20, `${today}T12:00:00.000Z`);
+    await store.setSubmissionNotifiedStatus(20, 'published');
+    await store.setPublication({
+      slug: 'comet-courier',
+      state: 'published',
+      currentVersion: 'v1',
+      publishedAt: `${today}T12:00:00.000Z`,
+    });
+    await store.archivePublication('comet-courier', 'deleted by creator', `${today}T13:00:00.000Z`);
+
+    const app = await buildApp({ store, sessionSecret, submissionRoutes: { submissionTokenSecret } });
+    const res = await app.inject({ method: 'GET', url: '/api/me/studio', headers: authHeaders('g:creator') });
+
+    const games = (res.json() as { games: CreatorStudioGame[] }).games;
+    expect(games).toHaveLength(1);
+    // History stands — the row still says when it published.
+    expect(games[0]).toMatchObject({ slug: 'comet-courier', publishedAt: `${today}T12:00:00.000Z`, live: false });
+
+    await app.close();
+  });
+
+  it('reads a game with no publication record as live (games-repo entries, legacy slugs)', async () => {
+    await store.createSubmission(21, 'g:creator', 'Legacy Game');
+    await store.setSubmissionSlug(21, 'legacy-game');
+    await store.setSubmissionPublishedAt(21, `${today}T12:00:00.000Z`);
+
+    const app = await buildApp({ store, sessionSecret, submissionRoutes: { submissionTokenSecret } });
+    const res = await app.inject({ method: 'GET', url: '/api/me/studio', headers: authHeaders('g:creator') });
+
+    const games = (res.json() as { games: CreatorStudioGame[] }).games;
+    expect(games[0]?.live).toBeUndefined();
+
+    await app.close();
+  });
+
   it('lists all distinct games even when improvement rounds exceed the job ceiling', async () => {
     for (let game = 0; game < 3; game++) {
       const slug = `game-${game}`;

--- a/apps/api/src/creator-studio.ts
+++ b/apps/api/src/creator-studio.ts
@@ -77,6 +77,8 @@ export interface CreatorStudioGame {
    * all, and absent entirely when the switch is off.
    */
   codeSurface?: boolean;
+  // `false` only when the slug's publication says archived/disabled.
+  live?: false;
 }
 
 export interface CreatorHealthResponse {
@@ -244,6 +246,17 @@ export async function registerCreatorStudioRoutes(
       );
     }
 
+    // publishedAt/catalogPublishedAt are history and stay; liveness is getPublication's call.
+    const notLiveSlugs = new Set<string>();
+    await Promise.all(
+      shelf
+        .filter(({ tip, catalogPublishedAt }) => tip.slug && (tip.publishedAt || catalogPublishedAt))
+        .map(async ({ tip }) => {
+          const publication = await store.getPublication(tip.slug as string);
+          if (publication && publication.state !== 'published') notLiveSlugs.add(tip.slug as string);
+        }),
+    );
+
     const games: CreatorStudioGame[] = shelf.map(({ tip, catalogPublishedAt }) => ({
       token: options.mintStatusToken!(tip.issueNumber),
       title: tip.title,
@@ -256,6 +269,7 @@ export async function registerCreatorStudioRoutes(
       ...(tip.slug ? { slug: tip.slug } : {}),
       ...(tip.publishedAt ? { publishedAt: tip.publishedAt } : {}),
       ...(catalogPublishedAt ? { livePublishedAt: catalogPublishedAt } : {}),
+      ...(tip.slug && notLiveSlugs.has(tip.slug) ? { live: false as const } : {}),
       ...(tip.draftSharedAt ? { draftShared: true } : {}),
       ...(tip.slug && editableSlugs.has(tip.slug) ? { editable: true } : {}),
       ...(codeSurfaceEnabled() ? { codeSurface: true } : {}),

--- a/apps/api/src/store.test.ts
+++ b/apps/api/src/store.test.ts
@@ -665,6 +665,24 @@ describe('publication registry', () => {
     expect(await store.takedownPublication('nope', 'x', '2026-07-30T12:00:00Z')).toBe(false);
   });
 
+  it('archives a game under its own state, distinct from a moderation takedown', async () => {
+    const store = new InMemoryStore();
+    await store.setPublication(published);
+
+    expect(await store.archivePublication('comet-courier', 'deleted by creator', '2026-07-30T12:00:00Z')).toBe(true);
+
+    expect(await store.getPublication('comet-courier')).toMatchObject({
+      state: 'archived',
+      takedownReason: 'deleted by creator',
+      takedownAt: '2026-07-30T12:00:00Z',
+    });
+  });
+
+  it('reports an archive of something never published rather than inventing a record', async () => {
+    const store = new InMemoryStore();
+    expect(await store.archivePublication('nope', 'x', '2026-07-30T12:00:00Z')).toBe(false);
+  });
+
   it('keeps a withdrawn game out of nothing — the bake decides, from state', async () => {
     // listPublications returns every record, including disabled ones. The bake filters on
     // state rather than on presence, so a withdrawn game is visibly withdrawn instead of

--- a/apps/api/src/store.ts
+++ b/apps/api/src/store.ts
@@ -2091,6 +2091,7 @@ export interface Store {
    * version pointer.
    */
   takedownPublication(slug: string, reason: string, at: string): Promise<boolean>;
+  archivePublication(slug: string, reason: string, at: string): Promise<boolean>;
   /**
    * Records or updates the publication's health re-gate (request, verdict, and
    * notified-at are all patches of the same record — see PublicationHealthCheck).
@@ -3564,6 +3565,13 @@ export class InMemoryStore implements Store {
     const record = this.publications.get(slug);
     if (!record) return false;
     this.publications.set(slug, { ...record, state: 'disabled', takedownAt: at, takedownReason: reason });
+    return true;
+  }
+
+  async archivePublication(slug: string, reason: string, at: string): Promise<boolean> {
+    const record = this.publications.get(slug);
+    if (!record) return false;
+    this.publications.set(slug, { ...record, state: 'archived', takedownAt: at, takedownReason: reason });
     return true;
   }
 
@@ -6219,6 +6227,21 @@ export class FirestoreStore implements Store {
       tx.set(
         ref,
         { publication: { ...current, state: 'disabled', takedownAt: at, takedownReason: reason } },
+        { merge: true },
+      );
+      return true;
+    });
+  }
+
+  async archivePublication(slug: string, reason: string, at: string): Promise<boolean> {
+    const ref = this.db.collection('games').doc(slug);
+    return this.db.runTransaction(async (tx) => {
+      const snap = await tx.get(ref);
+      const current = (snap.data() as { publication?: PublicationRecord } | undefined)?.publication;
+      if (!current) return false;
+      tx.set(
+        ref,
+        { publication: { ...current, state: 'archived', takedownAt: at, takedownReason: reason } },
         { merge: true },
       );
       return true;

--- a/apps/api/src/submissions.test.ts
+++ b/apps/api/src/submissions.test.ts
@@ -6043,6 +6043,180 @@ describe('operator health re-gate', () => {
   });
 });
 
+describe('creator deletes their own published game', () => {
+  async function appWithPublishedSubmission(
+    ownerUid: string,
+    publicationState: 'published' | 'archived' = 'published',
+  ) {
+    const { githubClient } = createGithubClientStub({});
+    const { app, authHeaders, store } = await createApp({ githubClient, submissionTokenSecret: secret });
+    await store.upsertUser({ uid: ownerUid });
+    await store.createSubmission(1_000_099, ownerUid, 'Sky Dodge');
+    await store.setSubmissionSlug(1_000_099, 'sky-dodge');
+    await store.setPublication({
+      slug: 'sky-dodge',
+      state: publicationState,
+      currentVersion: 'v1',
+      publishedAt: '2026-07-01T00:00:00.000Z',
+    });
+    return { app, authHeaders, store };
+  }
+
+  it('archives the publication and leaves nothing else touched', async () => {
+    const { app, authHeaders, store } = await appWithPublishedSubmission('g:test-user');
+
+    const response = await app.inject({
+      method: 'POST',
+      url: `/api/submissions/${mintToken(1_000_099, secret)}/delete-game`,
+      headers: authHeaders,
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toEqual({ ok: true, slug: 'sky-dodge' });
+    expect(await store.getPublication('sky-dodge')).toMatchObject({
+      state: 'archived',
+      takedownReason: 'deleted by creator',
+    });
+
+    await app.close();
+  });
+
+  it("refuses a token that is not the game's creator", async () => {
+    const { app, store } = await appWithPublishedSubmission('g:someone-else');
+    await store.upsertUser({ uid: 'g:test-user' });
+
+    const response = await app.inject({
+      method: 'POST',
+      url: `/api/submissions/${mintToken(1_000_099, secret)}/delete-game`,
+      headers: getAuthHeaders('g:test-user'),
+    });
+
+    expect(response.statusCode).toBe(403);
+    expect(await store.getPublication('sky-dodge')).toMatchObject({ state: 'published' });
+
+    await app.close();
+  });
+
+  it('refuses a game that is not currently published', async () => {
+    const { app, authHeaders, store } = await appWithPublishedSubmission('g:test-user', 'archived');
+
+    const response = await app.inject({
+      method: 'POST',
+      url: `/api/submissions/${mintToken(1_000_099, secret)}/delete-game`,
+      headers: authHeaders,
+    });
+
+    expect(response.statusCode).toBe(409);
+    expect(await store.getPublication('sky-dodge')).toMatchObject({ state: 'archived' });
+
+    await app.close();
+  });
+});
+
+describe('operator deletes a published game', () => {
+  const bossHeaders = () => getAuthHeaders('g:boss');
+
+  async function appWithPublishedGame(publicationState: 'published' | 'disabled' = 'published') {
+    const store = new InMemoryStore();
+    await store.upsertUser({ uid: 'g:test-user' });
+    await store.upsertUser({ uid: 'g:boss' });
+    await store.setPublication({
+      slug: 'sky-dodge',
+      state: publicationState,
+      currentVersion: 'v1',
+      publishedAt: '2026-07-01T00:00:00.000Z',
+    });
+
+    const { app } = await createApp({
+      githubClient: createGithubClientStub({}).githubClient,
+      store,
+      submissionTokenSecret: secret,
+      adminUids: 'g:boss',
+    });
+    return { app, store };
+  }
+
+  it('answers 404 to a non-operator', async () => {
+    const { app } = await appWithPublishedGame();
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/admin/games/sky-dodge/delete',
+      headers: getAuthHeaders('g:someone-else'),
+    });
+    expect(response.statusCode).toBe(404);
+
+    await app.close();
+  });
+
+  it('answers 404 for a slug with no publication at all', async () => {
+    const { app } = await appWithPublishedGame();
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/admin/games/never-published/delete',
+      headers: bossHeaders(),
+    });
+    expect(response.statusCode).toBe(404);
+
+    await app.close();
+  });
+
+  it('refuses a game that is not currently published', async () => {
+    const { app, store } = await appWithPublishedGame('disabled');
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/admin/games/sky-dodge/delete',
+      headers: bossHeaders(),
+    });
+
+    expect(response.statusCode).toBe(409);
+    expect(response.json()).toMatchObject({ error: 'not_published', state: 'disabled' });
+    expect(await store.getPublication('sky-dodge')).toMatchObject({ state: 'disabled' });
+
+    await app.close();
+  });
+
+  it('archives the game and records the operator-supplied reason', async () => {
+    const { app, store } = await appWithPublishedGame();
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/admin/games/sky-dodge/delete',
+      headers: { ...bossHeaders(), 'content-type': 'application/json' },
+      payload: { reason: 'infringing assets' },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toEqual({ ok: true, slug: 'sky-dodge' });
+    expect(await store.getPublication('sky-dodge')).toMatchObject({
+      state: 'archived',
+      takedownReason: 'infringing assets',
+    });
+
+    await app.close();
+  });
+
+  it('defaults the reason when the operator gives none', async () => {
+    const { app, store } = await appWithPublishedGame();
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/admin/games/sky-dodge/delete',
+      headers: bossHeaders(),
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(await store.getPublication('sky-dodge')).toMatchObject({
+      state: 'archived',
+      takedownReason: 'deleted by operator',
+    });
+
+    await app.close();
+  });
+});
+
 /**
  * Seeding through the whole submission path.
  *

--- a/apps/api/src/submissions.test.ts
+++ b/apps/api/src/submissions.test.ts
@@ -4861,6 +4861,48 @@ describe('games published from the store rather than the repo', () => {
 
     await app.close();
   });
+
+  it('evicts the bundle, catalog and media caches so a delete takes effect immediately', async () => {
+    const store = new InMemoryStore();
+    await store.upsertUser({ uid: 'g:boss' });
+    await store.setPublication({
+      slug: 'comet-courier',
+      state: 'published',
+      currentVersion: 'v1',
+      publishedAt: '2026-07-30T12:00:00Z',
+    });
+    const { githubClient } = createGithubClientStub({});
+    const { app } = await createApp({
+      githubClient,
+      store,
+      submissionTokenSecret: secret,
+      adminUids: 'g:boss',
+      agentChannel: { gamesStore: publishedGamesStore() },
+    });
+
+    expect((await app.inject({ method: 'GET', url: '/api/games/comet-courier' })).statusCode).toBe(200);
+    expect((await app.inject({ method: 'GET', url: '/api/games/comet-courier/media/opening.png' })).statusCode).toBe(
+      200,
+    );
+    const warmCatalog = await app.inject({ method: 'GET', url: '/api/catalog' });
+    expect(warmCatalog.json().some((item: CatalogGameEntry) => item.slug === 'comet-courier')).toBe(true);
+
+    const del = await app.inject({
+      method: 'POST',
+      url: '/api/admin/games/comet-courier/delete',
+      headers: getAuthHeaders('g:boss'),
+    });
+    expect(del.statusCode).toBe(200);
+
+    expect((await app.inject({ method: 'GET', url: '/api/games/comet-courier' })).statusCode).toBe(404);
+    expect((await app.inject({ method: 'GET', url: '/api/games/comet-courier/media/opening.png' })).statusCode).toBe(
+      404,
+    );
+    const coldCatalog = await app.inject({ method: 'GET', url: '/api/catalog' });
+    expect(coldCatalog.json().some((item: CatalogGameEntry) => item.slug === 'comet-courier')).toBe(false);
+
+    await app.close();
+  });
 });
 
 describe('a session that finishes without delivering', () => {
@@ -6107,6 +6149,43 @@ describe('creator deletes their own published game', () => {
     });
 
     expect(response.statusCode).toBe(409);
+    expect(await store.getPublication('sky-dodge')).toMatchObject({ state: 'archived' });
+
+    await app.close();
+  });
+
+  it("refuses the previous owner's token once a slug transfer moves the game on", async () => {
+    const { githubClient } = createGithubClientStub({});
+    const { app, store } = await createApp({ githubClient, submissionTokenSecret: secret });
+    await store.upsertUser({ uid: 'g:previous' });
+    await store.upsertUser({ uid: 'g:new-owner' });
+    await store.createSubmission(1_000_100, 'g:previous', 'Sky Dodge');
+    await store.setSubmissionSlug(1_000_100, 'sky-dodge');
+    await store.setSubmissionPublishedAt(1_000_100, '2026-07-01T00:00:00.000Z');
+    await new Promise((resolve) => setTimeout(resolve, 2));
+    await store.createSubmission(1_000_101, 'g:new-owner', 'Sky Dodge');
+    await store.setSubmissionSlug(1_000_101, 'sky-dodge');
+    await store.setPublication({
+      slug: 'sky-dodge',
+      state: 'published',
+      currentVersion: 'v1',
+      publishedAt: '2026-07-01T00:00:00.000Z',
+    });
+
+    const fromPrevious = await app.inject({
+      method: 'POST',
+      url: `/api/submissions/${mintToken(1_000_100, secret)}/delete-game`,
+      headers: getAuthHeaders('g:previous'),
+    });
+    expect(fromPrevious.statusCode).toBe(403);
+    expect(await store.getPublication('sky-dodge')).toMatchObject({ state: 'published' });
+
+    const fromNewOwner = await app.inject({
+      method: 'POST',
+      url: `/api/submissions/${mintToken(1_000_101, secret)}/delete-game`,
+      headers: getAuthHeaders('g:new-owner'),
+    });
+    expect(fromNewOwner.statusCode).toBe(200);
     expect(await store.getPublication('sky-dodge')).toMatchObject({ state: 'archived' });
 
     await app.close();

--- a/apps/api/src/submissions.ts
+++ b/apps/api/src/submissions.ts
@@ -3,6 +3,7 @@ import type { GameProject } from '@gamedevpl/game-generator';
 import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
 import { z } from 'zod';
 import { splitConceptBrief } from './agent-build-brief.js';
+import { creatorOwnsSlug } from './agent-game-key-resolve.js';
 import { registerAgentChannelRoutes, type AgentChannelOptions } from './agent-channel.js';
 import { mintAgentToken, mintManagedMcpOpener } from './agent-token.js';
 import { registerMcpServerRoutes } from './mcp-server.js';
@@ -2486,6 +2487,15 @@ export async function registerSubmissionRoutes(
   const maxCachedMediaEntries = 400;
   const mediaCache = new Map<string, { expiresAt: number; etag: string; contentType: string; body: Buffer }>();
 
+  // These three trust a cache hit without re-checking publication state.
+  function invalidatePublishedGameCaches(slug: string): void {
+    gameCache.delete(slug);
+    storeCatalogCache = null;
+    for (const key of mediaCache.keys()) {
+      if (key.startsWith(`${slug}/`)) mediaCache.delete(key);
+    }
+  }
+
   // The cache-cold path is the dangerous one: with min-instances 0, a fresh
   // instance takes a page load's several catalog-touching requests at once.
   // getCatalog itself is now a handful of GraphQL round-trips (not ~2N Contents
@@ -3736,11 +3746,15 @@ export async function registerSubmissionRoutes(
       }
 
       const record = await store.getSubmission(issueNumber);
-      if (!record || record.ownerUid !== request.user!.uid) {
+      if (!record) {
         return reply.status(403).send({ error: 'only the creator can delete this game' });
       }
       if (!record.slug) {
         return reply.status(409).send({ error: 'this game has no address yet' });
+      }
+      // Not record.ownerUid — a slug transfer can move ownership on.
+      if (!(await creatorOwnsSlug(store, record.slug, request.user!.uid))) {
+        return reply.status(403).send({ error: 'only the creator can delete this game' });
       }
 
       const publication = await store.getPublication(record.slug);
@@ -3749,6 +3763,7 @@ export async function registerSubmissionRoutes(
       }
 
       await store.archivePublication(record.slug, 'deleted by creator', new Date(now()).toISOString());
+      invalidatePublishedGameCaches(record.slug);
       invalidateStatusCache(issueNumber);
 
       return reply.send({ ok: true, slug: record.slug });
@@ -4823,6 +4838,7 @@ export async function registerSubmissionRoutes(
           ? request.body.reason.trim()
           : 'deleted by operator';
       await store.archivePublication(slug, reason, new Date(now()).toISOString());
+      invalidatePublishedGameCaches(slug);
 
       return reply.send({ ok: true, slug });
     },

--- a/apps/api/src/submissions.ts
+++ b/apps/api/src/submissions.ts
@@ -3712,6 +3712,49 @@ export async function registerSubmissionRoutes(
     },
   );
 
+  app.post(
+    '/api/submissions/:token/delete-game',
+    { config: { rateLimit: { max: 20, timeWindow: '1 hour' } } },
+    async (request, reply) => {
+      if (!submissionTokenSecret) {
+        return reply.status(503).send({ error: 'submissions are not configured' });
+      }
+      if (!checkUserAccess(request, reply)) return;
+      if (!store) {
+        return reply.status(503).send({ error: 'submissions are not configured' });
+      }
+
+      const token = z.string().parse((request.params as { token?: string }).token);
+      let issueNumber: number;
+      try {
+        issueNumber = verifyToken(token, submissionTokenSecret);
+      } catch (error) {
+        if (error instanceof InvalidTokenError) {
+          return reply.status(400).send({ error: 'invalid submission token' });
+        }
+        throw error;
+      }
+
+      const record = await store.getSubmission(issueNumber);
+      if (!record || record.ownerUid !== request.user!.uid) {
+        return reply.status(403).send({ error: 'only the creator can delete this game' });
+      }
+      if (!record.slug) {
+        return reply.status(409).send({ error: 'this game has no address yet' });
+      }
+
+      const publication = await store.getPublication(record.slug);
+      if (!publication || publication.state !== 'published') {
+        return reply.status(409).send({ error: 'not_published' });
+      }
+
+      await store.archivePublication(record.slug, 'deleted by creator', new Date(now()).toISOString());
+      invalidateStatusCache(issueNumber);
+
+      return reply.send({ ok: true, slug: record.slug });
+    },
+  );
+
   /** Lets a creator replace the current builder without creating feedback. */
   app.post(
     '/api/submissions/:token/handoff',
@@ -4761,6 +4804,29 @@ export async function registerSubmissionRoutes(
 
     return reply.send({ ok: true, slug, version: start.version, ...(start.buildId ? { buildId: start.buildId } : {}) });
   });
+
+  app.post<{ Params: { slug: string }; Body: { reason?: string } }>(
+    '/api/admin/games/:slug/delete',
+    async (request, reply) => {
+      if (!isAdminSession(request, adminUids)) return reply.status(404).send({ error: 'not_found' });
+      if (!store) return reply.status(503).send({ error: 'store_unavailable' });
+
+      const slug = request.params.slug;
+      const publication = await store.getPublication(slug);
+      if (!publication) return reply.status(404).send({ error: 'not_found' });
+      if (publication.state !== 'published') {
+        return reply.status(409).send({ error: 'not_published', state: publication.state });
+      }
+
+      const reason =
+        typeof request.body?.reason === 'string' && request.body.reason.trim()
+          ? request.body.reason.trim()
+          : 'deleted by operator';
+      await store.archivePublication(slug, reason, new Date(now()).toISOString());
+
+      return reply.send({ ok: true, slug });
+    },
+  );
 
   /**
    * Gives an address to every game still missing one.

--- a/apps/web/src/AdminJobsPanel.test.tsx
+++ b/apps/web/src/AdminJobsPanel.test.tsx
@@ -13,6 +13,7 @@ const mocked = vi.hoisted(() => ({
   retryJob: vi.fn(),
   fetchPublishedGames: vi.fn(),
   regateGame: vi.fn(),
+  deleteGame: vi.fn(),
 }));
 
 vi.mock('./adminJobsApi.js', () => mocked);
@@ -269,6 +270,51 @@ describe('AdminJobsPanel', () => {
     });
     expect(mocked.regateGame).toHaveBeenCalledWith('comet-courier');
     expect(shelf?.textContent).toContain('health check started');
+
+    await act(async () => root.unmount());
+  });
+
+  it('deletes a published game after a second, confirming click', async () => {
+    mocked.fetchJobQueue.mockResolvedValue(queue([]));
+    mocked.fetchPublishedGames.mockResolvedValue([
+      { slug: 'comet-courier', state: 'published', currentVersion: 'v1', publishedAt: '2026-07-01T10:00:00Z' },
+    ]);
+    mocked.deleteGame.mockResolvedValue({ ok: true });
+
+    const { container, root } = await render();
+    const shelf = container.querySelector('.admin-published');
+
+    const del = Array.from(shelf?.querySelectorAll('button') ?? []).find(
+      (button) => button.textContent === 'Delete',
+    ) as HTMLButtonElement;
+    await act(async () => {
+      del.click();
+    });
+    expect(mocked.deleteGame).not.toHaveBeenCalled();
+    expect(del.textContent).toBe('Sure? This is final');
+
+    await act(async () => {
+      del.click();
+      await Promise.resolve();
+    });
+    expect(mocked.deleteGame).toHaveBeenCalledWith('comet-courier');
+    expect(shelf?.textContent).toContain('deleted — the game is offline');
+
+    await act(async () => root.unmount());
+  });
+
+  it('offers no action on a game that is no longer published', async () => {
+    mocked.fetchJobQueue.mockResolvedValue(queue([]));
+    mocked.fetchPublishedGames.mockResolvedValue([
+      { slug: 'comet-courier', state: 'archived', currentVersion: 'v1', publishedAt: '2026-07-01T10:00:00Z' },
+    ]);
+
+    const { container, root } = await render();
+    const shelf = container.querySelector('.admin-published');
+
+    expect(shelf?.textContent).toContain('comet-courier');
+    expect(shelf?.textContent).toContain('archived');
+    expect(shelf?.querySelectorAll('button')).toHaveLength(0);
 
     await act(async () => root.unmount());
   });

--- a/apps/web/src/AdminJobsPanel.tsx
+++ b/apps/web/src/AdminJobsPanel.tsx
@@ -1,12 +1,14 @@
 import { useCallback, useEffect, useState } from 'react';
 import {
   cancelJob,
+  deleteGame,
   fetchJobQueue,
   fetchPublishedGames,
   publishJob,
   regateGame,
   retryJob,
   type CancelRefusal,
+  type DeleteGameRefusal,
   type JobQueueEntry,
   type JobQueueResponse,
   type PublishedGame,
@@ -78,6 +80,12 @@ const REGATE_COPY: Record<RegateRefusal, string> = {
   unknown: 'refused, and the reason was not one this console knows',
 };
 
+const DELETE_COPY: Record<DeleteGameRefusal, string> = {
+  not_published: 'not currently published — already taken down',
+  store_unavailable: 'the store is not configured on this deployment',
+  unknown: 'refused, and the reason was not one this console knows',
+};
+
 /**
  * The health column in words. Three honest states: never asked, asked and waiting
  * (with the age, because a request the gate never picked up looks exactly like a slow
@@ -99,12 +107,14 @@ function healthLabel(game: PublishedGame, now: number): string {
 }
 
 function PublishedRow({ game, onChanged }: { game: PublishedGame; onChanged: () => void }) {
-  const [busy, setBusy] = useState(false);
+  const [busy, setBusy] = useState<'regate' | 'delete' | null>(null);
   const [message, setMessage] = useState<string | null>(null);
+  const [deleteArmed, setDeleteArmed] = useState(false);
 
   const onRegate = useCallback(async () => {
-    setBusy(true);
+    setBusy('regate');
     setMessage(null);
+    setDeleteArmed(false);
     try {
       const result = await regateGame(game.slug);
       if ('refused' in result) {
@@ -116,11 +126,35 @@ function PublishedRow({ game, onChanged }: { game: PublishedGame; onChanged: () 
     } catch {
       setMessage('could not reach the API');
     } finally {
-      setBusy(false);
+      setBusy(null);
     }
   }, [game.slug, onChanged]);
 
+  const onDelete = useCallback(async () => {
+    if (!deleteArmed) {
+      setDeleteArmed(true);
+      return;
+    }
+    setBusy('delete');
+    setMessage(null);
+    setDeleteArmed(false);
+    try {
+      const result = await deleteGame(game.slug);
+      if ('refused' in result) {
+        setMessage(DELETE_COPY[result.refused]);
+      } else {
+        setMessage('deleted — the game is offline');
+        onChanged();
+      }
+    } catch {
+      setMessage('could not reach the API');
+    } finally {
+      setBusy(null);
+    }
+  }, [deleteArmed, game.slug, onChanged]);
+
   const failing = game.healthCheck?.verdictAt && game.healthCheck.green === false;
+  const published = game.state === 'published';
 
   return (
     <tr className={failing ? 'admin-job-row is-stalled' : 'admin-job-row'}>
@@ -130,13 +164,24 @@ function PublishedRow({ game, onChanged }: { game: PublishedGame; onChanged: () 
       </td>
       <td>{game.publishedAt.slice(0, 10)}</td>
       <td>
-        <span className="admin-job-state">{healthLabel(game, Date.now())}</span>
+        <span className="admin-job-state">{published ? healthLabel(game, Date.now()) : game.state}</span>
         {failing ? <div className="admin-job-stall">creator nudged to refresh</div> : null}
       </td>
       <td>
-        <button className="admin-job-publish" onClick={onRegate} disabled={busy}>
-          {busy ? 'Starting…' : 'Re-gate'}
-        </button>
+        {published ? (
+          <div className="admin-job-actions">
+            <button className="admin-job-publish" onClick={onRegate} disabled={busy !== null}>
+              {busy === 'regate' ? 'Starting…' : 'Re-gate'}
+            </button>
+            <button
+              className={deleteArmed ? 'admin-job-cancel is-armed' : 'admin-job-cancel'}
+              onClick={onDelete}
+              disabled={busy !== null}
+            >
+              {busy === 'delete' ? 'Deleting…' : deleteArmed ? 'Sure? This is final' : 'Delete'}
+            </button>
+          </div>
+        ) : null}
         {message ? <div className="admin-job-message">{message}</div> : null}
       </td>
     </tr>

--- a/apps/web/src/CreatorStudioView.test.tsx
+++ b/apps/web/src/CreatorStudioView.test.tsx
@@ -2068,6 +2068,42 @@ describe('CreatorStudioView delete', () => {
     root.unmount();
   });
 
+  it('offers delete alongside abandon while an improvement round is open on a live game', async () => {
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    await i18n.changeLanguage('en');
+    fetchStudioGames.mockResolvedValue(
+      studioShelf([
+        {
+          token: 'token-improve',
+          title: 'TV Tycoon',
+          createdAt: '2026-08-01T09:00:00.000Z',
+          lastKnownStatus: 'building',
+          slug: 'tv-tycoon',
+          livePublishedAt: '2026-07-31T09:00:00.000Z',
+        },
+      ]),
+    );
+
+    const { container, root } = await renderStudio({ selectedGame: 'tv-tycoon', selectedTab: 'details' });
+
+    expect(container.querySelector('.status-abandon')).not.toBeNull();
+    const del = container.querySelector<HTMLButtonElement>('.status-delete');
+    expect(del).not.toBeNull();
+
+    await act(async () => {
+      del!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    await act(async () => {
+      container
+        .querySelector<HTMLButtonElement>('.status-delete.is-danger')!
+        .dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
+    expect(deleteGame).toHaveBeenCalledWith('token-improve');
+
+    root.unmount();
+  });
+
   it('deletes the game and refetches the shelf', async () => {
     (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
     await i18n.changeLanguage('en');

--- a/apps/web/src/CreatorStudioView.test.tsx
+++ b/apps/web/src/CreatorStudioView.test.tsx
@@ -8,6 +8,7 @@ import i18n from './i18n/index.js';
 import type { StudioGame, StudioGamesResponse, StudioScorecard } from './studioApi.js';
 
 const abandonSubmission = vi.fn();
+const deleteGame = vi.fn();
 const fetchStudioGames = vi.fn();
 const fetchStudioHealth = vi.fn();
 const fetchStudioScorecards = vi.fn();
@@ -29,6 +30,7 @@ vi.mock('./submissionApi', async () => {
     ...actual,
     getSubmissionStatus: vi.fn(async () => ({ media: [] })),
     abandonSubmission: (...args: unknown[]) => abandonSubmission(...args),
+    deleteGame: (...args: unknown[]) => deleteGame(...args),
   };
 });
 
@@ -101,6 +103,8 @@ describe('CreatorStudioView', () => {
     authUser = null;
     abandonSubmission.mockReset();
     abandonSubmission.mockResolvedValue(undefined);
+    deleteGame.mockReset();
+    deleteGame.mockResolvedValue(undefined);
     fetchStudioGames.mockReset();
     fetchStudioHealth.mockReset();
     fetchStudioHealth.mockResolvedValue({ days: [], truncated: false, games: [] });
@@ -1638,6 +1642,8 @@ describe('CreatorStudioView abandon', () => {
     authUser = { uid: 'g:studio-demo', name: 'Studio Demo' };
     abandonSubmission.mockReset();
     abandonSubmission.mockResolvedValue(undefined);
+    deleteGame.mockReset();
+    deleteGame.mockResolvedValue(undefined);
     fetchStudioGames.mockReset();
     fetchStudioHealth.mockReset();
     fetchStudioHealth.mockResolvedValue({ days: [], truncated: false, games: [] });
@@ -1997,6 +2003,104 @@ describe('CreatorStudioView abandon', () => {
     expect(onNavigate).not.toHaveBeenCalledWith('/studio');
     expect(onNavigate).toHaveBeenLastCalledWith('/studio/third-game/details', { replace: true });
     expect(container.querySelector('.studio-strip-title')?.textContent).toContain('Third Game');
+
+    root.unmount();
+  });
+});
+
+describe('CreatorStudioView delete', () => {
+  beforeEach(() => {
+    authUser = { uid: 'g:studio-demo', name: 'Studio Demo' };
+    abandonSubmission.mockReset();
+    abandonSubmission.mockResolvedValue(undefined);
+    deleteGame.mockReset();
+    deleteGame.mockResolvedValue(undefined);
+    fetchStudioGames.mockReset();
+    fetchStudioHealth.mockReset();
+    fetchStudioHealth.mockResolvedValue({ days: [], truncated: false, games: [] });
+    fetchStudioScorecards.mockReset();
+    fetchStudioScorecards.mockResolvedValue([]);
+    fetchStudioSuggestions.mockReset();
+    fetchStudioSuggestions.mockResolvedValue([]);
+    fetchGameAutonomy.mockReset();
+    fetchGameAutonomy.mockRejectedValue(new Error('not owned'));
+    setDraftShared.mockReset();
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('offers delete, not abandon, on a published game', async () => {
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    await i18n.changeLanguage('en');
+    fetchStudioGames.mockResolvedValue(
+      studioShelf([
+        {
+          token: 'token-gts',
+          title: 'Global Thermonuclear Strategy',
+          createdAt: '2026-07-02T00:00:00.000Z',
+          lastKnownStatus: 'published',
+          slug: 'global-thermonuclear-strategy',
+          publishedAt: '2026-07-02T00:00:00.000Z',
+        },
+      ]),
+    );
+
+    const { container, root } = await renderStudio({
+      selectedGame: 'global-thermonuclear-strategy',
+      selectedTab: 'details',
+    });
+
+    expect(container.querySelector('.status-abandon')).toBeNull();
+    const del = container.querySelector<HTMLButtonElement>('.status-delete');
+    expect(del?.textContent).toContain('Delete this game');
+
+    await act(async () => {
+      del!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
+    expect(container.querySelector('.studio-delete-hint')?.textContent).toContain(
+      'takes the game off the site immediately',
+    );
+    expect(container.querySelector('.status-delete')?.textContent).toContain('Yes, delete it — the game goes offline');
+
+    root.unmount();
+  });
+
+  it('deletes the game and refetches the shelf', async () => {
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    await i18n.changeLanguage('en');
+    const live = {
+      token: 'token-gts',
+      title: 'Global Thermonuclear Strategy',
+      createdAt: '2026-07-02T00:00:00.000Z',
+      lastKnownStatus: 'published' as const,
+      slug: 'global-thermonuclear-strategy',
+      publishedAt: '2026-07-02T00:00:00.000Z',
+    };
+    fetchStudioGames.mockResolvedValueOnce(studioShelf([live]));
+    fetchStudioGames.mockResolvedValueOnce(studioShelf([]));
+
+    const { container, root, onNavigate } = await renderStudio({
+      selectedGame: 'global-thermonuclear-strategy',
+      selectedTab: 'details',
+    });
+
+    const del = container.querySelector<HTMLButtonElement>('.status-delete');
+    await act(async () => {
+      del!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    await act(async () => {
+      container
+        .querySelector<HTMLButtonElement>('.status-delete.is-danger')!
+        .dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
+    expect(deleteGame).toHaveBeenCalledWith('token-gts');
+    expect(fetchStudioGames).toHaveBeenCalledTimes(2);
+    expect(fetchStudioGames).toHaveBeenLastCalledWith('global-thermonuclear-strategy');
+    expect(onNavigate).toHaveBeenCalledWith('/studio');
 
     root.unmount();
   });

--- a/apps/web/src/CreatorStudioView.tsx
+++ b/apps/web/src/CreatorStudioView.tsx
@@ -1546,7 +1546,7 @@ function DetailsPanel({
                     </button>
                   </div>
                 ) : null}
-                {publishedJob && game.lastKnownStatus !== 'abandoned' ? (
+                {catalogLive && game.lastKnownStatus !== 'abandoned' ? (
                   <div className="studio-delete-block">
                     {deleteArmed ? <p className="studio-delete-hint">{t('studioPanel.overview.deleteHint')}</p> : null}
                     <button

--- a/apps/web/src/CreatorStudioView.tsx
+++ b/apps/web/src/CreatorStudioView.tsx
@@ -8,7 +8,7 @@ import type { GameHealth } from './healthApi.js';
 import { PixelIcon, type PixelIconName } from './PixelIcon.js';
 import { formatRelativeTime } from './relativeTime.js';
 import { playPath, studioPath, type StudioTab } from './router.js';
-import { abandonSubmission, handoffToPlatform } from './submissionApi.js';
+import { abandonSubmission, deleteGame, handoffToPlatform } from './submissionApi.js';
 import { StudioShotToasts } from './StudioShotToasts.js';
 import { type CodeActionsMode } from './CodeActionsMenu.js';
 import { CodeSurface } from './CodeSurface.js';
@@ -1422,6 +1422,8 @@ function DetailsPanel({
   const publishedAt = game.publishedAt ?? game.livePublishedAt;
   const [abandonArmed, setAbandonArmed] = useState(false);
   const [abandoning, setAbandoning] = useState(false);
+  const [deleteArmed, setDeleteArmed] = useState(false);
+  const [deleting, setDeleting] = useState(false);
   const shotToken = mediaToken ?? game.token;
 
   async function handleAbandon() {
@@ -1436,6 +1438,21 @@ function DetailsPanel({
     } catch {
       setAbandoning(false);
       setAbandonArmed(false);
+    }
+  }
+
+  async function handleDelete() {
+    if (!deleteArmed) {
+      setDeleteArmed(true);
+      return;
+    }
+    setDeleting(true);
+    try {
+      await deleteGame(game.token);
+      await onRemoved(game.token);
+    } catch {
+      setDeleting(false);
+      setDeleteArmed(false);
     }
   }
 
@@ -1526,6 +1543,19 @@ function DetailsPanel({
                               : 'studioPanel.overview.abandonConfirmRemove',
                           )
                         : t(catalogLive ? 'studioPanel.overview.abandon' : 'studioPanel.overview.abandonRemove')}
+                    </button>
+                  </div>
+                ) : null}
+                {publishedJob && game.lastKnownStatus !== 'abandoned' ? (
+                  <div className="studio-delete-block">
+                    {deleteArmed ? <p className="studio-delete-hint">{t('studioPanel.overview.deleteHint')}</p> : null}
+                    <button
+                      type="button"
+                      className={`status-delete${deleteArmed ? ' is-danger' : ''}`}
+                      onClick={() => void handleDelete()}
+                      disabled={deleting}
+                    >
+                      {deleteArmed ? t('studioPanel.overview.deleteConfirm') : t('studioPanel.overview.delete')}
                     </button>
                   </div>
                 ) : null}

--- a/apps/web/src/adminJobsApi.ts
+++ b/apps/web/src/adminJobsApi.ts
@@ -153,6 +153,23 @@ export async function regateGame(slug: string): Promise<{ ok: true; buildId?: st
   return { refused: known.find((code) => code === body.error) ?? 'unknown' };
 }
 
+export type DeleteGameRefusal = 'not_published' | 'store_unavailable' | 'unknown';
+
+export async function deleteGame(
+  slug: string,
+  reason?: string,
+): Promise<{ ok: true } | { refused: DeleteGameRefusal }> {
+  const response = await fetch(`/api/admin/games/${encodeURIComponent(slug)}/delete`, {
+    method: 'POST',
+    credentials: 'include',
+    ...(reason ? { headers: { 'content-type': 'application/json' }, body: JSON.stringify({ reason }) } : {}),
+  });
+  if (response.ok) return (await response.json()) as { ok: true };
+  const body = (await response.json().catch(() => ({}))) as { error?: string };
+  const known: DeleteGameRefusal[] = ['not_published', 'store_unavailable'];
+  return { refused: known.find((code) => code === body.error) ?? 'unknown' };
+}
+
 export interface RetryResult {
   ok: true;
   state: 'building';

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -510,7 +510,10 @@
       "abandonConfirmRemove": "Yes, remove it — the game leaves Studio",
       "abandonHintRemove": "This draft was never published. Removing it stops the build and takes the game off your Studio shelf.",
       "abandonNotice": "\"{{title}}\" removed from Studio.",
-      "abandonNoticeDismiss": "Dismiss"
+      "abandonNoticeDismiss": "Dismiss",
+      "delete": "Delete this game",
+      "deleteConfirm": "Yes, delete it — the game goes offline",
+      "deleteHint": "This takes the game off the site immediately. It leaves your Studio shelf too."
     },
     "rail": {
       "connect": "Connect your agent",

--- a/apps/web/src/i18n/locales/pl.json
+++ b/apps/web/src/i18n/locales/pl.json
@@ -516,7 +516,10 @@
       "abandonConfirmRemove": "Tak, usuń — gra zniknie ze Studio",
       "abandonHintRemove": "Ten szkic nigdy nie był opublikowany. Usunięcie zatrzyma build i zdejmie grę z półki Studio.",
       "abandonNotice": "„{{title}}” usunięto ze Studio.",
-      "abandonNoticeDismiss": "Zamknij"
+      "abandonNoticeDismiss": "Zamknij",
+      "delete": "Usuń tę grę",
+      "deleteConfirm": "Tak, usuń — gra zniknie ze strony",
+      "deleteHint": "Gra natychmiast znika ze strony. Zniknie też z półki Studio."
     },
     "rail": {
       "connect": "Podłącz agenta",

--- a/apps/web/src/studioApi.ts
+++ b/apps/web/src/studioApi.ts
@@ -29,6 +29,8 @@ export type StudioGame = {
   editable?: boolean;
   /** Whether the Code surface's kill switch (CE-02) is on for this deployment. */
   codeSurface?: boolean;
+  /** `false` only when the game has been deleted — `publishedAt` stays as history. */
+  live?: false;
 };
 
 /* ---------------------------------------------------------------------------

--- a/apps/web/src/studioShelf.test.ts
+++ b/apps/web/src/studioShelf.test.ts
@@ -3,6 +3,7 @@ import type { StudioGame } from './studioApi.js';
 import {
   collapseStudioGames,
   filterStudioGames,
+  isStudioGamePublished,
   isStudioGameShelfLive,
   sortStudioGames,
   studioGameInitials,
@@ -116,6 +117,53 @@ describe('studioShelf', () => {
     expect(collapsed[0]?.livePublishedAt).toBe('');
     expect(isStudioGameShelfLive(collapsed[0]!)).toBe(true);
     expect(filterStudioGames(collapsed, { filter: 'live' }).map((item) => item.token)).toEqual(['tip']);
+  });
+
+  it('treats live: false as deleted, regardless of publishedAt history', () => {
+    const deleted = game({
+      token: 'gone',
+      title: 'Comet Courier',
+      slug: 'comet-courier',
+      lastKnownStatus: 'published',
+      publishedAt: '2026-07-01T00:00:00.000Z',
+      live: false,
+    });
+    expect(isStudioGamePublished(deleted)).toBe(false);
+    expect(isStudioGameShelfLive(deleted)).toBe(false);
+  });
+
+  it('keeps a sibling with no publication record out of the deleted read (games-repo entries)', () => {
+    const legacy = game({
+      token: 'legacy',
+      title: 'TV Tycoon',
+      slug: 'tv-tycoon',
+      lastKnownStatus: 'published',
+      publishedAt: '2026-07-01T00:00:00.000Z',
+    });
+    expect(isStudioGamePublished(legacy)).toBe(true);
+  });
+
+  it("does not resurrect a deleted publication as an improve tip's live sibling", () => {
+    const collapsed = collapseStudioGames([
+      game({
+        token: 'deleted-live',
+        title: 'Sky Dodge',
+        slug: 'sky-dodge',
+        lastKnownStatus: 'published',
+        publishedAt: '2026-06-01T00:00:00.000Z',
+        live: false,
+      }),
+      game({
+        token: 'tip',
+        title: 'Sky Dodge',
+        slug: 'sky-dodge',
+        lastKnownStatus: 'building',
+        createdAt: '2026-07-20T00:00:00.000Z',
+      }),
+    ]);
+
+    expect(collapsed[0]?.livePublishedAt).toBeUndefined();
+    expect(isStudioGameShelfLive(collapsed[0]!)).toBe(false);
   });
 
   it('filters by building / live and by title or slug query', () => {

--- a/apps/web/src/studioShelf.ts
+++ b/apps/web/src/studioShelf.ts
@@ -23,6 +23,7 @@ export type StudioShelfGame = StudioGame & { livePublishedAt?: string };
 export const STUDIO_SHELF_TOOLS_AT = 5;
 
 export function isStudioGamePublished(game: StudioGame): boolean {
+  if (game.live === false) return false;
   return Boolean(game.publishedAt && game.slug) || game.lastKnownStatus === 'published';
 }
 

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -9685,6 +9685,44 @@ button.builder-mode-selector:disabled {
   color: var(--muted);
 }
 
+.status-delete {
+  display: inline-flex;
+  align-items: center;
+  min-height: 44px;
+  padding: 0 2px;
+  border: none;
+  background: none;
+  color: var(--muted);
+  font-size: 0.82rem;
+  text-decoration: underline;
+  cursor: pointer;
+}
+
+.status-delete:hover {
+  color: var(--text);
+}
+
+.status-delete.is-danger {
+  color: #f87171;
+  font-weight: 600;
+}
+
+.studio-delete-block {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 6px;
+  width: 100%;
+}
+
+.studio-delete-hint {
+  margin: 0;
+  max-width: 28rem;
+  font-size: 0.8rem;
+  line-height: 1.35;
+  color: var(--muted);
+}
+
 /* Click-to-fill prompt starters, shown only where a caller passes exampleChips. */
 .prompt-examples {
   display: flex;

--- a/apps/web/src/submissionApi.ts
+++ b/apps/web/src/submissionApi.ts
@@ -384,6 +384,17 @@ export async function abandonSubmission(token: string): Promise<void> {
   }
 }
 
+export async function deleteGame(token: string): Promise<void> {
+  const response = await fetch(`${API_BASE}/api/submissions/${encodeURIComponent(token)}/delete-game`, {
+    method: 'POST',
+    credentials: 'include',
+  });
+
+  if (!response.ok) {
+    await throwResponseError(response);
+  }
+}
+
 export type BuilderHandoffResponse = { pending?: boolean; acknowledgedAt?: string };
 
 export async function handoffToPlatform(


### PR DESCRIPTION
## Summary
- New `Store.archivePublication(slug, reason, at)` — soft-withdraws a game (state → `archived`), sibling to `takedownPublication` but kept distinct so a self-service delete never reads as a DSA-facing moderation takedown.
- `POST /api/submissions/:token/delete-game` — creator deletes their own published game (ownership checked against the store, same pattern as `/abandon`).
- `POST /api/admin/games/:slug/delete` — operator delete, same 404-not-403 gate and refusal shape as `/regate`.
- Creator Studio: a "Delete this game" danger action appears once a game is published (mirrors the abandon two-click confirm, opposite gating).
- Admin console: a "Delete" button next to Re-gate in the published-games table, two-click confirm like job-cancel.

Soft delete only: one Firestore write flips the publication out of `published`, which every consuming route (votes, `/play`, catalog gate, remix, proposals, creator profile, follow) already treats as unpublished — no GCS or games-repo objects are touched, and it's reversible by re-publishing. Scoped to store-era (self-build) games; games-repo entries are unaffected (no delete-file/merge capability exists for that repo today).

## Test plan
- [x] `apps/api/src/store.test.ts` — archivePublication happy path + no-publication-false
- [x] `apps/api/src/submissions.test.ts` — creator delete route (403 wrong owner, 409 not published, 200 archives) + admin delete route (404 non-admin, 404 unknown slug, 409 not published, 200 with/without custom reason)
- [x] `apps/web/src/CreatorStudioView.test.tsx` — delete button shown instead of abandon on a published game, two-click delete refetches the shelf
- [x] `apps/web/src/AdminJobsPanel.test.tsx` — two-click delete, no action offered once a game is no longer published
- [x] Full API suite (3307 tests) and web suite (1573 tests) pass
- [x] `npm run lint` (incl. comment-prose word-budget gate) clean; both packages typecheck

🤖 Generated with [Claude Code](https://claude.com/claude-code)