### PR TITLE
Extract Creator-Kit file-browsing routes out of agent-channel.ts (Wave D batch 1)

### DIFF
--- a/apps/api/src/agent-surface/agent-channel-kit-files.ts
+++ b/apps/api/src/agent-surface/agent-channel-kit-files.ts
@@ -1,0 +1,219 @@
+import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
+import { AGENT_CHANNEL_ROUTES } from '@gamedevpl/contract';
+import {
+  KitFilesError,
+  listKitFiles,
+  readKitFile,
+  readKitFileFragment,
+  readKitFiles,
+  searchKitFiles,
+  type KitFileStore,
+} from './kit-files.js';
+import { KitRegistryError } from '../platform/kit-registry.js';
+import type { AgentTokenAccess } from './agent-token.js';
+import type { SubmissionRecord } from '../platform/store.js';
+
+// The Creator Kit read cluster: single file, batch, and windowed fragment reads.
+export interface AgentChannelKitFileRoutesDeps {
+  resolveBuild: (
+    request: FastifyRequest,
+    reply: FastifyReply,
+  ) => Promise<{ issueNumber: number; record: SubmissionRecord; access: AgentTokenAccess } | null>;
+  kitFileStore: KitFileStore | null;
+}
+
+function optionalFiniteQuery(raw: string | undefined): number | undefined {
+  if (raw === undefined) return undefined;
+  const value = Number(raw);
+  return Number.isFinite(value) ? value : undefined;
+}
+
+function sendKitFilesError(reply: FastifyReply, error: unknown): FastifyReply | null {
+  if (error instanceof KitFilesError) {
+    const status =
+      error.code === 'kit_store_unavailable'
+        ? 503
+        : error.code === 'kit_registry_missing' ||
+            error.code === 'kit_registry_invalid' ||
+            error.code === 'kit_artifact_missing' ||
+            error.code === 'kit_file_missing'
+          ? 404
+          : error.code === 'kit_revision_unsupported'
+            ? 409
+            : 400;
+    return reply.status(status).send({ error: error.code, message: error.message });
+  }
+  if (error instanceof KitRegistryError) {
+    return reply.status(404).send({ error: error.code, message: error.message });
+  }
+  return null;
+}
+
+export function registerAgentChannelKitFileRoutes(app: FastifyInstance, deps: AgentChannelKitFileRoutesDeps): void {
+  const { resolveBuild, kitFileStore } = deps;
+
+  app.get(
+    AGENT_CHANNEL_ROUTES.KIT_FILES,
+    { config: { rateLimit: { max: 120, timeWindow: '1 hour' } } },
+    async (request, reply) => {
+      const resolved = await resolveBuild(request, reply);
+      if (!resolved) return reply;
+      if (!kitFileStore) {
+        return reply.status(503).send({ error: 'kit_store_unavailable', message: 'the kit store is not configured' });
+      }
+      try {
+        const query = request.query as {
+          prefix?: string;
+          glob?: string;
+          limit?: string;
+          offset?: string;
+          engineRef?: string;
+        };
+        const tree = await kitFileStore.loadTree(query.engineRef);
+        return reply.send(
+          listKitFiles(tree, {
+            prefix: query.prefix,
+            glob: query.glob,
+            limit: optionalFiniteQuery(query.limit),
+            offset: optionalFiniteQuery(query.offset),
+          }),
+        );
+      } catch (error) {
+        const sent = sendKitFilesError(reply, error);
+        if (sent) return sent;
+        throw error;
+      }
+    },
+  );
+
+  app.get(
+    AGENT_CHANNEL_ROUTES.KIT_SEARCH,
+    { config: { rateLimit: { max: 120, timeWindow: '1 hour' } } },
+    async (request, reply) => {
+      const resolved = await resolveBuild(request, reply);
+      if (!resolved) return reply;
+      if (!kitFileStore) {
+        return reply.status(503).send({ error: 'kit_store_unavailable', message: 'the kit store is not configured' });
+      }
+      try {
+        const query = request.query as {
+          q?: string;
+          query?: string;
+          prefix?: string;
+          limit?: string;
+          engineRef?: string;
+        };
+        const tree = await kitFileStore.loadTree(query.engineRef);
+        return reply.send(
+          searchKitFiles(tree, {
+            query: query.q ?? query.query ?? '',
+            prefix: query.prefix,
+            limit: optionalFiniteQuery(query.limit),
+          }),
+        );
+      } catch (error) {
+        const sent = sendKitFilesError(reply, error);
+        if (sent) return sent;
+        throw error;
+      }
+    },
+  );
+
+  app.get(
+    AGENT_CHANNEL_ROUTES.KIT_FILE,
+    { config: { rateLimit: { max: 240, timeWindow: '1 hour' } } },
+    async (request, reply) => {
+      const resolved = await resolveBuild(request, reply);
+      if (!resolved) return reply;
+      if (!kitFileStore) {
+        return reply.status(503).send({ error: 'kit_store_unavailable', message: 'the kit store is not configured' });
+      }
+      try {
+        const query = request.query as { path?: string; encoding?: string; engineRef?: string };
+        if (!query.path?.trim()) {
+          return reply.status(400).send({ error: 'kit_path_invalid', message: 'path is required' });
+        }
+        const encoding = query.encoding === 'base64' || query.encoding === 'utf8' ? query.encoding : undefined;
+        const tree = await kitFileStore.loadTree(query.engineRef);
+        return reply.send(readKitFile(tree, query.path, { encoding }));
+      } catch (error) {
+        const sent = sendKitFilesError(reply, error);
+        if (sent) return sent;
+        throw error;
+      }
+    },
+  );
+
+  app.post(
+    AGENT_CHANNEL_ROUTES.KIT_FILES_READ,
+    { config: { rateLimit: { max: 120, timeWindow: '1 hour' } } },
+    async (request, reply) => {
+      const resolved = await resolveBuild(request, reply);
+      if (!resolved) return reply;
+      if (!kitFileStore) {
+        return reply.status(503).send({ error: 'kit_store_unavailable', message: 'the kit store is not configured' });
+      }
+      try {
+        const body = (request.body ?? {}) as {
+          paths?: unknown;
+          encoding?: string;
+          engineRef?: string;
+        };
+        if (!Array.isArray(body.paths)) {
+          return reply.status(400).send({ error: 'kit_query_invalid', message: 'paths must be an array of strings' });
+        }
+        const paths = body.paths.filter((path): path is string => typeof path === 'string');
+        if (paths.length === 0) {
+          return reply.status(400).send({ error: 'kit_query_invalid', message: 'paths must be a non-empty array' });
+        }
+        const encoding = body.encoding === 'base64' || body.encoding === 'utf8' ? body.encoding : undefined;
+        const tree = await kitFileStore.loadTree(body.engineRef);
+        return reply.send(readKitFiles(tree, paths, { encoding }));
+      } catch (error) {
+        const sent = sendKitFilesError(reply, error);
+        if (sent) return sent;
+        throw error;
+      }
+    },
+  );
+
+  app.get(
+    AGENT_CHANNEL_ROUTES.KIT_FILE_FRAGMENT,
+    { config: { rateLimit: { max: 240, timeWindow: '1 hour' } } },
+    async (request, reply) => {
+      const resolved = await resolveBuild(request, reply);
+      if (!resolved) return reply;
+      if (!kitFileStore) {
+        return reply.status(503).send({ error: 'kit_store_unavailable', message: 'the kit store is not configured' });
+      }
+      try {
+        const query = request.query as {
+          path?: string;
+          offset?: string;
+          limit?: string;
+          unit?: string;
+          encoding?: string;
+          engineRef?: string;
+        };
+        if (!query.path?.trim()) {
+          return reply.status(400).send({ error: 'kit_path_invalid', message: 'path is required' });
+        }
+        const encoding = query.encoding === 'base64' || query.encoding === 'utf8' ? query.encoding : undefined;
+        const unit = query.unit === 'bytes' || query.unit === 'lines' ? query.unit : undefined;
+        const tree = await kitFileStore.loadTree(query.engineRef);
+        return reply.send(
+          readKitFileFragment(tree, query.path, {
+            offset: optionalFiniteQuery(query.offset),
+            limit: optionalFiniteQuery(query.limit),
+            unit,
+            encoding,
+          }),
+        );
+      } catch (error) {
+        const sent = sendKitFilesError(reply, error);
+        if (sent) return sent;
+        throw error;
+      }
+    },
+  );
+}

--- a/apps/api/src/agent-surface/agent-channel.ts
+++ b/apps/api/src/agent-surface/agent-channel.ts
@@ -49,15 +49,8 @@ import {
 import { parseGameMedia } from '../catalog/github-client.js';
 import { canTransition, resolveJobState, type JobState } from '../creation/job-state.js';
 import { gateCrashStall } from '../delivery/gate-crash.js';
-import {
-  KitFilesError,
-  createKitFileStore,
-  listKitFiles,
-  readKitFile,
-  readKitFileFragment,
-  readKitFiles,
-  searchKitFiles,
-} from './kit-files.js';
+import { createKitFileStore } from './kit-files.js';
+import { registerAgentChannelKitFileRoutes } from './agent-channel-kit-files.js';
 import { logKnowledgeQuery } from '../platform/knowledge-metrics.js';
 import type {
   KnowledgeMode,
@@ -720,27 +713,6 @@ export async function registerAgentChannelRoutes(
             ? 404
             : 400;
       return reply.status(status).send({ error: error.code, message: error.message });
-    }
-    return null;
-  }
-
-  function sendKitFilesError(reply: FastifyReply, error: unknown): FastifyReply | null {
-    if (error instanceof KitFilesError) {
-      const status =
-        error.code === 'kit_store_unavailable'
-          ? 503
-          : error.code === 'kit_registry_missing' ||
-              error.code === 'kit_registry_invalid' ||
-              error.code === 'kit_artifact_missing' ||
-              error.code === 'kit_file_missing'
-            ? 404
-            : error.code === 'kit_revision_unsupported'
-              ? 409
-              : 400;
-      return reply.status(status).send({ error: error.code, message: error.message });
-    }
-    if (error instanceof KitRegistryError) {
-      return reply.status(404).send({ error: error.code, message: error.message });
     }
     return null;
   }
@@ -2598,180 +2570,7 @@ export async function registerAgentChannelRoutes(
     },
   );
 
-  /**
-   * List files inside the current Creator Kit without downloading the tarball to the agent.
-   */
-  app.get(
-    AGENT_CHANNEL_ROUTES.KIT_FILES,
-    { config: { rateLimit: { max: 120, timeWindow: '1 hour' } } },
-    async (request, reply) => {
-      const resolved = await resolveBuild(request, reply);
-      if (!resolved) return reply;
-      if (!kitFileStore) {
-        return reply.status(503).send({ error: 'kit_store_unavailable', message: 'the kit store is not configured' });
-      }
-      try {
-        const query = request.query as {
-          prefix?: string;
-          glob?: string;
-          limit?: string;
-          offset?: string;
-          engineRef?: string;
-        };
-        const tree = await kitFileStore.loadTree(query.engineRef);
-        return reply.send(
-          listKitFiles(tree, {
-            prefix: query.prefix,
-            glob: query.glob,
-            limit: optionalFiniteQuery(query.limit),
-            offset: optionalFiniteQuery(query.offset),
-          }),
-        );
-      } catch (error) {
-        const sent = sendKitFilesError(reply, error);
-        if (sent) return sent;
-        throw error;
-      }
-    },
-  );
-
-  /** Grep text files in the current Creator Kit. */
-  app.get(
-    AGENT_CHANNEL_ROUTES.KIT_SEARCH,
-    { config: { rateLimit: { max: 120, timeWindow: '1 hour' } } },
-    async (request, reply) => {
-      const resolved = await resolveBuild(request, reply);
-      if (!resolved) return reply;
-      if (!kitFileStore) {
-        return reply.status(503).send({ error: 'kit_store_unavailable', message: 'the kit store is not configured' });
-      }
-      try {
-        const query = request.query as {
-          q?: string;
-          query?: string;
-          prefix?: string;
-          limit?: string;
-          engineRef?: string;
-        };
-        const tree = await kitFileStore.loadTree(query.engineRef);
-        return reply.send(
-          searchKitFiles(tree, {
-            query: query.q ?? query.query ?? '',
-            prefix: query.prefix,
-            limit: optionalFiniteQuery(query.limit),
-          }),
-        );
-      } catch (error) {
-        const sent = sendKitFilesError(reply, error);
-        if (sent) return sent;
-        throw error;
-      }
-    },
-  );
-
-  /** Read one small kit file (refuse oversized — use /fragment). */
-  app.get(
-    AGENT_CHANNEL_ROUTES.KIT_FILE,
-    { config: { rateLimit: { max: 240, timeWindow: '1 hour' } } },
-    async (request, reply) => {
-      const resolved = await resolveBuild(request, reply);
-      if (!resolved) return reply;
-      if (!kitFileStore) {
-        return reply.status(503).send({ error: 'kit_store_unavailable', message: 'the kit store is not configured' });
-      }
-      try {
-        const query = request.query as { path?: string; encoding?: string; engineRef?: string };
-        if (!query.path?.trim()) {
-          return reply.status(400).send({ error: 'kit_path_invalid', message: 'path is required' });
-        }
-        const encoding = query.encoding === 'base64' || query.encoding === 'utf8' ? query.encoding : undefined;
-        const tree = await kitFileStore.loadTree(query.engineRef);
-        return reply.send(readKitFile(tree, query.path, { encoding }));
-      } catch (error) {
-        const sent = sendKitFilesError(reply, error);
-        if (sent) return sent;
-        throw error;
-      }
-    },
-  );
-
-  /**
-   * Read several small kit files in one request — collapses ChatGPT/Claude per-turn
-   * tool-call budgets when browsing a scaffold.
-   */
-  app.post(
-    AGENT_CHANNEL_ROUTES.KIT_FILES_READ,
-    { config: { rateLimit: { max: 120, timeWindow: '1 hour' } } },
-    async (request, reply) => {
-      const resolved = await resolveBuild(request, reply);
-      if (!resolved) return reply;
-      if (!kitFileStore) {
-        return reply.status(503).send({ error: 'kit_store_unavailable', message: 'the kit store is not configured' });
-      }
-      try {
-        const body = (request.body ?? {}) as {
-          paths?: unknown;
-          encoding?: string;
-          engineRef?: string;
-        };
-        if (!Array.isArray(body.paths)) {
-          return reply.status(400).send({ error: 'kit_query_invalid', message: 'paths must be an array of strings' });
-        }
-        const paths = body.paths.filter((path): path is string => typeof path === 'string');
-        if (paths.length === 0) {
-          return reply.status(400).send({ error: 'kit_query_invalid', message: 'paths must be a non-empty array' });
-        }
-        const encoding = body.encoding === 'base64' || body.encoding === 'utf8' ? body.encoding : undefined;
-        const tree = await kitFileStore.loadTree(body.engineRef);
-        return reply.send(readKitFiles(tree, paths, { encoding }));
-      } catch (error) {
-        const sent = sendKitFilesError(reply, error);
-        if (sent) return sent;
-        throw error;
-      }
-    },
-  );
-
-  /** Read a byte/line window of one kit file. */
-  app.get(
-    AGENT_CHANNEL_ROUTES.KIT_FILE_FRAGMENT,
-    { config: { rateLimit: { max: 240, timeWindow: '1 hour' } } },
-    async (request, reply) => {
-      const resolved = await resolveBuild(request, reply);
-      if (!resolved) return reply;
-      if (!kitFileStore) {
-        return reply.status(503).send({ error: 'kit_store_unavailable', message: 'the kit store is not configured' });
-      }
-      try {
-        const query = request.query as {
-          path?: string;
-          offset?: string;
-          limit?: string;
-          unit?: string;
-          encoding?: string;
-          engineRef?: string;
-        };
-        if (!query.path?.trim()) {
-          return reply.status(400).send({ error: 'kit_path_invalid', message: 'path is required' });
-        }
-        const encoding = query.encoding === 'base64' || query.encoding === 'utf8' ? query.encoding : undefined;
-        const unit = query.unit === 'bytes' || query.unit === 'lines' ? query.unit : undefined;
-        const tree = await kitFileStore.loadTree(query.engineRef);
-        return reply.send(
-          readKitFileFragment(tree, query.path, {
-            offset: optionalFiniteQuery(query.offset),
-            limit: optionalFiniteQuery(query.limit),
-            unit,
-            encoding,
-          }),
-        );
-      } catch (error) {
-        const sent = sendKitFilesError(reply, error);
-        if (sent) return sent;
-        throw error;
-      }
-    },
-  );
+  registerAgentChannelKitFileRoutes(app, { resolveBuild, kitFileStore });
 
   // knowledge_query's route. A capped round still returns 200, not an error.
   app.get(

--- a/eslint-rules/comment-prose-baseline.json
+++ b/eslint-rules/comment-prose-baseline.json
@@ -23,7 +23,7 @@
     "apps/api/src/agent-surface/agent-build-brief.ts": 95,
     "apps/api/src/agent-surface/agent-build-examples.ts": 103,
     "apps/api/src/agent-surface/agent-channel.test.ts": 1226,
-    "apps/api/src/agent-surface/agent-channel.ts": 4217,
+    "apps/api/src/agent-surface/agent-channel.ts": 4157,
     "apps/api/src/agent-surface/agent-creator-key-resolve.ts": 172,
     "apps/api/src/agent-surface/agent-creator-key.test.ts": 15,
     "apps/api/src/agent-surface/agent-creator-key.ts": 257,

--- a/eslint-rules/module-boundary-map.mjs
+++ b/eslint-rules/module-boundary-map.mjs
@@ -174,6 +174,7 @@ const FILE_BUCKET = {
 
   // agent-surface: channel + MCP + kit
   'agent-channel': 'agent-surface',
+  'agent-channel-kit-files': 'agent-surface',
   'mcp-server': 'agent-surface',
   'mcp-tool-support': 'agent-surface',
   'mcp-example-tools': 'agent-surface',


### PR DESCRIPTION
## Summary
- Starts Wave D — decomposition of `apps/api/src/agent-surface/agent-channel.ts` (3311 lines), the next largest untouched file after Wave B (`submissions.ts`) and Wave C (`mcp-server.ts`) concluded.
- Batch 1: `agent-channel.ts` 3311 → 3110 lines.
- Moves `KIT_FILES`/`KIT_SEARCH`/`KIT_FILE`/`KIT_FILES_READ`/`KIT_FILE_FRAGMENT` — all thin wrappers over `kit-files.ts`'s pure functions — into a new `apps/api/src/agent-surface/agent-channel-kit-files.ts` as `registerAgentChannelKitFileRoutes(app, deps)`, following the same `register<Name>Routes(app, options)` shape already used by `creator-agent-key-routes.ts`.
- `sendKitFilesError` moves with the cluster (its only callers). `kitFileStore` stays constructed in `agent-channel.ts` (also needed by the staging routes) and is passed in as a dep. `optionalFiniteQuery` is duplicated locally (a cheap 3-line helper still used elsewhere in the parent file).
- Adds a `FILE_BUCKET` entry (`agent-surface`) and reseals the comment-prose baseline downward (`agent-channel.ts` 4217 → 4157 words; new file frozen at 0).

## Test plan
- [x] `tsc --noEmit` clean across `apps/api`
- [x] `npm run lint` (eslint on both touched files) — 0 errors, 0 new warnings
- [x] `npm run comment-prose` — all files at or under baseline
- [x] `npm run module-size` — new file 219 lines, well under the 500-line cap
- [x] `npx vitest run src/agent-surface/agent-channel.test.ts src/agent-build-reads.test.ts` — 127/127 passing

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01VaPzGSyNfZ7nvGcJgYNSdL

---
_Generated by [Claude Code](https://claude.ai/code/session_01VaPzGSyNfZ7nvGcJgYNSdL)_