### PR TITLE
Extract Creator Kit routes out of agent-channel.ts (Wave D batch 5)

### DIFF
--- a/apps/api/src/agent-surface/agent-channel-kit.ts
+++ b/apps/api/src/agent-surface/agent-channel-kit.ts
@@ -1,0 +1,141 @@
+import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
+import { AGENT_CHANNEL_ROUTES } from '@gamedevpl/contract';
+import { DEFAULT_SIGNED_URL_TTL_SECONDS, type GcsObjectStore } from '../delivery/gcs-sign.js';
+import { DEFAULT_MCP_DIGEST_MAX_BYTES, compactKitDigestForApi } from './kit-digest.js';
+import {
+  KIT_ENTRY,
+  KitRegistryError,
+  kitUnpackCommand,
+  parseKitRegistry,
+  parseKitSidecar,
+} from '../platform/kit-registry.js';
+import type { GateVerdictSummary } from '../delivery/gate-verdict.js';
+import type { AgentTokenAccess } from './agent-token.js';
+import type { Store, SubmissionRecord } from '../platform/store.js';
+
+export interface AgentChannelKitRoutesDeps {
+  resolveBuild: (
+    request: FastifyRequest,
+    reply: FastifyReply,
+  ) => Promise<{ issueNumber: number; record: SubmissionRecord; access: AgentTokenAccess } | null>;
+  store: Store | undefined;
+  objectStore: GcsObjectStore | undefined;
+  gateVerdict: (record: SubmissionRecord) => Promise<GateVerdictSummary | null>;
+}
+
+export function registerAgentChannelKitRoutes(app: FastifyInstance, deps: AgentChannelKitRoutesDeps): void {
+  const { resolveBuild, store, objectStore, gateVerdict } = deps;
+
+  // Current Creator Kit — engine-pinned tarball from kits/current.json.
+  app.get(
+    AGENT_CHANNEL_ROUTES.KIT,
+    { config: { rateLimit: { max: 60, timeWindow: '1 hour' } } },
+    async (request, reply) => {
+      const resolved = await resolveBuild(request, reply);
+      if (!resolved) return reply;
+
+      if (!objectStore) {
+        return reply.status(503).send({ error: 'kit_store_unavailable', message: 'the kit store is not configured' });
+      }
+
+      try {
+        const registryBody = await objectStore.readObject('kits/current.json');
+        if (!registryBody) {
+          return reply.status(404).send({
+            error: 'kit_registry_missing',
+            message: 'kits/current.json is not published yet — the games-repo kit publisher has not run',
+          });
+        }
+        const registry = parseKitRegistry(registryBody.toString('utf8'));
+        const previousPin = resolved.record.roundKitEngineRef;
+        const outdated = (await gateVerdict(resolved.record))?.status === 'kit_outdated';
+        let engineRef =
+          (await store!.pinRoundKitEngineRef(resolved.issueNumber, registry.current, outdated)) ?? registry.current;
+        if (engineRef !== registry.current && !(await objectStore.objectExists(`kits/${engineRef}.tgz`))) {
+          engineRef =
+            (await store!.pinRoundKitEngineRef(resolved.issueNumber, registry.current, true)) ?? registry.current;
+        }
+        const kitEngineChanged = Boolean(previousPin) && previousPin !== engineRef;
+        const sidecarBody = await objectStore.readObject(`kits/${engineRef}.json`);
+        if (!sidecarBody) {
+          return reply.status(404).send({
+            error: 'kit_artifact_missing',
+            message: `kits/${engineRef}.json sidecar is missing for the current registry entry`,
+          });
+        }
+        const sidecar = parseKitSidecar(sidecarBody.toString('utf8'));
+        if (!(await objectStore.objectExists(`kits/${engineRef}.tgz`))) {
+          return reply.status(404).send({
+            error: 'kit_artifact_missing',
+            message: `kits/${engineRef}.tgz is missing for the current registry entry`,
+          });
+        }
+
+        const kitUrl = await objectStore.signReadUrl(`kits/${engineRef}.tgz`, DEFAULT_SIGNED_URL_TTL_SECONDS);
+        return reply.send({
+          engineRef,
+          kitUrl,
+          sha256: sidecar.sha256,
+          unpack: kitUnpackCommand(kitUrl),
+          entry: KIT_ENTRY,
+          ...(kitEngineChanged ? { kitEngineChanged: true } : {}),
+          browse: {
+            list: 'list_kit_files',
+            search: 'search_kit_files',
+            read: 'read_kit_file',
+            readMany: 'read_kit_files',
+            fragment: 'read_kit_file_fragment',
+          },
+        });
+      } catch (error) {
+        if (error instanceof KitRegistryError) {
+          return reply.status(404).send({ error: error.code, message: error.message });
+        }
+        throw error;
+      }
+    },
+  );
+
+  // Prompt-ready API reference for MCP get_kit_api — see byoca-mcp SKILL.md.
+  app.get(
+    AGENT_CHANNEL_ROUTES.KIT_API,
+    { config: { rateLimit: { max: 60, timeWindow: '1 hour' } } },
+    async (request, reply) => {
+      const resolved = await resolveBuild(request, reply);
+      if (!resolved) return reply;
+      if (!objectStore) {
+        return reply.status(503).send({ error: 'kit_store_unavailable', message: 'the kit store is not configured' });
+      }
+      try {
+        const query = request.query as { engineRef?: string };
+        let engineRef = query.engineRef?.trim();
+        if (!engineRef) {
+          const registryBody = await objectStore.readObject('kits/current.json');
+          if (!registryBody) {
+            return reply.status(404).send({
+              error: 'kit_registry_missing',
+              message: 'kits/current.json is not published yet — the games-repo kit publisher has not run',
+            });
+          }
+          engineRef = parseKitRegistry(registryBody.toString('utf8')).current;
+        }
+        const digestBody = await objectStore.readObject(`kits/${engineRef}.digest.md`);
+        if (!digestBody) {
+          return reply.status(404).send({
+            error: 'kit_artifact_missing',
+            message: `kits/${engineRef}.digest.md is missing for engineRef ${engineRef}`,
+          });
+        }
+        return reply.send({
+          engineRef,
+          digest: compactKitDigestForApi(digestBody.toString('utf8'), DEFAULT_MCP_DIGEST_MAX_BYTES),
+        });
+      } catch (error) {
+        if (error instanceof KitRegistryError) {
+          return reply.status(404).send({ error: error.code, message: error.message });
+        }
+        throw error;
+      }
+    },
+  );
+}

--- a/apps/api/src/agent-surface/agent-channel.ts
+++ b/apps/api/src/agent-surface/agent-channel.ts
@@ -5,6 +5,7 @@ import { createExampleFileStore } from '../creation/example-files.js';
 import { registerAgentChannelExamplesRoutes } from './agent-channel-examples.js';
 import { registerAgentChannelBriefRoutes } from './agent-channel-brief.js';
 import { registerAgentChannelSeedRoutes } from './agent-channel-seed.js';
+import { registerAgentChannelKitRoutes } from './agent-channel-kit.js';
 import {
   assertAgentTokenActive,
   classifyAgentTokenAccess,
@@ -28,7 +29,6 @@ import { loadBuildTranscript } from '../delivery/build-transcript.js';
 import { canonicalAppBaseUrl } from '../platform/canonical-app-url.js';
 import { deriveGateStatusString, readGateVerdict } from '../delivery/gate-verdict.js';
 import { DEFAULT_SIGNED_URL_TTL_SECONDS, type GcsObjectStore } from '../delivery/gcs-sign.js';
-import { DEFAULT_MCP_DIGEST_MAX_BYTES, compactKitDigestForApi } from './kit-digest.js';
 import {
   forbiddenIndexHtmlWriteReason,
   InvalidUploadError,
@@ -49,13 +49,6 @@ import type {
   KnowledgeScope,
   QueryKnowledgeFn,
 } from '../creation/knowledge-search.js';
-import {
-  KIT_ENTRY,
-  KitRegistryError,
-  kitUnpackCommand,
-  parseKitRegistry,
-  parseKitSidecar,
-} from '../platform/kit-registry.js';
 import { seedPayload } from './seed-status.js';
 import { largeSourceFileHint } from '../creation/module-size.js';
 import { gameManifestHint } from './game-manifest-hint.js';
@@ -2251,128 +2244,7 @@ export async function registerAgentChannelRoutes(
     onRegenerateSeed: options.onRegenerateSeed,
   });
 
-  /**
-   * Current Creator Kit — engine-pinned tarball from `kits/current.json`.
-   *
-   * Missing registry is a clear machine-readable error (bucket empty until the first
-   * games-repo publish), never a fabricated engineRef.
-   */
-  app.get(
-    AGENT_CHANNEL_ROUTES.KIT,
-    { config: { rateLimit: { max: 60, timeWindow: '1 hour' } } },
-    async (request, reply) => {
-      const resolved = await resolveBuild(request, reply);
-      if (!resolved) return reply;
-
-      if (!options.objectStore) {
-        return reply.status(503).send({ error: 'kit_store_unavailable', message: 'the kit store is not configured' });
-      }
-
-      try {
-        const registryBody = await options.objectStore.readObject('kits/current.json');
-        if (!registryBody) {
-          return reply.status(404).send({
-            error: 'kit_registry_missing',
-            message: 'kits/current.json is not published yet — the games-repo kit publisher has not run',
-          });
-        }
-        const registry = parseKitRegistry(registryBody.toString('utf8'));
-        // The pointer can advance mid-round; the round builds against one engine.
-        const previousPin = resolved.record.roundKitEngineRef;
-        const outdated = (await gateVerdict(resolved.record))?.status === 'kit_outdated';
-        let engineRef =
-          (await store!.pinRoundKitEngineRef(resolved.issueNumber, registry.current, outdated)) ?? registry.current;
-        // Re-pin when the pinned kit has aged out of retention.
-        if (engineRef !== registry.current && !(await options.objectStore.objectExists(`kits/${engineRef}.tgz`))) {
-          engineRef =
-            (await store!.pinRoundKitEngineRef(resolved.issueNumber, registry.current, true)) ?? registry.current;
-        }
-        const kitEngineChanged = Boolean(previousPin) && previousPin !== engineRef;
-        const sidecarBody = await options.objectStore.readObject(`kits/${engineRef}.json`);
-        if (!sidecarBody) {
-          return reply.status(404).send({
-            error: 'kit_artifact_missing',
-            message: `kits/${engineRef}.json sidecar is missing for the current registry entry`,
-          });
-        }
-        const sidecar = parseKitSidecar(sidecarBody.toString('utf8'));
-        // Metadata probe only — do not pull the multi-MB kit into the request path.
-        if (!(await options.objectStore.objectExists(`kits/${engineRef}.tgz`))) {
-          return reply.status(404).send({
-            error: 'kit_artifact_missing',
-            message: `kits/${engineRef}.tgz is missing for the current registry entry`,
-          });
-        }
-
-        const kitUrl = await options.objectStore.signReadUrl(`kits/${engineRef}.tgz`, DEFAULT_SIGNED_URL_TTL_SECONDS);
-        return reply.send({
-          engineRef,
-          kitUrl,
-          sha256: sidecar.sha256,
-          unpack: kitUnpackCommand(kitUrl),
-          entry: KIT_ENTRY,
-          // The round's engine moved: rebuild against the one in this reply.
-          ...(kitEngineChanged ? { kitEngineChanged: true } : {}),
-          // Shell-less clients browse via these tools instead of unpacking.
-          browse: {
-            list: 'list_kit_files',
-            search: 'search_kit_files',
-            read: 'read_kit_file',
-            readMany: 'read_kit_files',
-            fragment: 'read_kit_file_fragment',
-          },
-        });
-      } catch (error) {
-        if (error instanceof KitRegistryError) {
-          return reply.status(404).send({ error: error.code, message: error.message });
-        }
-        throw error;
-      }
-    },
-  );
-
-  // Prompt-ready API reference for MCP get_kit_api — see byoca-mcp SKILL.md.
-  app.get(
-    AGENT_CHANNEL_ROUTES.KIT_API,
-    { config: { rateLimit: { max: 60, timeWindow: '1 hour' } } },
-    async (request, reply) => {
-      const resolved = await resolveBuild(request, reply);
-      if (!resolved) return reply;
-      if (!options.objectStore) {
-        return reply.status(503).send({ error: 'kit_store_unavailable', message: 'the kit store is not configured' });
-      }
-      try {
-        const query = request.query as { engineRef?: string };
-        let engineRef = query.engineRef?.trim();
-        if (!engineRef) {
-          const registryBody = await options.objectStore.readObject('kits/current.json');
-          if (!registryBody) {
-            return reply.status(404).send({
-              error: 'kit_registry_missing',
-              message: 'kits/current.json is not published yet — the games-repo kit publisher has not run',
-            });
-          }
-          engineRef = parseKitRegistry(registryBody.toString('utf8')).current;
-        }
-        const digestBody = await options.objectStore.readObject(`kits/${engineRef}.digest.md`);
-        if (!digestBody) {
-          return reply.status(404).send({
-            error: 'kit_artifact_missing',
-            message: `kits/${engineRef}.digest.md is missing for engineRef ${engineRef}`,
-          });
-        }
-        return reply.send({
-          engineRef,
-          digest: compactKitDigestForApi(digestBody.toString('utf8'), DEFAULT_MCP_DIGEST_MAX_BYTES),
-        });
-      } catch (error) {
-        if (error instanceof KitRegistryError) {
-          return reply.status(404).send({ error: error.code, message: error.message });
-        }
-        throw error;
-      }
-    },
-  );
+  registerAgentChannelKitRoutes(app, { resolveBuild, store, objectStore: options.objectStore, gateVerdict });
 
   registerAgentChannelKitFileRoutes(app, { resolveBuild, kitFileStore });
 

--- a/eslint-rules/comment-prose-baseline.json
+++ b/eslint-rules/comment-prose-baseline.json
@@ -23,7 +23,7 @@
     "apps/api/src/agent-surface/agent-build-brief.ts": 95,
     "apps/api/src/agent-surface/agent-build-examples.ts": 103,
     "apps/api/src/agent-surface/agent-channel.test.ts": 1226,
-    "apps/api/src/agent-surface/agent-channel.ts": 3971,
+    "apps/api/src/agent-surface/agent-channel.ts": 3927,
     "apps/api/src/agent-surface/agent-creator-key-resolve.ts": 172,
     "apps/api/src/agent-surface/agent-creator-key.test.ts": 15,
     "apps/api/src/agent-surface/agent-creator-key.ts": 257,

--- a/eslint-rules/module-boundary-map.mjs
+++ b/eslint-rules/module-boundary-map.mjs
@@ -178,6 +178,7 @@ const FILE_BUCKET = {
   'agent-channel-examples': 'agent-surface',
   'agent-channel-brief': 'agent-surface',
   'agent-channel-seed': 'agent-surface',
+  'agent-channel-kit': 'agent-surface',
   'mcp-server': 'agent-surface',
   'mcp-tool-support': 'agent-surface',
   'mcp-example-tools': 'agent-surface',


### PR DESCRIPTION
## Summary
- Continues Wave D (`apps/api/src/agent-surface/agent-channel.ts` decomposition), batch 5: 2771 → 2643 lines.
- Moves `KIT`/`KIT_API` into a new `apps/api/src/agent-surface/agent-channel-kit.ts` as `registerAgentChannelKitRoutes(app, deps)`, same pattern as batches 1-4. Completes the kit trio started by batch 1's `agent-channel-kit-files.ts` (`KIT` → `KIT_API` → `KIT_FILES`).
- `store` and `objectStore` are passed by reference (`| undefined`, matching the established pattern) since both are shared with other routes still in the parent file. `gateVerdict` — a thin closure over `options.gamesStore`, also called from `channelState` and `GATE` — is passed by reference the same way `resolveBuild` already is.
- `KIT_ENTRY`/`KitRegistryError`/`kitUnpackCommand`/`parseKitRegistry`/`parseKitSidecar`/`compactKitDigestForApi`/`DEFAULT_MCP_DIGEST_MAX_BYTES` move with the cluster (their only callers).
- Adds a `FILE_BUCKET` entry (`agent-surface`) and reseals the comment-prose baseline downward (`agent-channel.ts` 3971 → 3927 words; new file frozen at 0).

## Test plan
- [x] `tsc --noEmit` clean across `apps/api`
- [x] `npm run lint` — 0 errors, 131 warnings (+1 from batch 4's 130, from the `GateVerdictSummary` type import crossing buckets — same accepted pattern as prior batches)
- [x] `npm run comment-prose` — all files at or under baseline
- [x] `npm run module-size` — new file 140 lines, well under the 500-line cap
- [x] `npx vitest run src/agent-surface/agent-channel.test.ts src/agent-build-reads.test.ts` — 127/127 passing

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01VaPzGSyNfZ7nvGcJgYNSdL

---
_Generated by [Claude Code](https://claude.ai/code/session_01VaPzGSyNfZ7nvGcJgYNSdL)_