### PR TITLE
Extract seed routes out of agent-channel.ts (Wave D batch 4)

### DIFF
--- a/apps/api/src/agent-surface/agent-channel-seed.ts
+++ b/apps/api/src/agent-surface/agent-channel-seed.ts
@@ -1,0 +1,144 @@
+import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
+import { z } from 'zod';
+import { AGENT_CHANNEL_ROUTES } from '@gamedevpl/contract';
+import { seedPayload } from './seed-status.js';
+import type { GamesStore } from '../delivery/games-store.js';
+import type { Store, SubmissionRecord } from '../platform/store.js';
+import type { AgentTokenAccess } from './agent-token.js';
+
+// Empty body is ordinary: a steer is optional.
+const RegenerateSeedRequestSchema = z.object({
+  steer: z.string().trim().min(1).max(600, 'steer is too long').optional(),
+});
+
+const REGENERATE_SEED_REFUSALS: Record<string, string> = {
+  not_configured: 'this deployment does not generate seeds',
+  not_found: 'no round to regenerate a seed for',
+  seed_not_readable:
+    'this round was handed its seed as a workspace rather than reading it, so replacing the stored copy would not reach the agent',
+  already_delivered: 'this round already delivered — build on what you delivered rather than restarting from a draft',
+  cap_reached: 'this job has used its seed regenerations; continue from the draft you have or scaffold from the kit',
+  seeding_off: 'seeding is off right now; continue from the kit, or try again once it is back on',
+};
+
+export interface AgentChannelSeedRoutesDeps {
+  resolveBuild: (
+    request: FastifyRequest,
+    reply: FastifyReply,
+  ) => Promise<{ issueNumber: number; record: SubmissionRecord; access: AgentTokenAccess } | null>;
+  store: Store | undefined;
+  gamesStore: GamesStore | undefined;
+  onRegenerateSeed:
+    | ((input: { issueNumber: number; steer?: string; log: FastifyRequest['log'] }) => Promise<
+        | { ok: true; status: 'pending'; regenerationsRemaining: number }
+        | {
+            ok: false;
+            reason:
+              | 'not_configured'
+              | 'not_found'
+              | 'seed_not_readable'
+              | 'already_delivered'
+              | 'cap_reached'
+              | 'seeding_off';
+          }
+      >)
+    | undefined;
+}
+
+export function registerAgentChannelSeedRoutes(app: FastifyInstance, deps: AgentChannelSeedRoutesDeps): void {
+  const { resolveBuild, store, gamesStore, onRegenerateSeed } = deps;
+
+  app.get(
+    AGENT_CHANNEL_ROUTES.SEED,
+    { config: { rateLimit: { max: 60, timeWindow: '1 hour' } } },
+    async (request, reply) => {
+      const resolved = await resolveBuild(request, reply);
+      if (!resolved) return reply;
+      const { record } = resolved;
+      const seed = seedPayload(record);
+
+      if (record.seed) {
+        return reply.send({
+          available: true,
+          status: seed.seedStatus,
+          notice: seed.seedNotice,
+          files: record.seed.files,
+          references: record.seed.references,
+          notes: record.seed.notes ?? null,
+        });
+      }
+      if (seed.seedStatus === 'pending') {
+        return reply.send({
+          available: false,
+          status: 'pending',
+          notice: seed.seedNotice,
+          files: [],
+          references: [],
+          notes: null,
+        });
+      }
+      return reply.status(404).send({
+        available: false,
+        status: 'unavailable',
+        notice: seed.seedNotice,
+        files: [],
+        references: [],
+        notes: null,
+      });
+    },
+  );
+
+  // Replaces an unusable draft; refused once staging has a base.
+  app.post(
+    AGENT_CHANNEL_ROUTES.SEED_REGENERATE,
+    { config: { rateLimit: { max: 10, timeWindow: '1 hour' } } },
+    async (request, reply) => {
+      const resolved = await resolveBuild(request, reply);
+      if (!resolved) return reply;
+      const { issueNumber, record } = resolved;
+
+      if (!onRegenerateSeed) {
+        return reply.status(503).send({ error: 'seeding_unavailable', message: 'this deployment does not seed' });
+      }
+
+      const parsed = RegenerateSeedRequestSchema.safeParse(request.body ?? {});
+      if (!parsed.success) {
+        return reply.status(400).send({ error: 'invalid_request', message: parsed.error.issues[0]?.message });
+      }
+
+      if (gamesStore && record.slug) {
+        const roundGeneration = store
+          ? ((await store.ensureRoundGeneration(issueNumber)) ?? record.roundGeneration ?? 1)
+          : (record.roundGeneration ?? 1);
+        const staged = await gamesStore.listStagedSources({
+          slug: record.slug,
+          issueNumber,
+          roundGeneration,
+        });
+        if (staged.files.length > 0) {
+          return reply.status(409).send({
+            error: 'already_staged',
+            message:
+              'you have staged files this round — a new seed would change the base they overlay. ' +
+              'Continue with what you have staged, or clear the staging buffer first.',
+          });
+        }
+      }
+
+      const result = await onRegenerateSeed({
+        issueNumber,
+        ...(parsed.data.steer ? { steer: parsed.data.steer } : {}),
+        log: request.log,
+      });
+      if (!result.ok) {
+        const status = result.reason === 'not_configured' ? 503 : result.reason === 'not_found' ? 404 : 409;
+        return reply.status(status).send({ error: result.reason, message: REGENERATE_SEED_REFUSALS[result.reason] });
+      }
+      return reply.send({
+        status: result.status,
+        regenerationsRemaining: result.regenerationsRemaining,
+        notice: 'A new draft is generating. Call get_seed again in a minute or two; do not wait in a loop.',
+      });
+    },
+  );
+}

--- a/apps/api/src/agent-surface/agent-channel.ts
+++ b/apps/api/src/agent-surface/agent-channel.ts
@@ -4,6 +4,7 @@ import { AGENT_CHANNEL_ROUTES } from '@gamedevpl/contract';
 import { createExampleFileStore } from '../creation/example-files.js';
 import { registerAgentChannelExamplesRoutes } from './agent-channel-examples.js';
 import { registerAgentChannelBriefRoutes } from './agent-channel-brief.js';
+import { registerAgentChannelSeedRoutes } from './agent-channel-seed.js';
 import {
   assertAgentTokenActive,
   classifyAgentTokenAccess,
@@ -104,21 +105,6 @@ const BuildEventInputSchema = z.object({
 const AckRequestSchema = z.object({
   ids: z.array(z.string().trim().min(1).max(64)).max(50),
 });
-
-// Empty body is ordinary: a steer is optional.
-const RegenerateSeedRequestSchema = z.object({
-  steer: z.string().trim().min(1).max(600, 'steer is too long').optional(),
-});
-
-const REGENERATE_SEED_REFUSALS: Record<string, string> = {
-  not_configured: 'this deployment does not generate seeds',
-  not_found: 'no round to regenerate a seed for',
-  seed_not_readable:
-    'this round was handed its seed as a workspace rather than reading it, so replacing the stored copy would not reach the agent',
-  already_delivered: 'this round already delivered — build on what you delivered rather than restarting from a draft',
-  cap_reached: 'this job has used its seed regenerations; continue from the draft you have or scaffold from the kit',
-  seeding_off: 'seeding is off right now; continue from the kit, or try again once it is back on',
-};
 
 // Empty body stays valid — every existing client sends one.
 const EndRequestSchema = z.object({
@@ -2258,104 +2244,12 @@ export async function registerAgentChannelRoutes(
 
   registerAgentChannelBriefRoutes(app, { resolveBuild, store });
 
-  /**
-   * Round-0 seed draft stored on the job (self builds and platform seeds that persisted).
-   * 404-shaped `{ available: false }` when none and not pending — not an auth failure.
-   * Pending seeds return 200 so MCP clients recheck instead of scaffolding.
-   */
-  app.get(
-    AGENT_CHANNEL_ROUTES.SEED,
-    { config: { rateLimit: { max: 60, timeWindow: '1 hour' } } },
-    async (request, reply) => {
-      const resolved = await resolveBuild(request, reply);
-      if (!resolved) return reply;
-      const { record } = resolved;
-      const seed = seedPayload(record);
-
-      if (record.seed) {
-        return reply.send({
-          available: true,
-          status: seed.seedStatus,
-          notice: seed.seedNotice,
-          files: record.seed.files,
-          references: record.seed.references,
-          notes: record.seed.notes ?? null,
-        });
-      }
-      if (seed.seedStatus === 'pending') {
-        return reply.send({
-          available: false,
-          status: 'pending',
-          notice: seed.seedNotice,
-          files: [],
-          references: [],
-          notes: null,
-        });
-      }
-      return reply.status(404).send({
-        available: false,
-        status: 'unavailable',
-        notice: seed.seedNotice,
-        files: [],
-        references: [],
-        notes: null,
-      });
-    },
-  );
-
-  // Replaces an unusable draft; refused once staging has a base.
-  app.post(
-    AGENT_CHANNEL_ROUTES.SEED_REGENERATE,
-    { config: { rateLimit: { max: 10, timeWindow: '1 hour' } } },
-    async (request, reply) => {
-      const resolved = await resolveBuild(request, reply);
-      if (!resolved) return reply;
-      const { issueNumber, record } = resolved;
-
-      if (!options.onRegenerateSeed) {
-        return reply.status(503).send({ error: 'seeding_unavailable', message: 'this deployment does not seed' });
-      }
-
-      const parsed = RegenerateSeedRequestSchema.safeParse(request.body ?? {});
-      if (!parsed.success) {
-        return reply.status(400).send({ error: 'invalid_request', message: parsed.error.issues[0]?.message });
-      }
-
-      if (options.gamesStore && record.slug) {
-        const roundGeneration = store
-          ? ((await store.ensureRoundGeneration(issueNumber)) ?? record.roundGeneration ?? 1)
-          : (record.roundGeneration ?? 1);
-        const staged = await options.gamesStore.listStagedSources({
-          slug: record.slug,
-          issueNumber,
-          roundGeneration,
-        });
-        if (staged.files.length > 0) {
-          return reply.status(409).send({
-            error: 'already_staged',
-            message:
-              'you have staged files this round — a new seed would change the base they overlay. ' +
-              'Continue with what you have staged, or clear the staging buffer first.',
-          });
-        }
-      }
-
-      const result = await options.onRegenerateSeed({
-        issueNumber,
-        ...(parsed.data.steer ? { steer: parsed.data.steer } : {}),
-        log: request.log,
-      });
-      if (!result.ok) {
-        const status = result.reason === 'not_configured' ? 503 : result.reason === 'not_found' ? 404 : 409;
-        return reply.status(status).send({ error: result.reason, message: REGENERATE_SEED_REFUSALS[result.reason] });
-      }
-      return reply.send({
-        status: result.status,
-        regenerationsRemaining: result.regenerationsRemaining,
-        notice: 'A new draft is generating. Call get_seed again in a minute or two; do not wait in a loop.',
-      });
-    },
-  );
+  registerAgentChannelSeedRoutes(app, {
+    resolveBuild,
+    store,
+    gamesStore: options.gamesStore,
+    onRegenerateSeed: options.onRegenerateSeed,
+  });
 
   /**
    * Current Creator Kit — engine-pinned tarball from `kits/current.json`.

--- a/eslint-rules/comment-prose-baseline.json
+++ b/eslint-rules/comment-prose-baseline.json
@@ -23,7 +23,7 @@
     "apps/api/src/agent-surface/agent-build-brief.ts": 95,
     "apps/api/src/agent-surface/agent-build-examples.ts": 103,
     "apps/api/src/agent-surface/agent-channel.test.ts": 1226,
-    "apps/api/src/agent-surface/agent-channel.ts": 4010,
+    "apps/api/src/agent-surface/agent-channel.ts": 3971,
     "apps/api/src/agent-surface/agent-creator-key-resolve.ts": 172,
     "apps/api/src/agent-surface/agent-creator-key.test.ts": 15,
     "apps/api/src/agent-surface/agent-creator-key.ts": 257,

--- a/eslint-rules/module-boundary-map.mjs
+++ b/eslint-rules/module-boundary-map.mjs
@@ -177,6 +177,7 @@ const FILE_BUCKET = {
   'agent-channel-kit-files': 'agent-surface',
   'agent-channel-examples': 'agent-surface',
   'agent-channel-brief': 'agent-surface',
+  'agent-channel-seed': 'agent-surface',
   'mcp-server': 'agent-surface',
   'mcp-tool-support': 'agent-surface',
   'mcp-example-tools': 'agent-surface',


### PR DESCRIPTION
## Summary
- Continues Wave D (`apps/api/src/agent-surface/agent-channel.ts` decomposition), batch 4: 2877 → 2771 lines.
- Moves `SEED`/`SEED_REGENERATE` into a new `apps/api/src/agent-surface/agent-channel-seed.ts` as `registerAgentChannelSeedRoutes(app, deps)`, same pattern as batches 1-3.
- A full risk/deps assessment compared this cluster against INBOX/TRANSCRIPT/INBOX_ACK: neither `SEED` nor `SEED_REGENERATE` touches `channelState`/`stopReason`/the rate-limit `Map`s — the lower-risk of the two, since INBOX/TRANSCRIPT would be the first batch to promote `channelState` itself (called 26 times across the file) into a cross-file dependency.
- `store` and `gamesStore` are passed by reference (`| undefined`, matching `agent-channel-brief.ts`'s `store` pattern) since both are shared with other routes still in the parent file; `onRegenerateSeed` is exclusive to this cluster. `RegenerateSeedRequestSchema`/`REGENERATE_SEED_REFUSALS` move with the cluster (their only callers).
- Adds a `FILE_BUCKET` entry (`agent-surface`) and reseals the comment-prose baseline downward (`agent-channel.ts` 4010 → 3971 words; new file frozen at 0).

## Test plan
- [x] `tsc --noEmit` clean across `apps/api`
- [x] `npm run lint` — 0 errors, 130 warnings (unchanged from batch 3)
- [x] `npm run comment-prose` — all files at or under baseline
- [x] `npm run module-size` — new file 144 lines, well under the 500-line cap
- [x] `npx vitest run src/agent-surface/agent-channel.test.ts src/agent-build-reads.test.ts` — 127/127 passing

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01VaPzGSyNfZ7nvGcJgYNSdL

---
_Generated by [Claude Code](https://claude.ai/code/session_01VaPzGSyNfZ7nvGcJgYNSdL)_