### PR TITLE
Extract slug resolution out of submissions.ts

### DIFF
--- a/apps/api/src/catalog/slug-resolver.ts
+++ b/apps/api/src/catalog/slug-resolver.ts
@@ -1,0 +1,52 @@
+import { mintGameSlug } from './slug.js';
+import { settleSlugClaim } from './slug-backfill.js';
+import type { Store, SubmissionRecord } from '../platform/store.js';
+
+export interface SlugResolverOptions {
+  store?: Store;
+  isSlugPublished: (slug: string) => Promise<boolean>;
+}
+
+export interface SlugResolver {
+  isSlugClaimed(slug: string, except?: number): Promise<boolean>;
+  confirmSlugClaim(issueNumber: number, slug: string, title: string): Promise<string | null>;
+  ensureSubmissionSlug(issueNumber: number, record: SubmissionRecord): Promise<string | null>;
+}
+
+// Settles who holds a slug across the store, publications, and the catalog.
+export function createSlugResolver(options: SlugResolverOptions): SlugResolver {
+  const { store, isSlugPublished } = options;
+
+  // Deliberately forgiving of its own failures — an outage must not block creation.
+  async function isSlugClaimed(slug: string, except?: number): Promise<boolean> {
+    if (store) {
+      try {
+        const existing = await store.getSubmissionBySlug(slug);
+        if (existing && existing.issueNumber !== except) return true;
+        const publication = await store.getPublication(slug);
+        if (publication) return true;
+      } catch {
+        // Fall through: an unavailable store must not block creation.
+      }
+    }
+    try {
+      if (await isSlugPublished(slug)) return true;
+    } catch {
+      // Same reasoning; this one is likeliest to fail since it reads GitHub.
+    }
+    return false;
+  }
+
+  async function confirmSlugClaim(issueNumber: number, slug: string, title: string): Promise<string | null> {
+    if (!store) return slug;
+    return settleSlugClaim(store, issueNumber, slug, title, isSlugClaimed);
+  }
+
+  async function ensureSubmissionSlug(issueNumber: number, record: SubmissionRecord): Promise<string | null> {
+    if (record.slug) return record.slug;
+    const wanted = await mintGameSlug(record.title, async (candidate) => isSlugClaimed(candidate, issueNumber));
+    return confirmSlugClaim(issueNumber, wanted, record.title);
+  }
+
+  return { isSlugClaimed, confirmSlugClaim, ensureSubmissionSlug };
+}

--- a/apps/api/src/submissions.ts
+++ b/apps/api/src/submissions.ts
@@ -28,6 +28,7 @@ import { postGateScreenshotToThread } from './delivery/gate-screenshot.js';
 import { createGitHubClient, type CatalogGameEntry, type GitHubClient } from './catalog/github-client.js';
 import { createSnapshotReaderFromEnv, type GameSnapshotReader } from './catalog/game-snapshot.js';
 import { registerAdminGameRoutes } from './catalog/admin-game-routes.js';
+import { createSlugResolver } from './catalog/slug-resolver.js';
 import { registerSelfBuildConnectRoutes } from './agent-surface/self-build-connect-routes.js';
 import { registerDraftLifecycleRoutes } from './creation/draft-lifecycle-routes.js';
 import { createSeedPipeline } from './creation/seed-pipeline.js';
@@ -105,7 +106,6 @@ import { seedOutcomeFor } from './agent-surface/seed-status.js';
 import { isAdminSession } from './platform/admin-session.js';
 import { peekQuota } from './creation/quota-gate.js';
 import { mintGameSlug } from './catalog/slug.js';
-import { settleSlugClaim } from './catalog/slug-backfill.js';
 import {
   type AgentKeysStore,
   type BuildLogStore,
@@ -1637,60 +1637,10 @@ export async function registerSubmissionRoutes(
     catalogRoutes.invalidatePublishedGameCache(slug);
   }
 
-  // The cache-cold path is the dangerous one: with min-instances 0, a fresh
-  /**
-   * Reads back a slug this job just wrote, and settles who actually holds it.
-   *
-   * The settling itself is {@link settleSlugClaim}, shared with the backfill CLI; this
-   * binds it to this server's store and its GitHub-aware `isSlugClaimed`.
-   */
-  async function confirmSlugClaim(issueNumber: number, slug: string, title: string): Promise<string | null> {
-    // No store means nothing can hold a name against us, so the claim stands as written.
-    if (!store) return slug;
-    return settleSlugClaim(store, issueNumber, slug, title, isSlugClaimed);
-  }
-
-  /**
-   * Ensures a submission has a settled slug, minting one on demand for legacy rounds
-   * that predated slug-at-submission.
-   */
-  async function ensureSubmissionSlug(issueNumber: number, record: SubmissionRecord): Promise<string | null> {
-    if (record.slug) return record.slug;
-    const wanted = await mintGameSlug(record.title, async (candidate) => isSlugClaimed(candidate, issueNumber));
-    return confirmSlugClaim(issueNumber, wanted, record.title);
-  }
-
-  /**
-   * Whether anything already answers to this name.
-   *
-   * Three namespaces, because a game can exist in three places and a new build must not
-   * be given an address that already means something else: another submission (building
-   * or built), a game published through the store, and a game published in the games
-   * repo's catalog. `except` lets a job ask about a name it may already hold itself.
-   *
-   * Deliberately forgiving of its own failures. This runs inside submission creation, and
-   * a GitHub outage that made every name look taken would refuse builds the creator has
-   * already paid a quota slot for; a name that is wrongly *available* costs far less than
-   * a submission that will not start, and the delivery path checks again before writing.
-   */
-  async function isSlugClaimed(slug: string, except?: number): Promise<boolean> {
-    if (store) {
-      try {
-        const existing = await store.getSubmissionBySlug(slug);
-        if (existing && existing.issueNumber !== except) return true;
-        const publication = await store.getPublication(slug);
-        if (publication) return true;
-      } catch {
-        // Fall through: see above — an unavailable store must not block creation.
-      }
-    }
-    try {
-      if (await catalogRoutes.isSlugPublished(slug)) return true;
-    } catch {
-      // Same reasoning, and this one is the likeliest to fail: it reads GitHub.
-    }
-    return false;
-  }
+  const { isSlugClaimed, confirmSlugClaim, ensureSubmissionSlug } = createSlugResolver({
+    store,
+    isSlugPublished: catalogRoutes.isSlugPublished,
+  });
 
   await registerAdminGameRoutes(app, {
     store,

--- a/eslint-rules/comment-prose-baseline.json
+++ b/eslint-rules/comment-prose-baseline.json
@@ -330,7 +330,7 @@
     "apps/api/src/store/records/telemetry.ts": 1136,
     "apps/api/src/store/slices/rounds.ts": 25,
     "apps/api/src/submissions.test.ts": 4637,
-    "apps/api/src/submissions.ts": 8972,
+    "apps/api/src/submissions.ts": 8749,
     "apps/api/src/telemetry/creator-metrics.test.ts": 81,
     "apps/api/src/telemetry/creator-metrics.ts": 310,
     "apps/api/src/telemetry/telemetry-trends.ts": 476,

--- a/eslint-rules/module-boundary-map.mjs
+++ b/eslint-rules/module-boundary-map.mjs
@@ -246,6 +246,7 @@ const FILE_BUCKET = {
   // catalog: github-client, snapshots, assemble, play
   'admin-game-routes': 'catalog',
   'game-play-route': 'catalog',
+  'slug-resolver': 'catalog',
   'music-tracks': 'catalog',
   'catalog-enricher': 'catalog',
   'catalog-vector-index': 'catalog',


### PR DESCRIPTION
## Summary
- Moves `confirmSlugClaim`/`ensureSubmissionSlug`/`isSlugClaimed` out of `apps/api/src/submissions.ts` into a new `apps/api/src/catalog/slug-resolver.ts`, exposed as `createSlugResolver({ store, isSlugPublished })`.
- Dependency surface is 2 options (`store`, `isSlugPublished`); the three call sites in `submissions.ts` (`registerAdminGameRoutes`, `registerSelfBuildConnectRoutes`, `createGame`) are untouched since they already reference the bare identifiers, now destructured from the resolver.
- This closes out the Phase 3 Wave B seam extraction series (batch 13, final). The remaining ~3700 lines of `submissions.ts` are `dispatchBuild`/`resumeBuild`/`reconcileNativeJob`/`reconcileGateVerdict`/`createGame`/`refreshStatus` plus the routes that call them directly — genuinely interconnected central machinery that doesn't decompose cleanly via the injected-options pattern without either an oversized options surface or an actual architectural change.

## Test plan
- [x] `tsc --noEmit` clean
- [x] `npm run lint` — 0 errors (122 pre-existing warnings, same pattern as prior batches)
- [x] `npm run comment-prose` — new file at 0 words, `submissions.ts` baseline resealed (8972 → 8749)
- [x] `submissions.test.ts` — 213/213 passing
- [x] Full `apps/api` suite — 224 files / 3521 tests passing

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01VaPzGSyNfZ7nvGcJgYNSdL

---
_Generated by [Claude Code](https://claude.ai/code/session_01VaPzGSyNfZ7nvGcJgYNSdL)_