### PR TITLE
EK2-19: keep controller editor docked beside the game

### DIFF
--- a/apps/web/src/CreatorStudioView.editorSurface.test.ts
+++ b/apps/web/src/CreatorStudioView.editorSurface.test.ts
@@ -1,0 +1,12 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const source = readFileSync(fileURLToPath(new URL('./CreatorStudioView.tsx', import.meta.url)), 'utf8');
+
+describe('Creator Studio editor surface posture', () => {
+  it('passes the panel-selected mode to the explicit data attribute', () => {
+    expect(source).toContain('data-surface={editorSurfaceMode}');
+    expect(source).not.toMatch(/editorController\?\.status[^\n]+['"]full['"]/);
+  });
+});

--- a/apps/web/src/CreatorStudioView.tsx
+++ b/apps/web/src/CreatorStudioView.tsx
@@ -1124,7 +1124,7 @@ export function CreatorStudioView({
                         {tab === 'edit' ? (
                           <div
                             className="studio-edit-overlay"
-                            data-surface={editorController?.status === 'ready' ? 'full' : editorSurfaceMode}
+                            data-surface={editorSurfaceMode}
                           >
                             <EditorPanel
                               key={activeGame.token}

--- a/apps/web/src/EditorPanel.surfaceMode.test.ts
+++ b/apps/web/src/EditorPanel.surfaceMode.test.ts
@@ -20,7 +20,15 @@ const layered: EditorDefinition = {
 
 describe('EditorPanel surface mode', () => {
   it('docks declaration-only tuning beside the running game', () => {
-    expect(editorSurfaceModeForDefinition({ version: 1, content: {} })).toBe('docked');
+    expect(
+      editorSurfaceModeForDefinition({
+        version: 1,
+        content: {},
+        params: {
+          speed: { type: 'number', min: 0.5, max: 2, default: 1, label: { en: 'Speed', pl: 'Tempo' } },
+        },
+      }),
+    ).toBe('docked');
   });
 
   it('uses the full surface for a declaration-rendered board', () => {

--- a/apps/web/src/EditorPanel.surfaceMode.test.ts
+++ b/apps/web/src/EditorPanel.surfaceMode.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+import { editorSurfaceModeForDefinition } from './editorSurfaceMode.js';
+import type { EditorDefinition } from './studioApi.js';
+
+const label = { en: 'Terrain', pl: 'Teren' };
+const layered: EditorDefinition = {
+  version: 2,
+  content: {},
+  layers: {
+    terrain: {
+      widget: 'tilemap',
+      label,
+      grid: { minCols: 1, maxCols: 4, minRows: 1, maxRows: 4 },
+      tiles: [],
+      properties: {},
+      constraints: [],
+    },
+  },
+};
+
+describe('EditorPanel surface mode', () => {
+  it('docks declaration-only tuning beside the running game', () => {
+    expect(editorSurfaceModeForDefinition({ version: 1, content: {} })).toBe('docked');
+  });
+
+  it('uses the full surface for a declaration-rendered board', () => {
+    expect(editorSurfaceModeForDefinition(layered)).toBe('full');
+  });
+
+  it('keeps controller-rendered boards docked beside the running game', () => {
+    expect(editorSurfaceModeForDefinition({ ...layered, controller: true })).toBe('docked');
+  });
+});

--- a/apps/web/src/EditorPanel.surfaceMode.test.ts
+++ b/apps/web/src/EditorPanel.surfaceMode.test.ts
@@ -35,7 +35,11 @@ describe('EditorPanel surface mode', () => {
     expect(editorSurfaceModeForDefinition(layered)).toBe('full');
   });
 
-  it('keeps controller-rendered boards docked beside the running game', () => {
-    expect(editorSurfaceModeForDefinition({ ...layered, controller: true })).toBe('docked');
+  it('keeps an active controller docked beside the running game', () => {
+    expect(editorSurfaceModeForDefinition({ ...layered, controller: true }, true)).toBe('docked');
+  });
+
+  it('restores a controller board fallback to the full surface', () => {
+    expect(editorSurfaceModeForDefinition({ ...layered, controller: true }, false)).toBe('full');
   });
 });

--- a/apps/web/src/EditorPanel.tsx
+++ b/apps/web/src/EditorPanel.tsx
@@ -169,6 +169,9 @@ export function EditorPanel(props: {
   const [utterance, setUtterance] = useState('');
   const [assist, setAssist] = useState<AssistState>({ kind: 'idle' });
   const [controllerDisabled, setControllerDisabled] = useState(false);
+  const controllerActive = Boolean(
+    props.controller?.status === 'ready' && !controllerDisabled && props.controller.view,
+  );
   const lastControllerChangeRef = useRef<string | null>(null);
   const document = useEditorDocument({ slug, onPush: (next) => pushLive(next) });
   const {
@@ -213,7 +216,6 @@ export function EditorPanel(props: {
         // The revision funnel's first rung: this creator can edit and did open it.
         recordEditorStep('opened');
         setEditor(loaded);
-        onSurfaceModeChange?.(editorSurfaceModeForDefinition(loaded.definition));
         const merged = mergeDraft(loaded);
         resetDocument(merged, loaded.draft?.revision ?? 0);
         const defaultKey = defaultCollectionKey(loaded.definition.content);
@@ -241,6 +243,11 @@ export function EditorPanel(props: {
       cancelled = true;
     };
   }, [onSurfaceModeChange, pushLive, resetDocument, slug]);
+
+  useEffect(() => {
+    if (!editor) return;
+    onSurfaceModeChange?.(editorSurfaceModeForDefinition(editor.definition, controllerActive));
+  }, [controllerActive, editor, onSurfaceModeChange]);
 
   // Guards a stale async reply from pushing into a game switched to since (editorPushRef
   // is shared, parent-owned).
@@ -597,10 +604,6 @@ export function EditorPanel(props: {
   const boardSpec = tilemapCollection(spec);
   const pathSpec = pathCollection(spec);
   const width = tilemapItem ? (tilemapItem.rows[0]?.length ?? 0) : 0;
-  const controllerActive = Boolean(
-    props.controller?.status === 'ready' && !controllerDisabled && props.controller.view,
-  );
-
   return (
     <div className="editor-panel">
       <div className="editor-panel-head">

--- a/apps/web/src/EditorPanel.tsx
+++ b/apps/web/src/EditorPanel.tsx
@@ -18,6 +18,7 @@ import {
 } from './editorContentTools.js';
 import { LayeredBoard, LayeredSidebar } from './LayeredEditorSurface.js';
 import { EditorSurface } from './EditorSurface.js';
+import { editorSurfaceModeForDefinition } from './editorSurfaceMode.js';
 import { useEditorDocument } from './useEditorDocument.js';
 import { recordAssistStep, recordEditorStep } from './visitTelemetry.js';
 import type { EditorContentPush, EditorControllerState, EditorSelection } from './editorBridge.js';
@@ -212,12 +213,7 @@ export function EditorPanel(props: {
         // The revision funnel's first rung: this creator can edit and did open it.
         recordEditorStep('opened');
         setEditor(loaded);
-        const needsFullSurface =
-          Object.keys(loaded.definition.layers ?? {}).length > 0 ||
-          Object.values(loaded.definition.content).some(
-            (collection) => collection.item.widget === 'tilemap' || collection.item.widget === 'path',
-          );
-        onSurfaceModeChange?.(needsFullSurface ? 'full' : 'docked');
+        onSurfaceModeChange?.(editorSurfaceModeForDefinition(loaded.definition));
         const merged = mergeDraft(loaded);
         resetDocument(merged, loaded.draft?.revision ?? 0);
         const defaultKey = defaultCollectionKey(loaded.definition.content);

--- a/apps/web/src/editorSurfaceMode.ts
+++ b/apps/web/src/editorSurfaceMode.ts
@@ -1,0 +1,13 @@
+import type { EditorDefinition } from './studioApi.js';
+
+export type EditorSurfaceMode = 'docked' | 'full';
+
+export function editorSurfaceModeForDefinition(definition: EditorDefinition): EditorSurfaceMode {
+  if (definition.controller === true) return 'docked';
+  const hasBoard =
+    Object.keys(definition.layers ?? {}).length > 0 ||
+    Object.values(definition.content).some(
+      (collection) => collection.item.widget === 'tilemap' || collection.item.widget === 'path',
+    );
+  return hasBoard ? 'full' : 'docked';
+}

--- a/apps/web/src/editorSurfaceMode.ts
+++ b/apps/web/src/editorSurfaceMode.ts
@@ -2,8 +2,11 @@ import type { EditorDefinition } from './studioApi.js';
 
 export type EditorSurfaceMode = 'docked' | 'full';
 
-export function editorSurfaceModeForDefinition(definition: EditorDefinition): EditorSurfaceMode {
-  if (definition.controller === true) return 'docked';
+export function editorSurfaceModeForDefinition(
+  definition: EditorDefinition,
+  controllerActive = false,
+): EditorSurfaceMode {
+  if (definition.controller === true && controllerActive) return 'docked';
   const hasBoard =
     Object.keys(definition.layers ?? {}).length > 0 ||
     Object.values(definition.content).some(

--- a/apps/web/src/styles.editorSurface.test.ts
+++ b/apps/web/src/styles.editorSurface.test.ts
@@ -11,7 +11,6 @@ function declarations(selector: string): string {
   expect(end, `unclosed ${selector} rule`).toBeGreaterThan(start);
   return css.slice(start, end);
 }
-
 describe('layered editor surface CSS contract', () => {
   it('pins the stacked board posture and active-layer interaction', () => {
     expect(declarations('.editor-layer-stack')).toMatch(/display:\s*grid/);
@@ -28,6 +27,7 @@ describe('layered editor surface CSS contract', () => {
 
   it('pins the edit overlay dock posture used by layered definitions', () => {
     const dock = ".studio-edit-overlay:not(.studio-code-overlay)[data-surface='docked']";
+    expect(css).not.toContain(':has(.editor-board-col)');
     expect(declarations(dock)).toMatch(/inset:\s*0 0 0 auto/);
     expect(declarations(dock)).toMatch(/width:\s*min\(360px, 100%\)/);
   });


### PR DESCRIPTION
## Summary

- derive the editor overlay posture explicitly from the delivered editor definition
- keep an active controller docked beside the live game instead of covering it
- restore the full surface when a controller fails and the declaration-rendered board takes over
- pin panel mode selection, Creator wiring, fallback behavior, and the CSS selector contract

## Verification

Exact head: `de931c4c11fe9d01912c5c98f281499bd1ef556d`

- `npm install` — PASS
- `npm run type-check` — PASS
- `npm run lint` — PASS (132 pre-existing warnings, 0 errors)
- `npm run test` — PASS
- `npm run build` — PASS
- `npm run test -w @gamedevpl/web -- --run src/EditorPanel.surfaceMode.test.ts src/CreatorStudioView.editorSurface.test.ts src/styles.editorSurface.test.ts` — PASS (8/8)

The first full test attempt hit the existing 5-second timeout in two unchanged self-build handoff tests; an isolated longer-timeout run proved the slow path completed in 5.8 seconds, and the required unmodified `npm run test` rerun then passed cleanly.

GitHub CI [run #3409](https://github.com/gamedevpl/www.gamedev.pl/actions/runs/32990810176) — PASS on this exact head:

- Secret Scanning — PASS
- Lint, Test & Build — PASS
- Production image — PASS
- Games-repo contract — PASS