### PR TITLE
Fix fresh EditorKit v2 content pairing

### DIFF
--- a/apps/api/src/delivery/editor-delivery-contract.test.ts
+++ b/apps/api/src/delivery/editor-delivery-contract.test.ts
@@ -43,6 +43,37 @@ describe('new-game editor delivery contract', () => {
     }
   });
 
+  it('requires the content document paired with a fresh v2 declaration', () => {
+    const v2Files = [...FILES, { path: 'EDITOR.json', content: '{"version":2}' }];
+
+    expect(() => validateSourceUpload(v2Files, 'preview', false, true)).toThrow(
+      /EDITOR\.content\.json is required/,
+    );
+    try {
+      validateSourceUpload(v2Files, 'preview', false, true);
+    } catch (error) {
+      expect(error).toMatchObject({ missingPaths: ['EDITOR.content.json'] });
+    }
+
+    expect(
+      validateSourceUpload(
+        [...v2Files, { path: 'EDITOR.content.json', content: '{"params":{}}' }],
+        'preview',
+        false,
+        true,
+      ),
+    ).toHaveLength(v2Files.length + 1);
+  });
+
+  it('keeps v1 and malformed declarations on their existing gate-validation path', () => {
+    expect(
+      validateSourceUpload([...FILES, { path: 'EDITOR.json', content: '{"version":1}' }], 'preview', false, true),
+    ).toHaveLength(FILES.length + 1);
+    expect(
+      validateSourceUpload([...FILES, { path: 'EDITOR.json', content: '{' }], 'preview', false, true),
+    ).toHaveLength(FILES.length + 1);
+  });
+
   it('keeps legacy revision uploads compatible by default', () => {
     expect(validateSourceUpload(FILES, 'preview')).toHaveLength(FILES.length);
   });

--- a/apps/api/src/delivery/editor-upload-requirements.ts
+++ b/apps/api/src/delivery/editor-upload-requirements.ts
@@ -1,0 +1,31 @@
+import type { SourceFile } from './games-store.js';
+
+export type MissingFreshEditorFile = {
+  path: 'EDITOR.json' | 'EDITOR.content.json';
+  message: string;
+};
+
+export function missingFreshEditorFile(files: SourceFile[]): MissingFreshEditorFile | null {
+  const editorJson = files.find((file) => file.path.trim() === 'EDITOR.json');
+  if (!editorJson) {
+    return {
+      path: 'EDITOR.json',
+      message: 'EDITOR.json is required for a new game — deliver the compiled editor contract before preview or publish',
+    };
+  }
+
+  try {
+    const definition = JSON.parse(editorJson.content) as { version?: unknown } | null;
+    if (definition?.version === 2 && !files.some((file) => file.path.trim() === 'EDITOR.content.json')) {
+      return {
+        path: 'EDITOR.content.json',
+        message:
+          'EDITOR.content.json is required for an EditorKit v2 game — deliver the content document paired with EDITOR.json',
+      };
+    }
+  } catch {
+    // The authoritative editor parser reports malformed declarations in the gate.
+  }
+
+  return null;
+}

--- a/apps/api/src/delivery/games-store.test.ts
+++ b/apps/api/src/delivery/games-store.test.ts
@@ -638,25 +638,6 @@ describe('GCS games store', () => {
     });
   });
 
-  it('refuses a fresh v2 candidate without its content document before writing', async () => {
-    const { impl, objects } = stubGcs();
-    const store = createGcsGamesStore({ ...base, fetchImpl: impl });
-
-    await expect(
-      store.putCandidateSources({
-        slug: 'fresh-v2',
-        issueNumber: 43,
-        mode: 'preview',
-        requireCompiledEditor: true,
-        files: [...MINIMAL, { path: 'EDITOR.json', content: '{"version":2}' }],
-      }),
-    ).rejects.toMatchObject({
-      message: expect.stringMatching(/EDITOR\.content\.json is required/),
-      missingPaths: ['EDITOR.content.json'],
-    });
-    expect(objects.size).toBe(0);
-  });
-
   it('writes the manifest last, so a dead run leaves no version claiming missing files', async () => {
     const writes: string[] = [];
     const impl = (async (url: string | URL, init: RequestInit = {}) => {

--- a/apps/api/src/delivery/games-store.test.ts
+++ b/apps/api/src/delivery/games-store.test.ts
@@ -638,6 +638,25 @@ describe('GCS games store', () => {
     });
   });
 
+  it('refuses a fresh v2 candidate without its content document before writing', async () => {
+    const { impl, objects } = stubGcs();
+    const store = createGcsGamesStore({ ...base, fetchImpl: impl });
+
+    await expect(
+      store.putCandidateSources({
+        slug: 'fresh-v2',
+        issueNumber: 43,
+        mode: 'preview',
+        requireCompiledEditor: true,
+        files: [...MINIMAL, { path: 'EDITOR.json', content: '{"version":2}' }],
+      }),
+    ).rejects.toMatchObject({
+      message: expect.stringMatching(/EDITOR\.content\.json is required/),
+      missingPaths: ['EDITOR.content.json'],
+    });
+    expect(objects.size).toBe(0);
+  });
+
   it('writes the manifest last, so a dead run leaves no version claiming missing files', async () => {
     const writes: string[] = [];
     const impl = (async (url: string | URL, init: RequestInit = {}) => {

--- a/apps/api/src/delivery/games-store.ts
+++ b/apps/api/src/delivery/games-store.ts
@@ -301,8 +301,6 @@ export function validateSourceUpload(
           );
         }
       } catch (error) {
-        // Malformed declarations are reported by the authoritative editor parser in
-        // the gate. This preflight only enforces the structural v2 file pair.
         if (error instanceof InvalidUploadError) throw error;
       }
     }

--- a/apps/api/src/delivery/games-store.ts
+++ b/apps/api/src/delivery/games-store.ts
@@ -288,6 +288,25 @@ export function validateSourceUpload(
       ['EDITOR.json'],
     );
   }
+  if (requireCompiledEditor) {
+    const editorJson = files.find((file) => file.path.trim() === 'EDITOR.json');
+    if (editorJson) {
+      try {
+        const definition = JSON.parse(editorJson.content) as { version?: unknown } | null;
+        if (definition?.version === 2 && !seen.has('EDITOR.content.json')) {
+          throw new InvalidUploadError(
+            'EDITOR.content.json is required for an EditorKit v2 game — deliver the content document paired with EDITOR.json',
+            undefined,
+            ['EDITOR.content.json'],
+          );
+        }
+      } catch (error) {
+        // Malformed declarations are reported by the authoritative editor parser in
+        // the gate. This preflight only enforces the structural v2 file pair.
+        if (error instanceof InvalidUploadError) throw error;
+      }
+    }
+  }
   const gameJson = files.find((file) => file.path.trim() === 'GAME.json');
 
   // A blank index.html is absent, same as getGameSources treats it.

--- a/apps/api/src/delivery/games-store.ts
+++ b/apps/api/src/delivery/games-store.ts
@@ -34,6 +34,7 @@ import { parseKitSidecar } from '../platform/kit-registry.js';
 import { KIT_REGISTRY_OBJECT, parseKitRegistry, type KitRegistry } from '../platform/kit-window.js';
 import { findUnresolvedSourceLinks, formatSourceLinkError, sourceFilesToMap } from './source-link-check.js';
 import { BANNED_ANY_GUIDANCE, describeBannedAnyFinding, findBannedAnyUsages } from './ts-any-scan.js';
+import { missingFreshEditorFile } from './editor-upload-requirements.js';
 
 export type { GateProgress } from './gate-progress.js';
 
@@ -281,29 +282,9 @@ export function validateSourceUpload(
   if (!seen.has('game.ts')) {
     throw new InvalidUploadError('game.ts is required — a game must be playable', undefined, ['game.ts']);
   }
-  if (requireCompiledEditor && !seen.has('EDITOR.json')) {
-    throw new InvalidUploadError(
-      'EDITOR.json is required for a new game — deliver the compiled editor contract before preview or publish',
-      undefined,
-      ['EDITOR.json'],
-    );
-  }
-  if (requireCompiledEditor) {
-    const editorJson = files.find((file) => file.path.trim() === 'EDITOR.json');
-    if (editorJson) {
-      try {
-        const definition = JSON.parse(editorJson.content) as { version?: unknown } | null;
-        if (definition?.version === 2 && !seen.has('EDITOR.content.json')) {
-          throw new InvalidUploadError(
-            'EDITOR.content.json is required for an EditorKit v2 game — deliver the content document paired with EDITOR.json',
-            undefined,
-            ['EDITOR.content.json'],
-          );
-        }
-      } catch (error) {
-        if (error instanceof InvalidUploadError) throw error;
-      }
-    }
+  const missingEditorFile = requireCompiledEditor ? missingFreshEditorFile(files) : null;
+  if (missingEditorFile) {
+    throw new InvalidUploadError(missingEditorFile.message, undefined, [missingEditorFile.path]);
   }
   const gameJson = files.find((file) => file.path.trim() === 'GAME.json');
 


### PR DESCRIPTION
## Summary

- reject fresh EditorKit v2 candidates that omit `EDITOR.content.json`
- enforce the pair at the shared games-store boundary before any source object is written
- preserve the existing v1 and malformed-declaration paths
- keep the structural detector in a focused module so large-file budgets do not grow

## Production evidence

A non-public production verification fixture showed that a fresh v2 preview with `EDITOR.json` but no `EDITOR.content.json` was stored and sent to the gate. The same fixture without compiled `EDITOR.json` was correctly refused. This change closes that structural gap.

## Verification

Current head: `dbf4a262f08307f700ed1fcaa402880b9c8258d2`

CI run: https://github.com/gamedevpl/www.gamedev.pl/actions/runs/32909865954

Focused coverage in `apps/api/src/delivery/editor-delivery-contract.test.ts` proves:
- v2 without content is refused with `missingPaths: ['EDITOR.content.json']`
- the paired v2 upload is accepted
- v1 is unchanged
- malformed declarations remain on the authoritative gate-parser path

After merge and deploy, the same non-public fixture will be retried for the missing-content negative and paired-content positive controls.