### PR TITLE
fix(e2e): stub the published-game fallback route in studio-shell gate

### DIFF
--- a/apps/e2e/src/studio-shell.test.ts
+++ b/apps/e2e/src/studio-shell.test.ts
@@ -159,6 +159,20 @@ async function stubStudioThreadData(page: Page) {
     }
     await route.fulfill({ status: 404, contentType: 'application/json', body: '{"error":"not found"}' });
   });
+
+  // Published-game fallback route, stubbed read-only (#980 fetches on slug alone —
+  // this fixture's round is 'needs_changes', so useStageSource hits this unconditionally).
+  await page.route(`**/api/games/${FIXTURE_SLUG}`, async (route) => {
+    if (route.request().method() !== 'GET') {
+      await route.fulfill({ status: 405, contentType: 'application/json', body: '{"error":"method not allowed"}' });
+      return;
+    }
+    await fulfillJson(route, {
+      slug: FIXTURE_SLUG,
+      title: 'E2E Studio Shell Fixture',
+      html: '<!doctype html><title>E2E Studio Shell Fixture</title>',
+    });
+  });
 }
 
 describe.skipIf(!prereq.ok)('the studio thread as an app screen', () => {

--- a/apps/e2e/src/studio-shell.test.ts
+++ b/apps/e2e/src/studio-shell.test.ts
@@ -160,8 +160,7 @@ async function stubStudioThreadData(page: Page) {
     await route.fulfill({ status: 404, contentType: 'application/json', body: '{"error":"not found"}' });
   });
 
-  // Published-game fallback route, stubbed read-only (#980 fetches on slug alone —
-  // this fixture's round is 'needs_changes', so useStageSource hits this unconditionally).
+  // Published-game fallback route, stubbed read-only (#980).
   await page.route(`**/api/games/${FIXTURE_SLUG}`, async (route) => {
     if (route.request().method() !== 'GET') {
       await route.fulfill({ status: 405, contentType: 'application/json', body: '{"error":"method not allowed"}' });

--- a/eslint-rules/comment-prose-baseline.json
+++ b/eslint-rules/comment-prose-baseline.json
@@ -347,7 +347,7 @@
     "apps/e2e/src/gate-prerequisites.test.ts": 164,
     "apps/e2e/src/globalSetup.ts": 153,
     "apps/e2e/src/resilience.test.ts": 356,
-    "apps/e2e/src/studio-shell.test.ts": 900,
+    "apps/e2e/src/studio-shell.test.ts": 877,
     "apps/e2e/src/walkthrough.test.ts": 713,
     "apps/e2e/vitest.config.ts": 93,
     "apps/web/src/AccessTokensPanel.test.tsx": 75,

--- a/eslint-rules/comment-prose-baseline.json
+++ b/eslint-rules/comment-prose-baseline.json
@@ -347,7 +347,7 @@
     "apps/e2e/src/gate-prerequisites.test.ts": 164,
     "apps/e2e/src/globalSetup.ts": 153,
     "apps/e2e/src/resilience.test.ts": 356,
-    "apps/e2e/src/studio-shell.test.ts": 877,
+    "apps/e2e/src/studio-shell.test.ts": 900,
     "apps/e2e/src/walkthrough.test.ts": 713,
     "apps/e2e/vitest.config.ts": 93,
     "apps/web/src/AccessTokensPanel.test.tsx": 75,

--- a/eslint-rules/module-size-baseline.json
+++ b/eslint-rules/module-size-baseline.json
@@ -472,7 +472,7 @@
     "apps/e2e/src/gate-prerequisites.test.ts": 38,
     "apps/e2e/src/globalSetup.ts": 61,
     "apps/e2e/src/resilience.test.ts": 145,
-    "apps/e2e/src/studio-shell.test.ts": 597,
+    "apps/e2e/src/studio-shell.test.ts": 611,
     "apps/e2e/src/walkthrough.test.ts": 235,
     "apps/e2e/vitest.config.ts": 20,
     "apps/web/src/AccessTokensPanel.test.tsx": 181,

--- a/eslint-rules/module-size-baseline.json
+++ b/eslint-rules/module-size-baseline.json
@@ -472,7 +472,7 @@
     "apps/e2e/src/gate-prerequisites.test.ts": 38,
     "apps/e2e/src/globalSetup.ts": 61,
     "apps/e2e/src/resilience.test.ts": 145,
-    "apps/e2e/src/studio-shell.test.ts": 611,
+    "apps/e2e/src/studio-shell.test.ts": 610,
     "apps/e2e/src/walkthrough.test.ts": 235,
     "apps/e2e/vitest.config.ts": 20,
     "apps/web/src/AccessTokensPanel.test.tsx": 181,


### PR DESCRIPTION
## Summary

The deploy pipeline's browser gate started failing right after #980 (fetch on slug alone, unrelated to Phase 3 Wave A) landed: `useStageSource` now calls `fetchPublishedGame(slug)` → `GET /api/games/<slug>` whenever a round has a slug at all, not only once it publishes — so it fires for this fixture's `'needs_changes'` round too. `studio-shell.test.ts` stubs every other endpoint the studio shell touches but not this one, so the call hit the real candidate server and 404'd — a real network problem the suite's own `collectProblems`/`describeProblems` watcher correctly flagged, failing every "keeps the Code header..." case (all four viewports) and blocking candidate promotion.

Added a read-only stub for `GET /api/games/${FIXTURE_SLUG}` alongside the file's other stubs (same `fulfillJson`/`page.route` pattern already used for `/api/me/studio` and `/api/submissions/<token>`), returning a minimal `PublishedGame` body. No production code changed — this is a test-fixture-only fix.

## Test plan

- [x] `npm run type-check -w @gamedevpl/e2e` clean
- [x] `npx eslint apps/e2e/src/studio-shell.test.ts` clean
- [x] `npx prettier --check apps/e2e/src/studio-shell.test.ts` clean
- [x] `npx vitest run` in `apps/api` — 219 files / 3485 tests passed (unaffected, sanity check)
- [x] `npm run lint` at repo root — exits 0, back to the same 233 pre-existing cross-domain warnings, non-blocking
- [x] Could not run the e2e suite itself locally (needs a live `GAMEDEV_ACCESS_TOKEN` and real deployed backend) — the next "Deploy to Cloud Run" run's browser gate is the actual verification

---
_Generated by [Claude Code](https://claude.ai/code/session_01VaPzGSyNfZ7nvGcJgYNSdL)_