### PR TITLE
Improve GameKit touch UI hiding for hybrid pointer devices

### DIFF
--- a/apps/web/src/gamePlayer.test.ts
+++ b/apps/web/src/gamePlayer.test.ts
@@ -9,9 +9,9 @@ describe('embedGameHtml', () => {
     // Style + script land inside <head> so rAF patches precede game scripts.
     expect(out).toContain('<style id="gdpl-embed">');
     expect(out).toContain('#game-title,#game-desc,.game-controls,.hint{display:none!important}');
-    // Desktop mouse: hide buttons-only GameKit chrome (pointer-native tactics UIs).
-    expect(out).toContain('@media not all and (any-pointer:coarse)');
-    expect(out).toContain('.gamekit-touch:not(:has(.gamekit-touch-pad))');
+    // Fine/hover primary pointer (desktops, incl. hybrid touchscreens): no touch chrome.
+    expect(out).toContain('@media (hover:hover),(pointer:fine)');
+    expect(out).toContain('.gamekit-touch{display:none!important}');
     expect(out).toContain('gdpl-player');
     expect(out.indexOf('<style id="gdpl-embed">')).toBeLessThan(out.indexOf('</head>'));
     expect(out.indexOf('<script>')).toBeLessThan(out.indexOf('</head>'));

--- a/apps/web/src/gamePlayer.ts
+++ b/apps/web/src/gamePlayer.ts
@@ -396,10 +396,7 @@ const BRIDGE = `(function(){
 // Fit the logical canvas to the iframe without distorting pointer coordinates.
 const HIDE_CHROME =
   `#game-title,#game-desc,.game-controls,.hint{display:none!important}` +
-  // Hide all GameKit touch chrome when the primary pointer is fine or can hover:
-  // hybrid mouse+touchscreen devices match any-pointer:coarse and used to get the
-  // full phone pad+button overlay on top of a desktop-sized playfield. Keyboard
-  // and mouse still work; real phones (hover:none + pointer:coarse) keep the pad.
+  // Hide touch chrome on hover/fine pointers; hybrid touchscreens are not phones.
   `@media (hover:hover),(pointer:fine){` +
   `.gamekit-touch{display:none!important}` +
   `}` +

--- a/apps/web/src/gamePlayer.ts
+++ b/apps/web/src/gamePlayer.ts
@@ -396,9 +396,12 @@ const BRIDGE = `(function(){
 // Fit the logical canvas to the iframe without distorting pointer coordinates.
 const HIDE_CHROME =
   `#game-title,#game-desc,.game-controls,.hint{display:none!important}` +
-  // Hide buttons-only GameKit chrome on mouse desktops.
-  `@media not all and (any-pointer:coarse){` +
-  `.gamekit-touch:not(:has(.gamekit-touch-pad)){display:none!important}` +
+  // Hide all GameKit touch chrome when the primary pointer is fine or can hover:
+  // hybrid mouse+touchscreen devices match any-pointer:coarse and used to get the
+  // full phone pad+button overlay on top of a desktop-sized playfield. Keyboard
+  // and mouse still work; real phones (hover:none + pointer:coarse) keep the pad.
+  `@media (hover:hover),(pointer:fine){` +
+  `.gamekit-touch{display:none!important}` +
   `}` +
   `html,body{width:100%;height:100%;margin:0;background:#000}` +
   `body{display:flex;align-items:center;justify-content:center;` +


### PR DESCRIPTION
## Summary
Updated the CSS media query logic for hiding GameKit touch UI chrome to better handle hybrid mouse+touchscreen devices while preserving the touch interface on actual mobile phones.

## Key Changes
- Changed media query from `@media not all and (any-pointer:coarse)` to `@media (hover:hover),(pointer:fine)` to more accurately detect devices with fine/hoverable primary pointers
- Simplified the selector from `.gamekit-touch:not(:has(.gamekit-touch-pad))` to `.gamekit-touch` since the new media query is more precise
- Updated test expectations to match the new media query and selector logic

## Implementation Details
The previous approach used a negative selector that only hid touch UI on devices without coarse pointers, which incorrectly showed the full phone pad+button overlay on hybrid devices (mouse+touchscreen). These devices report `any-pointer:coarse` due to having both input types, but users primarily interact via mouse/keyboard on desktop-sized playfields.

The new approach uses positive selectors for devices with hover capability or fine pointers, which correctly identifies:
- Desktop computers with mice (hover:hover)
- Hybrid touchscreen devices used with mouse (pointer:fine)
- While preserving the touch UI on actual phones (hover:none + pointer:coarse)

This provides a better user experience on hybrid devices by hiding the touch-optimized overlay when the primary interaction method is mouse/keyboard.

https://claude.ai/code/session_01PVsxn4fjeuRHgvy5FVAw9d