### PR TITLE
Extract BUILD_STEPS and BUILD_EVENT_KINDS to shared contract

### DIFF
--- a/apps/api/src/submission-status.ts
+++ b/apps/api/src/submission-status.ts
@@ -6,7 +6,13 @@
 
 import type { LinkedPullRequest } from './github-client.js';
 import type { JobStall, JobState } from './job-state.js';
-import type { SubmissionState } from '@gamedevpl/contract';
+import {
+  BUILD_EVENT_KINDS,
+  BUILD_STEPS,
+  type BuildEventKind,
+  type BuildStep,
+  type SubmissionState,
+} from '@gamedevpl/contract';
 
 // Same seven values apps/web/src/submissionApi.ts calls SubmissionState.
 export type SubmissionStatus = SubmissionState;
@@ -43,28 +49,8 @@ export interface CreatorRevision {
 // submissions.ts) because both the writer and this reader need it.
 export const CREATOR_FEEDBACK_MARKER = '<!-- gamedevpl:creator-feedback -->';
 
-/**
- * The steps a game build actually moves through, as a closed set. This is the whole
- * i18n answer for progress reporting: the enum carries the *meaning* and is rendered
- * from our own translated copy, so a Polish creator reads correct Polish even when
- * the agent wrote its sentence in English and machine translation is off or failing.
- * The free-text sentence alongside it carries only flavour.
- */
-export const BUILD_STEPS = [
-  'planning',
-  'art',
-  'mechanics',
-  'audio',
-  'balancing',
-  'fixing',
-  'testing',
-  'polishing',
-] as const;
-export type BuildStep = (typeof BUILD_STEPS)[number];
-
-/** What kind of moment this is — drives the icon and how loudly the UI says it. */
-export const BUILD_EVENT_KINDS = ['step', 'milestone', 'asking', 'blocked', 'done'] as const;
-export type BuildEventKind = (typeof BUILD_EVENT_KINDS)[number];
+// Same values apps/web/src/submissionApi.ts calls BuildStep/BuildEventKind.
+export { BUILD_STEPS, BUILD_EVENT_KINDS, type BuildStep, type BuildEventKind };
 
 /**
  * One update pushed by the agent over the build channel, rather than inferred from

--- a/apps/web/src/submissionApi.ts
+++ b/apps/web/src/submissionApi.ts
@@ -1,8 +1,8 @@
-import type { SubmissionState } from '@gamedevpl/contract';
+import type { BuildEventKind, BuildStep, SubmissionState } from '@gamedevpl/contract';
 
 const API_BASE = import.meta.env.VITE_API_BASE_URL ?? '';
 
-export type { SubmissionState };
+export type { BuildEventKind, BuildStep, SubmissionState };
 
 export type BuildProgress = {
   /** Head commit SHA of the PR — changes when the agent pushes new work. */
@@ -50,11 +50,6 @@ export type MySubmission = {
    */
   livePublishedAt?: string;
 };
-
-/** The build steps an agent can report. Rendered from our own translated copy. */
-export type BuildStep = 'planning' | 'art' | 'mechanics' | 'audio' | 'balancing' | 'fixing' | 'testing' | 'polishing';
-
-export type BuildEventKind = 'step' | 'milestone' | 'asking' | 'blocked' | 'done';
 
 /**
  * An update the agent pushed over the build channel. Unlike a commit subject, this

--- a/eslint-rules/module-size-baseline.json
+++ b/eslint-rules/module-size-baseline.json
@@ -874,7 +874,7 @@
     "packages/contract/src/agent-channel-routes.ts": 39,
     "packages/contract/src/gate-status.test.ts": 49,
     "packages/contract/src/gate-status.ts": 25,
-    "packages/contract/src/index.ts": 5,
+    "packages/contract/src/index.ts": 6,
     "packages/game-generator/src/engine/engine.test.ts": 35,
     "packages/game-generator/src/index.ts": 2,
     "packages/game-generator/src/mock.test.ts": 67,

--- a/packages/contract/src/build-event.test.ts
+++ b/packages/contract/src/build-event.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+import { BUILD_EVENT_KINDS, BUILD_STEPS } from './build-event.js';
+
+describe('BUILD_STEPS', () => {
+  it('lists the eight steps the API and web both derive', () => {
+    expect(BUILD_STEPS).toEqual([
+      'planning',
+      'art',
+      'mechanics',
+      'audio',
+      'balancing',
+      'fixing',
+      'testing',
+      'polishing',
+    ]);
+  });
+});
+
+describe('BUILD_EVENT_KINDS', () => {
+  it('lists the five kinds the API and web both derive', () => {
+    expect(BUILD_EVENT_KINDS).toEqual(['step', 'milestone', 'asking', 'blocked', 'done']);
+  });
+});

--- a/packages/contract/src/build-event.ts
+++ b/packages/contract/src/build-event.ts
@@ -1,0 +1,16 @@
+// The steps a game build moves through, rendered from local copy.
+export const BUILD_STEPS = [
+  'planning',
+  'art',
+  'mechanics',
+  'audio',
+  'balancing',
+  'fixing',
+  'testing',
+  'polishing',
+] as const;
+export type BuildStep = (typeof BUILD_STEPS)[number];
+
+// What kind of moment a build channel event is.
+export const BUILD_EVENT_KINDS = ['step', 'milestone', 'asking', 'blocked', 'done'] as const;
+export type BuildEventKind = (typeof BUILD_EVENT_KINDS)[number];

--- a/packages/contract/src/index.ts
+++ b/packages/contract/src/index.ts
@@ -1,5 +1,6 @@
 // Types, constants, and schemas shared across workspaces — no I/O.
 
 export { AGENT_CHANNEL_ROUTES, type AgentChannelRouteKey, type AgentChannelRoutePath } from './agent-channel-routes.js';
+export { BUILD_EVENT_KINDS, BUILD_STEPS, type BuildEventKind, type BuildStep } from './build-event.js';
 export { deriveGateStatusString, derivePreviewGateStatus, GATE_STATUS_VALUES, type GateStatus } from './gate-status.js';
 export { SUBMISSION_STATES, type SubmissionState } from './submission-state.js';


### PR DESCRIPTION
## Summary
Consolidates the `BUILD_STEPS` and `BUILD_EVENT_KINDS` constants and their associated types into a shared contract package, eliminating duplication between the API and web applications.

## Key Changes
- Created new `packages/contract/src/build-event.ts` module containing:
  - `BUILD_STEPS` constant (8 build phase values)
  - `BUILD_EVENT_KINDS` constant (5 event type values)
  - `BuildStep` and `BuildEventKind` type definitions
- Added `packages/contract/src/build-event.test.ts` with tests verifying the constants match expected values
- Updated `apps/api/src/submission-status.ts` to import from contract instead of defining locally
- Updated `apps/web/src/submissionApi.ts` to import from contract instead of defining locally
- Exported new types from `packages/contract/src/index.ts`
- Updated module size baseline for contract index

## Implementation Details
- The constants were previously defined in two separate locations with identical values
- By moving to the shared contract package, both applications now reference a single source of truth
- This ensures consistency and simplifies future maintenance of these shared enumerations
- Tests verify the constants maintain their expected values across the codebase

https://claude.ai/code/session_01VaPzGSyNfZ7nvGcJgYNSdL