### PR TITLE
fix(e2e): mock the studio-shell fixture's published-fallback fetch

### DIFF
--- a/apps/e2e/src/studio-shell.test.ts
+++ b/apps/e2e/src/studio-shell.test.ts
@@ -159,6 +159,10 @@ async function stubStudioThreadData(page: Page) {
     }
     await route.fulfill({ status: 404, contentType: 'application/json', body: '{"error":"not found"}' });
   });
+
+  await page.route(`**/api/games/${FIXTURE_SLUG}`, async (route) => {
+    await fulfillJson(route, { slug: FIXTURE_SLUG, title: 'E2E Studio Shell Fixture', html: '<p>fixture</p>' });
+  });
 }
 
 describe.skipIf(!prereq.ok)('the studio thread as an app screen', () => {

--- a/eslint-rules/module-size-baseline.json
+++ b/eslint-rules/module-size-baseline.json
@@ -472,7 +472,7 @@
     "apps/e2e/src/gate-prerequisites.test.ts": 38,
     "apps/e2e/src/globalSetup.ts": 61,
     "apps/e2e/src/resilience.test.ts": 145,
-    "apps/e2e/src/studio-shell.test.ts": 597,
+    "apps/e2e/src/studio-shell.test.ts": 601,
     "apps/e2e/src/walkthrough.test.ts": 235,
     "apps/e2e/vitest.config.ts": 20,
     "apps/web/src/AccessTokensPanel.test.tsx": 181,


### PR DESCRIPTION
## Summary

Fixes the deploy gate blocking every deploy since PR #980 merged: the "Browser gate against the candidate" step in `deploy.yml` fails 4/4 viewport checks in `studio-shell.test.ts` with a stray `404` console error against `GET /api/games/e2e-studio-shell`.

## Why

PR #980 made the stage's fallback-to-last-published fetch (`useStageSource.ts`) fire for any status carrying a `slug`, not only `status: 'published'`, so an improvement round on an already-live game still shows the last known-good build. `studio-shell.test.ts`'s fixture uses `status: 'needs_changes'` with a `slug`, which now reaches that fetch — but its `GET /api/games/e2e-studio-shell` was never mocked (only `/api/submissions/...` and `/api/me/studio/games/.../sources` were), since before #980 that status never triggered it. The request hits the real candidate server, which correctly 404s (the fixture slug isn't actually published), and the test's zero-console-errors assertion trips.

Root-caused by comparing the failing job's log (`[http.404] GET .../api/games/e2e-studio-shell`) against `useStageSource.ts`'s new fetch condition and this fixture's `fixtureGames()`/submission-status stub, which already implies a published slug (`publishedAt` is set) — so mocking the route with a 200 is the realistic fix, not loosening the assertion.

## Fix
Added a `page.route` mock for `GET /api/games/e2e-studio-shell` in `stubStudioThreadData`, returning a minimal `PublishedGame` payload.

## Test plan
- [x] `npx tsc --noEmit` clean in `apps/e2e`.
- [x] `npm run lint` clean (0 errors).
- [ ] Can't run this suite locally (needs a signed-in `bot:e2e` context against a live Cloud Run candidate) — verification is the next deploy's browser-gate run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
