### PR TITLE
Issue OAuth challenge at MCP initialize, not tools/call

### DIFF
--- a/.claude/skills/byoca-mcp/SKILL.md
+++ b/.claude/skills/byoca-mcp/SKILL.md
@@ -849,6 +849,44 @@ cache), so a resume cannot keep showing “finished this round” next to live p
   MCP tools refuse an already-issued key with a reconnect instruction. Do not restore a
   per-game compatibility path in UI, API routes, or MCP tool handling.
 - An opener is checked by `start`; later calls use the returned round-scoped `sessionKey`.
+
+### The handshake carries the OAuth challenge, not the first `tools/call`
+
+`shouldIssueMcpOAuthChallenge` (`apps/api/src/mcp-oauth-metadata.ts`) answers a
+credential-less `initialize` with the 401 + `WWW-Authenticate` challenge. That 401 is the
+**only** in-band signal that starts OAuth discovery (RFC 9728 / the MCP auth flow): a
+client that handshakes to a clean 200 concludes the server needs no auth, never probes the
+protected-resource document, and so has no authorization endpoint to send anyone to.
+
+Deferring the challenge to the first `tools/call` therefore looked harmless — every
+credentialed lane worked, an anonymous visitor got a readable tool list — while silently
+breaking every browser-capable client. Observed as Claude connectors reporting
+"gamedev.pl didn't provide a sign-in link" while listing all 34 tools, and, earlier,
+as Cursor desktop stalling after DCR (then read as the client's bug, and worked around
+with `MCP_NO_ACCOUNT_HINT` instead). The authorization server (`oauth-as.ts`) —
+metadata, DCR, `/oauth/authorize` → `/studio?oauth_return=…`, PKCE, token — was reachable
+and correct the whole time. Nothing ever told a client to go there.
+
+What this does **not** change:
+
+- **`tools/list` stays anonymous**, so the surface is still readable as a directory.
+  `ping` and `notifications/*` too. Only `initialize` gained the gate.
+- **Every real credentialed lane already presents a Bearer at `initialize`**, so none of
+  them notice: the keyless connect flow puts the creator key in the client's configured
+  `Authorization` header (`self-build-connect.ts`); managed Anthropic/Gemini/OpenAI get a
+  vaulted `mcpBearerCredential` from `brief.mcpOpenerToken` (`agent-backend-env.ts`);
+  Copilot's connector authenticates with `COPILOT_MCP_CONNECTOR_SECRET`.
+- **Any token shape clears the handshake** — validity is still decided per call, because
+  the point of the challenge is to name the sign-in path, not to vet the credential.
+
+The one lane it would have broken passed its opener as a `start({ key })` argument with no
+header — durable per-game keys, already retired (`mintGameKeyKickoff` has no production
+callers). If a keyless-opener lane is ever reintroduced, it needs a header at `initialize`
+or this gate has to learn about it.
+
+Tests: `apps/api/src/mcp-oauth-handshake.test.ts`. Test helpers that open a session send a
+throwaway `Bearer handshake`; a case that means to arrive without one says so.
+
 - **`show_media` is how the creator sees the game.** `get_gate_media` attaches frames as
   image blocks, which reach the _model_ — it can look at them and describe them, and there is
   no path back out. Asked to display them, ChatGPT answered "the image attachments apparently

--- a/apps/api/src/creator-agent-key-routes.test.ts
+++ b/apps/api/src/creator-agent-key-routes.test.ts
@@ -70,7 +70,7 @@ async function mcpCall(app: FastifyInstance, method: string, params?: unknown, h
     headers: {
       'content-type': 'application/json',
       accept: 'application/json, text/event-stream',
-      ...headers,
+      ...(method === 'initialize' ? { authorization: 'Bearer handshake', ...headers } : headers),
     },
     payload: { jsonrpc: '2.0', id: 1, method, ...(params !== undefined ? { params } : {}) },
   });

--- a/apps/api/src/mcp-debug-log.test.ts
+++ b/apps/api/src/mcp-debug-log.test.ts
@@ -155,7 +155,7 @@ describe('mcp tool refusal logging', () => {
     const init = await app.inject({
       method: 'POST',
       url: MCP_ENDPOINT_PATH,
-      headers: { 'content-type': 'application/json', 'user-agent': 'openai-mcp/1.0.0' },
+      headers: { 'content-type': 'application/json', 'user-agent': 'openai-mcp/1.0.0', authorization: 'Bearer h' },
       payload: {
         jsonrpc: '2.0',
         id: 1,

--- a/apps/api/src/mcp-oauth-handshake.test.ts
+++ b/apps/api/src/mcp-oauth-handshake.test.ts
@@ -1,0 +1,107 @@
+import type { FastifyInstance } from 'fastify';
+import { afterEach, describe, expect, it } from 'vitest';
+import { buildApp } from './app.js';
+import { MCP_ENDPOINT_PATH } from './self-build-connect.js';
+import { InMemoryStore } from './store.js';
+
+const secret = 'oauth-handshake-secret';
+const ISSUE = 42;
+
+function initializePayload() {
+  return {
+    jsonrpc: '2.0',
+    id: 1,
+    method: 'initialize',
+    params: { protocolVersion: '2025-11-25', capabilities: {}, clientInfo: { name: 'test', version: '0' } },
+  };
+}
+
+async function buildMcpApp(store: InMemoryStore) {
+  return buildApp({
+    store,
+    sessionSecret: 'dev-session-secret-change-me',
+    submissionRoutes: {
+      githubClient: {
+        createIssue: async () => ({ number: ISSUE }),
+        getIssueState: async () => ({ state: 'open' as const }),
+        findLinkedPR: async () => null,
+        createIssueComment: async () => ({ id: 1 }),
+        updateIssueBody: async () => {},
+        closeIssue: async () => {},
+        closePullRequest: async () => {},
+        ensureOpenPullRequest: async () => ({ number: 1 }),
+        deleteBranch: async () => {},
+        getGameSources: async () => null,
+        getGameMedia: async () => null,
+        getCatalog: async () => [],
+        getProgressNotes: async () => null,
+      },
+      githubToken: 'gh-token',
+      submissionTokenSecret: secret,
+      agentChannel: {},
+    },
+  });
+}
+
+async function seedJob(store: InMemoryStore) {
+  await store.createSubmission(ISSUE, 'g:owner', 'Comet Courier');
+  await store.setSubmissionSlug(ISSUE, 'comet-courier');
+  await store.setRoundBuilder(ISSUE, 'self');
+  await store.setSubmissionBrief(ISSUE, { spec: 'Build it.', qa: [] });
+  await store.recordJobTransition(ISSUE, { to: 'dispatched', at: new Date().toISOString(), by: 'system' });
+}
+
+describe('MCP handshake OAuth challenge', () => {
+  let app: FastifyInstance | undefined;
+
+  afterEach(async () => {
+    delete process.env.CANONICAL_HOST;
+    if (app) await app.close();
+    app = undefined;
+  });
+
+  // A 200 here leaves a client no sign-in link to offer.
+  it('challenges initialize without credentials so OAuth discovery starts', async () => {
+    process.env.CANONICAL_HOST = 'www.gamedev.pl';
+    const store = new InMemoryStore();
+    await seedJob(store);
+    app = await buildMcpApp(store);
+    const res = await app.inject({
+      method: 'POST',
+      url: MCP_ENDPOINT_PATH,
+      headers: { 'content-type': 'application/json' },
+      payload: initializePayload(),
+    });
+    expect(res.statusCode).toBe(401);
+    expect(res.headers['www-authenticate']).toContain('resource_metadata="https://www.gamedev.pl');
+  });
+
+  // The configured-header lane must be untouched by that.
+  it('allows initialize when the client presents a Bearer credential', async () => {
+    const store = new InMemoryStore();
+    await seedJob(store);
+    app = await buildMcpApp(store);
+    const res = await app.inject({
+      method: 'POST',
+      url: MCP_ENDPOINT_PATH,
+      headers: { 'content-type': 'application/json', authorization: 'Bearer some-creator-key' },
+      payload: initializePayload(),
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.headers['www-authenticate']).toBeUndefined();
+  });
+
+  // Reading the surface stays open — the directory case.
+  it('still lists tools without credentials', async () => {
+    const store = new InMemoryStore();
+    await seedJob(store);
+    app = await buildMcpApp(store);
+    const res = await app.inject({
+      method: 'POST',
+      url: MCP_ENDPOINT_PATH,
+      headers: { 'content-type': 'application/json' },
+      payload: { jsonrpc: '2.0', id: 1, method: 'tools/list' },
+    });
+    expect(res.statusCode).toBe(200);
+  });
+});

--- a/apps/api/src/mcp-oauth-metadata.test.ts
+++ b/apps/api/src/mcp-oauth-metadata.test.ts
@@ -288,29 +288,6 @@ describe('MCP OAuth 401 challenge (BY-18a)', () => {
     expect(res.headers['www-authenticate']).toContain('resource_metadata="https://www.gamedev.pl');
     expect(res.headers['www-authenticate']).not.toContain('evil.test');
   });
-
-  it('still allows initialize without credentials', async () => {
-    const store = new InMemoryStore();
-    await seedJob(store);
-    app = await buildMcpApp(store);
-    const res = await app.inject({
-      method: 'POST',
-      url: MCP_ENDPOINT_PATH,
-      headers: { 'content-type': 'application/json' },
-      payload: {
-        jsonrpc: '2.0',
-        id: 1,
-        method: 'initialize',
-        params: {
-          protocolVersion: '2025-11-25',
-          capabilities: {},
-          clientInfo: { name: 'test', version: '0' },
-        },
-      },
-    });
-    expect(res.statusCode).toBe(200);
-    expect(res.headers['www-authenticate']).toBeUndefined();
-  });
 });
 
 describe('MCP OAuth challenge regressions (BY-18a)', () => {
@@ -367,7 +344,8 @@ describe('MCP OAuth challenge regressions (BY-18a)', () => {
     const res = await app.inject({
       method: 'POST',
       url: MCP_ENDPOINT_PATH,
-      headers: { 'content-type': 'application/json' },
+      // Any Bearer shape clears the handshake challenge.
+      headers: { 'content-type': 'application/json', authorization: 'Bearer handshake' },
       payload: {
         jsonrpc: '2.0',
         id: 1,

--- a/apps/api/src/mcp-oauth-metadata.ts
+++ b/apps/api/src/mcp-oauth-metadata.ts
@@ -84,18 +84,19 @@ export function mcpRequestLacksCredential(request: FastifyRequest, message: Json
   return true;
 }
 
-/** Protocol methods that never receive an OAuth challenge — existing clients handshake here. */
+// Not initialize — see below. tools/list stays an open directory.
 export function mcpMethodAllowsAnonymousHandshake(method: string | undefined): boolean {
   if (!method) return true;
-  if (method === 'initialize') return true;
   if (method === 'ping') return true;
   if (method === 'tools/list') return true;
   if (method.startsWith('notifications/')) return true;
   return false;
 }
 
+// A 200 handshake reads as "no auth needed"; discovery never starts.
 export function shouldIssueMcpOAuthChallenge(request: FastifyRequest, message: JsonRpcMessage): boolean {
   if (mcpMethodAllowsAnonymousHandshake(message.method)) return false;
+  if (message.method === 'initialize') return !readBearerToken(request.headers.authorization);
   if (message.method !== 'tools/call') return false;
   return mcpRequestLacksCredential(request, message);
 }
@@ -118,10 +119,9 @@ export const MCP_MISSING_CREDENTIAL_HINT =
  *
  * The sentence above tells an agent to go find a key, which is a dead end for a visitor
  * with no account — and a directory listing puts exactly that visitor here: anonymous
- * `initialize` and `tools/list` succeed, every tool looks healthy, and the first write is
- * where they learn otherwise. Say it in this string specifically: it is the only
- * explanation reaching a client that never opens a browser — headless agents, and Cursor
- * desktop while its OAuth stalls after DCR.
+ * `tools/list` succeeds and every tool looks healthy. Say it in this string specifically:
+ * it is the only explanation reaching a client that never opens a browser. One that can
+ * gets the challenge at `initialize` instead, so this is the fallback, not the only path.
  *
  * Product state, not a per-user verdict: an account is required, never whether a given
  * account has one. It names no launch stage, so it survives one changing.

--- a/apps/api/src/mcp-server.test.ts
+++ b/apps/api/src/mcp-server.test.ts
@@ -263,7 +263,7 @@ async function mcpCall(
     headers: {
       'content-type': 'application/json',
       accept: 'application/json, text/event-stream',
-      ...headers,
+      ...(method === 'initialize' ? { authorization: 'Bearer handshake', ...headers } : headers),
     },
     payload: { jsonrpc: '2.0', id, method, ...(params !== undefined ? { params } : {}) },
   });
@@ -1499,7 +1499,7 @@ declare const GameKit: { defineGame(): unknown };
     const res = await app.inject({
       method: 'POST',
       url: '/api/mcp',
-      headers: { 'content-type': 'application/json' },
+      headers: { 'content-type': 'application/json', authorization: 'Bearer handshake' },
       payload: {
         jsonrpc: '2.0',
         id: 1,
@@ -1511,7 +1511,6 @@ declare const GameKit: { defineGame(): unknown };
         },
       },
     });
-    expect(res.statusCode).not.toBe(401);
     expect(res.statusCode).toBe(200);
     expect(res.json()).toMatchObject({ jsonrpc: '2.0', id: 1 });
 
@@ -1528,7 +1527,7 @@ declare const GameKit: { defineGame(): unknown };
     const res = await app.inject({
       method: 'POST',
       url: '/api/mcp',
-      headers: { 'content-type': 'application/json' },
+      headers: { 'content-type': 'application/json', authorization: 'Bearer handshake' },
       payload: {
         jsonrpc: '2.0',
         id: 1,

--- a/apps/api/src/self-build-connect.test.ts
+++ b/apps/api/src/self-build-connect.test.ts
@@ -25,6 +25,12 @@ import {
 import { InMemoryStore } from './store.js';
 import { mintToken } from './submission-token.js';
 
+const MCP_HANDSHAKE_HEADERS = {
+  'content-type': 'application/json',
+  accept: 'application/json, text/event-stream',
+  authorization: 'Bearer handshake',
+};
+
 const secret = 'self-build-connect-test-secret';
 const sessionSecret = 'dev-session-secret-change-me';
 const CONCEPT = 'A squad tactics game about clearing rooms with careful timing and cover.';
@@ -332,10 +338,7 @@ describe('GET /api/submissions/:id/connect (BY-03 / BY-27b)', () => {
     const init = await app.inject({
       method: 'POST',
       url: '/api/mcp',
-      headers: {
-        'content-type': 'application/json',
-        accept: 'application/json, text/event-stream',
-      },
+      headers: MCP_HANDSHAKE_HEADERS,
       payload: {
         jsonrpc: '2.0',
         id: 1,
@@ -629,10 +632,7 @@ async function mcpStart(
   const init = await app.inject({
     method: 'POST',
     url: '/api/mcp',
-    headers: {
-      'content-type': 'application/json',
-      accept: 'application/json, text/event-stream',
-    },
+    headers: MCP_HANDSHAKE_HEADERS,
     payload: {
       jsonrpc: '2.0',
       id: 1,


### PR DESCRIPTION
## Summary

Move the MCP OAuth 401 challenge from the first `tools/call` to the `initialize` handshake. This ensures browser-capable clients receive the `WWW-Authenticate` header at the correct point in the protocol flow, allowing them to discover and initiate OAuth sign-in before attempting tool calls.

## Problem

Previously, the OAuth challenge was deferred to the first `tools/call`, which meant credentialed clients worked fine but anonymous visitors received a 200 response at `initialize`. Per RFC 9728, a 200 handshake signals "no auth needed," so clients never probed the protected-resource metadata document and had no way to discover the authorization endpoint. This broke browser-capable clients (Claude connectors, Cursor desktop) that expected to find a sign-in link.

## Changes

- **`mcp-oauth-metadata.ts`**: Modified `shouldIssueMcpOAuthChallenge()` to issue the challenge at `initialize` when no Bearer token is present, while keeping `tools/list` and other read-only methods anonymous
- **`mcp-oauth-metadata.ts`**: Updated `mcpMethodAllowsAnonymousHandshake()` to remove `initialize` from the anonymous methods list
- **`mcp-oauth-metadata.ts`**: Clarified comments explaining that the challenge must happen at `initialize` for OAuth discovery to work
- **New test file `mcp-oauth-handshake.test.ts`**: Added comprehensive tests for the handshake behavior:
  - Verifies `initialize` without credentials returns 401 with `WWW-Authenticate` header
  - Confirms `initialize` with Bearer token returns 200
  - Ensures `tools/list` remains accessible without credentials
- **Updated existing tests**: Added `authorization: 'Bearer handshake'` headers to all `initialize` calls across test files to reflect the new requirement

## Implementation Details

- Any Bearer token shape (including throwaway values) clears the handshake challenge; actual token validation still happens per-call
- All existing credentialed lanes already present a Bearer at `initialize` (creator keys in headers, vaulted tokens from brief, Copilot secrets), so no production code paths are broken
- The change is backward-compatible for all real clients; only the keyless-opener lane (already retired) would have been affected
- `tools/list`, `ping`, and `notifications/*` remain anonymous to keep the tool surface readable as a directory

https://claude.ai/code/session_01SQPm5imykfyW283rvvsegs