### PR TITLE
Extract exemplar routes out of agent-channel.ts (Wave D batch 2)

### DIFF
--- a/apps/api/src/agent-surface/agent-channel-examples.ts
+++ b/apps/api/src/agent-surface/agent-channel-examples.ts
@@ -1,0 +1,175 @@
+import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
+import { AGENT_CHANNEL_ROUTES } from '@gamedevpl/contract';
+import { getAgentBuildExample, listAgentBuildExamples } from './agent-build-examples.js';
+import {
+  ExampleFilesError,
+  listExampleFiles,
+  readExampleFile,
+  type ExampleFileStore,
+} from '../creation/example-files.js';
+import { exampleUnpackCommand } from '../platform/kit-registry.js';
+import { DEFAULT_SIGNED_URL_TTL_SECONDS, type GcsObjectStore } from '../delivery/gcs-sign.js';
+import type { AgentTokenAccess } from './agent-token.js';
+import type { SubmissionRecord } from '../platform/store.js';
+
+// The curated first-party exemplar cluster: catalog, tarball, and file reads.
+export interface AgentChannelExamplesRoutesDeps {
+  resolveBuild: (
+    request: FastifyRequest,
+    reply: FastifyReply,
+  ) => Promise<{ issueNumber: number; record: SubmissionRecord; access: AgentTokenAccess } | null>;
+  objectStore: GcsObjectStore | undefined;
+  exampleFileStore: ExampleFileStore | null;
+}
+
+function optionalFiniteQuery(raw: string | undefined): number | undefined {
+  if (raw === undefined) return undefined;
+  const value = Number(raw);
+  return Number.isFinite(value) ? value : undefined;
+}
+
+function sendExampleFilesError(reply: FastifyReply, error: unknown): FastifyReply | null {
+  if (error instanceof ExampleFilesError) {
+    const status =
+      error.code === 'example_store_unavailable'
+        ? 503
+        : error.code === 'example_unavailable' || error.code === 'example_file_missing'
+          ? 404
+          : 400;
+    return reply.status(status).send({ error: error.code, message: error.message });
+  }
+  return null;
+}
+
+export function registerAgentChannelExamplesRoutes(app: FastifyInstance, deps: AgentChannelExamplesRoutesDeps): void {
+  const { resolveBuild, objectStore, exampleFileStore } = deps;
+
+  app.get(
+    AGENT_CHANNEL_ROUTES.EXAMPLES,
+    { config: { rateLimit: { max: 60, timeWindow: '1 hour' } } },
+    async (request, reply) => {
+      const resolved = await resolveBuild(request, reply);
+      if (!resolved) return reply;
+      return reply.send({ examples: listAgentBuildExamples() });
+    },
+  );
+
+  app.get(
+    AGENT_CHANNEL_ROUTES.EXAMPLES_BY_SLUG,
+    { config: { rateLimit: { max: 60, timeWindow: '1 hour' } } },
+    async (request, reply) => {
+      const resolved = await resolveBuild(request, reply);
+      if (!resolved) return reply;
+
+      const slug = String((request.params as { slug?: string }).slug ?? '');
+      const example = getAgentBuildExample(slug);
+      if (!example) {
+        return reply.status(404).send({ error: 'unknown_example', message: 'slug is not on the exemplar allowlist' });
+      }
+
+      if (!objectStore) {
+        return reply
+          .status(503)
+          .send({ error: 'example_store_unavailable', message: 'the example store is not configured' });
+      }
+
+      const objectName = `examples/${example.slug}.tgz`;
+      if (!(await objectStore.objectExists(objectName))) {
+        return reply.status(404).send({
+          error: 'example_unavailable',
+          message: `no packed sources for allowlisted slug ${example.slug}`,
+        });
+      }
+
+      let sha256: string | null = null;
+      const sidecarBody = await objectStore.readObject(`examples/${example.slug}.json`);
+      if (sidecarBody) {
+        try {
+          const parsed = JSON.parse(sidecarBody.toString('utf8')) as { sha256?: unknown };
+          if (typeof parsed.sha256 === 'string' && /^[a-f0-9]{64}$/i.test(parsed.sha256)) {
+            sha256 = parsed.sha256.toLowerCase();
+          }
+        } catch {
+          // A corrupt sidecar must not block the download.
+        }
+      }
+
+      const tarballUrl = await objectStore.signReadUrl(objectName, DEFAULT_SIGNED_URL_TTL_SECONDS);
+      return reply.send({
+        slug: example.slug,
+        title: example.title,
+        tarballUrl,
+        ...(sha256 ? { sha256 } : {}),
+        unpack: exampleUnpackCommand(tarballUrl),
+      });
+    },
+  );
+
+  app.get(
+    AGENT_CHANNEL_ROUTES.EXAMPLES_BY_SLUG_FILES,
+    { config: { rateLimit: { max: 120, timeWindow: '1 hour' } } },
+    async (request, reply) => {
+      const resolved = await resolveBuild(request, reply);
+      if (!resolved) return reply;
+
+      const example = getAgentBuildExample(String((request.params as { slug?: string }).slug ?? ''));
+      if (!example) {
+        return reply.status(404).send({ error: 'unknown_example', message: 'slug is not on the exemplar allowlist' });
+      }
+      if (!exampleFileStore) {
+        return reply
+          .status(503)
+          .send({ error: 'example_store_unavailable', message: 'the example store is not configured' });
+      }
+
+      try {
+        const query = request.query as { prefix?: string; limit?: string; offset?: string };
+        const tree = await exampleFileStore.loadTree(example.slug);
+        return reply.send(
+          listExampleFiles(tree, {
+            prefix: query.prefix,
+            limit: optionalFiniteQuery(query.limit),
+            offset: optionalFiniteQuery(query.offset),
+          }),
+        );
+      } catch (error) {
+        const sent = sendExampleFilesError(reply, error);
+        if (sent) return sent;
+        throw error;
+      }
+    },
+  );
+
+  app.get(
+    AGENT_CHANNEL_ROUTES.EXAMPLES_BY_SLUG_FILE,
+    { config: { rateLimit: { max: 120, timeWindow: '1 hour' } } },
+    async (request, reply) => {
+      const resolved = await resolveBuild(request, reply);
+      if (!resolved) return reply;
+
+      const example = getAgentBuildExample(String((request.params as { slug?: string }).slug ?? ''));
+      if (!example) {
+        return reply.status(404).send({ error: 'unknown_example', message: 'slug is not on the exemplar allowlist' });
+      }
+      if (!exampleFileStore) {
+        return reply
+          .status(503)
+          .send({ error: 'example_store_unavailable', message: 'the example store is not configured' });
+      }
+
+      try {
+        const query = request.query as { path?: string; encoding?: string };
+        const encoding = query.encoding === 'base64' ? 'base64' : query.encoding === 'utf8' ? 'utf8' : undefined;
+        if (query.encoding && !encoding) {
+          return reply.status(400).send({ error: 'example_query_invalid', message: 'encoding must be utf8 or base64' });
+        }
+        const tree = await exampleFileStore.loadTree(example.slug);
+        return reply.send(readExampleFile(tree, query.path ?? '', { ...(encoding ? { encoding } : {}) }));
+      } catch (error) {
+        const sent = sendExampleFilesError(reply, error);
+        if (sent) return sent;
+        throw error;
+      }
+    },
+  );
+}

--- a/apps/api/src/agent-surface/agent-channel.ts
+++ b/apps/api/src/agent-surface/agent-channel.ts
@@ -7,13 +7,8 @@ import {
   buildConstraints,
   DEFAULT_BUILD_ORIENTATION,
 } from './agent-build-brief.js';
-import { getAgentBuildExample, listAgentBuildExamples } from './agent-build-examples.js';
-import {
-  ExampleFilesError,
-  createExampleFileStore,
-  listExampleFiles,
-  readExampleFile,
-} from '../creation/example-files.js';
+import { createExampleFileStore } from '../creation/example-files.js';
+import { registerAgentChannelExamplesRoutes } from './agent-channel-examples.js';
 import {
   assertAgentTokenActive,
   classifyAgentTokenAccess,
@@ -61,7 +56,6 @@ import type {
 import {
   KIT_ENTRY,
   KitRegistryError,
-  exampleUnpackCommand,
   kitUnpackCommand,
   parseKitRegistry,
   parseKitSidecar,
@@ -702,19 +696,6 @@ export async function registerAgentChannelRoutes(
     if (raw === undefined) return undefined;
     const value = Number(raw);
     return Number.isFinite(value) ? value : undefined;
-  }
-
-  function sendExampleFilesError(reply: FastifyReply, error: unknown): FastifyReply | null {
-    if (error instanceof ExampleFilesError) {
-      const status =
-        error.code === 'example_store_unavailable'
-          ? 503
-          : error.code === 'example_unavailable' || error.code === 'example_file_missing'
-            ? 404
-            : 400;
-      return reply.status(status).send({ error: error.code, message: error.message });
-    }
-    return null;
   }
 
   /**
@@ -2617,150 +2598,7 @@ export async function registerAgentChannelRoutes(
     },
   );
 
-  /**
-   * Curated first-party exemplars — allowlist JSON in-repo, never a store listing.
-   */
-  app.get(
-    AGENT_CHANNEL_ROUTES.EXAMPLES,
-    { config: { rateLimit: { max: 60, timeWindow: '1 hour' } } },
-    async (request, reply) => {
-      const resolved = await resolveBuild(request, reply);
-      if (!resolved) return reply;
-      return reply.send({ examples: listAgentBuildExamples() });
-    },
-  );
-
-  /**
-   * Signed tarball of one allowlisted exemplar's sources (`examples/<slug>.tgz`).
-   * Non-allowlisted slugs 404 even if an object happens to exist under that name.
-   */
-  app.get(
-    AGENT_CHANNEL_ROUTES.EXAMPLES_BY_SLUG,
-    { config: { rateLimit: { max: 60, timeWindow: '1 hour' } } },
-    async (request, reply) => {
-      const resolved = await resolveBuild(request, reply);
-      if (!resolved) return reply;
-
-      const slug = String((request.params as { slug?: string }).slug ?? '');
-      const example = getAgentBuildExample(slug);
-      if (!example) {
-        return reply.status(404).send({ error: 'unknown_example', message: 'slug is not on the exemplar allowlist' });
-      }
-
-      if (!options.objectStore) {
-        return reply
-          .status(503)
-          .send({ error: 'example_store_unavailable', message: 'the example store is not configured' });
-      }
-
-      const objectName = `examples/${example.slug}.tgz`;
-      if (!(await options.objectStore.objectExists(objectName))) {
-        return reply.status(404).send({
-          error: 'example_unavailable',
-          message: `no packed sources for allowlisted slug ${example.slug}`,
-        });
-      }
-
-      let sha256: string | null = null;
-      const sidecarBody = await options.objectStore.readObject(`examples/${example.slug}.json`);
-      if (sidecarBody) {
-        try {
-          const parsed = JSON.parse(sidecarBody.toString('utf8')) as { sha256?: unknown };
-          if (typeof parsed.sha256 === 'string' && /^[a-f0-9]{64}$/i.test(parsed.sha256)) {
-            sha256 = parsed.sha256.toLowerCase();
-          }
-        } catch {
-          // Sidecar is optional; a corrupt one must not block the download.
-        }
-      }
-
-      const tarballUrl = await options.objectStore.signReadUrl(objectName, DEFAULT_SIGNED_URL_TTL_SECONDS);
-      return reply.send({
-        slug: example.slug,
-        title: example.title,
-        tarballUrl,
-        ...(sha256 ? { sha256 } : {}),
-        unpack: exampleUnpackCommand(tarballUrl),
-      });
-    },
-  );
-
-  /**
-   * Exemplar sources as files, for agents that cannot fetch the tarball.
-   *
-   * Same allowlist gate as the signed-URL route above — the exemplar catalog is a
-   * hand-curated list of first-party slugs, and a slug that is not on it does not
-   * become readable just because a different verb reaches the same bucket. What
-   * changes is only the transport: bytes through the tool instead of a link.
-   */
-  app.get(
-    AGENT_CHANNEL_ROUTES.EXAMPLES_BY_SLUG_FILES,
-    { config: { rateLimit: { max: 120, timeWindow: '1 hour' } } },
-    async (request, reply) => {
-      const resolved = await resolveBuild(request, reply);
-      if (!resolved) return reply;
-
-      const example = getAgentBuildExample(String((request.params as { slug?: string }).slug ?? ''));
-      if (!example) {
-        return reply.status(404).send({ error: 'unknown_example', message: 'slug is not on the exemplar allowlist' });
-      }
-      if (!exampleFileStore) {
-        return reply
-          .status(503)
-          .send({ error: 'example_store_unavailable', message: 'the example store is not configured' });
-      }
-
-      try {
-        const query = request.query as { prefix?: string; limit?: string; offset?: string };
-        const tree = await exampleFileStore.loadTree(example.slug);
-        return reply.send(
-          listExampleFiles(tree, {
-            prefix: query.prefix,
-            limit: optionalFiniteQuery(query.limit),
-            offset: optionalFiniteQuery(query.offset),
-          }),
-        );
-      } catch (error) {
-        const sent = sendExampleFilesError(reply, error);
-        if (sent) return sent;
-        throw error;
-      }
-    },
-  );
-
-  /** One file from an allowlisted exemplar, inline. */
-  app.get(
-    AGENT_CHANNEL_ROUTES.EXAMPLES_BY_SLUG_FILE,
-    { config: { rateLimit: { max: 120, timeWindow: '1 hour' } } },
-    async (request, reply) => {
-      const resolved = await resolveBuild(request, reply);
-      if (!resolved) return reply;
-
-      const example = getAgentBuildExample(String((request.params as { slug?: string }).slug ?? ''));
-      if (!example) {
-        return reply.status(404).send({ error: 'unknown_example', message: 'slug is not on the exemplar allowlist' });
-      }
-      if (!exampleFileStore) {
-        return reply
-          .status(503)
-          .send({ error: 'example_store_unavailable', message: 'the example store is not configured' });
-      }
-
-      try {
-        const query = request.query as { path?: string; encoding?: string };
-        const encoding = query.encoding === 'base64' ? 'base64' : query.encoding === 'utf8' ? 'utf8' : undefined;
-        if (query.encoding && !encoding) {
-          return reply.status(400).send({ error: 'example_query_invalid', message: 'encoding must be utf8 or base64' });
-        }
-        const tree = await exampleFileStore.loadTree(example.slug);
-        return reply.send(readExampleFile(tree, query.path ?? '', { ...(encoding ? { encoding } : {}) }));
-      } catch (error) {
-        const sent = sendExampleFilesError(reply, error);
-        if (sent) return sent;
-        throw error;
-      }
-    },
-  );
+  registerAgentChannelExamplesRoutes(app, { resolveBuild, objectStore: options.objectStore, exampleFileStore });
 
   /**
    * Gate verdict for the job's delivery (BY-05 terminal receipt).

--- a/eslint-rules/comment-prose-baseline.json
+++ b/eslint-rules/comment-prose-baseline.json
@@ -23,7 +23,7 @@
     "apps/api/src/agent-surface/agent-build-brief.ts": 95,
     "apps/api/src/agent-surface/agent-build-examples.ts": 103,
     "apps/api/src/agent-surface/agent-channel.test.ts": 1226,
-    "apps/api/src/agent-surface/agent-channel.ts": 4157,
+    "apps/api/src/agent-surface/agent-channel.ts": 4046,
     "apps/api/src/agent-surface/agent-creator-key-resolve.ts": 172,
     "apps/api/src/agent-surface/agent-creator-key.test.ts": 15,
     "apps/api/src/agent-surface/agent-creator-key.ts": 257,

--- a/eslint-rules/module-boundary-map.mjs
+++ b/eslint-rules/module-boundary-map.mjs
@@ -175,6 +175,7 @@ const FILE_BUCKET = {
   // agent-surface: channel + MCP + kit
   'agent-channel': 'agent-surface',
   'agent-channel-kit-files': 'agent-surface',
+  'agent-channel-examples': 'agent-surface',
   'mcp-server': 'agent-surface',
   'mcp-tool-support': 'agent-surface',
   'mcp-example-tools': 'agent-surface',


### PR DESCRIPTION
## Summary
- Continues Wave D (`apps/api/src/agent-surface/agent-channel.ts` decomposition), batch 2: 3110 → 2948 lines.
- Moves `EXAMPLES`/`EXAMPLES_BY_SLUG`/`EXAMPLES_BY_SLUG_FILES`/`EXAMPLES_BY_SLUG_FILE` into a new `apps/api/src/agent-surface/agent-channel-examples.ts` as `registerAgentChannelExamplesRoutes(app, deps)`, the same pattern as batch 1's `agent-channel-kit-files.ts`.
- `sendExampleFilesError` and `exampleUnpackCommand` move with the cluster (their only callers). `exampleFileStore` stays constructed in `agent-channel.ts` and is passed in as a dep; `objectStore` is passed through too since `EXAMPLES_BY_SLUG` reads/signs the tarball URL directly. `optionalFiniteQuery` is duplicated locally, same as batch 1.
- Adds a `FILE_BUCKET` entry (`agent-surface`) and reseals the comment-prose baseline downward (`agent-channel.ts` 4157 → 4046 words; new file frozen at 0).

## Test plan
- [x] `tsc --noEmit` clean across `apps/api`
- [x] `npm run lint` — 0 errors, 130 warnings (+3 from batch 1's 127, all pre-existing cross-bucket import patterns duplicated into the new file, same acceptance basis as batch 1)
- [x] `npm run comment-prose` — all files at or under baseline
- [x] `npm run module-size` — new file 175 lines, well under the 500-line cap
- [x] `npx vitest run src/agent-surface/agent-channel.test.ts src/agent-build-reads.test.ts` — 127/127 passing

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01VaPzGSyNfZ7nvGcJgYNSdL

---
_Generated by [Claude Code](https://claude.ai/code/session_01VaPzGSyNfZ7nvGcJgYNSdL)_