### PR TITLE
feat(contract): consolidate selfBuildCopy's JobStall into @gamedevpl/contract

### DIFF
--- a/apps/web/src/selfBuildCopy.ts
+++ b/apps/web/src/selfBuildCopy.ts
@@ -8,15 +8,15 @@
  *
  * Pure functions so the selection is unit-tested without mounting Studio.
  */
+import type { JobStall } from '@gamedevpl/contract';
 
 export type SelfStatusCopy = 'no_agent_yet' | 'quiet_agent' | 'agent_ended' | 'delivery_cap';
 
 /** Where a self-round composer message will actually go. */
 export type SelfComposerRoute = 'active' | 'waiting';
-
 export type SelfBuildCopyInput = {
   builder?: 'platform' | 'self' | null;
-  stall?: 'awaiting_input' | 'not_dispatched' | 'quiet' | 'ended' | 'gate_not_started' | 'no_agent_yet' | null;
+  stall?: JobStall | null;
   failureReason?: string | null;
   /**
    * Internal job phase when the coarse status is lossy. Gate-green drafts project as


### PR DESCRIPTION
north-star-architecture.md Phase 1, ninth slice. `apps/web/src/selfBuildCopy.ts` hand-typed the full 6-value `stall` union (plus `| null`) inline on `SelfBuildCopyInput`, rather than importing the `JobStall` type `@gamedevpl/contract` already owns.

`SelfBuildCopyInput.stall` is now typed as `JobStall | null`, imported directly from `@gamedevpl/contract`. No other local declarations needed updating — the file's comparisons (`input.stall === 'no_agent_yet'`, etc.) type-check unchanged against the imported type, and its two consumers already pass `SubmissionStatus['stall']` through, which has been the contract's `JobStall` since PR #922.

https://claude.ai/code/session_01VaPzGSyNfZ7nvGcJgYNSdL

---
_Generated by [Claude Code](https://claude.ai/code/session_01VaPzGSyNfZ7nvGcJgYNSdL)_