### PR TITLE
feat(lint): exempt type-only imports from the module-boundary rule

### DIFF
--- a/eslint-rules/module-boundary.mjs
+++ b/eslint-rules/module-boundary.mjs
@@ -98,7 +98,12 @@ export const moduleBoundary = {
 
     const directory = path.dirname(filename);
 
-    function check(source) {
+    function check(node, source) {
+      // Erased at compile time -- a type-only edge is the contract N2 plans to give its own
+      // package, not runtime coupling. Only the whole-statement form (`import type { X }
+      // from`) is exempt; a mixed statement (`import { type X, y }`) still imports a real
+      // value and is checked like any other.
+      if (node.importKind === 'type' || node.exportKind === 'type') return;
       if (!source || source.type !== 'Literal' || typeof source.value !== 'string') return;
       const specifier = source.value;
       if (!specifier.startsWith('./') && !specifier.startsWith('../')) return;
@@ -130,10 +135,10 @@ export const moduleBoundary = {
     }
 
     return {
-      ImportDeclaration: (node) => check(node.source),
-      ExportNamedDeclaration: (node) => check(node.source),
-      ExportAllDeclaration: (node) => check(node.source),
-      ImportExpression: (node) => check(node.source),
+      ImportDeclaration: (node) => check(node, node.source),
+      ExportNamedDeclaration: (node) => check(node, node.source),
+      ExportAllDeclaration: (node) => check(node, node.source),
+      ImportExpression: (node) => check(node, node.source),
     };
   },
 };

--- a/eslint-rules/module-boundary.test.mjs
+++ b/eslint-rules/module-boundary.test.mjs
@@ -7,11 +7,16 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { RuleTester } from 'eslint';
+import tsParser from '@typescript-eslint/parser';
 import { afterAll, describe, it } from 'vitest';
 import { moduleBoundary } from './module-boundary.mjs';
 
 RuleTester.describe = describe;
 RuleTester.it = it;
+
+// `import type` / `export type` are TS syntax -- the default espree parser rejects them,
+// so cases exercising the type-only exemption need the real TS parser.
+const tsLanguageOptions = { parser: tsParser, sourceType: 'module', ecmaVersion: 'latest' };
 
 const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'module-boundary-'));
 const apiSrcRoot = path.join(repoRoot, 'apps', 'api', 'src');
@@ -68,8 +73,27 @@ ruleTester.run('module-boundary', moduleBoundary, {
     { code: "import { a } from './x.js';", filename: path.join(repoRoot, 'apps', 'web', 'src', 'App.ts') },
     // Test fixtures are exempt -- they wire across domains deliberately.
     { code: "import { a } from '../mp.js';", filename: path.join(apiSrcRoot, '__tests__', 'cross-domain-fixture.ts') },
+    // Whole-statement type-only edges are erased at compile time -- no runtime coupling.
+    {
+      code: "import type { A } from './mp.js';",
+      filename: filenameIn('.', 'votes'),
+      languageOptions: tsLanguageOptions,
+    },
+    {
+      code: "export type { A } from './mp.js';",
+      filename: filenameIn('.', 'review'),
+      languageOptions: tsLanguageOptions,
+    },
   ],
   invalid: [
+    // A mixed import (one real value alongside an inline type specifier) still pulls in a
+    // runtime dependency -- the exemption is whole-statement only.
+    {
+      code: "import { a, type B } from './mp.js';",
+      filename: filenameIn('.', 'votes'),
+      languageOptions: tsLanguageOptions,
+      errors: [{ messageId: 'crossBucket' }],
+    },
     // community reaching into realtime's internals.
     {
       code: "import { a } from './mp.js';",


### PR DESCRIPTION
## Summary

Phase 3 of `north-star-architecture.md` (private ops repo) asks to flip the `gamedev/module-boundary` rule from warn to error, module by module, now that Wave A physically moved files into their N1 buckets.

Before starting that flip, this fixes a gap in the rule itself: a whole-statement `import type { X } from '...'` (or `export type { X } from`) is erased at compile time — it carries no runtime coupling. Flagging it the same as a real value import conflates "a domain depends on another's published type" (exactly the shape `packages/contract` — N2 — is meant to formalize) with actual behavioral coupling that the boundary rule should catch.

A mixed statement importing at least one real value (`import { a, type B } from './x.js'`) is still checked — the exemption is whole-statement only.

## Effect

- `apps/api/src` warnings: 237 → 179 total; `crossBucket` specifically: 186 → 132.
- Zero behavior change to the app — this only changes what the (still warn-mode) `npm run module-boundary` reports.
- The 132 remaining `crossBucket` warnings are genuine value-level cross-domain calls — the real work for the module-by-module error flip, coming in follow-up PRs.

## Test plan
- [x] Added `module-boundary.test.mjs` cases for the exemption (`import type`, `export type`) and confirmed a mixed import (`import { a, type B }`) still reports `crossBucket`
- [x] `npx vitest run eslint-rules/module-boundary.test.mjs` — 19/19 passing
- [x] Re-ran `npm run module-boundary` against real `apps/api/src` and confirmed the count drop matches expectations
- [x] Full root `npm run build` (lint + typecheck + unit tests + build) passes

---
_Generated by [Claude Code](https://claude.ai/code/session_01VaPzGSyNfZ7nvGcJgYNSdL)_