### PR TITLE
fix(lint): drop private-plan reference from module-boundary.mjs comment

### DIFF
--- a/eslint-rules/module-boundary.mjs
+++ b/eslint-rules/module-boundary.mjs
@@ -99,10 +99,9 @@ export const moduleBoundary = {
     const directory = path.dirname(filename);
 
     function check(node, source) {
-      // Erased at compile time -- a type-only edge is the contract N2 plans to give its own
-      // package, not runtime coupling. Only the whole-statement form (`import type { X }
-      // from`) is exempt; a mixed statement (`import { type X, y }`) still imports a real
-      // value and is checked like any other.
+      // Erased at compile time, so a type-only edge carries no runtime coupling. Only the
+      // whole-statement form (`import type { X } from`) is exempt; a mixed statement
+      // (`import { type X, y }`) still imports a real value and is checked like any other.
       if (node.importKind === 'type' || node.exportKind === 'type') return;
       if (!source || source.type !== 'Literal' || typeof source.value !== 'string') return;
       const specifier = source.value;


### PR DESCRIPTION
## Summary

Codex review on #994 (already merged) flagged a real P1: the type-only-import exemption's comment named the private ops repo's N2 plan and summarized its decision ("the contract N2 plans to give its own package"), which AGENTS.md's leak-hygiene rule prohibits copying into this public repo.

The comment only needs the local, implementation-level reason — compile-time erasure means no runtime coupling — which stands on its own without the private cross-reference.

## Test plan
- [x] `npx vitest run eslint-rules/module-boundary.test.mjs` — 19/19 passing (unaffected, comment-only change)
- [x] Full root `npm run build` (lint + typecheck + unit tests + build) passes

---
_Generated by [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VaPzGSyNfZ7nvGcJgYNSdL)_