### PR TITLE
Extract JobState types to shared contract package

### DIFF
--- a/apps/api/src/job-state.ts
+++ b/apps/api/src/job-state.ts
@@ -13,52 +13,10 @@
 
 import type { AgentTaskState } from './agent-state.js';
 import type { ManagedBudgetStop, ManagedSessionUsage } from './managed-agent.js';
+import { JOB_STATES, type JobState } from '@gamedevpl/contract';
 import type { SubmissionStatus } from './submission-status.js';
 
-/**
- * Internal job vocabulary. Richer than the creator-facing {@link SubmissionStatus},
- * because several distinct situations currently collapse into "building" and stay
- * invisible: sources delivered but unverified, our own gate running, an agent that
- * failed outright.
- */
-export const JOB_STATES = [
-  /** Accepted and paid for out of quota; not yet handed to an agent. */
-  'queued',
-  /** Handed to an agent backend; the agent has not started working yet. */
-  'dispatched',
-  /** An agent session is actively working. */
-  'building',
-  /** The agent delivered candidate sources; nothing has verified them yet. */
-  'submitted',
-  /**
-   * Our own gate is running against the delivered sources.
-   *
-   * Nothing writes this today. The gate runs in Cloud Build and reports by writing its
-   * verdict to the version manifest, which we read on a poll — so the job goes from
-   * `submitted` to the verdict in one hop and is never observed mid-gate. Kept because
-   * stored records may still hold it and the projection reads it, not because it is a
-   * step anything passes through.
-   */
-  'gating',
-  /** Gate green. Waiting on the human review that is the moderation boundary. */
-  'ready_for_review',
-  /** Approved; the snapshot bake is in flight. */
-  'publishing',
-  /** Live on the site. Terminal. */
-  'published',
-  /** Bounced back for another round — gate red past retries, or reviewer rejected. */
-  'needs_changes',
-  /**
-   * The agent failed, timed out, or finished without delivering. Terminal for the
-   * round — no observation reopens it — but creator feedback dispatches another.
-   */
-  'failed',
-  /** Stopped by the creator or the operator. Terminal. */
-  'canceled',
-  /** Creator walked away. Terminal, and distinct from canceled for reporting. */
-  'abandoned',
-] as const;
-export type JobState = (typeof JOB_STATES)[number];
+export { JOB_STATES, type JobState };
 
 export const TERMINAL_JOB_STATES: ReadonlySet<JobState> = new Set<JobState>([
   'published',

--- a/apps/web/src/submissionApi.ts
+++ b/apps/web/src/submissionApi.ts
@@ -1,8 +1,8 @@
-import type { BuildEventKind, BuildStep, SubmissionState } from '@gamedevpl/contract';
+import type { BuildEventKind, BuildStep, JobState, SubmissionState } from '@gamedevpl/contract';
 
 const API_BASE = import.meta.env.VITE_API_BASE_URL ?? '';
 
-export type { BuildEventKind, BuildStep, SubmissionState };
+export type { BuildEventKind, BuildStep, JobState, SubmissionState };
 
 export type BuildProgress = {
   /** Head commit SHA of the PR — changes when the agent pushes new work. */
@@ -66,31 +66,17 @@ export type BuildEvent = {
   createdAt: string;
 };
 
-/**
- * The build job's own state, finer than {@link SubmissionState}.
- *
- * `status` drives the five-step timeline and cannot grow without changing what the
- * timeline draws; this says which of the several situations behind one step the build
- * is actually in, so the sentence under the timeline can be true. Absent on builds we
- * derive from GitHub rather than run ourselves.
- */
-export type BuildPhase =
-  | 'queued'
-  | 'dispatched'
-  | 'building'
-  | 'submitted'
-  | 'gating'
-  | 'ready_for_review'
-  | 'publishing'
-  | 'published'
-  | 'needs_changes'
-  | 'failed'
-  | 'canceled'
-  | 'abandoned';
-
 export type SubmissionStatus = {
   status: SubmissionState;
-  phase?: BuildPhase;
+  /**
+   * The build job's own state, finer than {@link SubmissionState}.
+   *
+   * `status` drives the five-step timeline and cannot grow without changing what the
+   * timeline draws; this says which of the several situations behind one step the build
+   * is actually in, so the sentence under the timeline can be true. Absent on builds we
+   * derive from GitHub rather than run ourselves.
+   */
+  phase?: JobState;
   slug?: string;
   /**
    * `'remix'` when this Studio draft was saved from an in-player remix (private

--- a/eslint-rules/module-size-baseline.json
+++ b/eslint-rules/module-size-baseline.json
@@ -874,7 +874,7 @@
     "packages/contract/src/agent-channel-routes.ts": 39,
     "packages/contract/src/gate-status.test.ts": 49,
     "packages/contract/src/gate-status.ts": 25,
-    "packages/contract/src/index.ts": 6,
+    "packages/contract/src/index.ts": 7,
     "packages/game-generator/src/engine/engine.test.ts": 35,
     "packages/game-generator/src/index.ts": 2,
     "packages/game-generator/src/mock.test.ts": 67,

--- a/packages/contract/src/index.ts
+++ b/packages/contract/src/index.ts
@@ -3,4 +3,5 @@
 export { AGENT_CHANNEL_ROUTES, type AgentChannelRouteKey, type AgentChannelRoutePath } from './agent-channel-routes.js';
 export { BUILD_EVENT_KINDS, BUILD_STEPS, type BuildEventKind, type BuildStep } from './build-event.js';
 export { deriveGateStatusString, derivePreviewGateStatus, GATE_STATUS_VALUES, type GateStatus } from './gate-status.js';
+export { JOB_STATES, type JobState } from './job-state.js';
 export { SUBMISSION_STATES, type SubmissionState } from './submission-state.js';

--- a/packages/contract/src/job-state.test.ts
+++ b/packages/contract/src/job-state.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+import { JOB_STATES } from './job-state.js';
+
+describe('JOB_STATES', () => {
+  it('lists the twelve states the API and web both derive', () => {
+    expect(JOB_STATES).toEqual([
+      'queued',
+      'dispatched',
+      'building',
+      'submitted',
+      'gating',
+      'ready_for_review',
+      'publishing',
+      'published',
+      'needs_changes',
+      'failed',
+      'canceled',
+      'abandoned',
+    ]);
+  });
+});

--- a/packages/contract/src/job-state.ts
+++ b/packages/contract/src/job-state.ts
@@ -1,0 +1,28 @@
+// Internal job vocabulary — richer than the public SubmissionState.
+export const JOB_STATES = [
+  // Accepted and paid for out of quota; not dispatched yet.
+  'queued',
+  // Handed to an agent backend; work hasn't started yet.
+  'dispatched',
+  // An agent session is actively working.
+  'building',
+  // Agent delivered candidate sources; nothing has verified them yet.
+  'submitted',
+  // Our gate runs against delivered sources; never actually observed here.
+  'gating',
+  // Gate green; waiting on the human moderation review.
+  'ready_for_review',
+  // Approved; the snapshot bake is in flight.
+  'publishing',
+  // Live on the site. Terminal.
+  'published',
+  // Bounced back for another round — gate red or reviewer rejected.
+  'needs_changes',
+  // Agent failed, timed out, or never delivered. Terminal for the round.
+  'failed',
+  // Stopped by the creator or the operator. Terminal.
+  'canceled',
+  // Creator walked away. Terminal, distinct from canceled for reporting.
+  'abandoned',
+] as const;
+export type JobState = (typeof JOB_STATES)[number];


### PR DESCRIPTION
## Summary
Moves the `JobState` type definition and `JOB_STATES` constant from the API package to the shared contract package, eliminating duplication and establishing a single source of truth for job state vocabulary.

## Key Changes
- **Created `packages/contract/src/job-state.ts`**: New module exporting `JOB_STATES` constant and `JobState` type with comprehensive inline documentation
- **Added `packages/contract/src/job-state.test.ts`**: Test verifying the twelve job states are correctly defined
- **Updated `apps/api/src/job-state.ts`**: Removed local `JOB_STATES` and `JobState` definitions; now re-exports from contract package
- **Updated `apps/web/src/submissionApi.ts`**: 
  - Imports `JobState` from contract package
  - Replaced local `BuildPhase` type with `JobState` in `SubmissionStatus.phase` field
  - Moved phase documentation inline with the field definition
- **Updated `packages/contract/src/index.ts`**: Added export of `JOB_STATES` and `JobState`
- **Updated module size baseline**: Reflects the new contract module

## Implementation Details
- The job state definitions remain functionally identical; only the location and documentation format changed
- Simplified inline comments in the contract module while preserving semantic meaning
- The `TERMINAL_JOB_STATES` set in the API continues to reference the imported `JobState` type
- Web and API packages now share the authoritative job state definitions through the contract package

https://claude.ai/code/session_01VaPzGSyNfZ7nvGcJgYNSdL