### PR TITLE
Move JobStall type to contract package for shared use

### DIFF
--- a/apps/api/src/job-state.ts
+++ b/apps/api/src/job-state.ts
@@ -13,10 +13,10 @@
 
 import type { AgentTaskState } from './agent-state.js';
 import type { ManagedBudgetStop, ManagedSessionUsage } from './managed-agent.js';
-import { JOB_STATES, type JobState } from '@gamedevpl/contract';
+import { JOB_STALL_VALUES, JOB_STATES, type JobStall, type JobState } from '@gamedevpl/contract';
 import type { SubmissionStatus } from './submission-status.js';
 
-export { JOB_STATES, type JobState };
+export { JOB_STALL_VALUES, JOB_STATES, type JobStall, type JobState };
 
 export const TERMINAL_JOB_STATES: ReadonlySet<JobState> = new Set<JobState>([
   'published',
@@ -376,32 +376,6 @@ export function reconcileAgentObservation(current: JobState, observation: AgentO
   if (!next || next.to === current) return null;
   return canTransition(current, next.to) ? next : null;
 }
-
-/**
- * Why a job looks stuck. This is the answer to the creator-experience finding that we
- * "still have no way to tell **stuck** from **slow**" — with an agent state machine and
- * our own transition timestamps, most of it stops being guesswork.
- */
-export type JobStall =
-  /** The agent is explicitly blocked on an answer. Known, not inferred. */
-  | 'awaiting_input'
-  /** Accepted but never handed to an agent — dispatch itself is wedged. */
-  | 'not_dispatched'
-  /** A live session that has said nothing for a while. The old heuristic, kept. */
-  | 'quiet'
-  /**
-   * The agent called MCP `end` — finished iterating this round on purpose.
-   * Prefer this over inferred quiet; unlocks creator self→platform handoff immediately.
-   */
-  | 'ended'
-  /** Delivered, but our own gate never picked it up. Our bug, not the agent's. */
-  | 'gate_not_started'
-  /**
-   * A self-build round waiting for the creator's agent to connect. Distinct from
-   * `not_dispatched` / `quiet`: nothing is wedged — the platform dispatched locally and
-   * is idle on purpose until the first channel signal.
-   */
-  | 'no_agent_yet';
 
 export interface StallThresholds {
   notDispatchedMs: number;

--- a/apps/web/src/submissionApi.ts
+++ b/apps/web/src/submissionApi.ts
@@ -1,8 +1,8 @@
-import type { BuildEventKind, BuildStep, JobState, SubmissionState } from '@gamedevpl/contract';
+import type { BuildEventKind, BuildStep, JobStall, JobState, SubmissionState } from '@gamedevpl/contract';
 
 const API_BASE = import.meta.env.VITE_API_BASE_URL ?? '';
 
-export type { BuildEventKind, BuildStep, JobState, SubmissionState };
+export type { BuildEventKind, BuildStep, JobStall, JobState, SubmissionState };
 
 export type BuildProgress = {
   /** Head commit SHA of the PR — changes when the agent pushes new work. */
@@ -128,7 +128,7 @@ export type SubmissionStatus = {
    * Why the build looks stuck, when it does. Closed vocabulary; the page renders its
    * own translated copy per value. Absent means progressing normally.
    */
-  stall?: 'awaiting_input' | 'not_dispatched' | 'quiet' | 'ended' | 'gate_not_started' | 'no_agent_yet';
+  stall?: JobStall;
   /**
    * When the self agent called MCP `end`. Survives when stall later becomes
    * `gate_not_started` — Studio still offers platform handoff.

--- a/packages/contract/src/index.ts
+++ b/packages/contract/src/index.ts
@@ -3,5 +3,5 @@
 export { AGENT_CHANNEL_ROUTES, type AgentChannelRouteKey, type AgentChannelRoutePath } from './agent-channel-routes.js';
 export { BUILD_EVENT_KINDS, BUILD_STEPS, type BuildEventKind, type BuildStep } from './build-event.js';
 export { deriveGateStatusString, derivePreviewGateStatus, GATE_STATUS_VALUES, type GateStatus } from './gate-status.js';
-export { JOB_STATES, type JobState } from './job-state.js';
+export { JOB_STALL_VALUES, JOB_STATES, type JobStall, type JobState } from './job-state.js';
 export { SUBMISSION_STATES, type SubmissionState } from './submission-state.js';

--- a/packages/contract/src/job-state.test.ts
+++ b/packages/contract/src/job-state.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { JOB_STATES } from './job-state.js';
+import { JOB_STALL_VALUES, JOB_STATES } from './job-state.js';
 
 describe('JOB_STATES', () => {
   it('lists the twelve states the API and web both derive', () => {
@@ -16,6 +16,19 @@ describe('JOB_STATES', () => {
       'failed',
       'canceled',
       'abandoned',
+    ]);
+  });
+});
+
+describe('JOB_STALL_VALUES', () => {
+  it('lists the six stall reasons the API and web both derive', () => {
+    expect(JOB_STALL_VALUES).toEqual([
+      'awaiting_input',
+      'not_dispatched',
+      'quiet',
+      'ended',
+      'gate_not_started',
+      'no_agent_yet',
     ]);
   });
 });

--- a/packages/contract/src/job-state.ts
+++ b/packages/contract/src/job-state.ts
@@ -26,3 +26,20 @@ export const JOB_STATES = [
   'abandoned',
 ] as const;
 export type JobState = (typeof JOB_STATES)[number];
+
+// Why a job looks stuck — stuck versus merely slow.
+export const JOB_STALL_VALUES = [
+  // Agent is explicitly blocked on an answer. Known, not inferred.
+  'awaiting_input',
+  // Accepted but never handed to an agent; dispatch itself wedged.
+  'not_dispatched',
+  // A live session that has said nothing for a while.
+  'quiet',
+  // Agent called MCP end; finished this round on purpose.
+  'ended',
+  // Delivered, but our own gate never picked it up.
+  'gate_not_started',
+  // A self-build round waiting for the creator's agent to connect.
+  'no_agent_yet',
+] as const;
+export type JobStall = (typeof JOB_STALL_VALUES)[number];


### PR DESCRIPTION
## Summary
Extracted the `JobStall` type and its associated values from the API package into the shared contract package, making it available to both API and web applications.

## Key Changes
- **Moved `JobStall` type definition** from `apps/api/src/job-state.ts` to `packages/contract/src/job-state.ts`
- **Created `JOB_STALL_VALUES` constant** in the contract package to define the six stall reasons as a single source of truth:
  - `awaiting_input` — agent blocked on answer
  - `not_dispatched` — dispatch wedged
  - `quiet` — silent session
  - `ended` — agent finished round intentionally
  - `gate_not_started` — gate didn't pick up delivery
  - `no_agent_yet` — waiting for agent connection
- **Updated exports** in both API and contract packages to include the new type and constant
- **Simplified web type definition** in `apps/web/src/submissionApi.ts` by replacing inline union type with `JobStall` import
- **Added test coverage** for `JOB_STALL_VALUES` in the contract package test suite

## Implementation Details
The `JobStall` type now follows the same pattern as `JobState` — defined as a union of values from a readonly constant array, ensuring type safety and consistency across packages. This eliminates duplication and provides a single source of truth for stall reason values.

https://claude.ai/code/session_01VaPzGSyNfZ7nvGcJgYNSdL