### PR TITLE
Fix stale destructive annotations, deploy-script parity, and domain-verification docs

### DIFF
--- a/infra/deploy-api.sh
+++ b/infra/deploy-api.sh
@@ -413,6 +413,12 @@ fi
 if [ -n "${REVIEWER_UIDS:-}" ]; then
   ENV_VARS="${ENV_VARS}|REVIEWER_UIDS=${REVIEWER_UIDS}"
 fi
+# OpenAI Apps domain-verification token (openai-apps-challenge.ts). Per-submission,
+# not a secret, and rotates — a repo/shell variable, not Secret Manager. Unset means
+# the route 404s, which is the correct default outside an active submission.
+if [ -n "${OPENAI_APPS_CHALLENGE_TOKEN:-}" ]; then
+  ENV_VARS="${ENV_VARS}|OPENAI_APPS_CHALLENGE_TOKEN=${OPENAI_APPS_CHALLENGE_TOKEN}"
+fi
 if [ -n "$MAIL_FROM" ]; then
   ENV_VARS="${ENV_VARS}|MAIL_FROM=${MAIL_FROM}"
 fi

--- a/listings/mcp/chatgpt-apps-connector/listing.md
+++ b/listings/mcp/chatgpt-apps-connector/listing.md
@@ -101,9 +101,18 @@ to prevent.
 
 ## Domain verification
 
-OpenAI may require a challenge file at `/.well-known/openai-apps-challenge` on the MCP
-host (or parent). **Do not add that route until the owner starts a real submission** —
-the token is issued by the portal per submission.
+The route is already live: `apps/api/src/openai-apps-challenge.ts` serves
+`GET /.well-known/openai-apps-challenge` from `OPENAI_APPS_CHALLENGE_TOKEN`, 404 when
+unset. Nothing to build — only owner steps remain:
+
+1. Start (or resume) the submission on the OpenAI Platform portal; it issues a token
+   for domain verification.
+2. Set `OPENAI_APPS_CHALLENGE_TOKEN` on the Cloud Run service (not a secret — it is
+   public per its own design, and rotates per submission) — `infra/deploy-api.sh` now
+   carries it through redeploys as long as the shell variable is exported when the
+   script runs, same pattern as `ADMIN_UIDS`/`REVIEWER_UIDS`.
+3. Let OpenAI fetch and verify it, then clear the variable once verification is done
+   (it is not needed outside an active submission).
 
 ## Directory change (2026-07-09) and submission notes
 

--- a/listings/mcp/chatgpt-apps-connector/listing.md
+++ b/listings/mcp/chatgpt-apps-connector/listing.md
@@ -174,8 +174,10 @@ Everything below needs the owner; none of it can be prepared in-repo:
    rejection. Note the tension with the account requirement: the reviewer needs an account
    that can actually open a round, so this is a real provisioning decision, not a form
    field.
-4. **Starting the submission**, which mints the `/.well-known/openai-apps-challenge` token.
-   The route stays unbuilt until then.
+4. **Starting the submission**, which mints the `/.well-known/openai-apps-challenge` token —
+   set (or confirm) it as the `OPENAI_APPS_CHALLENGE_TOKEN` Actions variable per the Domain
+   verification section above. The route itself is already built and live; only the token
+   value is per-submission.
 
 The eight test cases above and the field table are ready to paste; the four items here are
 the whole remaining cost.

--- a/listings/mcp/chatgpt-apps-connector/listing.md
+++ b/listings/mcp/chatgpt-apps-connector/listing.md
@@ -101,18 +101,25 @@ to prevent.
 
 ## Domain verification
 
-The route is already live: `apps/api/src/openai-apps-challenge.ts` serves
-`GET /.well-known/openai-apps-challenge` from `OPENAI_APPS_CHALLENGE_TOKEN`, 404 when
-unset. Nothing to build — only owner steps remain:
+The route is already live and already wired: `apps/api/src/openai-apps-challenge.ts`
+serves `GET /.well-known/openai-apps-challenge` from `OPENAI_APPS_CHALLENGE_TOKEN`
+(404 when unset), and `.github/workflows/deploy.yml` — the actual CI/CD path, not
+`infra/deploy-api.sh` (that one is owner-run, local-only, never invoked by CI) —
+already threads it from the GitHub Actions repo **variable** `vars.OPENAI_APPS_CHALLENGE_TOKEN`
+into every automated deploy, same pattern as `MP_RELAY_URL`/`ZONE_HOST_URL`/`REMIX_DEBUG`.
+Confirmed live 2026-08-23: the endpoint already returns a token, so this variable is
+already set. Nothing to build, nothing to redo on every deploy — only owner steps:
 
 1. Start (or resume) the submission on the OpenAI Platform portal; it issues a token
    for domain verification.
-2. Set `OPENAI_APPS_CHALLENGE_TOKEN` on the Cloud Run service (not a secret — it is
-   public per its own design, and rotates per submission) — `infra/deploy-api.sh` now
-   carries it through redeploys as long as the shell variable is exported when the
-   script runs, same pattern as `ADMIN_UIDS`/`REVIEWER_UIDS`.
-3. Let OpenAI fetch and verify it, then clear the variable once verification is done
-   (it is not needed outside an active submission).
+2. Set (or confirm) the **Actions variable** `OPENAI_APPS_CHALLENGE_TOKEN` in this
+   repo's Settings → Secrets and variables → Actions → Variables (a variable, not a
+   secret — the whole point is that it's public). A merge to `master` deploys it
+   automatically from there; no manual Cloud Run edit, no `infra/deploy-api.sh` run
+   needed for the normal path.
+3. Let OpenAI fetch and verify it, then clear the Actions variable once verification
+   is done (it is not needed outside an active submission) — clearing it takes effect
+   on the next deploy, same threading rule in reverse.
 
 ## Directory change (2026-07-09) and submission notes
 

--- a/listings/mcp/chatgpt-apps-connector/tool-annotations.md
+++ b/listings/mcp/chatgpt-apps-connector/tool-annotations.md
@@ -206,10 +206,10 @@ Calls only the gamedev.pl API on our own domain. It performs no web access, cont
 Queues generation of a replacement starter draft for the round, which writes state.
 ```
 
-**Destructive: False**
+**Destructive: True**
 
 ```
-Additive with respect to the agent's own work: it is refused once anything has been staged or delivered, so it can only replace a platform-generated draft nobody has built on. Nothing creator-authored is touched.
+Marked destructive because it replaces the round's current generated draft: once the replacement lands, the prior one is gone. It is refused once anything has been staged or delivered, so it can only ever discard a platform-generated draft, never creator-authored work — but replacing existing content is still not additive.
 ```
 
 **Idempotent: False**
@@ -466,10 +466,10 @@ Calls only the gamedev.pl API on our own domain. It performs no web access, cont
 Appends a progress note to the creator's thread for this round, which writes state.
 ```
 
-**Destructive: False**
+**Destructive: True**
 
 ```
-Append-only: it adds a note. Earlier notes are not edited or removed.
+Marked destructive because it sends a persistent, creator-visible message that this tool cannot retract or edit — the same reasoning that already applies to a closing summary from end.
 ```
 
 **Idempotent: False**
@@ -700,16 +700,16 @@ Calls only the gamedev.pl API on our own domain. It performs no web access, cont
 Commits and closes the round, which writes state.
 ```
 
-**Destructive: False**
+**Destructive: True**
 
 ```
-It closes a round rather than destroying its contents: delivered sources, screenshots, progress notes and the gate verdict all remain.
+Marked destructive because it can send a persistent, unretractable closing message (same reasoning as report_progress) and, via ackInboxIds, acknowledge creator messages so they stop being surfaced to the agent (same reasoning as ack_inbox) — even though delivered sources, screenshots, progress notes and the gate verdict all remain untouched.
 ```
 
 **Idempotent: True**
 
 ```
-Calling it again on a closed round changes nothing.
+Calling it again on a closed round changes nothing further; re-acknowledging already-acked ids is a no-op the same way ack_inbox is.
 ```
 
 **Open World: False**


### PR DESCRIPTION
## Summary

Three small, independent follow-ups found while cross-checking the MCP listing artifacts against the live server and deploy pipeline:

**`listings/mcp/chatgpt-apps-connector/tool-annotations.md`**
- Syncs the justification doc with `regenerate_seed`, `report_progress`, and `end` moving from `WRITES` to `CONSUMES` (`destructiveHint: true`) — replacing existing draft content, sending an unretractable creator message, and `end`'s `ackInboxIds` side effect respectively. The doc still claimed these were purely additive.

**`infra/deploy-api.sh`**
- Adds `OPENAI_APPS_CHALLENGE_TOKEN` to the preserved-env-var list, following the existing `ADMIN_UIDS`/`REVIEWER_UIDS` pattern. This script's `--set-env-vars` replaces the whole map on every run, so a hand-set value would otherwise be silently wiped by the next deploy through this script.

**`listings/mcp/chatgpt-apps-connector/listing.md`**
- Corrects two stale notes: the `/.well-known/openai-apps-challenge` route already exists in code (`apps/api/src/openai-apps-challenge.ts`), and the actual production deploy path is `.github/workflows/deploy.yml` (CI-triggered), not `infra/deploy-api.sh` (owner-run, local-only, never invoked by CI). The workflow already threads the token from the GitHub Actions repo variable `vars.OPENAI_APPS_CHALLENGE_TOKEN`, same pattern as `MP_RELAY_URL`/`ZONE_HOST_URL`. Confirmed live: the endpoint already returns a token, so that variable is already configured.

## Notes
- No behavior change to the live server — `mcp-server.ts` itself already had the correct annotations from an earlier commit; this just brings the doc and infra script in line.
- Docs-and-infra only; `mcp-server.test.ts` (92 tests) unaffected and passing.

https://claude.ai/code/session_01JMiLn3fSV2yj13wvuHdPYb

---
_Generated by [Claude Code](https://claude.ai/code/session_01JMiLn3fSV2yj13wvuHdPYb)_