### PR TITLE
Extract SubmissionState type to shared contract package

### DIFF
--- a/apps/api/src/submission-status.ts
+++ b/apps/api/src/submission-status.ts
@@ -6,17 +6,10 @@
 
 import type { LinkedPullRequest } from './github-client.js';
 import type { JobStall, JobState } from './job-state.js';
+import type { SubmissionState } from '@gamedevpl/contract';
 
-export type SubmissionStatus =
-  | 'queued'
-  | 'building'
-  | 'in_review'
-  | 'publishing'
-  | 'published'
-  | 'needs_changes'
-  // Terminal and creator-chosen: they stopped the build (issue + PR closed). Never
-  // produced by deriveStatus — the store records it and the status route answers it.
-  | 'abandoned';
+// Same seven values apps/web/src/submissionApi.ts calls SubmissionState.
+export type SubmissionStatus = SubmissionState;
 
 export interface ChecklistItem {
   text: string;

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -21,6 +21,7 @@
     "@codemirror/lint": "6.9.7",
     "@codemirror/state": "6.7.1",
     "@codemirror/view": "6.43.8",
+    "@gamedevpl/contract": "*",
     "@lezer/highlight": "1.2.3",
     "@mediapipe/tasks-vision": "^0.10.18",
     "@typescript/vfs": "1.6.4",

--- a/apps/web/src/submissionApi.ts
+++ b/apps/web/src/submissionApi.ts
@@ -1,14 +1,8 @@
+import type { SubmissionState } from '@gamedevpl/contract';
+
 const API_BASE = import.meta.env.VITE_API_BASE_URL ?? '';
 
-export type SubmissionState =
-  | 'queued'
-  | 'building'
-  | 'in_review'
-  | 'publishing'
-  | 'published'
-  | 'needs_changes'
-  /** Creator-chosen terminal state: they stopped the build. */
-  | 'abandoned';
+export type { SubmissionState };
 
 export type BuildProgress = {
   /** Head commit SHA of the PR — changes when the agent pushes new work. */

--- a/eslint-rules/module-size-baseline.json
+++ b/eslint-rules/module-size-baseline.json
@@ -874,7 +874,7 @@
     "packages/contract/src/agent-channel-routes.ts": 39,
     "packages/contract/src/gate-status.test.ts": 49,
     "packages/contract/src/gate-status.ts": 25,
-    "packages/contract/src/index.ts": 4,
+    "packages/contract/src/index.ts": 5,
     "packages/game-generator/src/engine/engine.test.ts": 35,
     "packages/game-generator/src/index.ts": 2,
     "packages/game-generator/src/mock.test.ts": 67,

--- a/package-lock.json
+++ b/package-lock.json
@@ -88,6 +88,7 @@
         "@codemirror/lint": "6.9.7",
         "@codemirror/state": "6.7.1",
         "@codemirror/view": "6.43.8",
+        "@gamedevpl/contract": "*",
         "@lezer/highlight": "1.2.3",
         "@mediapipe/tasks-vision": "^0.10.18",
         "@typescript/vfs": "1.6.4",

--- a/packages/contract/src/index.ts
+++ b/packages/contract/src/index.ts
@@ -2,3 +2,4 @@
 
 export { AGENT_CHANNEL_ROUTES, type AgentChannelRouteKey, type AgentChannelRoutePath } from './agent-channel-routes.js';
 export { deriveGateStatusString, derivePreviewGateStatus, GATE_STATUS_VALUES, type GateStatus } from './gate-status.js';
+export { SUBMISSION_STATES, type SubmissionState } from './submission-state.js';

--- a/packages/contract/src/submission-state.test.ts
+++ b/packages/contract/src/submission-state.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest';
+import { SUBMISSION_STATES } from './submission-state.js';
+
+describe('SUBMISSION_STATES', () => {
+  it('lists the seven states the API and web both derive', () => {
+    expect(SUBMISSION_STATES).toEqual([
+      'queued',
+      'building',
+      'in_review',
+      'publishing',
+      'published',
+      'needs_changes',
+      'abandoned',
+    ]);
+  });
+});

--- a/packages/contract/src/submission-state.ts
+++ b/packages/contract/src/submission-state.ts
@@ -1,0 +1,12 @@
+// Submission lifecycle state — same seven values on API and web.
+export const SUBMISSION_STATES = [
+  'queued',
+  'building',
+  'in_review',
+  'publishing',
+  'published',
+  'needs_changes',
+  'abandoned',
+] as const;
+
+export type SubmissionState = (typeof SUBMISSION_STATES)[number];


### PR DESCRIPTION
## Summary
Consolidates the `SubmissionState` type definition into the shared `@gamedevpl/contract` package to eliminate duplication and establish a single source of truth across the API and web applications.

## Key Changes
- Created `packages/contract/src/submission-state.ts` with:
  - `SUBMISSION_STATES` constant array defining the seven submission lifecycle states
  - `SubmissionState` type derived from the constant array
  - Added comprehensive test coverage in `submission-state.test.ts`
- Updated `apps/api/src/submission-status.ts`:
  - Replaced inline type definition with import from contract package
  - Simplified `SubmissionStatus` to be a type alias of `SubmissionState`
- Updated `apps/web/src/submissionApi.ts`:
  - Removed local `SubmissionState` type definition
  - Now re-exports `SubmissionState` from contract package
- Added `@gamedevpl/contract` dependency to `apps/web/package.json`
- Exported new types from `packages/contract/src/index.ts`

## Implementation Details
The seven submission states (`queued`, `building`, `in_review`, `publishing`, `published`, `needs_changes`, `abandoned`) are now defined once in the contract package using a `const` array with `as const` assertion, enabling the type to be derived from the array itself. This approach ensures type safety and prevents state value mismatches between API and web applications.

https://claude.ai/code/session_01VaPzGSyNfZ7nvGcJgYNSdL