### PR TITLE
Extract creator self-service reads out of submissions.ts

### DIFF
--- a/apps/api/src/creation/creator-self-routes.ts
+++ b/apps/api/src/creation/creator-self-routes.ts
@@ -1,0 +1,84 @@
+import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
+import { pageOwnerGames } from './owner-games.js';
+import { mintToken } from '../platform/submission-token.js';
+import type { ManagedAvailabilityGate } from '../agent-surface/managed-availability.js';
+import type { Store } from '../platform/store.js';
+
+export interface CreatorSelfRoutesOptions {
+  store?: Store;
+  now: () => number;
+  checkUserAccess: (request: FastifyRequest, reply: FastifyReply) => boolean;
+  dailySubmissionQuota: number;
+  submissionTokenSecret?: string;
+  managedAvailabilityGate?: ManagedAvailabilityGate | null;
+}
+
+// A creator's own read-only account state: quota and shelf.
+export async function registerCreatorSelfRoutes(
+  app: FastifyInstance,
+  options: CreatorSelfRoutesOptions,
+): Promise<void> {
+  const { store, now, checkUserAccess, dailySubmissionQuota, submissionTokenSecret, managedAvailabilityGate } = options;
+
+  // What's left of today's allowance — never increments, just reads.
+  app.get('/api/me/quota', async (request, reply) => {
+    if (!checkUserAccess(request, reply)) {
+      return;
+    }
+    const dateStr = new Date(now()).toISOString().slice(0, 10);
+    if (!store) {
+      return reply.send({
+        submissions: { used: 0, limit: dailySubmissionQuota },
+        ...(managedAvailabilityGate
+          ? { platformBuilder: await managedAvailabilityGate.peek(request.user!.uid, dateStr) }
+          : {}),
+      });
+    }
+
+    const [usage, user, platformBuilder] = await Promise.all([
+      store.getUsage(request.user!.uid, dateStr),
+      store.getUser(request.user!.uid),
+      managedAvailabilityGate ? managedAvailabilityGate.peek(request.user!.uid, dateStr) : undefined,
+    ]);
+    return reply.send({
+      submissions: {
+        used: usage.submissions,
+        // Trusted accounts bypass the counter — report no ceiling.
+        limit: user?.tier === 'trusted' ? null : dailySubmissionQuota,
+      },
+      ...(platformBuilder ? { platformBuilder } : {}),
+    });
+  });
+
+  app.get('/api/submissions/mine', async (request, reply) => {
+    if (!submissionTokenSecret) {
+      return reply.status(503).send({ error: 'submissions are not configured' });
+    }
+    if (!checkUserAccess(request, reply)) {
+      return;
+    }
+    if (!store) {
+      return reply.send({ submissions: [] });
+    }
+
+    const records = await store.listSubmissionsByOwner(request.user!.uid);
+    const { games: shelf, truncated, total } = pageOwnerGames(records, 'shelf');
+    return reply.send({
+      submissions: shelf.map(({ tip, catalogPublishedAt }) => ({
+        token: mintToken(tip.issueNumber, submissionTokenSecret),
+        title: tip.title,
+        createdAt: tip.createdAt,
+        // Last derived status, kept current by the two-minute sweep.
+
+        // lastNotifiedStatus is the fallback for older records.
+        lastKnownStatus: tip.lastStatus ?? tip.lastNotifiedStatus ?? null,
+        // So a published card can offer Play without deriving the slug itself.
+        slug: tip.slug ?? null,
+        ...(tip.publishedAt ? { publishedAt: tip.publishedAt } : {}),
+        ...(catalogPublishedAt ? { livePublishedAt: catalogPublishedAt } : {}),
+      })),
+      truncated,
+      totalGames: total,
+    });
+  });
+}

--- a/apps/api/src/submissions.ts
+++ b/apps/api/src/submissions.ts
@@ -31,6 +31,7 @@ import { registerAdminGameRoutes } from './catalog/admin-game-routes.js';
 import { registerSelfBuildConnectRoutes } from './agent-surface/self-build-connect-routes.js';
 import { registerDraftLifecycleRoutes } from './creation/draft-lifecycle-routes.js';
 import { createSeedPipeline } from './creation/seed-pipeline.js';
+import { registerCreatorSelfRoutes } from './creation/creator-self-routes.js';
 import { registerCatalogRoutes } from './catalog/catalog-routes.js';
 import { registerGamePlayRoute } from './catalog/game-play-route.js';
 import { registerCatalogSearchRoutes } from './catalog/catalog-search-routes.js';
@@ -109,7 +110,6 @@ import {
   type EmitDeps,
 } from './notifications/notify.js';
 import { detectOperatorAlerts, FEEDBACK_STALL_MS } from './notifications/operator-alerts.js';
-import { pageOwnerGames } from './creation/owner-games.js';
 import { seedOutcomeFor } from './agent-surface/seed-status.js';
 import { isAdminSession } from './platform/admin-session.js';
 import { peekQuota } from './creation/quota-gate.js';
@@ -1731,6 +1731,14 @@ export async function registerSubmissionRoutes(
     invalidateStatusCache,
     invalidatePublishedGameCaches,
   });
+  await registerCreatorSelfRoutes(app, {
+    store,
+    now,
+    checkUserAccess,
+    dailySubmissionQuota,
+    submissionTokenSecret,
+    managedAvailabilityGate,
+  });
 
   // Single source of GitHub-state → status derivation, shared by the on-demand
   // status route and the notification sweep so they never diverge.
@@ -2502,38 +2510,6 @@ export async function registerSubmissionRoutes(
     return reply.send({ token, slug: created.slug, statusUrl: `/api/submissions/${token}` });
   });
 
-  // What's left of today's allowance. Read-only (never increments), so the hero can
-  // show it before a creator spends their last submission on a surprise 429.
-  app.get('/api/me/quota', async (request, reply) => {
-    if (!checkUserAccess(request, reply)) {
-      return;
-    }
-    const dateStr = new Date(now()).toISOString().slice(0, 10);
-    if (!store) {
-      return reply.send({
-        submissions: { used: 0, limit: dailySubmissionQuota },
-        ...(managedAvailabilityGate
-          ? { platformBuilder: await managedAvailabilityGate.peek(request.user!.uid, dateStr) }
-          : {}),
-      });
-    }
-
-    const [usage, user, platformBuilder] = await Promise.all([
-      store.getUsage(request.user!.uid, dateStr),
-      store.getUser(request.user!.uid),
-      managedAvailabilityGate ? managedAvailabilityGate.peek(request.user!.uid, dateStr) : undefined,
-    ]);
-    return reply.send({
-      submissions: {
-        used: usage.submissions,
-        // Trusted accounts bypass the counter entirely — report no ceiling rather
-        // than a number that will never be enforced.
-        limit: user?.tier === 'trusted' ? null : dailySubmissionQuota,
-      },
-      ...(platformBuilder ? { platformBuilder } : {}),
-    });
-  });
-
   /** Lets a creator replace the current builder without creating feedback. */
   app.post(
     '/api/submissions/:token/handoff',
@@ -2853,40 +2829,6 @@ export async function registerSubmissionRoutes(
       return reply.send({ ok: true, version });
     },
   );
-
-  app.get('/api/submissions/mine', async (request, reply) => {
-    if (!submissionTokenSecret) {
-      return reply.status(503).send({ error: 'submissions are not configured' });
-    }
-    if (!checkUserAccess(request, reply)) {
-      return;
-    }
-    if (!store) {
-      return reply.send({ submissions: [] });
-    }
-
-    const records = await store.listSubmissionsByOwner(request.user!.uid);
-    const { games: shelf, truncated, total } = pageOwnerGames(records, 'shelf');
-    return reply.send({
-      submissions: shelf.map(({ tip, catalogPublishedAt }) => ({
-        token: mintToken(tip.issueNumber, submissionTokenSecret),
-        title: tip.title,
-        createdAt: tip.createdAt,
-        // The last derived status, kept current by the two-minute sweep. This is
-        // what the rail renders — it used to be a hint the rail immediately went
-        // and re-derived per card, six GitHub fan-outs every thirty seconds from
-        // one open tab, which is what was rate-limiting the whole token.
-        // lastNotifiedStatus is the fallback for records written before this.
-        lastKnownStatus: tip.lastStatus ?? tip.lastNotifiedStatus ?? null,
-        // So a published card can offer Play without deriving the slug itself.
-        slug: tip.slug ?? null,
-        ...(tip.publishedAt ? { publishedAt: tip.publishedAt } : {}),
-        ...(catalogPublishedAt ? { livePublishedAt: catalogPublishedAt } : {}),
-      })),
-      truncated,
-      totalGames: total,
-    });
-  });
 
   /**
    * Derives one submission's status from GitHub and caches it.

--- a/eslint-rules/comment-prose-baseline.json
+++ b/eslint-rules/comment-prose-baseline.json
@@ -330,7 +330,7 @@
     "apps/api/src/store/records/telemetry.ts": 1136,
     "apps/api/src/store/slices/rounds.ts": 25,
     "apps/api/src/submissions.test.ts": 4637,
-    "apps/api/src/submissions.ts": 9664,
+    "apps/api/src/submissions.ts": 9557,
     "apps/api/src/telemetry/creator-metrics.test.ts": 81,
     "apps/api/src/telemetry/creator-metrics.ts": 310,
     "apps/api/src/telemetry/telemetry-trends.ts": 476,

--- a/eslint-rules/module-boundary-map.mjs
+++ b/eslint-rules/module-boundary-map.mjs
@@ -121,6 +121,7 @@ const FILE_BUCKET = {
   // creation: jobs, rounds, dispatch, seed, refine
   'draft-lifecycle-routes': 'creation',
   'seed-pipeline': 'creation',
+  'creator-self-routes': 'creation',
   'job-state': 'creation',
   'job-costs': 'creation',
   'job-admin-routes': 'creation',


### PR DESCRIPTION
## Summary

Wave B batch 11: extracts two small, read-only creator self-service routes out of `apps/api/src/submissions.ts` into a new `apps/api/src/creation/creator-self-routes.ts` module.

- `GET /api/me/quota` — today's remaining submission allowance.
- `GET /api/submissions/mine` — the creator's own submission shelf.

Both are simple, single-caller routes with no dependency on the central dispatch/reconciler machinery — `store`/`now`/`checkUserAccess`/`dailySubmissionQuota`/`submissionTokenSecret`/`managedAvailabilityGate` are all passed in as injected options, the same pattern used by the previous 10 batches.

`submissions.ts`: 4032 → 3974 lines — the first time it's dropped under 4000 lines since Wave B started (it began this wave at 6427 lines). New file: 82 lines, 0 comment-prose debt.

## Test plan

- [x] `npx tsc --noEmit -p apps/api/tsconfig.json` — clean
- [x] `npm run lint` — 0 errors, same pre-existing warning shape (submissions.ts unmapped-import warnings, exit 0)
- [x] `npm run comment-prose -- apps/api/src/creation/creator-self-routes.ts` — 0 words
- [x] `npm run --workspace apps/api test -- submissions.test.ts` — 213/213 passing
- [x] Full suite: `npm run --workspace apps/api test` (224 files/3521 tests) — all passing
- [ ] Verify live on production after merge + deploy

---
_Generated by [Claude Code](https://claude.ai/code/session_01VaPzGSyNfZ7nvGcJgYNSdL)_