### PR TITLE
fix(ci): build workspace packages before nightly verify:erase

### DIFF
--- a/.github/workflows/verify-erase.yml
+++ b/.github/workflows/verify-erase.yml
@@ -70,6 +70,11 @@ jobs:
 
       - run: npm ci
 
+      # tsx follows package.json exports into packages/contract/dist (and
+      # zone-core). npm ci does not emit those. The 2026-08-24/25 nightlies
+      # died on ERR_MODULE_NOT_FOUND and the §8 proof never ran.
+      - run: npm run build:packages
+
       - name: Authenticate to GCP via Workload Identity Federation
         uses: google-github-actions/auth@c200f3691d83b41bf9bbd8638997a462592937ed # v2
         with:

--- a/apps/api/src/erase-verification-workflow.test.ts
+++ b/apps/api/src/erase-verification-workflow.test.ts
@@ -59,6 +59,12 @@ describe('verify-erase workflow', () => {
     // out. Anything beyond that is a workflow that can change the thing it is auditing.
     expect(workflow).toMatch(/permissions:\s*\n\s*contents: read\s*\n\s*id-token: write/);
   });
+
+  it('builds workspace packages before running the tsx script', () => {
+    // Nightly died on missing contract dist
+    const body = workflow.replace(/^\s*#.*$/gm, '');
+    expect(body).toMatch(/npm ci[\s\S]*npm run build:packages[\s\S]*npm run verify:erase/);
+  });
 });
 
 describe('setup-wif.sh', () => {

--- a/eslint-rules/module-size-baseline.json
+++ b/eslint-rules/module-size-baseline.json
@@ -289,7 +289,7 @@
     "apps/api/src/delivery/staged-preview.ts": 614,
     "apps/api/src/delivery/workspace-archive.test.ts": 189,
     "apps/api/src/delivery/workspace-archive.ts": 192,
-    "apps/api/src/erase-verification-workflow.test.ts": 79,
+    "apps/api/src/erase-verification-workflow.test.ts": 85,
     "apps/api/src/firestore-indexes.test.ts": 158,
     "apps/api/src/game-snapshot-serve.test.ts": 438,
     "apps/api/src/mcp-continue-draft.test.ts": 427,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Nightly `Verify erasure` has been red since 24 Aug: `tsx scripts/verify-erase-signals.ts` follows `@gamedevpl/contract` / `@gamedevpl/zone-core` package.json exports into `dist/`, which `npm ci` does not emit. The job died on `ERR_MODULE_NOT_FOUND` and never proved the §8 erasure path.
- Add `npm run build:packages` after `npm ci`, same step `publish-games.yml` already has.
- Ratchet: `erase-verification-workflow.test.ts` now asserts `npm ci` → `build:packages` → `verify:erase` in that order (comments stripped so a commented-out step cannot fake it).

Does not touch the live erase implementation — only the scheduled proof that it still works against Firestore.

## Test plan
- [x] Workflow YAML contains `npm run build:packages` between `npm ci` and `verify:erase`
- [x] `npm run test -w @gamedevpl/api -- src/erase-verification-workflow.test.ts` (7/7)
- [x] `npm run type-check && npm run lint && npm run test && npm run build`
- [ ] After merge, `workflow_dispatch` on Verify erasure (or wait for 03:47 UTC) should get past module resolution; a later auth/Firestore failure would be a different bug

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1695137d-580b-4ace-bf00-2c96b18c46a2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1695137d-580b-4ace-bf00-2c96b18c46a2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

