### PR TITLE
Extract brief/reference-image routes out of agent-channel.ts (Wave D batch 3)

### DIFF
--- a/apps/api/src/agent-surface/agent-channel-brief.ts
+++ b/apps/api/src/agent-surface/agent-channel-brief.ts
@@ -1,0 +1,77 @@
+import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
+import { AGENT_CHANNEL_ROUTES } from '@gamedevpl/contract';
+import {
+  AGENT_BUILD_RULES_DIGEST,
+  briefLocales,
+  buildConstraints,
+  DEFAULT_BUILD_ORIENTATION,
+} from './agent-build-brief.js';
+import { seedPayload } from './seed-status.js';
+import { dispatchAttempt, type Store, type SubmissionRecord } from '../platform/store.js';
+import type { AgentTokenAccess } from './agent-token.js';
+
+// Round brief and creator-attached reference images the agent starts from.
+export interface AgentChannelBriefRoutesDeps {
+  resolveBuild: (
+    request: FastifyRequest,
+    reply: FastifyReply,
+  ) => Promise<{ issueNumber: number; record: SubmissionRecord; access: AgentTokenAccess } | null>;
+  store: Store | undefined;
+}
+
+export function registerAgentChannelBriefRoutes(app: FastifyInstance, deps: AgentChannelBriefRoutesDeps): void {
+  const { resolveBuild, store } = deps;
+
+  app.get(
+    AGENT_CHANNEL_ROUTES.BRIEF,
+    { config: { rateLimit: { max: 120, timeWindow: '1 hour' } } },
+    async (request, reply) => {
+      const resolved = await resolveBuild(request, reply);
+      if (!resolved) return reply;
+      const { issueNumber, record } = resolved;
+
+      const pending = await store!.listPendingCreatorMessages(issueNumber);
+      const seed = seedPayload(record);
+      const referenceShots = (await store!.listBuildShots(issueNumber)).filter(
+        (shot) => shot.label === 'creator-reference',
+      );
+      return reply.send({
+        title: record.title,
+        slug: record.slug ?? null,
+        spec: record.spec ?? '',
+        qa: record.qa ?? [],
+        rules: AGENT_BUILD_RULES_DIGEST,
+        constraints: buildConstraints(DEFAULT_BUILD_ORIENTATION),
+        locales: briefLocales(record.locale),
+        ...seed,
+        dispatchAttempt: await dispatchAttempt(store!, record),
+        pendingMessages: pending.map((message) => ({
+          id: message.id,
+          text: message.text,
+          createdAt: message.createdAt,
+        })),
+        referenceImages: referenceShots.map((shot) => ({ id: shot.id, createdAt: shot.createdAt })),
+      });
+    },
+  );
+
+  app.get(
+    AGENT_CHANNEL_ROUTES.REFERENCE_IMAGES,
+    { config: { rateLimit: { max: 60, timeWindow: '1 hour' } } },
+    async (request, reply) => {
+      const resolved = await resolveBuild(request, reply);
+      if (!resolved) return reply;
+      const { issueNumber } = resolved;
+
+      const summaries = (await store!.listBuildShots(issueNumber)).filter((shot) => shot.label === 'creator-reference');
+      const images = await Promise.all(
+        summaries.map(async (summary) => {
+          const shot = await store!.getBuildShot(issueNumber, summary.id);
+          if (!shot) return null;
+          return { id: shot.id, createdAt: shot.createdAt, png: shot.data };
+        }),
+      );
+      return reply.send({ images: images.filter((image): image is NonNullable<typeof image> => image !== null) });
+    },
+  );
+}

--- a/apps/api/src/agent-surface/agent-channel.ts
+++ b/apps/api/src/agent-surface/agent-channel.ts
@@ -1,14 +1,9 @@
 import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
 import { z } from 'zod';
 import { AGENT_CHANNEL_ROUTES } from '@gamedevpl/contract';
-import {
-  AGENT_BUILD_RULES_DIGEST,
-  briefLocales,
-  buildConstraints,
-  DEFAULT_BUILD_ORIENTATION,
-} from './agent-build-brief.js';
 import { createExampleFileStore } from '../creation/example-files.js';
 import { registerAgentChannelExamplesRoutes } from './agent-channel-examples.js';
+import { registerAgentChannelBriefRoutes } from './agent-channel-brief.js';
 import {
   assertAgentTokenActive,
   classifyAgentTokenAccess,
@@ -68,13 +63,7 @@ import { computeStageAdvisories } from '../delivery/stage-hints.js';
 import { applyExactReplace, applySourcePatch, SourcePatchError } from '../creation/source-patch.js';
 import { overlayGameSources } from '../delivery/staged-preview.js';
 import { SourceDeliveryValidationError, type SourceDeliveryService } from '../delivery/source-delivery.js';
-import {
-  dispatchAttempt,
-  type BuilderHandoff,
-  type CreatorMessage,
-  type Store,
-  type SubmissionRecord,
-} from '../platform/store.js';
+import { type BuilderHandoff, type CreatorMessage, type Store, type SubmissionRecord } from '../platform/store.js';
 import { pickLatestChangelogText } from '../delivery/build-changelog.js';
 import { BUILD_EVENT_KINDS, BUILD_STEPS, sanitizeCreatorText, type BuildEvent } from '../platform/submission-status.js';
 import { normalizeAtIntake, type IntakeText } from '../platform/localize-intake.js';
@@ -2267,67 +2256,7 @@ export async function registerAgentChannelRoutes(
     },
   );
 
-  /**
-   * Everything an agent needs to start a round without reading a GitHub issue.
-   *
-   * Spec/qa live on the job document (written at submission). Rules and the byte
-   * ceiling are static / contract-derived — never invented per job.
-   */
-  app.get(
-    AGENT_CHANNEL_ROUTES.BRIEF,
-    { config: { rateLimit: { max: 120, timeWindow: '1 hour' } } },
-    async (request, reply) => {
-      const resolved = await resolveBuild(request, reply);
-      if (!resolved) return reply;
-      const { issueNumber, record } = resolved;
-
-      const pending = await store!.listPendingCreatorMessages(issueNumber);
-      const seed = seedPayload(record);
-      const referenceShots = (await store!.listBuildShots(issueNumber)).filter(
-        (shot) => shot.label === 'creator-reference',
-      );
-      return reply.send({
-        title: record.title,
-        slug: record.slug ?? null,
-        spec: record.spec ?? '',
-        qa: record.qa ?? [],
-        rules: AGENT_BUILD_RULES_DIGEST,
-        constraints: buildConstraints(DEFAULT_BUILD_ORIENTATION),
-        locales: briefLocales(record.locale),
-        ...seed,
-        // > 1 means get_transcript may know more than this brief's spec.
-        dispatchAttempt: await dispatchAttempt(store!, record),
-        pendingMessages: pending.map((message) => ({
-          id: message.id,
-          text: message.text,
-          createdAt: message.createdAt,
-        })),
-        // Ids only — fetch pixels via get_reference_images / GET .../reference-images.
-        referenceImages: referenceShots.map((shot) => ({ id: shot.id, createdAt: shot.createdAt })),
-      });
-    },
-  );
-
-  // Creator-attached reference images, with bytes — mirrors /build/media.
-  app.get(
-    AGENT_CHANNEL_ROUTES.REFERENCE_IMAGES,
-    { config: { rateLimit: { max: 60, timeWindow: '1 hour' } } },
-    async (request, reply) => {
-      const resolved = await resolveBuild(request, reply);
-      if (!resolved) return reply;
-      const { issueNumber } = resolved;
-
-      const summaries = (await store!.listBuildShots(issueNumber)).filter((shot) => shot.label === 'creator-reference');
-      const images = await Promise.all(
-        summaries.map(async (summary) => {
-          const shot = await store!.getBuildShot(issueNumber, summary.id);
-          if (!shot) return null;
-          return { id: shot.id, createdAt: shot.createdAt, png: shot.data };
-        }),
-      );
-      return reply.send({ images: images.filter((image): image is NonNullable<typeof image> => image !== null) });
-    },
-  );
+  registerAgentChannelBriefRoutes(app, { resolveBuild, store });
 
   /**
    * Round-0 seed draft stored on the job (self builds and platform seeds that persisted).

--- a/eslint-rules/comment-prose-baseline.json
+++ b/eslint-rules/comment-prose-baseline.json
@@ -23,7 +23,7 @@
     "apps/api/src/agent-surface/agent-build-brief.ts": 95,
     "apps/api/src/agent-surface/agent-build-examples.ts": 103,
     "apps/api/src/agent-surface/agent-channel.test.ts": 1226,
-    "apps/api/src/agent-surface/agent-channel.ts": 4046,
+    "apps/api/src/agent-surface/agent-channel.ts": 4010,
     "apps/api/src/agent-surface/agent-creator-key-resolve.ts": 172,
     "apps/api/src/agent-surface/agent-creator-key.test.ts": 15,
     "apps/api/src/agent-surface/agent-creator-key.ts": 257,

--- a/eslint-rules/module-boundary-map.mjs
+++ b/eslint-rules/module-boundary-map.mjs
@@ -176,6 +176,7 @@ const FILE_BUCKET = {
   'agent-channel': 'agent-surface',
   'agent-channel-kit-files': 'agent-surface',
   'agent-channel-examples': 'agent-surface',
+  'agent-channel-brief': 'agent-surface',
   'mcp-server': 'agent-surface',
   'mcp-tool-support': 'agent-surface',
   'mcp-example-tools': 'agent-surface',


### PR DESCRIPTION
## Summary
- Continues Wave D (`apps/api/src/agent-surface/agent-channel.ts` decomposition), batch 3: 2948 → 2877 lines.
- Moves `BRIEF`/`REFERENCE_IMAGES` into a new `apps/api/src/agent-surface/agent-channel-brief.ts` as `registerAgentChannelBriefRoutes(app, deps)`, same pattern as batches 1-2.
- A fresh scoping pass checked three small remaining clusters (INBOX/TRANSCRIPT/INBOX_ACK, BRIEF/REFERENCE_IMAGES, SEED/SEED_REGENERATE) before picking this one: neither `BRIEF` nor `REFERENCE_IMAGES` touches the composition-root state (`channelState`, `markBuildingFromChannel`, the rate-limit `Map`s) that everything else in the file closes over — the cleanest of the three.
- `AGENT_BUILD_RULES_DIGEST`/`briefLocales`/`buildConstraints`/`DEFAULT_BUILD_ORIENTATION` and `dispatchAttempt` move with the cluster (their only callers in this file); `seedPayload` stays imported in `agent-channel.ts` (still used by the `SEED`/`SOURCES` routes).
- Adds a `FILE_BUCKET` entry (`agent-surface`) and reseals the comment-prose baseline downward (`agent-channel.ts` 4046 → 4010 words; new file frozen at 0).

## Test plan
- [x] `tsc --noEmit` clean across `apps/api`
- [x] `npm run lint` — 0 errors, 130 warnings (unchanged from batch 2 — no new cross-bucket imports)
- [x] `npm run comment-prose` — all files at or under baseline
- [x] `npm run module-size` — new file 77 lines, well under the 500-line cap
- [x] `npx vitest run src/agent-surface/agent-channel.test.ts src/agent-build-reads.test.ts` — 127/127 passing

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01VaPzGSyNfZ7nvGcJgYNSdL

---
_Generated by [Claude Code](https://claude.ai/code/session_01VaPzGSyNfZ7nvGcJgYNSdL)_