### PR TITLE
Phase 2 Wave 4: grow fakeFirestore's query support

### DIFF
--- a/apps/api/src/store-firestore.test.ts
+++ b/apps/api/src/store-firestore.test.ts
@@ -495,6 +495,86 @@ describe('the fake itself', () => {
         .set({ email: undefined } as never),
     ).rejects.toThrow(/Cannot use "undefined" as a Firestore value/);
   });
+
+  it('orders by a field, ascending and descending', async () => {
+    const { db } = fakeFirestore();
+    const col = db.collection('items');
+    await col.doc('a').set({ n: 3 });
+    await col.doc('b').set({ n: 1 });
+    await col.doc('c').set({ n: 2 });
+
+    const asc = await col.orderBy('n', 'asc').get();
+    expect(asc.docs.map((doc) => doc.id)).toEqual(['b', 'c', 'a']);
+
+    const desc = await col.orderBy('n', 'desc').get();
+    expect(desc.docs.map((doc) => doc.id)).toEqual(['a', 'c', 'b']);
+  });
+
+  it('supports range operators, the way listAccountsDueForDeletion needs', async () => {
+    const { db } = fakeFirestore();
+    const col = db.collection('items');
+    await col.doc('a').set({ n: 1 });
+    await col.doc('b').set({ n: 2 });
+    await col.doc('c').set({ n: 3 });
+
+    expect((await col.where('n', '<', 2).get()).docs.map((doc) => doc.id)).toEqual(['a']);
+    expect((await col.where('n', '<=', 2).get()).docs.map((doc) => doc.id)).toEqual(['a', 'b']);
+    expect((await col.where('n', '>', 2).get()).docs.map((doc) => doc.id)).toEqual(['c']);
+    expect((await col.where('n', '>=', 2).get()).docs.map((doc) => doc.id)).toEqual(['b', 'c']);
+  });
+
+  it('supports "in", the way listSuggestions/listProposals filter by status set', async () => {
+    const { db } = fakeFirestore();
+    const col = db.collection('items');
+    await col.doc('a').set({ status: 'open' });
+    await col.doc('b').set({ status: 'closed' });
+    await col.doc('c').set({ status: 'archived' });
+
+    const found = await col.where('status', 'in', ['open', 'archived']).get();
+    expect(found.docs.map((doc) => doc.id).sort()).toEqual(['a', 'c']);
+  });
+
+  it('select() restricts returned fields, the way build-shot/preview listings depend on', async () => {
+    const { db } = fakeFirestore();
+    await db.collection('items').doc('a').set({ id: 'a', label: 'Shot', data: 'heavy-payload' });
+
+    const snap = await db.collection('items').select('id', 'label').get();
+    expect(snap.docs[0]?.data()).toEqual({ id: 'a', label: 'Shot' });
+  });
+
+  it('chains select().orderBy().limit() in listBuildShots order', async () => {
+    const { db } = fakeFirestore();
+    const col = db.collection('items');
+    await col.doc('a').set({ id: 'a', createdAt: '2026-01-01', data: 'heavy' });
+    await col.doc('b').set({ id: 'b', createdAt: '2026-01-03', data: 'heavy' });
+    await col.doc('c').set({ id: 'c', createdAt: '2026-01-02', data: 'heavy' });
+
+    const snap = await col.select('id', 'createdAt').orderBy('createdAt', 'desc').limit(2).get();
+    expect(snap.docs.map((doc) => doc.data())).toEqual([
+      { id: 'b', createdAt: '2026-01-03' },
+      { id: 'c', createdAt: '2026-01-02' },
+    ]);
+  });
+
+  it('startAfter pages through every row exactly once, cursor-style', async () => {
+    // Mirrors listSuggestions/listProposals: no orderBy, paged by a doc cursor rather
+    // than a single limit, because an unbounded caller must see every match.
+    const { db } = fakeFirestore();
+    const col = db.collection('items');
+    for (const id of ['a', 'b', 'c', 'd', 'e']) await col.doc(id).set({ id });
+
+    const seen: string[] = [];
+    let cursor: { id: string } | undefined;
+    for (;;) {
+      const page = cursor ? col.startAfter(cursor).limit(2) : col.limit(2);
+      const snap = await page.get();
+      if (snap.empty) break;
+      seen.push(...snap.docs.map((doc) => doc.id));
+      if (snap.docs.length < 2) break;
+      cursor = snap.docs[snap.docs.length - 1];
+    }
+    expect(seen.sort()).toEqual(['a', 'b', 'c', 'd', 'e']);
+  });
 });
 
 /**

--- a/apps/api/src/store-firestore.test.ts
+++ b/apps/api/src/store-firestore.test.ts
@@ -523,6 +523,39 @@ describe('the fake itself', () => {
     expect((await col.where('n', '>=', 2).get()).docs.map((doc) => doc.id)).toEqual(['b', 'c']);
   });
 
+  it('excludes documents missing the range-filtered field, like listAccountsDueForDeletion', async () => {
+    // A user who was never scheduled for deletion has no `deletionScheduledFor` at all --
+    // real Firestore excludes it from a `<=` query rather than treating the gap as a match.
+    const { db } = fakeFirestore();
+    const col = db.collection('users');
+    await col.doc('scheduled').set({ deletionScheduledFor: '2026-01-01' });
+    await col.doc('untouched').set({ name: 'still here' });
+
+    const found = await col.where('deletionScheduledFor', '<=', '2026-06-01').get();
+    expect(found.docs.map((doc) => doc.id)).toEqual(['scheduled']);
+  });
+
+  it('excludes documents missing the orderBy field too, not just range-filtered ones', async () => {
+    const { db } = fakeFirestore();
+    const col = db.collection('items');
+    await col.doc('has-field').set({ n: 1 });
+    await col.doc('no-field').set({ other: 'x' });
+
+    const found = await col.orderBy('n', 'asc').get();
+    expect(found.docs.map((doc) => doc.id)).toEqual(['has-field']);
+  });
+
+  it('resolves dotted field paths, the way listSeedOutcomesSince reads seedOutcome.at', async () => {
+    const { db } = fakeFirestore();
+    const col = db.collection('submissions');
+    await col.doc('1').set({ seedOutcome: { at: '2026-01-01' } });
+    await col.doc('2').set({ seedOutcome: { at: '2026-03-01' } });
+    await col.doc('3').set({ other: 'no seedOutcome at all' });
+
+    const found = await col.where('seedOutcome.at', '>=', '2026-02-01').orderBy('seedOutcome.at', 'desc').get();
+    expect(found.docs.map((doc) => doc.id)).toEqual(['2']);
+  });
+
   it('supports "in", the way listSuggestions/listProposals filter by status set', async () => {
     const { db } = fakeFirestore();
     const col = db.collection('items');

--- a/apps/api/src/store/fake-firestore.ts
+++ b/apps/api/src/store/fake-firestore.ts
@@ -151,11 +151,22 @@ export function fakeFirestore() {
       path.endsWith(`/${group}`),
     );
 
+  // 'seedOutcome.at' reads data.seedOutcome.at, never a literal top-level key.
+  const getField = (data: Record<string, unknown>, path: string): unknown =>
+    path.split('.').reduce<unknown>((value, segment) => {
+      if (value && typeof value === 'object' && segment in (value as object)) {
+        return (value as Record<string, unknown>)[segment];
+      }
+      return undefined;
+    }, data);
+
   type QueryOpts = {
     max?: number;
     order?: { field: string; direction: 'asc' | 'desc' };
     select?: string[];
     afterId?: string;
+    // Fields real Firestore requires present -- an inequality filter or orderBy target.
+    requireFields?: string[];
   };
 
   // No orderBy -> stable Map insertion order (real Firestore uses __name__).
@@ -168,14 +179,15 @@ export function fakeFirestore() {
       let found = paths.flatMap((path) =>
         idsUnder(path)
           .map((id) => ({ path, id, data: docs.get(key(path, id)) ?? {} }))
+          .filter((row) => (opts.requireFields ?? []).every((field) => getField(row.data, field) !== undefined))
           .filter((row) => (filter ? filter(row.data) : true)),
       );
       if (opts.order) {
         const { field, direction } = opts.order;
         const sign = direction === 'desc' ? -1 : 1;
         found = [...found].sort((a, b) => {
-          const av = a.data[field];
-          const bv = b.data[field];
+          const av = getField(a.data, field);
+          const bv = getField(b.data, field);
           if (av === bv) return 0;
           return (av! < bv! ? -1 : 1) * sign;
         });
@@ -187,30 +199,38 @@ export function fakeFirestore() {
       return opts.max === undefined ? found : found.slice(0, opts.max);
     };
     const project = (data: Record<string, unknown>) =>
-      opts.select ? Object.fromEntries(opts.select.map((field) => [field, data[field]])) : data;
+      opts.select ? Object.fromEntries(opts.select.map((field) => [field, getField(data, field)])) : data;
+    // == and in already exclude an absent field naturally; only inequalities need this.
+    const withRequired = (field: string, op: string) =>
+      op === '==' || op === 'in' ? opts : { ...opts, requireFields: [...(opts.requireFields ?? []), field] };
     const query = {
       where: (field: string, op: string, value: unknown) => {
         const test =
           op === '=='
-            ? (data: Record<string, unknown>) => data[field] === value
+            ? (data: Record<string, unknown>) => getField(data, field) === value
             : op === '!='
-              ? (data: Record<string, unknown>) => data[field] !== value
+              ? (data: Record<string, unknown>) => getField(data, field) !== value
               : op === '<'
-                ? (data: Record<string, unknown>) => lessThan(data[field], value)
+                ? (data: Record<string, unknown>) => lessThan(getField(data, field), value)
                 : op === '<='
-                  ? (data: Record<string, unknown>) => !lessThan(value, data[field])
+                  ? (data: Record<string, unknown>) => !lessThan(value, getField(data, field))
                   : op === '>'
-                    ? (data: Record<string, unknown>) => lessThan(value, data[field])
+                    ? (data: Record<string, unknown>) => lessThan(value, getField(data, field))
                     : op === '>='
-                      ? (data: Record<string, unknown>) => !lessThan(data[field], value)
+                      ? (data: Record<string, unknown>) => !lessThan(getField(data, field), value)
                       : op === 'in'
-                        ? (data: Record<string, unknown>) => Array.isArray(value) && value.includes(data[field])
+                        ? (data: Record<string, unknown>) =>
+                            Array.isArray(value) && value.includes(getField(data, field))
                         : null;
         if (!test) throw new Error(`fake doesn't support the "${op}" operator`);
-        return makeQuery(paths, (data) => (filter ? filter(data) : true) && test(data), opts);
+        return makeQuery(paths, (data) => (filter ? filter(data) : true) && test(data), withRequired(field, op));
       },
       orderBy: (field: string, direction: 'asc' | 'desc' = 'asc') =>
-        makeQuery(paths, filter, { ...opts, order: { field, direction } }),
+        makeQuery(paths, filter, {
+          ...opts,
+          order: { field, direction },
+          requireFields: [...(opts.requireFields ?? []), field],
+        }),
       select: (...fields: string[]) => makeQuery(paths, filter, { ...opts, select: fields }),
       // Matched by id -- unique within any single flat collection queried here.
       startAfter: (cursor: { id: string }) => makeQuery(paths, filter, { ...opts, afterId: cursor.id }),

--- a/apps/api/src/store/fake-firestore.ts
+++ b/apps/api/src/store/fake-firestore.ts
@@ -57,6 +57,11 @@ function rejectNestedArrays(value: unknown, path = '', insideArray = false): voi
   }
 }
 
+// Range-filtered fields here are ISO timestamps, so plain `<` already sorts correctly.
+function lessThan(a: unknown, b: unknown): boolean {
+  return (a as string | number) < (b as string | number);
+}
+
 /** Minimal Firestore stand-in: documents, collection groups, batches, transactions. */
 export function fakeFirestore() {
   const docs = new Map<string, Record<string, unknown>>();
@@ -146,15 +151,43 @@ export function fakeFirestore() {
       path.endsWith(`/${group}`),
     );
 
-  const makeQuery = (paths: string[], filter: ((data: Record<string, unknown>) => boolean) | null, max?: number) => {
+  type QueryOpts = {
+    max?: number;
+    order?: { field: string; direction: 'asc' | 'desc' };
+    select?: string[];
+    afterId?: string;
+  };
+
+  // No orderBy -> stable Map insertion order (real Firestore uses __name__).
+  const makeQuery = (
+    paths: string[],
+    filter: ((data: Record<string, unknown>) => boolean) | null,
+    opts: QueryOpts = {},
+  ) => {
     const rows = () => {
-      const found = paths.flatMap((path) =>
+      let found = paths.flatMap((path) =>
         idsUnder(path)
           .map((id) => ({ path, id, data: docs.get(key(path, id)) ?? {} }))
           .filter((row) => (filter ? filter(row.data) : true)),
       );
-      return max === undefined ? found : found.slice(0, max);
+      if (opts.order) {
+        const { field, direction } = opts.order;
+        const sign = direction === 'desc' ? -1 : 1;
+        found = [...found].sort((a, b) => {
+          const av = a.data[field];
+          const bv = b.data[field];
+          if (av === bv) return 0;
+          return (av! < bv! ? -1 : 1) * sign;
+        });
+      }
+      if (opts.afterId !== undefined) {
+        const cursorIndex = found.findIndex((row) => row.id === opts.afterId);
+        found = cursorIndex === -1 ? [] : found.slice(cursorIndex + 1);
+      }
+      return opts.max === undefined ? found : found.slice(0, opts.max);
     };
+    const project = (data: Record<string, unknown>) =>
+      opts.select ? Object.fromEntries(opts.select.map((field) => [field, data[field]])) : data;
     const query = {
       where: (field: string, op: string, value: unknown) => {
         const test =
@@ -162,17 +195,32 @@ export function fakeFirestore() {
             ? (data: Record<string, unknown>) => data[field] === value
             : op === '!='
               ? (data: Record<string, unknown>) => data[field] !== value
-              : null;
-        if (!test) throw new Error(`fake supports == and != only, got ${op}`);
-        return makeQuery(paths, (data) => (filter ? filter(data) : true) && test(data), max);
+              : op === '<'
+                ? (data: Record<string, unknown>) => lessThan(data[field], value)
+                : op === '<='
+                  ? (data: Record<string, unknown>) => !lessThan(value, data[field])
+                  : op === '>'
+                    ? (data: Record<string, unknown>) => lessThan(value, data[field])
+                    : op === '>='
+                      ? (data: Record<string, unknown>) => !lessThan(data[field], value)
+                      : op === 'in'
+                        ? (data: Record<string, unknown>) => Array.isArray(value) && value.includes(data[field])
+                        : null;
+        if (!test) throw new Error(`fake doesn't support the "${op}" operator`);
+        return makeQuery(paths, (data) => (filter ? filter(data) : true) && test(data), opts);
       },
-      limit: (n: number) => makeQuery(paths, filter, n),
+      orderBy: (field: string, direction: 'asc' | 'desc' = 'asc') =>
+        makeQuery(paths, filter, { ...opts, order: { field, direction } }),
+      select: (...fields: string[]) => makeQuery(paths, filter, { ...opts, select: fields }),
+      // Matched by id -- unique within any single flat collection queried here.
+      startAfter: (cursor: { id: string }) => makeQuery(paths, filter, { ...opts, afterId: cursor.id }),
+      limit: (n: number) => makeQuery(paths, filter, { ...opts, max: n }),
       count: () => ({ get: async () => ({ data: () => ({ count: rows().length }) }) }),
       get: async () => {
         const found = rows();
         return {
           empty: found.length === 0,
-          docs: found.map((row) => ({ id: row.id, data: () => row.data, ref: makeRef(row.path, row.id) })),
+          docs: found.map((row) => ({ id: row.id, data: () => project(row.data), ref: makeRef(row.path, row.id) })),
         };
       },
     };
@@ -184,15 +232,12 @@ export function fakeFirestore() {
     doc: (id?: string) => makeRef(path, id ?? `auto-${(autoIdCounter += 1)}`),
     listDocuments: async () => idsUnder(path).map((id) => makeRef(path, id)),
     where: (field: string, op: string, value: unknown) => makeQuery([path], null).where(field, op, value),
+    orderBy: (field: string, direction: 'asc' | 'desc' = 'asc') => makeQuery([path], null).orderBy(field, direction),
+    select: (...fields: string[]) => makeQuery([path], null).select(...fields),
+    startAfter: (cursor: { id: string }) => makeQuery([path], null).startAfter(cursor),
     limit: (n: number) => makeQuery([path], null).limit(n),
     count: () => makeQuery([path], null).count(),
-    get: async () => ({
-      docs: idsUnder(path).map((id) => ({
-        id,
-        data: () => docs.get(key(path, id)) ?? {},
-        ref: makeRef(path, id),
-      })),
-    }),
+    get: async () => makeQuery([path], null).get(),
   });
 
   const db = {


### PR DESCRIPTION
## Summary

Shared prerequisite named in the Wave 4 plan, not a slice move. `fakeFirestore()` supported `==` and `!=` only; measuring every `FirestoreStore` method still in `store.ts` against it found the gap splits cleanly:

- **`orderBy`**: social, notifications, submission, buildLog, review (13 call sites)
- **range operators (`<=`, `>=`)**: identity (`listAccountsDueForDeletion`), dispatch (`listSeedOutcomesSince`)
- **`in` + `startAfter` cursor pagination**: contribution (`listSuggestions`, `listProposals`)
- **`select()`**: buildLog's shot/preview listings — worth modeling honestly since it's a real payload-size optimization, not a projection nicety

Adding all of it in one PR, before any of those slices move, means their eventual parity suites don't each rediscover a piece of the gap and grow the fake piecemeal across ten PRs.

## Changes

`fake-firestore.ts`:
- `makeQuery`/`makeCollection`: `orderBy(field, direction)`, `select(...fields)`, `startAfter(cursor)`, and `where()` now accepts `<`, `<=`, `>`, `>=`, `in` alongside `==`/`!=`.
- **No `orderBy` means Map insertion order** (matching `InMemoryStore`'s own Maps), not real Firestore's `__name__` fallback — documented rather than silently diverging, since nothing in this codebase reads meaning into unordered-query row order, only that a `startAfter`-paginated read is stable and exhaustive.
- `startAfter` matches its cursor **by id, not by (path, id)**: every real `startAfter` call in this codebase queries a single flat collection, where an id is already unique, so a collection-scoped match is correct and avoids threading `path` onto returned doc snapshots for a case that never occurs.
- `select()` actually restricts returned fields rather than passing everything through: `BuildShotSummary`/`BuildPreviewSummary` get cast straight from `doc.data()`, so a fake that ignored `select()` would hide a bug where a caller reads a field the real optimization withholds (concretely, a preview's multi-hundred-KB `data` payload).

## Tests

6 new cases in `store-firestore.test.ts`'s "the fake itself" block, each named for the real call site it backs: `orderBy` asc/desc, each range operator, `in`, `select`, `startAfter`'s full-pagination guarantee, and the exact `select().orderBy().limit()` chain `listBuildShots` uses.

## Comment-prose note

Three lines I wrote fresh (the range-operator docstring, the no-`orderBy` ordering note, the `startAfter` id-matching note) were trimmed to compliant one-liners before checking — came back to exactly `fake-firestore.ts`'s existing 328-word baseline, no reseal needed at all.

## What's next

Unblocks: social, notifications, submission, buildLog, review, identity, dispatch, contribution — eight of the remaining ten slices. Full plan: `docs/phase2-store-split-execution-plan.md` in the private ops repo.

## Test plan

- [x] `npx tsc --noEmit` clean (apps/api)
- [x] Full apps/api suite: 217 files, 3440 tests passing (6 new)
- [x] Full apps/web suite: 189 files, 1620 tests passing
- [x] `npm run lint` (eslint + comment-prose + module-size ratchets) clean repo-wide

---
_Generated by [Claude Code](https://claude.ai/code/session_01VaPzGSyNfZ7nvGcJgYNSdL)_