### PR TITLE
feat(contract): consolidate admin JobState/JobStall into @gamedevpl/contract

### DIFF
--- a/apps/web/src/adminApi.ts
+++ b/apps/web/src/adminApi.ts
@@ -5,6 +5,7 @@
 // rather than as an error, because the operator surface does not confirm its own
 // existence to someone who is not one.
 
+import type { JobStall } from './adminJobsApi.js';
 const API_BASE = import.meta.env.VITE_API_BASE_URL ?? '';
 
 export type OperatorAlertKind =
@@ -19,7 +20,7 @@ export interface OperatorAlert {
   ownerUid?: string;
   slug?: string;
   since: string;
-  stall?: 'awaiting_input' | 'not_dispatched' | 'quiet' | 'ended' | 'gate_not_started';
+  stall?: JobStall;
 }
 
 export interface AdminSummary {
@@ -54,10 +55,9 @@ export interface BetaInvite {
 }
 
 /**
- * The console's admission test as well as its header.
- *
- * Null is the whole answer for a non-operator: the nav draws no link, the page renders
- * "not found", and neither has to know why.
+ * The console's admission test as well as its header. Null is the whole answer for a
+ * non-operator: the nav draws no link, the page renders "not found", and neither has
+ * to know why.
  */
 export async function fetchAdminSummary(): Promise<AdminSummary | null> {
   const res = await fetch(`${API_BASE}/api/admin/summary`, { credentials: 'include' });

--- a/apps/web/src/adminJobsApi.ts
+++ b/apps/web/src/adminJobsApi.ts
@@ -9,22 +9,12 @@
  * than as an error, because the operator surface does not confirm its own existence.
  */
 
-/** Internal job vocabulary — richer than what a creator is shown. Mirrors job-state.ts. */
-export type JobState =
-  | 'queued'
-  | 'dispatched'
-  | 'building'
-  | 'submitted'
-  | 'gating'
-  | 'ready_for_review'
-  | 'publishing'
-  | 'published'
-  | 'needs_changes'
-  | 'failed'
-  | 'canceled'
-  | 'abandoned';
+import type { JobStall as ContractJobStall, JobState } from '@gamedevpl/contract';
 
-export type JobStall = 'awaiting_input' | 'not_dispatched' | 'quiet' | 'ended' | 'gate_not_started';
+export type { JobState };
+
+// Admin/operator stalls, minus no_agent_yet — that one is self-build-round only.
+export type JobStall = Exclude<ContractJobStall, 'no_agent_yet'>;
 
 export interface JobQueueEntry {
   issueNumber: number;


### PR DESCRIPTION
north-star-architecture.md Phase 1, seventh slice. `apps/web/src/adminJobsApi.ts` still hand-duplicated the 12-value `JobState` union (explicitly commented "Mirrors job-state.ts") and a 5-value `JobStall` subset, and `apps/web/src/adminApi.ts` repeated that same `JobStall` subset inline on `OperatorAlert.stall` — three more copies of vocabulary `@gamedevpl/contract` now owns.

`adminJobsApi.ts` imports `JobState` straight from the contract and re-exports it, and derives its `JobStall` as `Exclude<ContractJobStall, 'no_agent_yet'>` — the admin/operator surface deliberately never sees the self-build-only `no_agent_yet` stall, so the subset stays exact without hand-copying values. `adminApi.ts` now types `OperatorAlert.stall` as that same `JobStall`, imported from `adminJobsApi.ts` rather than the contract directly, since `adminJobsApi.ts` already owns the "admin-scoped `JobStall`" concept.

https://claude.ai/code/session_01VaPzGSyNfZ7nvGcJgYNSdL

---
_Generated by [Claude Code](https://claude.ai/code/session_01VaPzGSyNfZ7nvGcJgYNSdL)_