### PR TITLE
fix(ci): build packages before publishing the games snapshot

### DIFF
--- a/.github/workflows/publish-games.yml
+++ b/.github/workflows/publish-games.yml
@@ -85,6 +85,8 @@ jobs:
 
       - run: npm ci
 
+      - run: npm run build:packages
+
       - name: Resolve games-repo ref
         env:
           VALIDATED_SHA: ${{ needs.validate-games.outputs.games_sha }}


### PR DESCRIPTION
## Summary

The "Publish games snapshot" workflow has been failing since before this session's Phase 1 PRs (already red on `21976f20`, well before #942/#943 merged) — first spotted while verifying #943's deploy.

- `publish-snapshot.ts` runs through `apps/api/src/github-client.ts`, which imports from `@gamedevpl/contract`.
- The workflow runs `npm ci` but never builds the workspace packages, so `packages/contract/dist/index.js` doesn't exist when the script runs, and it dies with `ERR_MODULE_NOT_FOUND`.
- Every other workflow in this repo already runs `npm run build:packages` before anything that needs it; this one was missing that step.

Fix: add the same `npm run build:packages` step, right after `npm ci`.

## Test plan

- [x] Locally: `rm -rf packages/contract/dist && npm run build:packages` — confirms `dist/index.js` is produced
- [x] Locally: `npx tsx scripts/publish-snapshot.ts --ref <sha> --dry-run` after the build — module resolution succeeds; the script reaches its GitHub API call and only fails on a 401 (no `GAMES_REPO_TOKEN` outside CI), which is expected
- [x] `npm run lint` — clean (YAML-only change, no baseline impact)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VaPzGSyNfZ7nvGcJgYNSdL)_