### PR TITLE
Fix secret version validation in deployment scripts

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -119,7 +119,11 @@ jobs:
           if gcloud secrets describe meta-api-key --project "$PROJECT_ID" >/dev/null 2>&1; then
             SECRET_MAPPINGS+=("SEED_META_API_KEY=meta-api-key:latest")
           fi
-          if gcloud secrets describe openrouter-api-key --project "$PROJECT_ID" >/dev/null 2>&1; then
+          # describe only proves the secret container exists, not that it has a
+          # version — a container created without a version passes describe but
+          # makes --set-secrets fail deploy with "...versions/latest was not
+          # found" (2026-08-21 incident). Check for an accessible version instead.
+          if gcloud secrets versions access latest --secret=openrouter-api-key --project "$PROJECT_ID" >/dev/null 2>&1; then
             SECRET_MAPPINGS+=("SEED_OPENROUTER_API_KEY=openrouter-api-key:latest")
           fi
 

--- a/infra/deploy-api.sh
+++ b/infra/deploy-api.sh
@@ -234,7 +234,11 @@ if gcloud secrets describe meta-api-key --project "$PROJECT_ID" >/dev/null 2>&1;
   SECRET_MAPPINGS+=("SEED_META_API_KEY=meta-api-key:latest")
   echo "==> meta-api-key found; selectable as a seed provider once SEED_META_MODEL is also set."
 fi
-if gcloud secrets describe openrouter-api-key --project "$PROJECT_ID" >/dev/null 2>&1; then
+# describe only proves the secret container exists, not that it has a version
+# — a container created without a version passes describe but makes
+# --set-secrets fail deploy with "...versions/latest was not found"
+# (2026-08-21 incident). Check for an accessible version instead.
+if gcloud secrets versions access latest --secret=openrouter-api-key --project "$PROJECT_ID" >/dev/null 2>&1; then
   SECRET_MAPPINGS+=("SEED_OPENROUTER_API_KEY=openrouter-api-key:latest")
   echo "==> openrouter-api-key found; selectable as a seed provider once SEED_OPENROUTER_MODEL is also set."
 fi


### PR DESCRIPTION
## Summary
Updated secret validation logic in deployment scripts to check for actual secret versions rather than just secret container existence. This prevents deployment failures when a secret container exists but has no accessible versions.

## Key Changes
- **`.github/workflows/deploy.yml`**: Changed `openrouter-api-key` validation from `gcloud secrets describe` to `gcloud secrets versions access latest`
- **`infra/deploy-api.sh`**: Applied the same validation fix for `openrouter-api-key`
- Added explanatory comments documenting the issue: secret containers can exist without versions, causing `--set-secrets` to fail with "versions/latest was not found" errors

## Implementation Details
The fix replaces the existence check (`gcloud secrets describe`) with a version accessibility check (`gcloud secrets versions access latest`). This ensures that only secrets with actual accessible versions are added to `SECRET_MAPPINGS`, preventing deployment failures that occurred in the 2026-08-21 incident.

Both files were updated consistently to maintain parity between the GitHub Actions workflow and the local deployment script.

https://claude.ai/code/session_01PhfFvmbR8oHv8AH2pP5wjR