### PR TITLE
docs(verify-agent-work): record #1007 model-RPC and matcher misses

### DIFF
--- a/.claude/skills/verify-agent-work/SKILL.md
+++ b/.claude/skills/verify-agent-work/SKILL.md
@@ -112,6 +112,29 @@ Two concrete instances of that (observed 2026-07-23):
   edited dependency ranges in `package.json` without regenerating the lock — every local
   check green, CI dead on arrival at `npm ci` (EUSAGE). After ANY `package.json` edit,
   `npm install --package-lock-only` must produce a zero lockfile diff before committing.
+- **Swapping a Vertex / Gemini model id is not a one-line default change.** Observed
+  (#1007, 2026-08-25): `text-embedding-005` → `gemini-embedding-2` kept the legacy
+  `:predict` URL and `{ instances: [{ content }] }` body. Google dropped `:predict` for
+  that family (`400 FAILED_PRECONDITION`); live `embedText` swallows the error to `[]`,
+  so the vector index stays empty and every search returns `{ match: null, score: 0 }`.
+  The suite stayed green because it mocked the *old* prediction shape and never asserted
+  the request URL. When a model id changes, grep the RPC (`:predict` vs `:embedContent`
+  vs `:generateContent`), the request body, and the response parse path — and add a test
+  that the constructed URL contains the verb the new model actually serves.
+- **A lowered server threshold is a no-op if the client still gates the old value.**
+  Same PR: `/api/catalog/search` dropped `findBestMatch` from 0.65 to 0.55 for
+  "cross-lingual sensitivity", but `HeroPromptSection` still accepts a vector hit only
+  when `data.score >= 0.65`. Scores in the newly admitted band are discarded. When a
+  PR changes an accept-set, grep every caller for the old constant; a split threshold
+  is a behaviour change that no unit test will see if each side is tested in isolation.
+- **A widened substring / alias matcher needs negative controls, not just the prompt
+  that motivated it.** Same PR: the new local matcher made `chcę pograć w piłkę` →
+  `mexico-86` (intended) and also `I want to play a card game` → `carjack-city`
+  (`includes('car')`), `gold rush` / `golden axe` → `mexico-86` (`includes('gol')`),
+  `author` / `autumn leaves` → `carjack-city` (`includes('aut')`), `chess` / `szachy` →
+  `checker-champ`. The added test only mounted the happy-path prompt. When a matcher
+  grows `includes` / alias tables, run the same function on the pre-change branch and
+  require a control query that must *not* match.
 - **A games-repo PR that adds a GameKit module can 502 play/draft even when its own
   gate is green.** Observed (www.gamedev.pl-games#690, 2026-08-12): `platformer` was
   inserted into `GAME_KIT_MODULES` / `shared/assemble-contract.json` with no paired


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Records three verification misses found while reviewing #1007, so the next pass does not treat a green suite as proof:

- A Vertex / Gemini model id swap that still calls `:predict` (live `gemini-embedding-2` needs `:embedContent`; failures swallow to `[]`).
- A server accept threshold the client still rejects (0.55 vs 0.65).
- Widened substring / alias matchers tested only on the happy-path prompt.

No product code. See the review of #1007 for the probes.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e119f75e-45fd-4a22-b9d0-ed6ada3df25e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e119f75e-45fd-4a22-b9d0-ed6ada3df25e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

