### PR TITLE
fix(mcp): stop advertising index.html authoring

### DIFF
--- a/apps/api/src/build-prompt.ts
+++ b/apps/api/src/build-prompt.ts
@@ -103,7 +103,7 @@ function channelDelivery(brief: BuildBrief, creating: boolean): string[] {
     'MCP paths are relative to the slug: pass `GAME.json`, never `games/<slug>/GAME.json`.',
     'Stage calls sequentially; never parallelize mutating calls.',
     'After staging `game.ts` and `GAME.json`, submit immediately.',
-    'A `howToPlay` (goal + hint) in `GAME.json` can stand in for `index.html` — the body is generated.',
+    'Define `howToPlay` (goal + hint) in `GAME.json`; the body is generated. Never author `index.html`.',
     'A `theme` in `GAME.json` can stand in for `style.css` the same way — never stage that file.',
     'Do not stage metadata files before the first preview delivery.',
     '',

--- a/apps/api/src/games-store.test.ts
+++ b/apps/api/src/games-store.test.ts
@@ -77,7 +77,7 @@ describe('validateSourceUpload — the delivery contract', () => {
     expect(() => validateSourceUpload([{ path: 'game.ts', content: 'x' }])).toThrow(/SPEC.md is required/);
   });
 
-  describe('index.html or GAME.json howToPlay', () => {
+  describe('GAME.json howToPlay', () => {
     // A fresh write is refused elsewhere; this stays permissive for carry-forward.
     it('still accepts a delivery that ships a real index.html and no howToPlay', () => {
       const files = [...MINIMAL_WITHOUT_GAME_JSON, { path: 'index.html', content: '<canvas id="game"></canvas>' }];
@@ -95,7 +95,7 @@ describe('validateSourceUpload — the delivery contract', () => {
           { path: 'index.html', content: '   \n  ' },
           { path: 'GAME.json', content: JSON.stringify({ engine: { modules: [] } }) },
         ]),
-      ).toThrow(/index\.html or GAME\.json\.howToPlay is required/);
+      ).toThrow(/GAME\.json\.howToPlay is required/);
     });
 
     it('refuses a delivery with neither', () => {
@@ -104,7 +104,7 @@ describe('validateSourceUpload — the delivery contract', () => {
           ...MINIMAL_WITHOUT_GAME_JSON,
           { path: 'GAME.json', content: JSON.stringify({ engine: { modules: [] } }) },
         ]),
-      ).toThrow(/index\.html or GAME\.json\.howToPlay is required/);
+      ).toThrow(/GAME\.json\.howToPlay is required.*do not author index\.html/i);
     });
 
     it('refuses a howToPlay missing the pair the generator needs', () => {
@@ -117,13 +117,13 @@ describe('validateSourceUpload — the delivery contract', () => {
             content: JSON.stringify({ engine: { modules: [] }, howToPlay: { goal: HOW_TO_PLAY.goal } }),
           },
         ]),
-      ).toThrow(/index\.html or GAME\.json\.howToPlay is required/);
+      ).toThrow(/GAME\.json\.howToPlay is required/);
     });
 
     it('refuses a schema-only delivery whose GAME.json does not parse', () => {
       expect(() =>
         validateSourceUpload([...MINIMAL_WITHOUT_GAME_JSON, { path: 'GAME.json', content: '{"howToPlay": {' }]),
-      ).toThrow(/index\.html or GAME\.json\.howToPlay is required/);
+      ).toThrow(/GAME\.json\.howToPlay is required/);
     });
 
     it('refuses a howToPlay whose goal/hint are truthy but not {en, pl} strings', () => {
@@ -136,7 +136,7 @@ describe('validateSourceUpload — the delivery contract', () => {
             content: JSON.stringify({ engine: { modules: [] }, howToPlay: { goal: true, hint: HOW_TO_PLAY.hint } }),
           },
         ]),
-      ).toThrow(/index\.html or GAME\.json\.howToPlay is required/);
+      ).toThrow(/GAME\.json\.howToPlay is required/);
     });
   });
 

--- a/apps/api/src/games-store.ts
+++ b/apps/api/src/games-store.ts
@@ -291,9 +291,8 @@ export function validateSourceUpload(files: SourceFile[], mode: DeliveryMode = '
 
   if (!hasIndexHtml && !hasHowToPlay) {
     throw new InvalidUploadError(
-      'GAME.json.howToPlay is required — set howToPlay.goal and howToPlay.hint to non-empty ' +
-        '{"en":"...","pl":"..."} objects. The platform generates the playable page; do not author ' +
-        'index.html because fresh index.html writes are not supported.',
+      'GAME.json.howToPlay is required — set goal and hint to non-empty {"en":"...","pl":"..."} objects. ' +
+        'The platform generates the playable page; do not author index.html because fresh writes are unsupported.',
     );
   }
   if (mode === 'preview' && gameJson) {

--- a/apps/api/src/games-store.ts
+++ b/apps/api/src/games-store.ts
@@ -291,8 +291,9 @@ export function validateSourceUpload(files: SourceFile[], mode: DeliveryMode = '
 
   if (!hasIndexHtml && !hasHowToPlay) {
     throw new InvalidUploadError(
-      'index.html or GAME.json.howToPlay is required — a game must be playable. A fresh index.html write is ' +
-        'refused elsewhere; define howToPlay with goal and hint in GAME.json instead.',
+      'GAME.json.howToPlay is required — set howToPlay.goal and howToPlay.hint to non-empty ' +
+        '{"en":"...","pl":"..."} objects. The platform generates the playable page; do not author ' +
+        'index.html because fresh index.html writes are not supported.',
     );
   }
   if (mode === 'preview' && gameJson) {

--- a/docs/how-to-play-plan.md
+++ b/docs/how-to-play-plan.md
@@ -91,11 +91,12 @@ schema's `title` is what actually renders in the page when it differs, matching 
 games' hand-authored `index.html` already did. `canvas.ariaLabel` overrides the default
 `"{title} playfield"` / `"{title} — pole gry"` pair when a game wants a more specific label.
 
-**Delivery.** A game satisfies the markup requirement with `index.html` _or_ a `howToPlay`
-carrying both `goal` and `hint`. Generation happens inside `getGameSources`, the single
-point every assembly path converges on (gate, staged preview, remix, seed preview,
-published serve, snapshot bake), so no caller knows the difference. A shipped
-`index.html` always wins. Stored snapshots keep working untouched — no backfill.
+**Delivery.** New work satisfies the markup requirement with a `howToPlay` carrying both
+`goal` and `hint`; agents cannot stage, patch, or directly submit `index.html`. Generation
+happens inside `getGameSources`, the single point every assembly path converges on (gate,
+staged preview, remix, seed preview, published serve, snapshot bake), so no caller needs to
+generate the file. A legacy `index.html` carried forward from an older delivery still wins,
+and stored snapshots keep working untouched — no backfill.
 
 ## Out of scope
 


### PR DESCRIPTION
## Summary

- require bilingual `GAME.json.howToPlay.goal` and `.hint` in the delivery error
- stop the MCP/managed-agent contract from presenting `index.html` as an authoring option
- preserve carry-forward compatibility for legacy games that already contain `index.html`
- align tests and the how-to-play plan with the current contract

## Verification

- `npm run type-check`
- `npm run lint`
- `npm test --workspace @gamedevpl/api -- --run src/games-store.test.ts src/build-prompt.test.ts`
- `npm test --workspace @gamedevpl/api -- --run src/agent-channel.test.ts`
- `npm test --workspace @gamedevpl/api -- --run src/self-build.test.ts`
- `npm run build`

The aggregate test run passed 3,351 API tests; two unrelated tests hit their 5-second timeout under full-suite load and passed when rerun in isolation.