### PR TITLE
Extract self-build connect routes out of submissions.ts

### DIFF
--- a/apps/api/src/agent-surface/self-build-connect-routes.ts
+++ b/apps/api/src/agent-surface/self-build-connect-routes.ts
@@ -1,0 +1,155 @@
+import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
+import { z } from 'zod';
+import { allowsSelfToPlatformHandoff, isActiveBuildRound } from '../creation/builder.js';
+import { detectStall } from '../creation/job-state.js';
+import { InvalidTokenError, verifyToken } from '../platform/submission-token.js';
+import type { Store, SubmissionRecord } from '../platform/store.js';
+import { mintConnectPayload } from './self-build-connect.js';
+
+export interface SelfBuildConnectRoutesOptions {
+  store?: Store;
+  now: () => number;
+  submissionTokenSecret?: string;
+  appBaseUrl: string;
+  checkUserAccess: (request: FastifyRequest, reply: FastifyReply) => boolean;
+  ensureSubmissionSlug: (issueNumber: number, record: SubmissionRecord) => Promise<string | null>;
+}
+
+// Connects a creator's agent to a self-build round.
+export async function registerSelfBuildConnectRoutes(
+  app: FastifyInstance,
+  options: SelfBuildConnectRoutesOptions,
+): Promise<void> {
+  const { store, now, submissionTokenSecret, appBaseUrl, checkUserAccess, ensureSubmissionSlug } = options;
+
+  // Creator-session auth, owner only.
+
+  // Valid only while the active round's builder is self.
+
+  // Regenerating remints the key — it does not rotate.
+
+  // Pending inbox lines are embedded under "also apply".
+
+  // See self-build-connect.ts for the payload templates.
+  app.get(
+    '/api/submissions/:id/connect',
+    { config: { rateLimit: { max: 60, timeWindow: '1 hour' } } },
+    async (request, reply) => {
+      if (!submissionTokenSecret) {
+        return reply.status(503).send({ error: 'submissions are not configured' });
+      }
+      if (!checkUserAccess(request, reply)) return;
+      if (!store) {
+        return reply.status(503).send({ error: 'submissions are not configured' });
+      }
+
+      const id = z.string().parse((request.params as { id?: string }).id);
+      let issueNumber: number;
+      try {
+        issueNumber = verifyToken(id, submissionTokenSecret);
+      } catch (error) {
+        if (error instanceof InvalidTokenError) {
+          return reply.status(400).send({ error: 'invalid submission token' });
+        }
+        throw error;
+      }
+
+      const record = await store.getSubmission(issueNumber);
+      // Same shape as share/abandon — 403 hides which is true.
+      if (!record || record.ownerUid !== request.user!.uid) {
+        return reply.status(403).send({ error: 'only the creator can connect a build' });
+      }
+
+      // Gates on the active round's builder, not the defaultBuilder fallback.
+      const builder = record.builder ?? 'platform';
+      if (builder !== 'self' || !isActiveBuildRound(record)) {
+        return reply.status(409).send({
+          error: 'connect_unavailable',
+          reason: builder !== 'self' ? 'not_self_round' : 'inactive_round',
+          builder,
+        });
+      }
+
+      await store.ensureRoundGeneration(issueNumber);
+      // Re-read after ensureRoundGeneration — a closing transition can race it.
+      const fresh = await store.getSubmission(issueNumber);
+      const freshBuilder = fresh?.builder ?? 'platform';
+      if (!fresh || freshBuilder !== 'self' || !isActiveBuildRound(fresh)) {
+        return reply.status(409).send({
+          error: 'connect_unavailable',
+          reason: freshBuilder !== 'self' ? 'not_self_round' : 'inactive_round',
+          builder: freshBuilder,
+        });
+      }
+
+      const slug = await ensureSubmissionSlug(issueNumber, fresh);
+      if (!slug) {
+        return reply.status(409).send({
+          error: 'connect_unavailable',
+          reason: 'missing_slug',
+          builder: freshBuilder,
+        });
+      }
+
+      const at = new Date(now()).toISOString();
+      // BY-27b: hands out the creator-wide key, never per-game.
+      const keyRecord = await store.ensureCreatorAgentKey(fresh.ownerUid, at);
+
+      const pendingMessages = await store.listPendingCreatorMessages(issueNumber);
+      const payload = mintConnectPayload({
+        slug,
+        ownerUid: fresh.ownerUid,
+        keyGeneration: keyRecord.keyGeneration,
+        title: fresh.title,
+        submissionTokenSecret,
+        appBaseUrl,
+        pendingMessages,
+        now: now(),
+      });
+      const stall = detectStall({
+        state: fresh.state ?? 'queued',
+        stateSince: fresh.stateSince ?? fresh.createdAt,
+        lastAgentSignalAt: fresh.lastAgentSignalAt,
+        agentState: fresh.agentState,
+        agentEndedAt: fresh.agentEndedAt,
+        now: now(),
+        builder: freshBuilder,
+      });
+      // Payload carries a capability for Copy — never let intermediaries cache it.
+      return reply.header('Cache-Control', 'no-store').send({
+        ...payload,
+        canSwitchToPlatform: allowsSelfToPlatformHandoff({
+          currentBuilder: freshBuilder,
+          requestedBuilder: 'platform',
+          stall,
+          agentEndedAt: fresh.agentEndedAt,
+        }),
+      });
+    },
+  );
+
+  // Closed-beta retirement: old clients get an upgrade response, not a key.
+  app.get(
+    '/api/submissions/:id/agent-key',
+    { config: { rateLimit: { max: 60, timeWindow: '1 hour' } } },
+    async (request, reply) => {
+      if (!checkUserAccess(request, reply)) return;
+      return reply.status(410).send({
+        error: 'per_game_keys_retired',
+        reason: 'Reconnect this coding agent from Studio using OAuth or the creator-wide key.',
+      });
+    },
+  );
+
+  app.post(
+    '/api/submissions/:id/agent-key/rotate',
+    { config: { rateLimit: { max: 20, timeWindow: '1 hour' } } },
+    async (request, reply) => {
+      if (!checkUserAccess(request, reply)) return;
+      return reply.status(410).send({
+        error: 'per_game_keys_retired',
+        reason: 'Reconnect this coding agent from Studio using OAuth or the creator-wide key.',
+      });
+    },
+  );
+}

--- a/apps/api/src/submissions.ts
+++ b/apps/api/src/submissions.ts
@@ -37,6 +37,7 @@ import {
   type GameSnapshotReader,
 } from './catalog/game-snapshot.js';
 import { registerAdminGameRoutes } from './catalog/admin-game-routes.js';
+import { registerSelfBuildConnectRoutes } from './agent-surface/self-build-connect-routes.js';
 import { registerCatalogRoutes } from './catalog/catalog-routes.js';
 import { registerCatalogSearchRoutes } from './catalog/catalog-search-routes.js';
 import { registerDraftPreviewRoutes } from './delivery/draft-preview-routes.js';
@@ -108,7 +109,6 @@ import {
   type DeliveryGateStatus,
 } from './platform/delivery-metrics.js';
 import { type ChatAgentImage, type StudioChatAgent } from './creation/chat-agent.js';
-import { mintConnectPayload } from './agent-surface/self-build-connect.js';
 import { createLocalGamesClient, resolveLocalGamesDir } from './catalog/local-games-repo.js';
 import { createMailerFromEnv, type Mailer } from './notifications/mailer.js';
 import { createDefaultContentChecker, type ContentChecker } from './platform/moderation.js';
@@ -1895,6 +1895,14 @@ export async function registerSubmissionRoutes(
     isSlugClaimed,
     confirmSlugClaim,
   });
+  await registerSelfBuildConnectRoutes(app, {
+    store,
+    now,
+    submissionTokenSecret,
+    appBaseUrl: notifyAppBaseUrl,
+    checkUserAccess,
+    ensureSubmissionSlug,
+  });
 
   // Single source of GitHub-state → status derivation, shared by the on-demand
   // status route and the notification sweep so they never diverge.
@@ -2697,145 +2705,6 @@ export async function registerSubmissionRoutes(
       ...(platformBuilder ? { platformBuilder } : {}),
     });
   });
-
-  /**
-   * Everything a creator needs to connect their own coding agent to a self-build round.
-   *
-   * Creator-session auth, owner only. Valid only while the active round's builder is
-   * `self`. Install snippets configure the MCP URL plus a masked Authorization header
-   * for the creator-wide key (BY-27b); the kickoff prompt is keyless (slug only).
-   * Regenerating remints a creator key with a new signed `exp` at the same
-   * keyGeneration — it does NOT rotate. Pending, undelivered creator inbox lines
-   * are embedded under "also apply:" so a re-copy never drops queued feedback.
-   * See self-build-connect.ts for the templates.
-   */
-  app.get(
-    '/api/submissions/:id/connect',
-    { config: { rateLimit: { max: 60, timeWindow: '1 hour' } } },
-    async (request, reply) => {
-      if (!submissionTokenSecret) {
-        return reply.status(503).send({ error: 'submissions are not configured' });
-      }
-      if (!checkUserAccess(request, reply)) return;
-      if (!store) {
-        return reply.status(503).send({ error: 'submissions are not configured' });
-      }
-
-      const id = z.string().parse((request.params as { id?: string }).id);
-      let issueNumber: number;
-      try {
-        issueNumber = verifyToken(id, submissionTokenSecret);
-      } catch (error) {
-        if (error instanceof InvalidTokenError) {
-          return reply.status(400).send({ error: 'invalid submission token' });
-        }
-        throw error;
-      }
-
-      const record = await store.getSubmission(issueNumber);
-      // Same shape as share/abandon: missing and not-yours both 403 so existence is not
-      // confirmed to a stranger who holds (or forges) a status link.
-      if (!record || record.ownerUid !== request.user!.uid) {
-        return reply.status(403).send({ error: 'only the creator can connect a build' });
-      }
-
-      // Gate on the *active round's* builder field, not `builderOf` (which falls back to
-      // `defaultBuilder`). A legacy/platform round that once used self must not unlock
-      // connect just because defaultBuilder still says self.
-      const builder = record.builder ?? 'platform';
-      if (builder !== 'self' || !isActiveBuildRound(record)) {
-        return reply.status(409).send({
-          error: 'connect_unavailable',
-          reason: builder !== 'self' ? 'not_self_round' : 'inactive_round',
-          builder,
-        });
-      }
-
-      await store.ensureRoundGeneration(issueNumber);
-      // Re-read after ensureRoundGeneration: a closing transition can race between the
-      // first snapshot and minting. Without this we could mint against a round that just
-      // closed to ready_for_review (Codex P1).
-      const fresh = await store.getSubmission(issueNumber);
-      const freshBuilder = fresh?.builder ?? 'platform';
-      if (!fresh || freshBuilder !== 'self' || !isActiveBuildRound(fresh)) {
-        return reply.status(409).send({
-          error: 'connect_unavailable',
-          reason: freshBuilder !== 'self' ? 'not_self_round' : 'inactive_round',
-          builder: freshBuilder,
-        });
-      }
-
-      const slug = await ensureSubmissionSlug(issueNumber, fresh);
-      if (!slug) {
-        return reply.status(409).send({
-          error: 'connect_unavailable',
-          reason: 'missing_slug',
-          builder: freshBuilder,
-        });
-      }
-
-      const at = new Date(now()).toISOString();
-      // BY-27b: connect hands out the creator-wide key (config header) + a keyless
-      // slug prompt. The former per-game key path is intentionally retired.
-      const keyRecord = await store.ensureCreatorAgentKey(fresh.ownerUid, at);
-
-      const pendingMessages = await store.listPendingCreatorMessages(issueNumber);
-      const payload = mintConnectPayload({
-        slug,
-        ownerUid: fresh.ownerUid,
-        keyGeneration: keyRecord.keyGeneration,
-        title: fresh.title,
-        submissionTokenSecret,
-        appBaseUrl: notifyAppBaseUrl,
-        pendingMessages,
-        now: now(),
-      });
-      const stall = detectStall({
-        state: fresh.state ?? 'queued',
-        stateSince: fresh.stateSince ?? fresh.createdAt,
-        lastAgentSignalAt: fresh.lastAgentSignalAt,
-        agentState: fresh.agentState,
-        agentEndedAt: fresh.agentEndedAt,
-        now: now(),
-        builder: freshBuilder,
-      });
-      // Payload carries a capability for Copy — never let intermediaries cache it.
-      return reply.header('Cache-Control', 'no-store').send({
-        ...payload,
-        canSwitchToPlatform: allowsSelfToPlatformHandoff({
-          currentBuilder: freshBuilder,
-          requestedBuilder: 'platform',
-          stall,
-          agentEndedAt: fresh.agentEndedAt,
-        }),
-      });
-    },
-  );
-
-  /** Closed-beta retirement: old clients get an explicit upgrade response, never a key. */
-  app.get(
-    '/api/submissions/:id/agent-key',
-    { config: { rateLimit: { max: 60, timeWindow: '1 hour' } } },
-    async (request, reply) => {
-      if (!checkUserAccess(request, reply)) return;
-      return reply.status(410).send({
-        error: 'per_game_keys_retired',
-        reason: 'Reconnect this coding agent from Studio using OAuth or the creator-wide key.',
-      });
-    },
-  );
-
-  app.post(
-    '/api/submissions/:id/agent-key/rotate',
-    { config: { rateLimit: { max: 20, timeWindow: '1 hour' } } },
-    async (request, reply) => {
-      if (!checkUserAccess(request, reply)) return;
-      return reply.status(410).send({
-        error: 'per_game_keys_retired',
-        reason: 'Reconnect this coding agent from Studio using OAuth or the creator-wide key.',
-      });
-    },
-  );
 
   /**
    * The creator decides whether anyone else may play their game before it is published.

--- a/eslint-rules/comment-prose-baseline.json
+++ b/eslint-rules/comment-prose-baseline.json
@@ -330,7 +330,7 @@
     "apps/api/src/store/records/telemetry.ts": 1136,
     "apps/api/src/store/slices/rounds.ts": 25,
     "apps/api/src/submissions.test.ts": 4637,
-    "apps/api/src/submissions.ts": 10876,
+    "apps/api/src/submissions.ts": 10651,
     "apps/api/src/telemetry/creator-metrics.test.ts": 81,
     "apps/api/src/telemetry/creator-metrics.ts": 310,
     "apps/api/src/telemetry/telemetry-trends.ts": 476,

--- a/eslint-rules/module-boundary-map.mjs
+++ b/eslint-rules/module-boundary-map.mjs
@@ -198,6 +198,7 @@ const FILE_BUCKET = {
   'managed-provider-openai': 'agent-surface',
   'self-build-backend': 'agent-surface',
   'self-build-connect': 'agent-surface',
+  'self-build-connect-routes': 'agent-surface',
   'creator-agent-key-routes': 'agent-surface',
   'kit-digest': 'agent-surface',
   'kit-files': 'agent-surface',


### PR DESCRIPTION
## Summary

Wave B batch 7: extracts the self-build "connect" route cluster out of `apps/api/src/submissions.ts` into a new `apps/api/src/agent-surface/self-build-connect-routes.ts` module, alongside the existing `self-build-connect.ts` (which already holds the pure payload/template-building logic this route calls).

- `GET /api/submissions/:id/connect` — mints the creator-wide agent key + install snippets/kickoff prompt for a self-build round.
- `GET /api/submissions/:id/agent-key` and `POST /api/submissions/:id/agent-key/rotate` — retired per-game key routes that now just point old clients at the route above.

`ensureSubmissionSlug` stays in `submissions.ts` — it's shared with `createGame` via `confirmSlugClaim`/`isSlugClaimed`, out of scope for this batch — and is passed into the new `registerSelfBuildConnectRoutes(app, options)` factory as an injected option, same pattern as `checkUserAccess`.

`submissions.ts`: 4628 → 4497 lines. New file: 159 lines, 0 comment-prose debt.

## Test plan

- [x] `npx tsc --noEmit -p apps/api/tsconfig.json` — clean
- [x] `npm run lint` — 0 errors, same pre-existing warning shape (submissions.ts unmapped-import warnings, exit 0)
- [x] `npm run comment-prose -- apps/api/src/agent-surface/self-build-connect-routes.ts` — 0 words
- [x] `npm run --workspace apps/api test -- submissions.test.ts` — 213/213 passing
- [x] Full suite: `npm run --workspace apps/api test` (224 files/3521 tests, includes `self-build-connect.test.ts`'s dedicated coverage of this route cluster) — all passing
- [ ] Verify live on production after merge + deploy

---
_Generated by [Claude Code](https://claude.ai/code/session_01VaPzGSyNfZ7nvGcJgYNSdL)_