### PR TITLE
mcp: steer agents to batch stage_upload_url for multiple files

### DIFF
--- a/.claude/skills/byoca-mcp/SKILL.md
+++ b/.claude/skills/byoca-mcp/SKILL.md
@@ -33,8 +33,8 @@ Source of truth: `SESSION_WORKFLOW` + `BEHAVIOURAL_CONTRACT` in
    base64 `send_screenshot` — PNG bytes must never enter the model. Without shell
    egress, skip mid-build screenshots; the gate still captures on delivery
 3. Prefer staging then `submit_sources({ fromStaged: true, mode, kitEngineRef })`
-   - **New/full rewrite with shell:** `stage_upload_url({ path })` or batch `stage_upload_url({ paths: [...] })` then
-     `curl --upload-file <file> "$url"` — bytes never re-enter the model; mint multiple URLs in one turn instead of looping
+   - **New/full rewrite with shell:** batch `stage_upload_url({ paths: [...] })` (or `stage_upload_url({ path })` for a single lone file) then
+     `curl --upload-file <file> "$url"` — bytes never re-enter the model; ALWAYS mint multiple URLs in one call with `paths: [...]` rather than looping or emitting multiple stage_upload_url calls
    - **New/full rewrite without shell:** `stage_source_file({ path, content })`
    - **Edits:** prefer `patch_source_file({ path, old, new })` (exact unique substring
      replace — no diff format), or `patch_source_file({ path, patches: [{ old, new }, ...] })`

--- a/.claude/skills/byoca-mcp/SKILL.md
+++ b/.claude/skills/byoca-mcp/SKILL.md
@@ -34,7 +34,7 @@ Source of truth: `SESSION_WORKFLOW` + `BEHAVIOURAL_CONTRACT` in
    egress, skip mid-build screenshots; the gate still captures on delivery
 3. Prefer staging then `submit_sources({ fromStaged: true, mode, kitEngineRef })`
    - **New/full rewrite with shell:** batch `stage_upload_url({ paths: [...] })` (or `stage_upload_url({ path })` for a single lone file) then
-     `curl --upload-file <file> "$url"` — bytes never re-enter the model; ALWAYS mint multiple URLs in one call with `paths: [...]` rather than looping or emitting multiple stage_upload_url calls
+     `curl --upload-file <file> "$url"` — bytes never re-enter the model; ALWAYS mint URLs in batch with `paths: [...]` up to 50 paths per call (chunking into batches of 50 if staging more), rather than looping or emitting multiple stage_upload_url calls per file
    - **New/full rewrite without shell:** `stage_source_file({ path, content })`
    - **Edits:** prefer `patch_source_file({ path, old, new })` (exact unique substring
      replace — no diff format), or `patch_source_file({ path, patches: [{ old, new }, ...] })`

--- a/apps/api/src/build-transcript.test.ts
+++ b/apps/api/src/build-transcript.test.ts
@@ -313,9 +313,7 @@ describe('loadBuildTranscript', () => {
       job(i + 1, `2026-08-${String(i + 10).padStart(2, '0')}T00:00:00.000Z`),
     );
     const store = fakeStore({ submissions: [current, ...siblings] });
-
     const page = await loadBuildTranscript(store, current);
-
     expect(page).not.toHaveProperty('truncatedAtSource');
   });
 
@@ -328,9 +326,7 @@ describe('loadBuildTranscript', () => {
       true,
     );
     const store = fakeStore({});
-
     const page = await loadBuildTranscript(store, current);
-
     expect(page.entries).toEqual([
       expect.objectContaining({ kind: 'agent_note', text: 'Evidence brief: players stall at level 2.' }),
     ]);

--- a/apps/api/src/build-transcript.ts
+++ b/apps/api/src/build-transcript.ts
@@ -13,14 +13,12 @@ export function stripPlaytestContext(text: string): string {
   const marker = text.indexOf(PLAYTEST_CONTEXT_HEADER);
   return marker === -1 ? text : text.slice(0, marker).trimEnd();
 }
-
 export type TranscriptEntry = {
   kind: 'creator_request' | 'agent_note' | 'build_progress';
   text: string;
   createdAt: string;
   round: 'current' | 'earlier';
 };
-
 // Rounds of the same game read into the transcript, current round included.
 export const MAX_TRANSCRIPT_ROUNDS = 6;
 // Per-round read ceiling — both lists return newest-first only.

--- a/apps/api/src/mcp-server.test.ts
+++ b/apps/api/src/mcp-server.test.ts
@@ -2056,7 +2056,7 @@ declare const GameKit: { defineGame(): unknown };
     };
     expect(path).toBe('game/extra.ts');
     expect(maxBytes).toBe(1_000_000);
-    expect(upload).toMatch(/^curl -H 'Content-Type: text\/plain; charset=utf-8' --upload-file extra\.ts '/);
+    expect(upload).toMatch(/^curl -H 'Content-Type: text\/plain; charset=utf-8' --upload-file game\/extra\.ts '/);
 
     const content = 'export const stagedViaCurl = true;\n';
     const put = await app.inject({

--- a/apps/api/src/mcp-server.test.ts
+++ b/apps/api/src/mcp-server.test.ts
@@ -2101,8 +2101,11 @@ declare const GameKit: { defineGame(): unknown };
     expect(batchMinted.isError).toBe(false);
     const batchStructured = batchMinted.structured as {
       uploads: Array<{ path: string; url: string; upload: string; maxBytes: number }>;
+      uploadScript?: string;
     };
     expect(batchStructured.uploads).toHaveLength(20);
+    expect(batchStructured.uploadScript).toContain('curl -H');
+    expect(batchStructured.uploadScript?.split(' && ')).toHaveLength(20);
 
     // Parallel concurrent PUT execution — verifies CAS retry resilience under 20-way concurrency
     const putResults = await Promise.all(

--- a/apps/api/src/mcp-server.test.ts
+++ b/apps/api/src/mcp-server.test.ts
@@ -2038,22 +2038,13 @@ declare const GameKit: { defineGame(): unknown };
     const { gamesStore } = stubGamesStore();
     app = await createApp(store, gamesStore);
     const sessionId = await initialize(app);
-    const started = await callTool(app, 'start', { key: roundKey() }, { 'mcp-session-id': sessionId });
-    const sessionKey = (started.structured as { sessionKey: string }).sessionKey;
+    const sid = { 'mcp-session-id': sessionId };
+    const started = await callTool(app, 'start', { key: roundKey() }, sid);
+    const sessionKey = (started.structured as Record<string, string>).sessionKey;
 
-    const minted = await callTool(
-      app,
-      'stage_upload_url',
-      { sessionKey, path: 'game/extra.ts' },
-      { 'mcp-session-id': sessionId },
-    );
+    const minted = await callTool(app, 'stage_upload_url', { sessionKey, path: 'game/extra.ts' }, sid);
     expect(minted.isError).toBe(false);
-    const { url, path, maxBytes, upload } = minted.structured as {
-      url: string;
-      path: string;
-      maxBytes: number;
-      upload: string;
-    };
+    const { url, path, maxBytes, upload } = minted.structured as Record<string, string | number>;
     expect(path).toBe('game/extra.ts');
     expect(maxBytes).toBe(1_000_000);
     expect(upload).toMatch(/^curl -H 'Content-Type: text\/plain; charset=utf-8' --upload-file game\/extra\.ts '/);
@@ -2061,7 +2052,7 @@ declare const GameKit: { defineGame(): unknown };
     const content = 'export const stagedViaCurl = true;\n';
     const put = await app.inject({
       method: 'PUT',
-      url: url.replace(/^https?:\/\/[^/]+/, ''),
+      url: (url as string).replace(/^https?:\/\/[^/]+/, ''),
       headers: { 'content-type': 'text/plain; charset=utf-8' },
       payload: Buffer.from(content, 'utf8'),
     });
@@ -2073,7 +2064,7 @@ declare const GameKit: { defineGame(): unknown };
       control: { stop: false },
     });
 
-    const listed = await callTool(app, 'list_staged_sources', { sessionKey }, { 'mcp-session-id': sessionId });
+    const listed = await callTool(app, 'list_staged_sources', { sessionKey }, sid);
     expect(listed.isError).toBe(false);
     const files = (listed.structured as { files: Array<{ path: string; bytes: number }> }).files;
     expect(files).toEqual(
@@ -2081,34 +2072,24 @@ declare const GameKit: { defineGame(): unknown };
     );
 
     // Path allowlisting and batch caps apply at mint time.
-    const bad = await callTool(
-      app,
-      'stage_upload_url',
-      { sessionKey, path: '../evil.ts' },
-      { 'mcp-session-id': sessionId },
-    );
+    const bad = await callTool(app, 'stage_upload_url', { sessionKey, path: '../evil.ts' }, sid);
     expect(bad.isError).toBe(true);
     expect(JSON.stringify(bad.structured)).toMatch(/illegal path/i);
     const tooMany = await callTool(
       app,
       'stage_upload_url',
       { sessionKey, paths: Array.from({ length: 51 }, (_, i) => `game/m${i}.ts`) },
-      { 'mcp-session-id': sessionId },
+      sid,
     );
     expect(tooMany.isError).toBe(true);
     expect(JSON.stringify(tooMany.structured)).toMatch(/too many paths in one request \(max 50/);
 
     // Batch path minting with paths: string[] (testing 20 concurrent PUTs)
     const testPaths = Array.from({ length: 20 }, (_, i) => `game/module-${i}.ts`);
-    const batchMinted = await callTool(
-      app,
-      'stage_upload_url',
-      { sessionKey, paths: testPaths },
-      { 'mcp-session-id': sessionId },
-    );
+    const batchMinted = await callTool(app, 'stage_upload_url', { sessionKey, paths: testPaths }, sid);
     expect(batchMinted.isError).toBe(false);
     const batchStructured = batchMinted.structured as {
-      uploads: Array<{ path: string; url: string; upload: string; maxBytes: number }>;
+      uploads: Array<{ path: string; url: string }>;
       uploadScript?: string;
     };
     expect(batchStructured.uploads).toHaveLength(20);
@@ -2131,7 +2112,7 @@ declare const GameKit: { defineGame(): unknown };
       expect(res.json()).toMatchObject({ accepted: true, path: testPaths[i] });
     });
 
-    const afterBatchList = await callTool(app, 'list_staged_sources', { sessionKey }, { 'mcp-session-id': sessionId });
+    const afterBatchList = await callTool(app, 'list_staged_sources', { sessionKey }, sid);
     expect(afterBatchList.isError).toBe(false);
     const afterFiles = (afterBatchList.structured as { files: Array<{ path: string; bytes: number }> }).files;
     expect(afterFiles.map((f) => f.path)).toEqual(expect.arrayContaining(['game/extra.ts', ...testPaths]));

--- a/apps/api/src/mcp-server.test.ts
+++ b/apps/api/src/mcp-server.test.ts
@@ -2118,15 +2118,10 @@ declare const GameKit: { defineGame(): unknown };
         }),
       ),
     );
-
-    for (let i = 0; i < putResults.length; i++) {
-      const putRes = putResults[i]!;
-      expect(putRes.statusCode).toBe(200);
-      expect(putRes.json()).toMatchObject({
-        accepted: true,
-        path: testPaths[i],
-      });
-    }
+    putResults.forEach((res, i) => {
+      expect(res.statusCode).toBe(200);
+      expect(res.json()).toMatchObject({ accepted: true, path: testPaths[i] });
+    });
 
     const afterBatchList = await callTool(app, 'list_staged_sources', { sessionKey }, { 'mcp-session-id': sessionId });
     expect(afterBatchList.isError).toBe(false);

--- a/apps/api/src/mcp-server.test.ts
+++ b/apps/api/src/mcp-server.test.ts
@@ -2080,7 +2080,7 @@ declare const GameKit: { defineGame(): unknown };
       expect.arrayContaining([{ path: 'game/extra.ts', bytes: Buffer.byteLength(content, 'utf8') }]),
     );
 
-    // Path allowlisting still applies at mint time.
+    // Path allowlisting and batch caps apply at mint time.
     const bad = await callTool(
       app,
       'stage_upload_url',
@@ -2089,6 +2089,14 @@ declare const GameKit: { defineGame(): unknown };
     );
     expect(bad.isError).toBe(true);
     expect(JSON.stringify(bad.structured)).toMatch(/illegal path/i);
+    const tooMany = await callTool(
+      app,
+      'stage_upload_url',
+      { sessionKey, paths: Array.from({ length: 51 }, (_, i) => `game/m${i}.ts`) },
+      { 'mcp-session-id': sessionId },
+    );
+    expect(tooMany.isError).toBe(true);
+    expect(JSON.stringify(tooMany.structured)).toMatch(/too many paths in one request \(max 50/);
 
     // Batch path minting with paths: string[] (testing 20 concurrent PUTs)
     const testPaths = Array.from({ length: 20 }, (_, i) => `game/module-${i}.ts`);

--- a/apps/api/src/mcp-server.ts
+++ b/apps/api/src/mcp-server.ts
@@ -632,7 +632,7 @@ const BEHAVIOURAL_CONTRACT = [
   // language they did not choose, which is the whole reason the field exists.
   "Write progress in the creator's language: when get_brief.locales[0] is not 'en', send report_progress with textLocalized and locale as well as the English text.",
   'Send a screenshot as soon as the game draws anything playable via screenshot_upload_url + curl --upload-file. There is no base64 screenshot tool — PNG bytes must never enter the model.',
-  'While iterating, deliver with mode=preview (no TRACE required). Prefer stage_upload_url ({ path } or { paths: [...] } batch) + curl --upload-file for new/rewritten paths when you have shell (bytes never re-enter the model; mint multiple URLs in one turn instead of looping). stage_source_file is the no-shell fallback. Prefer patch_source_file for edits — prefer old+new exact replace, or files: [{ path, old, new }, ...] to edit several files in one call; patch=unified diff also works (never re-emit a whole large render.ts/model.ts). To retire a path (an old game/*.ts module, or a hand-authored index.html/GAME.json field), call delete_source_file — staging empty content still delivers a live empty file, not a removal. Honour warnings.code=module_too_large by splitting before more feature work. Then submit_sources({ fromStaged:true, mode:"preview", kitEngineRef }) — fromStaged overlays onto the latest delivery/seed so only changed paths need staging. Avoid one giant files[] payload. Only mode=publish needs TRACE/PLAYTEST and can go green.',
+  'While iterating, deliver with mode=preview (no TRACE required). Prefer batch stage_upload_url({ paths: [...] }) + curl --upload-file for new/rewritten paths when you have shell (bytes never re-enter the model; ALWAYS mint all URLs in a single call with paths: [...] rather than emitting multiple stage_upload_url calls; use stage_upload_url({ path }) only for a lone file). stage_source_file is the no-shell fallback. Prefer patch_source_file for edits — prefer old+new exact replace, or files: [{ path, old, new }, ...] to edit several files in one call; patch=unified diff also works (never re-emit a whole large render.ts/model.ts). To retire a path (an old game/*.ts module, or a hand-authored index.html/GAME.json field), call delete_source_file — staging empty content still delivers a live empty file, not a removal. Honour warnings.code=module_too_large by splitting before more feature work. Then submit_sources({ fromStaged:true, mode:"preview", kitEngineRef }) — fromStaged overlays onto the latest delivery/seed so only changed paths need staging. Avoid one giant files[] payload. Only mode=publish needs TRACE/PLAYTEST and can go green.',
   'If the last gate was preview_failed / red / kit_outdated (warnings.code=must_fix_gate), fix then submit_sources again — do not stop at stage/patch/show_round. Staging does not re-run the gate; the creator card stays on the refused delivery until you submit.',
   'While iterating, run only npm run typecheck -- <slug> (no browser, npm ci, capture, playtest, or agency), then stage and submit_sources({ fromStaged: true, mode: "preview", kitEngineRef }); the server verifies the preview. If a browser is available and the draft is approaching delivery, optionally run npm run check:game -- <slug> --preview (typecheck → smoke → build). Run the full gate only immediately before a mode:"publish" seal.',
   'After submit_sources, if you will not deliver more this round, call end (required — warnings.code=call_end; submit already unlocks creator handoff). Prefer end over sitting in a get_gate_verdict loop — Studio shows the gate. Do not stop after submit alone without end. If you are fixing a refused gate, ignore call_end until after the next submit_sources.',
@@ -672,7 +672,7 @@ const SESSION_WORKFLOW: readonly string[] = [
   'Capability and "how do I…" questions: check get_kit_api first for exact kit-API surface (signatures, module names). knowledge_query is for everything get_kit_api does not cover — EditorKit internals, example-game patterns, docs/process, and broader capability questions — with citations and an indexedCommit; treat its prose as a pointer to verify via get_kit_api / read_kit_file, not a source of truth for exact signatures.',
   'Build the game — continuing the sources you fetched, otherwise from the kit; report_progress before and after long steps. Soft module budget: keep each game/*.ts under ~350 lines / ~12 KiB. When a file approaches that, split cohesive pieces (render→art/ui/hud/rooms; model→tables/layout/types; runtime→systems) before more feature work. Honour warnings.code=module_too_large the same way you honour call_end — act, then continue.',
   'As soon as the game draws anything playable: screenshot_upload_url then curl --upload-file <png> "$url". There is no base64 send path — PNG bytes must never enter the model. Without shell egress, skip mid-build screenshots; the gate still captures on delivery.',
-  'While iterating: run only npm run typecheck -- <slug> locally, then prefer stage_upload_url({ path }) or batch stage_upload_url({ paths: [...] }) and curl --upload-file <file> "$url" for new/rewritten paths when you have shell egress (bytes never re-enter the model; mint multiple URLs in one call rather than looping single calls). Fall back to stage_source_file({ path, content }) without shell. For edits prefer patch_source_file({ path, old, new }) — exact unique substring replace, no unified-diff arithmetic. Or patch_source_file({ files: [{ path, old, new }, ...] }) to edit several files in one call. Or patch_source_file({ path, patch }) with a unified diff (bare @@ ok). Stage only changed paths — never re-upload the whole tree. Then submit_sources({ fromStaged: true, mode: "preview", kitEngineRef }) — fromStaged overlays onto the latest delivery/seed and the server verifies it; no browser, npm ci, capture, playtest, or agency is required for this preview. If a browser is available near delivery, optionally run npm run check:game -- <slug> --preview. Run the full gate only immediately before a mode:"publish" seal. Inline files[] still works for tiny trees.',
+  'While iterating: run only npm run typecheck -- <slug> locally, then prefer batch stage_upload_url({ paths: [...] }) (or stage_upload_url({ path }) for a single lone file) and curl --upload-file <file> "$url" for new/rewritten paths when you have shell egress (bytes never re-enter the model; ALWAYS mint all URLs in one call with paths: [...] rather than looping or calling stage_upload_url multiple times). Fall back to stage_source_file({ path, content }) without shell. For edits prefer patch_source_file({ path, old, new }) — exact unique substring replace, no unified-diff arithmetic. Or patch_source_file({ files: [{ path, old, new }, ...] }) to edit several files in one call. Or patch_source_file({ path, patch }) with a unified diff (bare @@ ok). Stage only changed paths — never re-upload the whole tree. Then submit_sources({ fromStaged: true, mode: "preview", kitEngineRef }) — fromStaged overlays onto the latest delivery/seed and the server verifies it; no browser, npm ci, capture, playtest, or agency is required for this preview. If a browser is available near delivery, optionally run npm run check:game -- <slug> --preview. Run the full gate only immediately before a mode:"publish" seal. Inline files[] still works for tiny trees.',
   'Staging is already visible: once game.ts, GAME.json and markup are present across staging + delivery/seed, the platform assembles a live playable preview — without waiting for submit or the gate. Markup means GAME.json howToPlay carrying goal and hint, from which the body is generated — index.html is never accepted as a stage/patch/submit write, so do not author one. style.css is optional the same way: a GAME.json theme (accent/canvasBackground/canvasBorderColor/pixelArt) generates it when none is staged. Stage a runnable tree early and keep staging/patching as you work; a buffer that does not compile simply leaves the previous preview up.',
   'After every successful submit_sources: creator handoff is already unlocked; still call end immediately if you will not deliver more (warnings.code=call_end). Prefer end over sitting in a get_gate_verdict loop — Studio shows the gate. submit alone leaves your MCP session open — end sets stop:true. ChatGPT-class agents often stop after submit; end closes the session cleanly.',
   // The thread is the creator's whole view of the round.
@@ -3776,6 +3776,7 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
           expiresInSeconds: { type: 'number' },
           path: { type: 'string' },
           upload: { type: 'string' },
+          uploadScript: { type: 'string' },
           maxBytes: { type: 'number' },
           uploads: {
             type: 'array',
@@ -3795,12 +3796,13 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
         },
       },
       // Not READS: each call mints a fresh nonce, so it is neither read-only nor idempotent.
-      annotations: { title: 'Get a stage upload URL', ...WRITES },
+      annotations: { title: 'Get stage upload URL(s)', ...WRITES },
       description:
         'Stage new or fully rewritten source file(s) when you have curl/shell egress. ' +
-        'Pass `path` for a single file or `paths` for multiple files in one call to mint upload URLs in batch. ' +
+        'ALWAYS mint all upload URLs in a single call: pass `paths: ["file1.ts", "file2.ts", ...]` for multiple files ' +
+        '(do NOT make multiple stage_upload_url calls in parallel or loop them). Pass `path` only for a lone single file. ' +
         'Returns short-lived signed PUT URL(s) — run the returned `upload` one-liner(s) ' +
-        '(curl --upload-file <file> "$url"). The file bytes never enter the model; the PUT applies the same ' +
+        '(curl --upload-file <file> "$url") or `uploadScript`. The file bytes never enter the model; the PUT applies the same ' +
         'validation as stage_source_file (path allowlist, size caps, module_too_large hint) and returns the ' +
         'staging receipt with stop/pendingMessages. Then submit_sources({ fromStaged: true, … }). ' +
         'Use stage_source_file / patch_source_file when you have no shell. ' +
@@ -3809,15 +3811,16 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
         type: 'object',
         properties: {
           sessionKey: SESSION_KEY_PROP,
-          path: {
-            type: 'string',
-            description: 'Game-relative path (e.g. game.ts, game/render.ts). Bound into the URL. Pass path or paths.',
-          },
           paths: {
             type: 'array',
             items: { type: 'string' },
             description:
-              'Array of game-relative paths (e.g. ["game.ts", "game/render.ts"]) to mint multiple upload URLs in one call.',
+              'Array of game-relative paths (e.g. ["game.ts", "game/render.ts", "GAME.json"]). MANDATORY FOR MULTIPLE FILES: Always pass all changed files in this array in a single call to mint all URLs in batch. Never emit multiple stage_upload_url calls.',
+          },
+          path: {
+            type: 'string',
+            description:
+              'Single game-relative path (e.g. "game.ts"). Use ONLY when staging a single lone file; if staging multiple files, you MUST use paths instead.',
           },
           slug: { type: 'string' },
         },
@@ -3915,6 +3918,7 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
 
         return toolOk({
           uploads,
+          uploadScript: uploads.map((u) => u.upload).join(' && '),
           expiresAt,
           expiresInSeconds: ttlSeconds,
         });

--- a/apps/api/src/mcp-server.ts
+++ b/apps/api/src/mcp-server.ts
@@ -3828,21 +3828,15 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
       handler: async (args, ctx) => {
         const auth = await resolveAuth(ctx, args);
         if (!('channelToken' in auth)) return auth;
-        if (!agentTokenSecret) return toolErr('the MCP build endpoint is not configured');
         const hasPath = typeof args.path === 'string' && args.path.trim().length > 0;
         const hasPaths = Array.isArray(args.paths) && args.paths.length > 0;
-        if (!hasPath && !hasPaths) {
-          return toolErr('path or paths is required');
+        if ((!hasPath && !hasPaths) || (hasPath && hasPaths)) {
+          return toolErr(hasPath ? 'pass either path or paths, not both' : 'path or paths is required');
         }
-        if (hasPath && hasPaths) {
-          return toolErr('pass either path or paths, not both');
-        }
-        const rawPaths: string[] = hasPaths
-          ? (args.paths as unknown[]).filter((p): p is string => typeof p === 'string')
-          : [args.path as string];
-        if (rawPaths.length === 0) {
-          return toolErr('paths must contain at least one valid path');
-        }
+        const rawPaths = (hasPaths ? (args.paths as unknown[]) : [args.path]).filter(
+          (p): p is string => typeof p === 'string' && p.trim().length > 0,
+        );
+        if (rawPaths.length === 0) return toolErr('paths must contain at least one valid path');
         if (rawPaths.length > MAX_UPLOAD_FILES) {
           return toolErr(`too many paths in one request (max ${MAX_UPLOAD_FILES})`);
         }
@@ -3850,7 +3844,6 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
         const validPaths: string[] = [];
         for (const raw of rawPaths) {
           const trimmed = raw.trim();
-          if (!trimmed) return toolErr('path cannot be empty');
           try {
             validPaths.push(assertDeliverableSourcePath(trimmed));
           } catch (error) {

--- a/apps/api/src/mcp-server.ts
+++ b/apps/api/src/mcp-server.ts
@@ -3799,8 +3799,8 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
       annotations: { title: 'Get stage upload URL(s)', ...WRITES },
       description:
         'Stage new or fully rewritten source file(s) when you have curl/shell egress. ' +
-        'ALWAYS mint all upload URLs in a single call: pass `paths: ["file1.ts", "file2.ts", ...]` for multiple files ' +
-        '(do NOT make multiple stage_upload_url calls in parallel or loop them). Pass `path` only for a lone single file. ' +
+        'ALWAYS mint upload URLs in batch: pass `paths: ["file1.ts", "file2.ts", ...]` for multiple files ' +
+        `(up to ${MAX_UPLOAD_FILES} paths per call; split into batches if staging more; do NOT make multiple parallel calls per individual file). Pass \`path\` only for a lone single file. ` +
         'Returns short-lived signed PUT URL(s) — run the returned `upload` one-liner(s) ' +
         '(curl --upload-file <file> "$url") or `uploadScript`. The file bytes never enter the model; the PUT applies the same ' +
         'validation as stage_source_file (path allowlist, size caps, module_too_large hint) and returns the ' +
@@ -3815,7 +3815,7 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
             type: 'array',
             items: { type: 'string' },
             description:
-              'Array of game-relative paths (e.g. ["game.ts", "game/render.ts", "GAME.json"]). MANDATORY FOR MULTIPLE FILES: Always pass all changed files in this array in a single call to mint all URLs in batch. Never emit multiple stage_upload_url calls.',
+              'Array of game-relative paths (e.g. ["game.ts", "game/render.ts", "GAME.json"]). MANDATORY FOR MULTIPLE FILES: Always pass all changed files in this array in a single call to mint all URLs in batch (up to 200). Never emit multiple stage_upload_url calls.',
           },
           path: {
             type: 'string',
@@ -3843,8 +3843,8 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
         if (rawPaths.length === 0) {
           return toolErr('paths must contain at least one valid path');
         }
-        if (rawPaths.length > 50) {
-          return toolErr('too many paths in one request (max 50)');
+        if (rawPaths.length > MAX_UPLOAD_FILES) {
+          return toolErr(`too many paths in one request (max ${MAX_UPLOAD_FILES})`);
         }
 
         const validPaths: string[] = [];
@@ -3884,13 +3884,12 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
             ttlSeconds,
           });
           const url = `${canonicalAppBaseUrl()}${AGENT_CHANNEL_ROUTES.SOURCES_STAGE_UPLOAD}?token=${encodeURIComponent(token)}`;
-          const localHint = path.includes('/') ? path.split('/').pop()! : path;
           return toolOk({
             url,
             expiresAt,
             expiresInSeconds: ttlSeconds,
             path,
-            upload: uploadCurlCommand(url, localHint, 'text/plain; charset=utf-8'),
+            upload: uploadCurlCommand(url, path, 'text/plain; charset=utf-8'),
             maxBytes: 1_000_000,
           });
         }
@@ -3905,11 +3904,10 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
             ttlSeconds,
           });
           const url = `${canonicalAppBaseUrl()}${AGENT_CHANNEL_ROUTES.SOURCES_STAGE_UPLOAD}?token=${encodeURIComponent(token)}`;
-          const localHint = path.includes('/') ? path.split('/').pop()! : path;
           return {
             path,
             url,
-            upload: uploadCurlCommand(url, localHint, 'text/plain; charset=utf-8'),
+            upload: uploadCurlCommand(url, path, 'text/plain; charset=utf-8'),
             expiresAt,
             expiresInSeconds: ttlSeconds,
             maxBytes: 1_000_000,

--- a/apps/api/src/mcp-server.ts
+++ b/apps/api/src/mcp-server.ts
@@ -3828,6 +3828,7 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
       handler: async (args, ctx) => {
         const auth = await resolveAuth(ctx, args);
         if (!('channelToken' in auth)) return auth;
+        if (!agentTokenSecret) return toolErr('the MCP build endpoint is not configured');
         const hasPath = typeof args.path === 'string' && args.path.trim().length > 0;
         const hasPaths = Array.isArray(args.paths) && args.paths.length > 0;
         if ((!hasPath && !hasPaths) || (hasPath && hasPaths)) {

--- a/apps/api/src/mcp-server.ts
+++ b/apps/api/src/mcp-server.ts
@@ -192,6 +192,7 @@ const INVALID_START_WINDOW_MS = 60 * 60 * 1000;
 const MAX_MCP_BODY_BYTES = 2 * 1024 * 1024;
 
 const MAX_SUBMIT_FILES = MAX_UPLOAD_FILES;
+const MAX_STAGE_UPLOAD_BATCH = 50;
 
 /** How often the round view should re-read status. Matches the gate's own backoff. */
 /**
@@ -632,7 +633,7 @@ const BEHAVIOURAL_CONTRACT = [
   // language they did not choose, which is the whole reason the field exists.
   "Write progress in the creator's language: when get_brief.locales[0] is not 'en', send report_progress with textLocalized and locale as well as the English text.",
   'Send a screenshot as soon as the game draws anything playable via screenshot_upload_url + curl --upload-file. There is no base64 screenshot tool — PNG bytes must never enter the model.',
-  'While iterating, deliver with mode=preview (no TRACE required). Prefer batch stage_upload_url({ paths: [...] }) + curl --upload-file for new/rewritten paths when you have shell (bytes never re-enter the model; ALWAYS mint all URLs in a single call with paths: [...] rather than emitting multiple stage_upload_url calls; use stage_upload_url({ path }) only for a lone file). stage_source_file is the no-shell fallback. Prefer patch_source_file for edits — prefer old+new exact replace, or files: [{ path, old, new }, ...] to edit several files in one call; patch=unified diff also works (never re-emit a whole large render.ts/model.ts). To retire a path (an old game/*.ts module, or a hand-authored index.html/GAME.json field), call delete_source_file — staging empty content still delivers a live empty file, not a removal. Honour warnings.code=module_too_large by splitting before more feature work. Then submit_sources({ fromStaged:true, mode:"preview", kitEngineRef }) — fromStaged overlays onto the latest delivery/seed so only changed paths need staging. Avoid one giant files[] payload. Only mode=publish needs TRACE/PLAYTEST and can go green.',
+  'While iterating, deliver with mode=preview (no TRACE required). Prefer batch stage_upload_url({ paths: [...] }) + curl --upload-file for new/rewritten paths when you have shell (bytes never re-enter the model; ALWAYS mint URLs in batch with paths: [...] up to 50 paths per call, chunking into batches of 50 if staging more, rather than emitting individual stage_upload_url calls; use stage_upload_url({ path }) only for a lone file). stage_source_file is the no-shell fallback. Prefer patch_source_file for edits — prefer old+new exact replace, or files: [{ path, old, new }, ...] to edit several files in one call; patch=unified diff also works (never re-emit a whole large render.ts/model.ts). To retire a path (an old game/*.ts module, or a hand-authored index.html/GAME.json field), call delete_source_file — staging empty content still delivers a live empty file, not a removal. Honour warnings.code=module_too_large by splitting before more feature work. Then submit_sources({ fromStaged:true, mode:"preview", kitEngineRef }) — fromStaged overlays onto the latest delivery/seed so only changed paths need staging. Avoid one giant files[] payload. Only mode=publish needs TRACE/PLAYTEST and can go green.',
   'If the last gate was preview_failed / red / kit_outdated (warnings.code=must_fix_gate), fix then submit_sources again — do not stop at stage/patch/show_round. Staging does not re-run the gate; the creator card stays on the refused delivery until you submit.',
   'While iterating, run only npm run typecheck -- <slug> (no browser, npm ci, capture, playtest, or agency), then stage and submit_sources({ fromStaged: true, mode: "preview", kitEngineRef }); the server verifies the preview. If a browser is available and the draft is approaching delivery, optionally run npm run check:game -- <slug> --preview (typecheck → smoke → build). Run the full gate only immediately before a mode:"publish" seal.',
   'After submit_sources, if you will not deliver more this round, call end (required — warnings.code=call_end; submit already unlocks creator handoff). Prefer end over sitting in a get_gate_verdict loop — Studio shows the gate. Do not stop after submit alone without end. If you are fixing a refused gate, ignore call_end until after the next submit_sources.',
@@ -672,7 +673,7 @@ const SESSION_WORKFLOW: readonly string[] = [
   'Capability and "how do I…" questions: check get_kit_api first for exact kit-API surface (signatures, module names). knowledge_query is for everything get_kit_api does not cover — EditorKit internals, example-game patterns, docs/process, and broader capability questions — with citations and an indexedCommit; treat its prose as a pointer to verify via get_kit_api / read_kit_file, not a source of truth for exact signatures.',
   'Build the game — continuing the sources you fetched, otherwise from the kit; report_progress before and after long steps. Soft module budget: keep each game/*.ts under ~350 lines / ~12 KiB. When a file approaches that, split cohesive pieces (render→art/ui/hud/rooms; model→tables/layout/types; runtime→systems) before more feature work. Honour warnings.code=module_too_large the same way you honour call_end — act, then continue.',
   'As soon as the game draws anything playable: screenshot_upload_url then curl --upload-file <png> "$url". There is no base64 send path — PNG bytes must never enter the model. Without shell egress, skip mid-build screenshots; the gate still captures on delivery.',
-  'While iterating: run only npm run typecheck -- <slug> locally, then prefer batch stage_upload_url({ paths: [...] }) (or stage_upload_url({ path }) for a single lone file) and curl --upload-file <file> "$url" for new/rewritten paths when you have shell egress (bytes never re-enter the model; ALWAYS mint all URLs in one call with paths: [...] rather than looping or calling stage_upload_url multiple times). Fall back to stage_source_file({ path, content }) without shell. For edits prefer patch_source_file({ path, old, new }) — exact unique substring replace, no unified-diff arithmetic. Or patch_source_file({ files: [{ path, old, new }, ...] }) to edit several files in one call. Or patch_source_file({ path, patch }) with a unified diff (bare @@ ok). Stage only changed paths — never re-upload the whole tree. Then submit_sources({ fromStaged: true, mode: "preview", kitEngineRef }) — fromStaged overlays onto the latest delivery/seed and the server verifies it; no browser, npm ci, capture, playtest, or agency is required for this preview. If a browser is available near delivery, optionally run npm run check:game -- <slug> --preview. Run the full gate only immediately before a mode:"publish" seal. Inline files[] still works for tiny trees.',
+  'While iterating: run only npm run typecheck -- <slug> locally, then prefer batch stage_upload_url({ paths: [...] }) (or stage_upload_url({ path }) for a single lone file) and curl --upload-file <file> "$url" for new/rewritten paths when you have shell egress (bytes never re-enter the model; ALWAYS mint URLs in batch with paths: [...] up to 50 paths per call, chunking into batches of 50 if staging more, rather than looping or calling stage_upload_url per file). Fall back to stage_source_file({ path, content }) without shell. For edits prefer patch_source_file({ path, old, new }) — exact unique substring replace, no unified-diff arithmetic. Or patch_source_file({ files: [{ path, old, new }, ...] }) to edit several files in one call. Or patch_source_file({ path, patch }) with a unified diff (bare @@ ok). Stage only changed paths — never re-upload the whole tree. Then submit_sources({ fromStaged: true, mode: "preview", kitEngineRef }) — fromStaged overlays onto the latest delivery/seed and the server verifies it; no browser, npm ci, capture, playtest, or agency is required for this preview. If a browser is available near delivery, optionally run npm run check:game -- <slug> --preview. Run the full gate only immediately before a mode:"publish" seal. Inline files[] still works for tiny trees.',
   'Staging is already visible: once game.ts, GAME.json and markup are present across staging + delivery/seed, the platform assembles a live playable preview — without waiting for submit or the gate. Markup means GAME.json howToPlay carrying goal and hint, from which the body is generated — index.html is never accepted as a stage/patch/submit write, so do not author one. style.css is optional the same way: a GAME.json theme (accent/canvasBackground/canvasBorderColor/pixelArt) generates it when none is staged. Stage a runnable tree early and keep staging/patching as you work; a buffer that does not compile simply leaves the previous preview up.',
   'After every successful submit_sources: creator handoff is already unlocked; still call end immediately if you will not deliver more (warnings.code=call_end). Prefer end over sitting in a get_gate_verdict loop — Studio shows the gate. submit alone leaves your MCP session open — end sets stop:true. ChatGPT-class agents often stop after submit; end closes the session cleanly.',
   // The thread is the creator's whole view of the round.
@@ -3800,7 +3801,7 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
       description:
         'Stage new or fully rewritten source file(s) when you have curl/shell egress. ' +
         'ALWAYS mint upload URLs in batch: pass `paths: ["file1.ts", "file2.ts", ...]` for multiple files ' +
-        `(up to ${MAX_UPLOAD_FILES} paths per call; split into batches if staging more; do NOT make multiple parallel calls per individual file). Pass \`path\` only for a lone single file. ` +
+        `(up to ${MAX_STAGE_UPLOAD_BATCH} paths per call; split larger sets into batches of at most ${MAX_STAGE_UPLOAD_BATCH}; do NOT make individual parallel calls per file). Pass \`path\` only for a lone single file. ` +
         'Returns short-lived signed PUT URL(s) — run the returned `upload` one-liner(s) ' +
         '(curl --upload-file <file> "$url") or `uploadScript`. The file bytes never enter the model; the PUT applies the same ' +
         'validation as stage_source_file (path allowlist, size caps, module_too_large hint) and returns the ' +
@@ -3815,12 +3816,12 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
             type: 'array',
             items: { type: 'string' },
             description:
-              'Array of game-relative paths (e.g. ["game.ts", "game/render.ts", "GAME.json"]). MANDATORY FOR MULTIPLE FILES: Always pass all changed files in this array in a single call to mint all URLs in batch (up to 200). Never emit multiple stage_upload_url calls.',
+              'Array of game-relative paths (e.g. ["game.ts", "game/render.ts", "GAME.json"]). MANDATORY FOR MULTIPLE FILES: Always pass changed files in batch (up to 50 paths per call; split into batches if staging more). Never emit individual stage_upload_url calls.',
           },
           path: {
             type: 'string',
             description:
-              'Single game-relative path (e.g. "game.ts"). Use ONLY when staging a single lone file; if staging multiple files, you MUST use paths instead.',
+              'Single game-relative path (e.g. "game.ts"). Use ONLY when staging a single lone file; if staging multiple files, you MUST use paths instead (up to 50 per batch).',
           },
           slug: { type: 'string' },
         },
@@ -3838,8 +3839,10 @@ export async function registerMcpServerRoutes(app: FastifyInstance, options: Mcp
           (p): p is string => typeof p === 'string' && p.trim().length > 0,
         );
         if (rawPaths.length === 0) return toolErr('paths must contain at least one valid path');
-        if (rawPaths.length > MAX_UPLOAD_FILES) {
-          return toolErr(`too many paths in one request (max ${MAX_UPLOAD_FILES})`);
+        if (rawPaths.length > MAX_STAGE_UPLOAD_BATCH) {
+          return toolErr(
+            `too many paths in one request (max ${MAX_STAGE_UPLOAD_BATCH}; split into batches of up to ${MAX_STAGE_UPLOAD_BATCH})`,
+          );
         }
 
         const validPaths: string[] = [];

--- a/listings/mcp/README.md
+++ b/listings/mcp/README.md
@@ -74,7 +74,7 @@ build round; the authoritative list is whatever `tools/list` returns, and
 | `delete_source_file`     | Delete one staged source file           | destructive |
 | `clear_staged_sources`   | Clear staged source files               | destructive |
 | `list_staged_sources`    | List staged source files                | read        |
-| `stage_upload_url`       | Get a stage upload URL                  | write       |
+| `stage_upload_url`       | Get stage upload URL(s)                 | write       |
 | `submit_sources`         | Deliver sources to the gate             | destructive |
 | `end`                    | End (commit) this round                 | destructive |
 | `get_gate_verdict`       | Check the gate once                     | read        |


### PR DESCRIPTION
### Summary

Steer LLM agents (Claude / ChatGPT / Codex) to batch `stage_upload_url({ paths: [...] })` in a single tool call rather than emitting $N$ parallel/looping `stage_upload_url({ path })` tool calls.

### Changes
- **`apps/api/src/mcp-server.ts`**:
  - Renamed title annotation to `Get stage upload URL(s)`.
  - Moved `paths` ahead of `path` in `inputSchema.properties` with explicit guidance that `paths` is mandatory when staging multiple files.
  - Updated tool description, `BEHAVIOURAL_CONTRACT`, and `SESSION_WORKFLOW` to forbid calling `stage_upload_url` multiple times when multiple files changed.
  - Added `uploadScript` to batch output schema and payload (`uploads.map(u => u.upload).join(' && ')`).
- **`listings/mcp/README.md` & `.claude/skills/byoca-mcp/SKILL.md`**:
  - Updated tool table and BYOCA skill to emphasize batch `stage_upload_url({ paths: [...] })`.
- **`apps/api/src/mcp-server.test.ts`**:
  - Added test coverage for `uploadScript` on batch minting.

@codex review