### PR TITLE
Phase 1: consolidate InputKey and RoomPhase into packages/contract

### DIFF
--- a/apps/api/src/mp.ts
+++ b/apps/api/src/mp.ts
@@ -1,6 +1,7 @@
 import { createHmac, randomInt, timingSafeEqual } from 'node:crypto';
 import type { FastifyInstance, FastifyRequest, FastifyReply } from 'fastify';
 import { z } from 'zod';
+import { INPUT_KEYS, ROOM_PHASES, type InputKey, type RoomPhase } from '@gamedevpl/contract';
 import { checkUserAccess } from './auth.js';
 import type { InternalAuthVerifier } from './internal-auth.js';
 import type { RelayClient } from './mp-relay.js';
@@ -39,9 +40,7 @@ export const SLOT_COLORS = [
 export const MAX_SLOTS = SLOT_COLORS.length;
 export const DEFAULT_SLOTS = 4;
 
-/** The v1 controller layout: a d-pad plus one action button. */
-const INPUT_KEYS = ['up', 'down', 'left', 'right', 'a'] as const;
-export type InputKey = (typeof INPUT_KEYS)[number];
+export { INPUT_KEYS, ROOM_PHASES, type InputKey, type RoomPhase };
 
 const ROOM_TTL_MS = 2 * 60 * 60 * 1000;
 const ROOM_IDLE_MS = 15 * 60 * 1000;
@@ -50,8 +49,6 @@ const JOIN_TOKEN_TTL_MS = ROOM_TTL_MS;
 const MAX_FRAMES_PER_SECOND = 40;
 /** Frames larger than this are refused unread — controller frames are tiny. */
 const MAX_FRAME_BYTES = 2 * 1024;
-
-export type RoomPhase = 'lobby' | 'playing' | 'ended';
 
 /** A connection we can write to. Kept structural so tests need no real socket. */
 export interface RelaySocket {
@@ -197,7 +194,7 @@ const InputFrameSchema = z.object({
 
 const PhaseFrameSchema = z.object({
   t: z.literal('phase'),
-  phase: z.enum(['lobby', 'playing', 'ended']),
+  phase: z.enum(ROOM_PHASES),
 });
 
 const KickFrameSchema = z.object({

--- a/apps/web/src/mp/protocol.ts
+++ b/apps/web/src/mp/protocol.ts
@@ -9,14 +9,13 @@
  * the other), so every frame is narrowed by the guards below before it is used.
  */
 
+import { INPUT_KEYS, ROOM_PHASES, type InputKey, type RoomPhase } from '@gamedevpl/contract';
+
+export { INPUT_KEYS, ROOM_PHASES, type InputKey, type RoomPhase };
+
 export const PROTOCOL_VERSION = 1;
 /** Namespace on the bridge, so a game's own postMessage traffic can't be confused for ours. */
 export const BRIDGE_NAMESPACE = 'gdp';
-
-export const INPUT_KEYS = ['up', 'down', 'left', 'right', 'a'] as const;
-export type InputKey = (typeof INPUT_KEYS)[number];
-
-export type RoomPhase = 'lobby' | 'playing' | 'ended';
 
 export interface RosterSlot {
   slot: number;

--- a/eslint-rules/module-size-baseline.json
+++ b/eslint-rules/module-size-baseline.json
@@ -879,7 +879,7 @@
     "packages/contract/src/gate-progress.ts": 3,
     "packages/contract/src/gate-status.test.ts": 49,
     "packages/contract/src/gate-status.ts": 25,
-    "packages/contract/src/index.ts": 12,
+    "packages/contract/src/index.ts": 13,
     "packages/contract/src/managed-agent-vendor.test.ts": 8,
     "packages/contract/src/managed-agent-vendor.ts": 3,
     "packages/game-generator/src/engine/engine.test.ts": 35,

--- a/packages/contract/src/index.ts
+++ b/packages/contract/src/index.ts
@@ -8,5 +8,6 @@ export { GATE_PROGRESS_LANES, type GateProgressLane } from './gate-progress.js';
 export { deriveGateStatusString, derivePreviewGateStatus, GATE_STATUS_VALUES, type GateStatus } from './gate-status.js';
 export { JOB_STALL_VALUES, JOB_STATES, type JobStall, type JobState } from './job-state.js';
 export { MANAGED_AGENT_VENDORS, type ManagedAgentVendorName } from './managed-agent-vendor.js';
+export { INPUT_KEYS, ROOM_PHASES, type InputKey, type RoomPhase } from './mp-protocol.js';
 export { PROPERTY_TYPES, type PropertyType } from './property-type.js';
 export { SUBMISSION_STATES, type SubmissionState } from './submission-state.js';

--- a/packages/contract/src/mp-protocol.test.ts
+++ b/packages/contract/src/mp-protocol.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest';
+import { INPUT_KEYS, ROOM_PHASES } from './mp-protocol.js';
+
+describe('INPUT_KEYS', () => {
+  it('lists the v1 controller layout', () => {
+    expect(INPUT_KEYS).toEqual(['up', 'down', 'left', 'right', 'a']);
+  });
+});
+
+describe('ROOM_PHASES', () => {
+  it('lists the room lifecycle phases', () => {
+    expect(ROOM_PHASES).toEqual(['lobby', 'playing', 'ended']);
+  });
+});

--- a/packages/contract/src/mp-protocol.ts
+++ b/packages/contract/src/mp-protocol.ts
@@ -1,0 +1,8 @@
+// Multiplayer relay wire vocabulary, shared by the room server and controller UI.
+export const INPUT_KEYS = ['up', 'down', 'left', 'right', 'a'] as const;
+
+export type InputKey = (typeof INPUT_KEYS)[number];
+
+export const ROOM_PHASES = ['lobby', 'playing', 'ended'] as const;
+
+export type RoomPhase = (typeof ROOM_PHASES)[number];


### PR DESCRIPTION
## Summary
- Fourteenth Phase 1 slice consolidating hand-duplicated closed-vocabulary types into `packages/contract`.
- Adds `INPUT_KEYS`/`InputKey` (up/down/left/right/a) and `ROOM_PHASES`/`RoomPhase` (lobby/playing/ended) — the multiplayer relay wire vocabulary — to `packages/contract` as the single source of truth.
- `apps/api/src/mp.ts` now imports/re-exports from `@gamedevpl/contract` instead of hand-declaring these; its `PhaseFrameSchema` zod enum now derives from the shared `ROOM_PHASES` array instead of a separately hand-typed literal list.
- `apps/web/src/mp/protocol.ts` now imports/re-exports from `@gamedevpl/contract` instead of hand-declaring these (all downstream web importers — `gamepadSpike.ts`, `ControllerView.tsx`, `voicePhrases.ts`, `roomClient.ts` — keep importing from `protocol.js` unchanged, since it re-exports).
- Scoped `module-size-baseline.json` reseal for `packages/contract/src/index.ts`, whose line count grew by one for the new export.

## Test plan
- [x] `npm run build:packages`
- [x] `npm run type-check` (all 6 workspaces clean)
- [x] `npm run lint` (both ratchets green)
- [x] `npm test` (full suite green)
- [x] `npm run build` (Vite web build)


---
_Generated by [Claude Code](https://claude.ai/code/session_01VaPzGSyNfZ7nvGcJgYNSdL)_