### PR TITLE
Extract draft lifecycle routes out of submissions.ts

### DIFF
--- a/apps/api/src/creation/draft-lifecycle-routes.ts
+++ b/apps/api/src/creation/draft-lifecycle-routes.ts
@@ -1,0 +1,211 @@
+import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
+import { z } from 'zod';
+import { creatorOwnsSlug } from '../platform/slug-ownership.js';
+import { InvalidTokenError, verifyToken } from '../platform/submission-token.js';
+import type { GitHubClient } from '../catalog/github-client.js';
+import type { AgentBackend } from '../agent-surface/agent-backend.js';
+import type { Store, SubmissionRecord } from '../platform/store.js';
+import type { BuilderKind } from './builder.js';
+
+export interface DraftLifecycleRoutesOptions {
+  store?: Store;
+  now: () => number;
+  submissionTokenSecret?: string;
+  githubClient: GitHubClient | null;
+  checkUserAccess: (request: FastifyRequest, reply: FastifyReply) => boolean;
+  backendFor: (builder: BuilderKind | undefined) => Promise<AgentBackend | undefined>;
+  builderOf: (record: SubmissionRecord | null | undefined) => BuilderKind;
+  releaseWorkspace: (
+    issueNumber: number,
+    workspace: string,
+    log: { error: (context: object, message: string) => void },
+    backendName?: string,
+  ) => Promise<void>;
+  invalidateStatusCache: (issueNumber: number) => void;
+  invalidatePublishedGameCaches: (slug: string) => void;
+}
+
+// Creator self-service on their submission: share, abandon, delete.
+export async function registerDraftLifecycleRoutes(
+  app: FastifyInstance,
+  options: DraftLifecycleRoutesOptions,
+): Promise<void> {
+  const {
+    store,
+    now,
+    submissionTokenSecret,
+    githubClient,
+    checkUserAccess,
+    backendFor,
+    builderOf,
+    releaseWorkspace,
+    invalidateStatusCache,
+    invalidatePublishedGameCaches,
+  } = options;
+
+  // No separate draft link — /play/<slug> is the address for life.
+
+  // Off by default means genuinely off: 404s for everyone but the creator.
+
+  // Ownership checked via the store — a shared link isn't enough.
+  app.post(
+    '/api/submissions/:token/share',
+    { config: { rateLimit: { max: 60, timeWindow: '1 hour' } } },
+    async (request, reply) => {
+      if (!submissionTokenSecret) {
+        return reply.status(503).send({ error: 'submissions are not configured' });
+      }
+      if (!checkUserAccess(request, reply)) return;
+      if (!store) {
+        return reply.status(503).send({ error: 'submissions are not configured' });
+      }
+
+      const parsedBody = z.object({ shared: z.boolean() }).safeParse(request.body ?? {});
+      if (!parsedBody.success) {
+        return reply.status(400).send({ error: 'shared must be true or false' });
+      }
+
+      const token = z.string().parse((request.params as { token?: string }).token);
+      let issueNumber: number;
+      try {
+        issueNumber = verifyToken(token, submissionTokenSecret);
+      } catch (error) {
+        if (error instanceof InvalidTokenError) {
+          return reply.status(400).send({ error: 'invalid token' });
+        }
+        throw error;
+      }
+
+      const record = await store.getSubmission(issueNumber);
+      if (!record || record.ownerUid !== request.user!.uid) {
+        return reply.status(403).send({ error: 'only the creator can share this game' });
+      }
+      if (!record.slug) {
+        return reply.status(409).send({ error: 'this game has no address yet' });
+      }
+
+      await store.setDraftShared(issueNumber, parsedBody.data.shared ? new Date(now()).toISOString() : null);
+      return reply.send({ shared: parsedBody.data.shared, slug: record.slug });
+    },
+  );
+
+  // Abandon closes the issue and the agent's open PR.
+
+  // Does not refund the daily quota — the agent time was spent.
+
+  // Ownership checked via the store, not just the token.
+  app.post(
+    '/api/submissions/:token/abandon',
+    { config: { rateLimit: { max: 20, timeWindow: '1 hour' } } },
+    async (request, reply) => {
+      if (!githubClient || !submissionTokenSecret) {
+        return reply.status(503).send({ error: 'submissions are not configured' });
+      }
+      if (!checkUserAccess(request, reply)) {
+        return;
+      }
+      if (!store) {
+        return reply.status(503).send({ error: 'submissions are not configured' });
+      }
+
+      const token = z.string().parse((request.params as { token?: string }).token);
+      let issueNumber: number;
+      try {
+        issueNumber = verifyToken(token, submissionTokenSecret);
+      } catch (error) {
+        if (error instanceof InvalidTokenError) {
+          return reply.status(400).send({ error: 'invalid submission token' });
+        }
+        throw error;
+      }
+
+      const record = await store.getSubmission(issueNumber);
+      if (!record || record.ownerUid !== request.user!.uid) {
+        return reply.status(403).send({ error: 'only the creator can abandon this build' });
+      }
+      if (record.abandonedAt) {
+        return reply.send({ ok: true, alreadyAbandoned: true });
+      }
+
+      // Cancellation asked of the backend; Copilot has no cancel endpoint.
+      const ref = record.dispatch?.refs.at(-1);
+      const cancelBackend = await backendFor(builderOf(record));
+      if (cancelBackend && ref) {
+        try {
+          await cancelBackend.cancel(ref, record.dispatch?.credentialRefs?.[ref]);
+        } catch (cancelError) {
+          request.log.error({ err: cancelError, issueNumber }, 'agent cancel failed');
+        }
+      }
+      await store.recordJobTransition(issueNumber, {
+        to: 'canceled',
+        at: new Date(now()).toISOString(),
+        by: 'creator',
+        reason: 'abandoned',
+      });
+      // Workspace deleted after the transition, since nothing will resume it.
+      if (record.dispatch?.workspace) {
+        await releaseWorkspace(issueNumber, record.dispatch.workspace, request.log, record.dispatch.backend);
+      }
+      // Seed branch released the same way — it outlives the dispatch.
+      if (record.dispatch?.seedWorkspace) {
+        await releaseWorkspace(issueNumber, record.dispatch.seedWorkspace, request.log, record.dispatch.backend);
+        // Forgotten too, so a later cleanup won't retry a deleted ref.
+        await store.clearDispatchSeedWorkspace(issueNumber);
+      }
+
+      await store.setSubmissionAbandoned(issueNumber, new Date(now()).toISOString());
+      invalidateStatusCache(issueNumber);
+
+      return reply.send({ ok: true });
+    },
+  );
+
+  app.post(
+    '/api/submissions/:token/delete-game',
+    { config: { rateLimit: { max: 20, timeWindow: '1 hour' } } },
+    async (request, reply) => {
+      if (!submissionTokenSecret) {
+        return reply.status(503).send({ error: 'submissions are not configured' });
+      }
+      if (!checkUserAccess(request, reply)) return;
+      if (!store) {
+        return reply.status(503).send({ error: 'submissions are not configured' });
+      }
+
+      const token = z.string().parse((request.params as { token?: string }).token);
+      let issueNumber: number;
+      try {
+        issueNumber = verifyToken(token, submissionTokenSecret);
+      } catch (error) {
+        if (error instanceof InvalidTokenError) {
+          return reply.status(400).send({ error: 'invalid submission token' });
+        }
+        throw error;
+      }
+
+      const record = await store.getSubmission(issueNumber);
+      if (!record) {
+        return reply.status(403).send({ error: 'only the creator can delete this game' });
+      }
+      if (!record.slug) {
+        return reply.status(409).send({ error: 'this game has no address yet' });
+      }
+      // Not record.ownerUid — a slug transfer can move ownership on.
+      if (!(await creatorOwnsSlug(store, record.slug, request.user!.uid))) {
+        return reply.status(403).send({ error: 'only the creator can delete this game' });
+      }
+
+      const publication = await store.getPublication(record.slug);
+      if (!publication || publication.state !== 'published') {
+        return reply.status(409).send({ error: 'not_published' });
+      }
+
+      await store.archivePublication(record.slug, 'deleted by creator', new Date(now()).toISOString());
+      invalidatePublishedGameCaches(record.slug);
+      invalidateStatusCache(issueNumber);
+
+      return reply.send({ ok: true, slug: record.slug });
+    },
+  );
+}

--- a/apps/api/src/submissions.ts
+++ b/apps/api/src/submissions.ts
@@ -9,7 +9,6 @@ import {
 import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
 import { z } from 'zod';
 import { splitConceptBrief } from './agent-surface/agent-build-brief.js';
-import { creatorOwnsSlug } from './platform/slug-ownership.js';
 import { registerAgentChannelRoutes, type AgentChannelOptions } from './agent-surface/agent-channel.js';
 import { mintAgentToken, mintManagedMcpOpener } from './agent-surface/agent-token.js';
 import { registerMcpServerRoutes } from './agent-surface/mcp-server.js';
@@ -38,6 +37,7 @@ import {
 } from './catalog/game-snapshot.js';
 import { registerAdminGameRoutes } from './catalog/admin-game-routes.js';
 import { registerSelfBuildConnectRoutes } from './agent-surface/self-build-connect-routes.js';
+import { registerDraftLifecycleRoutes } from './creation/draft-lifecycle-routes.js';
 import { registerCatalogRoutes } from './catalog/catalog-routes.js';
 import { registerCatalogSearchRoutes } from './catalog/catalog-search-routes.js';
 import { registerDraftPreviewRoutes } from './delivery/draft-preview-routes.js';
@@ -1903,6 +1903,18 @@ export async function registerSubmissionRoutes(
     checkUserAccess,
     ensureSubmissionSlug,
   });
+  await registerDraftLifecycleRoutes(app, {
+    store,
+    now,
+    submissionTokenSecret,
+    githubClient,
+    checkUserAccess,
+    backendFor,
+    builderOf,
+    releaseWorkspace,
+    invalidateStatusCache,
+    invalidatePublishedGameCaches,
+  });
 
   // Single source of GitHub-state → status derivation, shared by the on-demand
   // status route and the notification sweep so they never diverge.
@@ -2705,192 +2717,6 @@ export async function registerSubmissionRoutes(
       ...(platformBuilder ? { platformBuilder } : {}),
     });
   });
-
-  /**
-   * The creator decides whether anyone else may play their game before it is published.
-   *
-   * There is no separate draft link to hand out: the game answers at `/play/<slug>` for
-   * its whole life, and this decides who that includes. Off by default, and off is
-   * genuinely off — the game is not in the catalog, not in any rail, and 404s for
-   * everyone but its creator, so the link is the only way in and the creator controls
-   * whether it works.
-   *
-   * Ownership is checked against the store rather than against the token, for the same
-   * reason abandoning is: holding a link somebody shared with you must not be enough to
-   * change who else can see the game.
-   */
-  app.post(
-    '/api/submissions/:token/share',
-    { config: { rateLimit: { max: 60, timeWindow: '1 hour' } } },
-    async (request, reply) => {
-      if (!submissionTokenSecret) {
-        return reply.status(503).send({ error: 'submissions are not configured' });
-      }
-      if (!checkUserAccess(request, reply)) return;
-      if (!store) {
-        return reply.status(503).send({ error: 'submissions are not configured' });
-      }
-
-      const parsedBody = z.object({ shared: z.boolean() }).safeParse(request.body ?? {});
-      if (!parsedBody.success) {
-        return reply.status(400).send({ error: 'shared must be true or false' });
-      }
-
-      const token = z.string().parse((request.params as { token?: string }).token);
-      let issueNumber: number;
-      try {
-        issueNumber = verifyToken(token, submissionTokenSecret);
-      } catch (error) {
-        if (error instanceof InvalidTokenError) {
-          return reply.status(400).send({ error: 'invalid token' });
-        }
-        throw error;
-      }
-
-      const record = await store.getSubmission(issueNumber);
-      if (!record || record.ownerUid !== request.user!.uid) {
-        return reply.status(403).send({ error: 'only the creator can share this game' });
-      }
-      if (!record.slug) {
-        return reply.status(409).send({ error: 'this game has no address yet' });
-      }
-
-      await store.setDraftShared(issueNumber, parsedBody.data.shared ? new Date(now()).toISOString() : null);
-      return reply.send({ shared: parsedBody.data.shared, slug: record.slug });
-    },
-  );
-
-  /**
-   * The creator gives up on a build. Closes the issue and the agent's open PR, so
-   * neither the agent nor the human merge queue keeps working on something nobody
-   * wants. Deliberately does NOT refund the daily quota — the agent time was spent.
-   * Ownership is checked against the store, not just the token: abandoning is
-   * destructive, so holding a shared link must not be enough.
-   */
-  app.post(
-    '/api/submissions/:token/abandon',
-    { config: { rateLimit: { max: 20, timeWindow: '1 hour' } } },
-    async (request, reply) => {
-      if (!githubClient || !submissionTokenSecret) {
-        return reply.status(503).send({ error: 'submissions are not configured' });
-      }
-      if (!checkUserAccess(request, reply)) {
-        return;
-      }
-      if (!store) {
-        return reply.status(503).send({ error: 'submissions are not configured' });
-      }
-
-      const token = z.string().parse((request.params as { token?: string }).token);
-      let issueNumber: number;
-      try {
-        issueNumber = verifyToken(token, submissionTokenSecret);
-      } catch (error) {
-        if (error instanceof InvalidTokenError) {
-          return reply.status(400).send({ error: 'invalid submission token' });
-        }
-        throw error;
-      }
-
-      const record = await store.getSubmission(issueNumber);
-      if (!record || record.ownerUid !== request.user!.uid) {
-        return reply.status(403).send({ error: 'only the creator can abandon this build' });
-      }
-      if (record.abandonedAt) {
-        return reply.send({ ok: true, alreadyAbandoned: true });
-      }
-
-      // Nothing to close: there is no issue and no pull request. Cancellation is asked
-      // of the backend and its honesty is respected — Copilot has no cancel endpoint,
-      // so a live session keeps running and the guarantee we actually give the creator
-      // is that the job is terminal and whatever arrives afterwards is discarded.
-      const ref = record.dispatch?.refs.at(-1);
-      const cancelBackend = await backendFor(builderOf(record));
-      if (cancelBackend && ref) {
-        try {
-          await cancelBackend.cancel(ref, record.dispatch?.credentialRefs?.[ref]);
-        } catch (cancelError) {
-          request.log.error({ err: cancelError, issueNumber }, 'agent cancel failed');
-        }
-      }
-      await store.recordJobTransition(issueNumber, {
-        to: 'canceled',
-        at: new Date(now()).toISOString(),
-        by: 'creator',
-        reason: 'abandoned',
-      });
-      // The job is terminal, so its workspace has no next round to serve. Deleted
-      // after the transition is recorded: a build nobody will ever resume must not
-      // keep a branch alive on the strength of a delete that might fail.
-      if (record.dispatch?.workspace) {
-        await releaseWorkspace(issueNumber, record.dispatch.workspace, request.log, record.dispatch.backend);
-      }
-      // The seed branch outlives the dispatch that used it — the agent forks from it, so
-      // it cannot be deleted the moment the task is created — but it has no reader once
-      // the job is terminal. Released by the same path: deleting a branch is the same
-      // operation whichever branch it is.
-      if (record.dispatch?.seedWorkspace) {
-        await releaseWorkspace(issueNumber, record.dispatch.seedWorkspace, request.log, record.dispatch.backend);
-        // Forgotten as well as deleted. Leaving the name on the record would have a
-        // second abandon — or any later cleanup path — asking GitHub to delete a ref
-        // that is already gone, against the one credential that also dispatches.
-        await store.clearDispatchSeedWorkspace(issueNumber);
-      }
-
-      await store.setSubmissionAbandoned(issueNumber, new Date(now()).toISOString());
-      invalidateStatusCache(issueNumber);
-
-      return reply.send({ ok: true });
-    },
-  );
-
-  app.post(
-    '/api/submissions/:token/delete-game',
-    { config: { rateLimit: { max: 20, timeWindow: '1 hour' } } },
-    async (request, reply) => {
-      if (!submissionTokenSecret) {
-        return reply.status(503).send({ error: 'submissions are not configured' });
-      }
-      if (!checkUserAccess(request, reply)) return;
-      if (!store) {
-        return reply.status(503).send({ error: 'submissions are not configured' });
-      }
-
-      const token = z.string().parse((request.params as { token?: string }).token);
-      let issueNumber: number;
-      try {
-        issueNumber = verifyToken(token, submissionTokenSecret);
-      } catch (error) {
-        if (error instanceof InvalidTokenError) {
-          return reply.status(400).send({ error: 'invalid submission token' });
-        }
-        throw error;
-      }
-
-      const record = await store.getSubmission(issueNumber);
-      if (!record) {
-        return reply.status(403).send({ error: 'only the creator can delete this game' });
-      }
-      if (!record.slug) {
-        return reply.status(409).send({ error: 'this game has no address yet' });
-      }
-      // Not record.ownerUid — a slug transfer can move ownership on.
-      if (!(await creatorOwnsSlug(store, record.slug, request.user!.uid))) {
-        return reply.status(403).send({ error: 'only the creator can delete this game' });
-      }
-
-      const publication = await store.getPublication(record.slug);
-      if (!publication || publication.state !== 'published') {
-        return reply.status(409).send({ error: 'not_published' });
-      }
-
-      await store.archivePublication(record.slug, 'deleted by creator', new Date(now()).toISOString());
-      invalidatePublishedGameCaches(record.slug);
-      invalidateStatusCache(issueNumber);
-
-      return reply.send({ ok: true, slug: record.slug });
-    },
-  );
 
   /** Lets a creator replace the current builder without creating feedback. */
   app.post(

--- a/eslint-rules/comment-prose-baseline.json
+++ b/eslint-rules/comment-prose-baseline.json
@@ -330,7 +330,7 @@
     "apps/api/src/store/records/telemetry.ts": 1136,
     "apps/api/src/store/slices/rounds.ts": 25,
     "apps/api/src/submissions.test.ts": 4637,
-    "apps/api/src/submissions.ts": 10651,
+    "apps/api/src/submissions.ts": 10288,
     "apps/api/src/telemetry/creator-metrics.test.ts": 81,
     "apps/api/src/telemetry/creator-metrics.ts": 310,
     "apps/api/src/telemetry/telemetry-trends.ts": 476,

--- a/eslint-rules/module-boundary-map.mjs
+++ b/eslint-rules/module-boundary-map.mjs
@@ -119,6 +119,7 @@ const FILE_BUCKET = {
   'editor-kit-env': 'platform',
 
   // creation: jobs, rounds, dispatch, seed, refine
+  'draft-lifecycle-routes': 'creation',
   'job-state': 'creation',
   'job-costs': 'creation',
   'job-admin-routes': 'creation',


### PR DESCRIPTION
## Summary

Wave B batch 8: extracts the creator self-service routes on a submission's own lifecycle out of `apps/api/src/submissions.ts` into a new `apps/api/src/creation/draft-lifecycle-routes.ts` module.

- `POST /api/submissions/:token/share` — toggles whether the draft is playable by anyone with the link before publish.
- `POST /api/submissions/:token/abandon` — cancels a build (closes the round, releases its workspace).
- `POST /api/submissions/:token/delete-game` — archives a published game (the creator-facing sibling of `admin-game-routes.ts`'s operator-facing delete).

All three share the same shape (verify token → check ownership against the store → mutate → invalidate caches). `backendFor`/`builderOf`/`releaseWorkspace`/`invalidateStatusCache`/`invalidatePublishedGameCaches` stay in `submissions.ts` — each has other call sites throughout the file, out of scope for this batch — and are passed into the new `registerDraftLifecycleRoutes(app, options)` factory as injected options, same pattern used by the last several batches.

`submissions.ts`: 4497 → 4323 lines. New file: 219 lines, 0 comment-prose debt.

## Test plan

- [x] `npx tsc --noEmit -p apps/api/tsconfig.json` — clean
- [x] `npm run lint` — 0 errors, same pre-existing warning shape (submissions.ts unmapped-import warnings, exit 0)
- [x] `npm run comment-prose -- apps/api/src/creation/draft-lifecycle-routes.ts` — 0 words
- [x] `npm run --workspace apps/api test -- submissions.test.ts` — 213/213 passing
- [x] Full suite: `npm run --workspace apps/api test` (224 files/3521 tests) — all passing
- [ ] Verify live on production after merge + deploy

---
_Generated by [Claude Code](https://claude.ai/code/session_01VaPzGSyNfZ7nvGcJgYNSdL)_