### PR TITLE
diag(e2e): include the stack in pageerror problems

### DIFF
--- a/apps/e2e/src/browser.ts
+++ b/apps/e2e/src/browser.ts
@@ -265,7 +265,7 @@ export function collectProblems(page: Page, expectedStatuses: number[] = []) {
     if (!isExpected(text)) problems.push({ kind, text: text.slice(0, 400) });
   };
 
-  page.on('pageerror', (error) => push('pageerror', String(error)));
+  page.on('pageerror', (error) => push('pageerror', error.stack || String(error)));
 
   page.on('console', (message) => {
     if (message.type() !== 'error') return;


### PR DESCRIPTION
## Summary

Diagnostic-only PR, not a real fix — the browser gate has failed on the same `SecurityError: Failed to read the 'serviceWorker' property from 'Navigator'` for six deploy attempts running now, across two independently-verified different root causes:

1. #986's `serviceWorkers: 'block'` context option (removed in #990) — traced to an upstream Playwright bug ([microsoft/playwright#32292](https://github.com/microsoft/playwright/issues/32292)).
2. The `/sw.js` route returning 404, itself a >=400 response the gate flags (fixed in #990's second commit, per Codex review).

Both are gone as of #990's merge — and the deploy still failed on the *exact same error message*. I pulled the deployed candidate's bundle directly and verified all 12 `navigator.serviceWorker` accesses are correctly guarded (byte for byte against the compiled output). I've also checked `gamePlayer.ts`'s game-iframe bridge script for any reference — none.

## What's missing to actually fix it

`describeProblems` (`apps/e2e/src/browser.ts`) reports a `pageerror`'s `String(error)`, which is only the error's `name: message` — no stack, no source location. There is currently no way to tell *which script* throws this, only that something does.

## Change

`error.stack || String(error)` instead. Purely additive — the gate's actual assertion is still `describeProblems(...) === ''`, so this changes nothing about what passes or fails. Its only purpose is to make the *next* failure's log actually show a file:line, so the real fix (whatever it turns out to be — possibly inside a game-iframe's bootstrap given the sandboxed iframe this fixture now renders, per #980) can be targeted instead of guessed at again.

## Test plan
- [x] `npx tsc --noEmit` clean.
- [x] `npm run lint` clean (0 errors).
- This needs to merge and go through a deploy attempt to produce the diagnostic output it exists to capture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
