### PR TITLE
fix: include editor declarations in seed context

### DIFF
--- a/apps/api/src/creation/seed-context.test.ts
+++ b/apps/api/src/creation/seed-context.test.ts
@@ -23,7 +23,7 @@ const FILES: Record<string, string> = {
   [`games/${SEED_SCAFFOLD_SLUG}/SPEC.md`]: '---\ntitle: Block Cascade\n---\n',
   [`games/${SEED_SCAFFOLD_SLUG}/game.ts`]: "import { startGame } from './game/runtime.ts';\n",
   [`games/${SEED_SCAFFOLD_SLUG}/game/runtime.ts`]: 'export function startGame() {}\n',
-  'games/apex-sprint/SPEC.md': '---\ntitle: Apex Sprint\n---\n',
+  'games/apex-sprint/SPEC.md': '---\ntitle: Apex Sprint\n---\n', 'games/apex-sprint/EDITOR.ts': 'export default {};\n', 'games/apex-sprint/EDITOR.json': '{"version":2}\n', 'games/apex-sprint/EDITOR.content.json': '{"params":{}}\n',
   'games/apex-sprint/game.ts': 'export {};\n',
   'games/apex-sprint/game/model.ts': 'export const SPEED = 1;\n',
   'games/apex-sprint/game/render.ts': 'export function paint() {}\n',
@@ -57,7 +57,7 @@ describe('buildSeedContext', () => {
     const rendered = buildSeedContext(indexOf(FILES))!.renderReferences(['apex-sprint'], 100_000);
 
     expect(rendered).toContain('--- games/apex-sprint/SPEC.md ---');
-    expect(rendered).toContain('--- games/apex-sprint/game.ts ---');
+    expect(rendered).toContain('--- games/apex-sprint/game.ts ---'); expect(rendered).toContain('--- games/apex-sprint/EDITOR.json ---');
     // Sorted so the same picks always produce the same prompt; a prompt that varies run
     // to run makes any comparison between runs meaningless.
     expect(rendered.indexOf('game/model.ts')).toBeLessThan(rendered.indexOf('game/render.ts'));

--- a/apps/api/src/creation/seed-context.ts
+++ b/apps/api/src/creation/seed-context.ts
@@ -30,7 +30,7 @@ function seedInclude(relativePath: string): boolean {
 }
 
 /** Order matters: this is the shape a game has, and the order the model sees it in. */
-const GAME_TOP_LEVEL_FILES = ['SPEC.md', 'GAME.json', 'game.ts', 'index.html', 'style.css', 'ACCEPTANCE.json'];
+const GAME_TOP_LEVEL_FILES = ['SPEC.md', 'GAME.json', 'EDITOR.json', 'EDITOR.ts', 'EDITOR.content.json', 'game.ts', 'index.html', 'style.css', 'ACCEPTANCE.json'];
 
 /** One reference file this big is a generated blob, not something to learn a style from. */
 const MAX_REFERENCE_FILE_BYTES = 80_000;


### PR DESCRIPTION
Follow-up to merged #995.

Addresses Codex review feedback by including `EDITOR.ts`, `EDITOR.json`, and `EDITOR.content.json` in the website seeder's scaffold/reference context, with regression coverage. This keeps the seed prompt aligned with the editor-ready contract.