### PR TITLE
fix(catalog): retarget games-repo-contract-check's hardcoded creation/ paths

### DIFF
--- a/apps/api/src/catalog/games-repo-contract-check.ts
+++ b/apps/api/src/catalog/games-repo-contract-check.ts
@@ -55,8 +55,11 @@ import {
 } from './games-repo-contract.js';
 import { isRateLimitResponse } from './github-rate-limit.js';
 
-const LOCAL_EDITOR_CONTRACT_PATH = path.join(path.dirname(fileURLToPath(import.meta.url)), '../editor-contract.ts');
-const LOCAL_TS_ANY_SCAN_PATH = path.join(path.dirname(fileURLToPath(import.meta.url)), '../ts-any-scan.ts');
+const LOCAL_EDITOR_CONTRACT_PATH = path.join(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '../creation/editor-contract.ts',
+);
+const LOCAL_TS_ANY_SCAN_PATH = path.join(path.dirname(fileURLToPath(import.meta.url)), '../creation/ts-any-scan.ts');
 
 export type ContractCheckOutcome =
   /** No token configured — forks and fresh clones still go green. */
@@ -453,7 +456,7 @@ export async function runGamesRepoContractCheck(options: ContractCheckOptions): 
     return {
       kind: 'drift',
       reason:
-        `editor-contract mismatch (${EDITOR_CONTRACT_PATH} vs apps/api/src/editor-contract.ts): ` +
+        `editor-contract mismatch (${EDITOR_CONTRACT_PATH} vs apps/api/src/creation/editor-contract.ts): ` +
         `${describeTextDrift(remoteEditorContract, localEditorContract)}\n` +
         `  The two files must stay byte-equivalent below their own header comments — EditorKit L0/L4 ` +
         `is a lockstep, not an asymmetric rollout contract. Update both files in one paired change.`,
@@ -468,7 +471,7 @@ export async function runGamesRepoContractCheck(options: ContractCheckOptions): 
       return {
         kind: 'drift',
         reason:
-          `ts-any-scan mismatch (${TS_ANY_SCAN_PATH} vs apps/api/src/ts-any-scan.ts): ` +
+          `ts-any-scan mismatch (${TS_ANY_SCAN_PATH} vs apps/api/src/creation/ts-any-scan.ts): ` +
           `${describeTextDrift(remoteAnyScan, localAnyScan)}\n` +
           `  The two files must stay byte-equivalent below their own header comments. This side ` +
           `refuses an upload for \`any\` and the games repo fails validate Check 37 for it; if they ` +

--- a/eslint-rules/module-size-baseline.json
+++ b/eslint-rules/module-size-baseline.json
@@ -112,7 +112,7 @@
     "apps/api/src/catalog/games-repo-archive.test.ts": 92,
     "apps/api/src/catalog/games-repo-archive.ts": 132,
     "apps/api/src/catalog/games-repo-contract-check.test.ts": 526,
-    "apps/api/src/catalog/games-repo-contract-check.ts": 618,
+    "apps/api/src/catalog/games-repo-contract-check.ts": 621,
     "apps/api/src/catalog/games-repo-contract.test.ts": 382,
     "apps/api/src/catalog/games-repo-contract.ts": 510,
     "apps/api/src/catalog/github-client.test.ts": 1978,


### PR DESCRIPTION
## Summary

master's "Games-repo contract" CI check went red right after #979 merged, with `ENOENT: no such file or directory, open '.../apps/api/src/editor-contract.ts'`.

`LOCAL_EDITOR_CONTRACT_PATH` and `LOCAL_TS_ANY_SCAN_PATH` in `games-repo-contract-check.ts` are hardcoded string paths (not static imports), so the Phase 3 Wave A move script's import-rewriter never touched them — the exact same blind spot already fixed once for the catalog move in #973, now recurring because `editor-contract.ts` and `ts-any-scan.ts` moved again, this time into `creation/`, in #979.

The check reads the file directly off disk via `readFileSync` to diff it against the games-repo checkout's mirror copy, not via an import, so `tsc`/`eslint`/`vitest` all stayed green while this broke — only the live cross-repo CI job (which needs `GAMES_REPO_TOKEN`, unavailable locally) exercises this path.

Retargeted both path constants and their two error-message strings to `creation/`. Confirmed no other hardcoded string reference to either file remains anywhere in the repo, and that both new paths resolve to real files on disk.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx eslint apps/api/src apps/api/scripts` clean
- [x] `npx vitest run` in `apps/api` — 219 files / 3485 tests passed, including the 69 `games-repo-contract-check`/`games-repo-contract` unit tests
- [x] `npm run lint` at repo root — exits 0, back to the same 233 pre-existing cross-domain warnings, non-blocking
- [x] Verified `LOCAL_EDITOR_CONTRACT_PATH`/`LOCAL_TS_ANY_SCAN_PATH` resolve to real files on disk at the new location

---
_Generated by [Claude Code](https://claude.ai/code/session_01VaPzGSyNfZ7nvGcJgYNSdL)_