### PR TITLE
EK2-21: harden the editor controller protocol

### DIFF
--- a/apps/web/src/editorBridge.controllerProtocol.test.tsx
+++ b/apps/web/src/editorBridge.controllerProtocol.test.tsx
@@ -1,0 +1,114 @@
+// @vitest-environment jsdom
+
+import { act, type MutableRefObject } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const studioApi = vi.hoisted(() => ({ fetchGameEditor: vi.fn() }));
+vi.mock('./studioApi', () => studioApi);
+vi.mock('./visitTelemetry', () => ({ recordEditorStep: vi.fn() }));
+
+import { useEditorDraftBridge, type EditorControllerState } from './editorBridge.js';
+
+let latestController: EditorControllerState | null = null;
+
+function Harness({ frameRef }: { frameRef: MutableRefObject<HTMLIFrameElement | null> }) {
+  latestController = useEditorDraftBridge(frameRef, true, 'controller-fixture', true).controller;
+  return null;
+}
+
+describe('controller bridge boundary', () => {
+  let container: HTMLDivElement;
+  let root: Root | null;
+  let gameWindow: Window;
+  let otherWindow: Window;
+  let posted: Array<Record<string, unknown>>;
+
+  beforeEach(() => {
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    posted = [];
+    gameWindow = { postMessage: vi.fn((message: Record<string, unknown>) => posted.push(message)) } as unknown as Window;
+    otherWindow = { postMessage: vi.fn() } as unknown as Window;
+    studioApi.fetchGameEditor.mockResolvedValue({ definition: { version: 2, controller: true, content: {} }, draft: null });
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = null;
+    latestController = null;
+  });
+
+  afterEach(() => {
+    if (root) act(() => root!.unmount());
+    container.remove();
+    vi.clearAllMocks();
+  });
+
+  function mount() {
+    const frameRef = { current: { contentWindow: gameWindow } } as unknown as MutableRefObject<HTMLIFrameElement | null>;
+    root = createRoot(container);
+    act(() => root!.render(<Harness frameRef={frameRef} />));
+  }
+
+  function send(data: Record<string, unknown>, source = gameWindow, origin = 'null') {
+    const event = new MessageEvent('message', { data, origin });
+    Object.defineProperty(event, 'source', { value: source });
+    act(() => window.dispatchEvent(event));
+  }
+
+  function frame(body: Record<string, unknown>) {
+    return { ns: 'gdp', v: 1, ...body };
+  }
+
+  function connect() {
+    send(frame({ t: 'editor:hello', controller: true }));
+    send(frame({ t: 'editor:ui', doc: { type: 'note', text: 'Ready' } }));
+    expect(latestController?.status).toBe('ready');
+  }
+
+  it('ignores wrong origins and iframe sources before parsing', () => {
+    mount();
+    send(frame({ t: 'editor:hello', controller: true }), gameWindow, 'https://attacker.example');
+    send(frame({ t: 'editor:hello', controller: true }), otherWindow);
+    send({ ns: 'wrong', v: 1, t: 'editor:hello', controller: true });
+    send({ ns: 'gdp', v: 2, t: 'editor:hello', controller: true });
+    expect(latestController).toBeNull();
+    expect(studioApi.fetchGameEditor).not.toHaveBeenCalled();
+    expect(posted).toEqual([]);
+  });
+
+  it('sends event, selection, and fallback mode in the additive v1 envelope', () => {
+    mount();
+    connect();
+    posted.length = 0;
+    act(() => {
+      latestController!.sendEvent({ tool: 'paint' });
+      latestController!.sendSelection({ layer: 'actors', index: 2 });
+      latestController!.useFallback('controller stopped');
+    });
+    expect(posted).toEqual([
+      { ns: 'gdp', v: 1, t: 'editor:event', event: { tool: 'paint' } },
+      { ns: 'gdp', v: 1, t: 'editor:select', selection: { layer: 'actors', index: 2 } },
+      { ns: 'gdp', v: 1, t: 'editor:mode', mode: 'fallback' },
+    ]);
+  });
+
+  it('accepts valid change, selection, and canvas messages from the game frame', () => {
+    mount();
+    connect();
+    send(frame({ t: 'editor:change', id: 'change-1', patch: { op: 'replace' } }));
+    send(frame({ t: 'editor:select', selection: { layer: 'actors', index: 1 } }));
+    send(frame({ t: 'editor:canvas', box: { width: 640, height: 360, x: -2, y: 4, insetX: 0, scale: 2 } }));
+    expect(latestController).toMatchObject({
+      pendingChange: { id: 'change-1', patch: { op: 'replace' } },
+      selected: { layer: 'actors', index: 1 },
+      canvasBox: { width: 640, height: 360, x: -2, y: 4, insetX: 0, scale: 2 },
+    });
+  });
+
+  it('drops invalid canvas messages without replacing the last valid box', () => {
+    mount();
+    connect();
+    send(frame({ t: 'editor:canvas', box: { width: 640, height: 360, x: 0, y: 0 } }));
+    send(frame({ t: 'editor:canvas', box: { width: 0, height: 360, x: 0, y: 0 } }));
+    expect(latestController?.canvasBox).toEqual({ width: 640, height: 360, x: 0, y: 0 });
+  });
+});

--- a/apps/web/src/editorBridge.ts
+++ b/apps/web/src/editorBridge.ts
@@ -1,81 +1,42 @@
 import { useCallback, useEffect, useMemo, useRef, useState, type MutableRefObject } from 'react';
-import { PROPERTY_TYPES, type PropertyType } from '@gamedevpl/contract';
-import { BRIDGE_NAMESPACE, PROTOCOL_VERSION } from './mp/protocol.js';
 import { fetchGameEditor, type EditorContentDoc } from './studioApi.js';
 import { recordEditorStep } from './visitTelemetry.js';
+import {
+  BRIDGE_NAMESPACE,
+  PROTOCOL_VERSION,
+  parseEditorControllerEnvelope,
+  type EditorCanvasBox,
+  type EditorControllerChange,
+  type EditorControllerOutbound,
+  type EditorControllerSelection,
+  type EditorSelection,
+  type EditorUiDocument,
+  type EditorUiRequest,
+} from './editorControllerProtocol.js';
 
-// Collection item the painter is showing.
-export type EditorSelection = {
-  collection: string;
-  index: number;
-};
+export type {
+  EditorCanvasBox,
+  EditorControllerChange,
+  EditorControllerSelection,
+  EditorSelection,
+  EditorUiDocument,
+  EditorUiField,
+  EditorUiLabel,
+  EditorUiNode,
+  EditorUiRequest,
+} from './editorControllerProtocol.js';
 
 export type EditorContentPush = (content: EditorContentDoc, selection?: EditorSelection | null) => void;
 
-export type EditorControllerSelection = { layer: string; index: number | null };
-export type EditorUiLabel = string | { en: string; pl: string };
-export type EditorUiField = {
-  name: string;
-  label: EditorUiLabel;
-  type: PropertyType;
-  value?: string | number | boolean;
-  min?: number;
-  max?: number;
-  options?: string[];
-};
-export type EditorUiNode =
-  | { type: 'rail' | 'panel' | 'group'; children: EditorUiNode[]; title?: EditorUiLabel }
-  | { type: 'tabs'; tabs: Array<{ id: string; label: EditorUiLabel }>; active?: string }
-  | {
-      type: 'board';
-      layers: string[];
-      active?: string;
-      rows?: string[];
-      tiles?: Array<{ char: string; color?: string }>;
-    }
-  | { type: 'toolbar'; tools: string[]; active?: string }
-  | {
-      type: 'palette';
-      layer?: string;
-      tiles?: Array<{ key: string; char: string; label: EditorUiLabel; color?: string }>;
-    }
-  | { type: 'propertySheet'; layer: string; index: number; fields?: EditorUiField[] }
-  | {
-      type: 'list';
-      items: Array<{ id: string; label: EditorUiLabel; detail?: EditorUiLabel }>;
-      selected?: string;
-    }
-  | { type: 'note'; text: EditorUiLabel }
-  | { type: 'check'; ok: boolean; text: EditorUiLabel };
-
-export type EditorUiRequest = {
-  id: string;
-  spec: {
-    kind: 'form' | 'confirm' | 'toast';
-    title?: EditorUiLabel;
-    message?: EditorUiLabel;
-    text?: EditorUiLabel;
-    fields?: EditorUiField[];
-  };
-};
-export type EditorControllerChange = { id: string; patch: unknown };
 export type EditorControllerState = {
   status: 'connecting' | 'ready' | 'failed';
-  view: EditorUiNode | EditorUiNode[] | null;
+  view: EditorUiDocument | null;
   reason: string | null;
   selected: EditorControllerSelection | null;
   pendingChange: EditorControllerChange | null;
   uiRequest: EditorUiRequest | null;
   checks: { ok: boolean; problems: string[] } | null;
-  canvasBox: {
-    width: number;
-    height: number;
-    x: number;
-    y: number;
-    insetX?: number;
-    insetY?: number;
-    scale?: number;
-  } | null;
+  canvasBox: EditorCanvasBox | null;
   sendEvent: (event: Record<string, unknown>) => void;
   sendSelection: (selection: EditorControllerSelection | null) => void;
   sendUiResult: (id: string, value: unknown, cancelled?: boolean) => void;
@@ -83,175 +44,10 @@ export type EditorControllerState = {
   useFallback: (reason: string) => void;
 };
 
-function isLabel(value: unknown): value is EditorUiLabel {
-  return (
-    typeof value === 'string' ||
-    (typeof value === 'object' &&
-      value !== null &&
-      typeof (value as { en?: unknown }).en === 'string' &&
-      typeof (value as { pl?: unknown }).pl === 'string')
-  );
-}
-
-function parseUiField(value: unknown): EditorUiField | null {
-  if (!value || typeof value !== 'object' || Array.isArray(value)) return null;
-  const raw = value as Record<string, unknown>;
-  if (typeof raw.name !== 'string' || !isLabel(raw.label)) return null;
-  if (!(PROPERTY_TYPES as readonly string[]).includes(String(raw.type))) return null;
-  if (raw.value !== undefined && !['string', 'number', 'boolean'].includes(typeof raw.value)) return null;
-  const field: EditorUiField = { name: raw.name, label: raw.label, type: raw.type as EditorUiField['type'] };
-  if (typeof raw.value === 'string' || typeof raw.value === 'number' || typeof raw.value === 'boolean')
-    field.value = raw.value;
-  if (typeof raw.min === 'number' && Number.isFinite(raw.min)) field.min = raw.min;
-  if (typeof raw.max === 'number' && Number.isFinite(raw.max)) field.max = raw.max;
-  if (Array.isArray(raw.options) && raw.options.every((entry) => typeof entry === 'string'))
-    field.options = raw.options.slice(0, 32) as string[];
-  return field;
-}
-
-function parseUiPaletteTile(
-  value: unknown,
-): { key: string; char: string; label: EditorUiLabel; color?: string } | null {
-  if (!value || typeof value !== 'object' || Array.isArray(value)) return null;
-  const raw = value as Record<string, unknown>;
-  if (
-    typeof raw.key !== 'string' ||
-    raw.key.length === 0 ||
-    raw.key.length > 64 ||
-    typeof raw.char !== 'string' ||
-    raw.char.length === 0 ||
-    raw.char.length > 4 ||
-    !isLabel(raw.label)
-  )
-    return null;
-  if (raw.color !== undefined && typeof raw.color !== 'string') return null;
-  return {
-    key: raw.key,
-    char: raw.char,
-    label: raw.label,
-    ...(typeof raw.color === 'string' ? { color: raw.color } : {}),
-  };
-}
-
-function parseUiNode(value: unknown, depth = 0): EditorUiNode | null {
-  if (depth > 5 || !value || typeof value !== 'object' || Array.isArray(value)) return null;
-  const raw = value as Record<string, unknown>;
-  const type = raw.type;
-  if (type === 'rail' || type === 'panel' || type === 'group') {
-    if (!Array.isArray(raw.children) || raw.children.length > 32) return null;
-    const children = raw.children.map((child) => parseUiNode(child, depth + 1));
-    if (children.some((child) => child === null)) return null;
-    if (raw.title !== undefined && !isLabel(raw.title)) return null;
-    return { type, children: children as EditorUiNode[], ...(raw.title === undefined ? {} : { title: raw.title }) };
-  }
-  if (type === 'tabs') {
-    if (!Array.isArray(raw.tabs) || raw.tabs.length > 32) return null;
-    const tabs = raw.tabs.map((tab) => {
-      if (!tab || typeof tab !== 'object') return null;
-      const entry = tab as Record<string, unknown>;
-      return typeof entry.id === 'string' && isLabel(entry.label) ? { id: entry.id, label: entry.label } : null;
-    });
-    if (tabs.some((tab) => tab === null)) return null;
-    return {
-      type,
-      tabs: tabs as Array<{ id: string; label: EditorUiLabel }>,
-      ...(typeof raw.active === 'string' ? { active: raw.active } : {}),
-    };
-  }
-  if (type === 'board') {
-    if (!Array.isArray(raw.layers) || raw.layers.length > 32 || !raw.layers.every((layer) => typeof layer === 'string'))
-      return null;
-    const node: EditorUiNode = { type, layers: raw.layers as string[] };
-    if (typeof raw.active === 'string') (node as { active?: string }).active = raw.active;
-    if (Array.isArray(raw.rows) && raw.rows.length <= 128 && raw.rows.every((row) => typeof row === 'string'))
-      (node as { rows?: string[] }).rows = raw.rows as string[];
-    return node;
-  }
-  if (type === 'toolbar') {
-    return Array.isArray(raw.tools) && raw.tools.length <= 32 && raw.tools.every((tool) => typeof tool === 'string')
-      ? { type, tools: raw.tools as string[], ...(typeof raw.active === 'string' ? { active: raw.active } : {}) }
-      : null;
-  }
-  if (type === 'palette') {
-    if (raw.layer !== undefined && typeof raw.layer !== 'string') return null;
-    if (raw.tiles !== undefined && (!Array.isArray(raw.tiles) || raw.tiles.length > 32)) return null;
-    const tiles = raw.tiles === undefined ? undefined : raw.tiles.map(parseUiPaletteTile);
-    if (tiles?.some((tile) => tile === null)) return null;
-    return {
-      type,
-      ...(typeof raw.layer === 'string' ? { layer: raw.layer } : {}),
-      ...(tiles === undefined
-        ? {}
-        : { tiles: tiles as Array<{ key: string; char: string; label: EditorUiLabel; color?: string }> }),
-    };
-  }
-  if (type === 'propertySheet') {
-    if (typeof raw.layer !== 'string' || typeof raw.index !== 'number' || !Number.isInteger(raw.index) || raw.index < 0)
-      return null;
-    if (raw.fields !== undefined && (!Array.isArray(raw.fields) || raw.fields.length > 32)) return null;
-    const fields = raw.fields === undefined ? undefined : raw.fields.map(parseUiField);
-    if (fields?.some((field) => field === null)) return null;
-    return { type, layer: raw.layer, index: raw.index, ...(fields ? { fields: fields as EditorUiField[] } : {}) };
-  }
-  if (type === 'list') {
-    if (!Array.isArray(raw.items) || raw.items.length > 128) return null;
-    const items = raw.items.map((item) => {
-      if (!item || typeof item !== 'object') return null;
-      const entry = item as Record<string, unknown>;
-      return typeof entry.id === 'string' && isLabel(entry.label)
-        ? {
-            id: entry.id,
-            label: entry.label,
-            ...(entry.detail === undefined ? {} : { detail: isLabel(entry.detail) ? entry.detail : null }),
-          }
-        : null;
-    });
-    if (items.some((item) => item === null || ('detail' in item && item.detail === null))) return null;
-    return {
-      type,
-      items: items as Array<{ id: string; label: EditorUiLabel; detail?: EditorUiLabel }>,
-      ...(typeof raw.selected === 'string' ? { selected: raw.selected } : {}),
-    };
-  }
-  if (type === 'note') return isLabel(raw.text) ? { type, text: raw.text } : null;
-  if (type === 'check')
-    return typeof raw.ok === 'boolean' && isLabel(raw.text) ? { type, ok: raw.ok, text: raw.text } : null;
-  return null;
-}
-
-function parseUiDocument(value: unknown): EditorUiNode | EditorUiNode[] | null {
-  if (Array.isArray(value)) {
-    if (value.length > 32) return null;
-    const nodes = value.map((node) => parseUiNode(node));
-    return nodes.some((node) => node === null) ? null : (nodes as EditorUiNode[]);
-  }
-  return parseUiNode(value);
-}
-
-function parseUiRequest(value: unknown): EditorUiRequest | null {
-  if (!value || typeof value !== 'object' || Array.isArray(value)) return null;
-  const raw = value as Record<string, unknown>;
-  if (typeof raw.id !== 'string' || raw.id.length === 0 || raw.id.length > 128) return null;
-  if (!raw.spec || typeof raw.spec !== 'object' || Array.isArray(raw.spec)) return null;
-  const spec = raw.spec as Record<string, unknown>;
-  if (!['form', 'confirm', 'toast'].includes(String(spec.kind))) return null;
-  const parsedSpec: EditorUiRequest['spec'] = { kind: spec.kind as EditorUiRequest['spec']['kind'] };
-  for (const key of ['title', 'message', 'text'] as const) {
-    if (spec[key] !== undefined) {
-      if (!isLabel(spec[key])) return null;
-      parsedSpec[key] = spec[key];
-    }
-  }
-  if (spec.fields !== undefined) {
-    if (!Array.isArray(spec.fields) || spec.fields.length > 32) return null;
-    const fields = spec.fields.map(parseUiField);
-    if (fields.some((field) => field === null)) return null;
-    parsedSpec.fields = fields as EditorUiField[];
-  }
-  return { id: raw.id, spec: parsedSpec };
-}
-
-export function editorContentMessage(content: EditorContentDoc, selection?: EditorSelection | null) {
+export function editorContentMessage(
+  content: EditorContentDoc,
+  selection?: EditorSelection | null,
+): Extract<EditorControllerOutbound, { t: 'editor:content' }> {
   return {
     ns: BRIDGE_NAMESPACE,
     v: PROTOCOL_VERSION,
@@ -294,7 +90,7 @@ export function useEditorDraftBridge(
   const controllerHelloRef = useRef(false);
   const controllerTimerRef = useRef<number | null>(null);
   const [controllerStatus, setControllerStatus] = useState<EditorControllerState['status'] | null>(null);
-  const [controllerView, setControllerView] = useState<EditorUiNode | EditorUiNode[] | null>(null);
+  const [controllerView, setControllerView] = useState<EditorUiDocument | null>(null);
   const [controllerReason, setControllerReason] = useState<string | null>(null);
   const [controllerSelection, setControllerSelection] = useState<EditorControllerSelection | null>(null);
   const [pendingChange, setPendingChange] = useState<EditorControllerChange | null>(null);
@@ -371,70 +167,38 @@ export function useEditorDraftBridge(
       if (event.origin !== 'null') return;
       const frame = frameRef.current;
       if (!frame || event.source !== frame.contentWindow) return;
-      const data = event.data as Record<string, unknown> | null;
-      if (!data || data.ns !== BRIDGE_NAMESPACE || data.v !== PROTOCOL_VERSION) return;
-      if (data.t === 'editor:hello' && data.controller === true) {
+      const data = parseEditorControllerEnvelope(event.data);
+      if (!data) {
+        const raw = event.data as Record<string, unknown> | null;
+        if (raw?.ns === BRIDGE_NAMESPACE && raw.v === PROTOCOL_VERSION && raw.t === 'editor:ui') {
+          failController('The game editor sent an invalid view.');
+        }
+        return;
+      }
+      if (data.t === 'editor:hello' && data.controller) {
         controllerHelloRef.current = true;
         expectController();
       } else if (data.t === 'editor:ui') {
-        const parsed = parseUiDocument(data.doc);
-        if (!parsed) {
-          failController('The game editor sent an invalid view.');
-          return;
-        }
         if (controllerTimerRef.current !== null) window.clearTimeout(controllerTimerRef.current);
         controllerTimerRef.current = null;
-        setControllerView(parsed);
+        setControllerView(data.doc);
         setControllerStatus('ready');
         setControllerReason(null);
         recordEditorStep('controller_loaded');
       } else if (data.t === 'editor:change') {
-        if (typeof data.id !== 'string') return;
         setPendingChange({ id: data.id, patch: data.patch });
       } else if (data.t === 'editor:select') {
-        const rawSelection = data.selection;
-        if (rawSelection !== null && (!rawSelection || typeof rawSelection !== 'object')) return;
-        const layer =
-          rawSelection && typeof rawSelection === 'object' ? (rawSelection as { layer?: unknown }).layer : null;
-        const index =
-          rawSelection && typeof rawSelection === 'object' ? (rawSelection as { index?: unknown }).index : null;
-        if (
-          rawSelection !== null &&
-          (typeof layer !== 'string' || (index !== null && (!Number.isInteger(index) || (index as number) < 0)))
-        )
-          return;
-        setControllerSelection(
-          rawSelection === null ? null : { layer: layer as string, index: index as number | null },
-        );
+        setControllerSelection(data.selection);
       } else if (data.t === 'editor:canvas') {
-        const box = data.box;
-        if (!box || typeof box !== 'object') return;
-        const raw = box as Record<string, unknown>;
-        if ([raw.width, raw.height, raw.x, raw.y].some((value) => typeof value !== 'number' || !Number.isFinite(value)))
-          return;
-        setCanvasBox({
-          width: raw.width as number,
-          height: raw.height as number,
-          x: raw.x as number,
-          y: raw.y as number,
-          ...(typeof raw.insetX === 'number' ? { insetX: raw.insetX } : {}),
-          ...(typeof raw.insetY === 'number' ? { insetY: raw.insetY } : {}),
-          ...(typeof raw.scale === 'number' ? { scale: raw.scale } : {}),
-        });
+        setCanvasBox(data.box);
       } else if (data.t === 'editor:ui-request') {
-        const request = parseUiRequest({ id: data.id, spec: data.spec });
-        if (!request) return;
-        setUiRequest(request);
+        setUiRequest({ id: data.id, spec: data.spec });
       } else if (data.t === 'editor:check') {
-        if (typeof data.ok !== 'boolean' || !Array.isArray(data.problems)) return;
-        setControllerChecks({
-          ok: data.ok,
-          problems: data.problems.filter((problem): problem is string => typeof problem === 'string').slice(0, 12),
-        });
-      } else if (data.t === 'editor:ack' && data.ok === false && controllerStatusRef.current !== null) {
-        failController(typeof data.error === 'string' ? data.error : 'The game refused this content change.');
+        setControllerChecks({ ok: data.ok, problems: data.problems });
+      } else if (data.t === 'editor:ack' && !data.ok && controllerStatusRef.current !== null) {
+        failController(data.error ?? 'The game refused this content change.');
       } else if (data.t === 'editor:controller-error') {
-        failController(typeof data.error === 'string' ? data.error : 'The game editor stopped responding.');
+        failController(data.error ?? 'The game editor stopped responding.');
       } else if (data.t === 'editor:hello') {
         // A non-controller editor still receives the declaration-driven content push.
       } else {
@@ -473,8 +237,8 @@ export function useEditorDraftBridge(
   );
 
   const send = useCallback(
-    (payload: Record<string, unknown>) => {
-      frameRef.current?.contentWindow?.postMessage({ ns: BRIDGE_NAMESPACE, v: PROTOCOL_VERSION, ...payload }, '*');
+    (message: EditorControllerOutbound) => {
+      frameRef.current?.contentWindow?.postMessage(message, '*');
     },
     [frameRef],
   );
@@ -489,20 +253,28 @@ export function useEditorDraftBridge(
       uiRequest,
       checks: controllerChecks,
       canvasBox,
-      sendEvent: (event) => send({ t: 'editor:event', event }),
+      sendEvent: (event) => send({ ns: BRIDGE_NAMESPACE, v: PROTOCOL_VERSION, t: 'editor:event', event }),
       sendSelection: (selection) => {
         setControllerSelection(selection);
-        send({ t: 'editor:select', selection });
+        send({ ns: BRIDGE_NAMESPACE, v: PROTOCOL_VERSION, t: 'editor:select', selection });
       },
       sendUiResult: (id, value, cancelled = false) => {
         setUiRequest(null);
-        send({ t: 'editor:ui-result', id, value, cancelled });
+        send({ ns: BRIDGE_NAMESPACE, v: PROTOCOL_VERSION, t: 'editor:ui-result', id, value, cancelled });
       },
-      acknowledgeChange: (id, ok, error) => send({ t: 'editor:change:ack', id, ok, ...(error ? { error } : {}) }),
+      acknowledgeChange: (id, ok, error) =>
+        send({
+          ns: BRIDGE_NAMESPACE,
+          v: PROTOCOL_VERSION,
+          t: 'editor:change:ack',
+          id,
+          ok,
+          ...(error ? { error } : {}),
+        }),
       useFallback: (reason) => {
         setControllerStatus('failed');
         setControllerReason(reason);
-        send({ t: 'editor:mode', mode: 'fallback' });
+        send({ ns: BRIDGE_NAMESPACE, v: PROTOCOL_VERSION, t: 'editor:mode', mode: 'fallback' });
       },
     };
   }, [

--- a/apps/web/src/editorControllerProtocol.test.ts
+++ b/apps/web/src/editorControllerProtocol.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it } from 'vitest';
+import { parseEditorControllerEnvelope } from './editorControllerProtocol.js';
+
+const envelope = (body: Record<string, unknown>) => ({ ns: 'gdp', v: 1, ...body });
+
+describe('EditorKit controller protocol', () => {
+  it.each([
+    [
+      'ui',
+      envelope({
+        t: 'editor:ui',
+        doc: [
+          { type: 'toolbar', tools: ['paint'], active: 'paint' },
+          {
+            type: 'board',
+            layers: ['terrain'],
+            rows: ['..'],
+            tiles: [{ char: '.', color: '#123456' }],
+          },
+          {
+            type: 'propertySheet',
+            layer: 'terrain',
+            index: 0,
+            fields: [{ name: 'speed', label: 'Speed', type: 'number', value: 1 }],
+          },
+        ],
+      }),
+      'editor:ui',
+    ],
+    ['change', envelope({ t: 'editor:change', id: 'change-1', patch: { op: 'replace' } }), 'editor:change'],
+    ['selection', envelope({ t: 'editor:select', selection: { layer: 'actors', index: 2 } }), 'editor:select'],
+    ['cleared selection', envelope({ t: 'editor:select', selection: null }), 'editor:select'],
+    [
+      'canvas',
+      envelope({
+        t: 'editor:canvas',
+        box: { width: 640, height: 360, x: -12, y: 8, insetX: 4, insetY: 6, scale: 1.5 },
+      }),
+      'editor:canvas',
+    ],
+  ])('accepts a valid %s envelope', (_name, raw, type) => {
+    expect(parseEditorControllerEnvelope(raw)?.t).toBe(type);
+  });
+
+  it.each([
+    ['missing namespace', { v: 1, t: 'editor:change', id: 'x' }],
+    ['wrong namespace', { ns: 'other', v: 1, t: 'editor:change', id: 'x' }],
+    ['wrong version', { ns: 'gdp', v: 2, t: 'editor:change', id: 'x' }],
+    ['unknown type', envelope({ t: 'editor:future' })],
+    ['non-object', 'editor:hello'],
+    ['array', []],
+  ])('rejects %s', (_name, raw) => {
+    expect(parseEditorControllerEnvelope(raw)).toBeNull();
+  });
+
+  it('enforces UI depth and child-count budgets', () => {
+    let deep: Record<string, unknown> = { type: 'note', text: 'leaf' };
+    for (let level = 0; level < 7; level += 1) deep = { type: 'group', children: [deep] };
+    expect(parseEditorControllerEnvelope(envelope({ t: 'editor:ui', doc: deep }))).toBeNull();
+    expect(
+      parseEditorControllerEnvelope(
+        envelope({ t: 'editor:ui', doc: { type: 'group', children: Array(33).fill({ type: 'note', text: 'x' }) } }),
+      ),
+    ).toBeNull();
+    expect(
+      parseEditorControllerEnvelope(envelope({ t: 'editor:ui', doc: Array(33).fill({ type: 'note', text: 'x' }) })),
+    ).toBeNull();
+    const wide = Array(16).fill({ type: 'group', children: Array(16).fill({ type: 'note', text: 'x' }) });
+    expect(parseEditorControllerEnvelope(envelope({ t: 'editor:ui', doc: wide }))).toBeNull();
+  });
+
+  it.each([
+    ['unknown node', { type: 'video' }],
+    ['missing children', { type: 'panel' }],
+    ['bad label', { type: 'note', text: { en: 'Only English' } }],
+    ['fractional property index', { type: 'propertySheet', layer: 'actors', index: 0.5 }],
+    [
+      'nonfinite field value',
+      { type: 'propertySheet', layer: 'actors', index: 0, fields: [{ name: 'x', label: 'X', type: 'number', value: Infinity }] },
+    ],
+    ['oversized toolbar', { type: 'toolbar', tools: Array(33).fill('paint') }],
+    ['invalid toolbar selection', { type: 'toolbar', tools: ['paint'], active: 2 }],
+    ['malformed board tile', { type: 'board', layers: ['terrain'], tiles: [{ char: '' }] }],
+  ])('rejects malformed UI: %s', (_name, doc) => {
+    expect(parseEditorControllerEnvelope(envelope({ t: 'editor:ui', doc }))).toBeNull();
+  });
+
+  it.each([
+    ['missing selection', undefined],
+    ['primitive selection', 'actors'],
+    ['missing layer', { index: 0 }],
+    ['fractional index', { layer: 'actors', index: 1.5 }],
+    ['negative index', { layer: 'actors', index: -1 }],
+    ['string index', { layer: 'actors', index: '1' }],
+  ])('rejects invalid selection: %s', (_name, selection) => {
+    expect(parseEditorControllerEnvelope(envelope({ t: 'editor:select', selection }))).toBeNull();
+  });
+
+  const nonfiniteCanvasValues = ['width', 'height', 'x', 'y', 'insetX', 'insetY', 'scale'].flatMap((field) =>
+    [Number.NaN, Infinity, -Infinity].map((value) => [field, value] as const),
+  );
+
+  it.each(nonfiniteCanvasValues)('rejects nonfinite canvas %s=%s', (field, value) => {
+    const box = { width: 640, height: 360, x: 0, y: 0, insetX: 0, insetY: 0, scale: 1, [field]: value };
+    expect(parseEditorControllerEnvelope(envelope({ t: 'editor:canvas', box }))).toBeNull();
+  });
+
+  it.each([
+    ['width', 0],
+    ['width', -1],
+    ['height', 0],
+    ['height', -1],
+    ['insetX', -1],
+    ['insetY', -1],
+    ['scale', 0],
+    ['scale', -1],
+  ])('rejects out-of-range canvas %s=%s', (field, value) => {
+    const box = { width: 640, height: 360, x: 0, y: 0, insetX: 0, insetY: 0, scale: 1, [field]: value };
+    expect(parseEditorControllerEnvelope(envelope({ t: 'editor:canvas', box }))).toBeNull();
+  });
+
+  it('does not partially preserve invalid optional canvas fields', () => {
+    const parsed = parseEditorControllerEnvelope(
+      envelope({ t: 'editor:canvas', box: { width: 640, height: 360, x: 0, y: 0, insetX: '4' } }),
+    );
+    expect(parsed).toBeNull();
+  });
+
+  it.each([
+    ['empty id', ''],
+    ['oversized id', 'x'.repeat(129)],
+    ['numeric id', 3],
+  ])('rejects an invalid change id: %s', (_name, id) => {
+    expect(parseEditorControllerEnvelope(envelope({ t: 'editor:change', id, patch: {} }))).toBeNull();
+  });
+});

--- a/apps/web/src/editorControllerProtocol.ts
+++ b/apps/web/src/editorControllerProtocol.ts
@@ -1,0 +1,349 @@
+import { MP_PROTOCOL_VERSION, PROPERTY_TYPES, type PropertyType } from '@gamedevpl/contract';
+import type { EditorContentDoc } from './studioApi.js';
+
+export const BRIDGE_NAMESPACE = 'gdp';
+export const PROTOCOL_VERSION = MP_PROTOCOL_VERSION;
+
+export type GdpEnvelope<T extends string> = {
+  ns: typeof BRIDGE_NAMESPACE;
+  v: typeof PROTOCOL_VERSION;
+  t: T;
+};
+
+export type EditorSelection = { collection: string; index: number };
+export type EditorControllerSelection = { layer: string; index: number | null };
+export type EditorUiLabel = string | { en: string; pl: string };
+export type EditorUiField = {
+  name: string;
+  label: EditorUiLabel;
+  type: PropertyType;
+  value?: string | number | boolean;
+  min?: number;
+  max?: number;
+  options?: string[];
+};
+export type EditorUiNode =
+  | { type: 'rail' | 'panel' | 'group'; children: EditorUiNode[]; title?: EditorUiLabel }
+  | { type: 'tabs'; tabs: Array<{ id: string; label: EditorUiLabel }>; active?: string }
+  | {
+      type: 'board';
+      layers: string[];
+      active?: string;
+      rows?: string[];
+      tiles?: Array<{ char: string; color?: string }>;
+    }
+  | { type: 'toolbar'; tools: string[]; active?: string }
+  | {
+      type: 'palette';
+      layer?: string;
+      tiles?: Array<{ key: string; char: string; label: EditorUiLabel; color?: string }>;
+    }
+  | { type: 'propertySheet'; layer: string; index: number; fields?: EditorUiField[] }
+  | {
+      type: 'list';
+      items: Array<{ id: string; label: EditorUiLabel; detail?: EditorUiLabel }>;
+      selected?: string;
+    }
+  | { type: 'note'; text: EditorUiLabel }
+  | { type: 'check'; ok: boolean; text: EditorUiLabel };
+export type EditorUiDocument = EditorUiNode | EditorUiNode[];
+
+export type EditorUiRequest = {
+  id: string;
+  spec: {
+    kind: 'form' | 'confirm' | 'toast';
+    title?: EditorUiLabel;
+    message?: EditorUiLabel;
+    text?: EditorUiLabel;
+    fields?: EditorUiField[];
+  };
+};
+export type EditorControllerChange = { id: string; patch: unknown };
+export type EditorCanvasBox = {
+  width: number;
+  height: number;
+  x: number;
+  y: number;
+  insetX?: number;
+  insetY?: number;
+  scale?: number;
+};
+
+export type EditorControllerInbound =
+  | (GdpEnvelope<'editor:hello'> & { controller: boolean })
+  | (GdpEnvelope<'editor:ui'> & { doc: EditorUiDocument })
+  | (GdpEnvelope<'editor:change'> & EditorControllerChange)
+  | (GdpEnvelope<'editor:select'> & { selection: EditorControllerSelection | null })
+  | (GdpEnvelope<'editor:canvas'> & { box: EditorCanvasBox })
+  | (GdpEnvelope<'editor:ui-request'> & EditorUiRequest)
+  | (GdpEnvelope<'editor:check'> & { ok: boolean; problems: string[] })
+  | (GdpEnvelope<'editor:ack'> & { ok: boolean; error?: string })
+  | (GdpEnvelope<'editor:controller-error'> & { error?: string });
+
+export type EditorControllerOutbound =
+  | (GdpEnvelope<'editor:content'> & { content: EditorContentDoc; selection?: EditorSelection })
+  | (GdpEnvelope<'editor:event'> & { event: Record<string, unknown> })
+  | (GdpEnvelope<'editor:select'> & { selection: EditorControllerSelection | null })
+  | (GdpEnvelope<'editor:ui-result'> & { id: string; value: unknown; cancelled: boolean })
+  | (GdpEnvelope<'editor:change:ack'> & { id: string; ok: boolean; error?: string })
+  | (GdpEnvelope<'editor:mode'> & { mode: 'fallback' });
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function isLabel(value: unknown): value is EditorUiLabel {
+  return (
+    typeof value === 'string' ||
+    (isObject(value) && typeof value.en === 'string' && typeof value.pl === 'string')
+  );
+}
+
+function parseUiField(value: unknown): EditorUiField | null {
+  if (!isObject(value) || typeof value.name !== 'string' || !isLabel(value.label)) return null;
+  if (!(PROPERTY_TYPES as readonly string[]).includes(String(value.type))) return null;
+  if (value.value !== undefined && !['string', 'number', 'boolean'].includes(typeof value.value)) return null;
+  if (typeof value.value === 'number' && !Number.isFinite(value.value)) return null;
+  if (value.min !== undefined && !finite(value.min)) return null;
+  if (value.max !== undefined && !finite(value.max)) return null;
+  if (value.options !== undefined) {
+    if (!Array.isArray(value.options) || value.options.length > 32) return null;
+    if (!value.options.every((entry) => typeof entry === 'string')) return null;
+  }
+  const field: EditorUiField = {
+    name: value.name,
+    label: value.label,
+    type: value.type as PropertyType,
+  };
+  if (typeof value.value === 'string' || typeof value.value === 'boolean') field.value = value.value;
+  if (typeof value.value === 'number' && Number.isFinite(value.value)) field.value = value.value;
+  if (typeof value.min === 'number' && Number.isFinite(value.min)) field.min = value.min;
+  if (typeof value.max === 'number' && Number.isFinite(value.max)) field.max = value.max;
+  if (Array.isArray(value.options)) field.options = value.options;
+  return field;
+}
+
+function parsePaletteTile(value: unknown) {
+  if (!isObject(value)) return null;
+  if (
+    typeof value.key !== 'string' ||
+    value.key.length === 0 ||
+    value.key.length > 64 ||
+    typeof value.char !== 'string' ||
+    value.char.length === 0 ||
+    value.char.length > 4 ||
+    !isLabel(value.label) ||
+    (value.color !== undefined && typeof value.color !== 'string')
+  )
+    return null;
+  return {
+    key: value.key,
+    char: value.char,
+    label: value.label,
+    ...(typeof value.color === 'string' ? { color: value.color } : {}),
+  };
+}
+
+function parseBoardTile(value: unknown) {
+  if (!isObject(value) || typeof value.char !== 'string' || value.char.length === 0 || value.char.length > 4) return null;
+  if (value.color !== undefined && typeof value.color !== 'string') return null;
+  return { char: value.char, ...(typeof value.color === 'string' ? { color: value.color } : {}) };
+}
+
+type UiBudget = { nodes: number };
+
+function parseUiNode(value: unknown, depth: number, budget: UiBudget): EditorUiNode | null {
+  budget.nodes += 1;
+  if (depth > 5 || budget.nodes > 256 || !isObject(value)) return null;
+  const type = value.type;
+  if (type === 'rail' || type === 'panel' || type === 'group') {
+    if (!Array.isArray(value.children) || value.children.length > 32) return null;
+    const children = value.children.map((child) => parseUiNode(child, depth + 1, budget));
+    if (children.some((child) => child === null)) return null;
+    if (value.title !== undefined && !isLabel(value.title)) return null;
+    return { type, children: children as EditorUiNode[], ...(value.title === undefined ? {} : { title: value.title }) };
+  }
+  if (type === 'tabs') {
+    if (!Array.isArray(value.tabs) || value.tabs.length > 32) return null;
+    const tabs = value.tabs.map((tab) =>
+      isObject(tab) && typeof tab.id === 'string' && isLabel(tab.label) ? { id: tab.id, label: tab.label } : null,
+    );
+    if (tabs.some((tab) => tab === null)) return null;
+    if (value.active !== undefined && typeof value.active !== 'string') return null;
+    return {
+      type,
+      tabs: tabs as Array<{ id: string; label: EditorUiLabel }>,
+      ...(typeof value.active === 'string' ? { active: value.active } : {}),
+    };
+  }
+  if (type === 'board') {
+    if (!Array.isArray(value.layers) || value.layers.length > 32 || !value.layers.every((layer) => typeof layer === 'string'))
+      return null;
+    if (value.active !== undefined && typeof value.active !== 'string') return null;
+    if (value.rows !== undefined) {
+      if (!Array.isArray(value.rows) || value.rows.length > 128 || !value.rows.every((row) => typeof row === 'string'))
+        return null;
+    }
+    if (value.tiles !== undefined && (!Array.isArray(value.tiles) || value.tiles.length > 32)) return null;
+    const tiles = value.tiles === undefined ? undefined : value.tiles.map(parseBoardTile);
+    if (tiles?.some((tile) => tile === null)) return null;
+    return {
+      type,
+      layers: value.layers as string[],
+      ...(typeof value.active === 'string' ? { active: value.active } : {}),
+      ...(value.rows === undefined ? {} : { rows: value.rows as string[] }),
+      ...(tiles === undefined ? {} : { tiles: tiles as Array<{ char: string; color?: string }> }),
+    };
+  }
+  if (type === 'toolbar') {
+    if (value.active !== undefined && typeof value.active !== 'string') return null;
+    return Array.isArray(value.tools) && value.tools.length <= 32 && value.tools.every((tool) => typeof tool === 'string')
+      ? { type, tools: value.tools as string[], ...(typeof value.active === 'string' ? { active: value.active } : {}) }
+      : null;
+  }
+  if (type === 'palette') {
+    if (value.layer !== undefined && typeof value.layer !== 'string') return null;
+    if (value.tiles !== undefined && (!Array.isArray(value.tiles) || value.tiles.length > 32)) return null;
+    const tiles = value.tiles === undefined ? undefined : value.tiles.map(parsePaletteTile);
+    if (tiles?.some((tile) => tile === null)) return null;
+    return {
+      type,
+      ...(typeof value.layer === 'string' ? { layer: value.layer } : {}),
+      ...(tiles === undefined ? {} : { tiles: tiles as NonNullable<Extract<EditorUiNode, { type: 'palette' }>['tiles']> }),
+    };
+  }
+  if (type === 'propertySheet') {
+    if (typeof value.layer !== 'string' || !Number.isInteger(value.index) || (value.index as number) < 0) return null;
+    if (value.fields !== undefined && (!Array.isArray(value.fields) || value.fields.length > 32)) return null;
+    const fields = value.fields === undefined ? undefined : value.fields.map(parseUiField);
+    if (fields?.some((field) => field === null)) return null;
+    return {
+      type,
+      layer: value.layer,
+      index: value.index as number,
+      ...(fields === undefined ? {} : { fields: fields as EditorUiField[] }),
+    };
+  }
+  if (type === 'list') {
+    if (!Array.isArray(value.items) || value.items.length > 128) return null;
+    const items = value.items.map((item) => {
+      if (!isObject(item) || typeof item.id !== 'string' || !isLabel(item.label)) return null;
+      if (item.detail !== undefined && !isLabel(item.detail)) return null;
+      return { id: item.id, label: item.label, ...(item.detail === undefined ? {} : { detail: item.detail }) };
+    });
+    if (items.some((item) => item === null)) return null;
+    if (value.selected !== undefined && typeof value.selected !== 'string') return null;
+    return {
+      type,
+      items: items as Array<{ id: string; label: EditorUiLabel; detail?: EditorUiLabel }>,
+      ...(typeof value.selected === 'string' ? { selected: value.selected } : {}),
+    };
+  }
+  if (type === 'note') return isLabel(value.text) ? { type, text: value.text } : null;
+  if (type === 'check') return typeof value.ok === 'boolean' && isLabel(value.text) ? { type, ok: value.ok, text: value.text } : null;
+  return null;
+}
+
+function parseUiDocument(value: unknown): EditorUiDocument | null {
+  const budget = { nodes: 0 };
+  if (!Array.isArray(value)) return parseUiNode(value, 0, budget);
+  if (value.length > 32) return null;
+  const nodes = value.map((node) => parseUiNode(node, 0, budget));
+  return nodes.some((node) => node === null) ? null : (nodes as EditorUiNode[]);
+}
+
+function parseUiRequest(id: unknown, value: unknown): EditorUiRequest | null {
+  if (typeof id !== 'string' || id.length === 0 || id.length > 128 || !isObject(value)) return null;
+  if (!['form', 'confirm', 'toast'].includes(String(value.kind))) return null;
+  const spec: EditorUiRequest['spec'] = { kind: value.kind as EditorUiRequest['spec']['kind'] };
+  for (const key of ['title', 'message', 'text'] as const) {
+    if (value[key] === undefined) continue;
+    if (!isLabel(value[key])) return null;
+    spec[key] = value[key];
+  }
+  if (value.fields !== undefined) {
+    if (!Array.isArray(value.fields) || value.fields.length > 32) return null;
+    const fields = value.fields.map(parseUiField);
+    if (fields.some((field) => field === null)) return null;
+    spec.fields = fields as EditorUiField[];
+  }
+  return { id, spec };
+}
+
+function finite(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value);
+}
+
+function parseCanvasBox(value: unknown): EditorCanvasBox | null {
+  if (!isObject(value) || !finite(value.width) || value.width <= 0 || !finite(value.height) || value.height <= 0)
+    return null;
+  if (!finite(value.x) || !finite(value.y)) return null;
+  if (value.insetX !== undefined && (!finite(value.insetX) || value.insetX < 0)) return null;
+  if (value.insetY !== undefined && (!finite(value.insetY) || value.insetY < 0)) return null;
+  if (value.scale !== undefined && (!finite(value.scale) || value.scale <= 0)) return null;
+  return {
+    width: value.width,
+    height: value.height,
+    x: value.x,
+    y: value.y,
+    ...(value.insetX === undefined ? {} : { insetX: value.insetX }),
+    ...(value.insetY === undefined ? {} : { insetY: value.insetY }),
+    ...(value.scale === undefined ? {} : { scale: value.scale }),
+  };
+}
+
+export function parseEditorControllerEnvelope(raw: unknown): EditorControllerInbound | null {
+  if (!isObject(raw) || raw.ns !== BRIDGE_NAMESPACE || raw.v !== PROTOCOL_VERSION) return null;
+  if (raw.t === 'editor:hello') {
+    if (raw.controller !== undefined && typeof raw.controller !== 'boolean') return null;
+    return { ns: BRIDGE_NAMESPACE, v: PROTOCOL_VERSION, t: raw.t, controller: raw.controller === true };
+  }
+  if (raw.t === 'editor:ui') {
+    const doc = parseUiDocument(raw.doc);
+    return doc ? { ns: BRIDGE_NAMESPACE, v: PROTOCOL_VERSION, t: raw.t, doc } : null;
+  }
+  if (raw.t === 'editor:change') {
+    return typeof raw.id === 'string' && raw.id.length > 0 && raw.id.length <= 128
+      ? { ns: BRIDGE_NAMESPACE, v: PROTOCOL_VERSION, t: raw.t, id: raw.id, patch: raw.patch }
+      : null;
+  }
+  if (raw.t === 'editor:select') {
+    if (raw.selection === null) return { ns: BRIDGE_NAMESPACE, v: PROTOCOL_VERSION, t: raw.t, selection: null };
+    if (!isObject(raw.selection) || typeof raw.selection.layer !== 'string') return null;
+    if (raw.selection.index !== null && (!Number.isInteger(raw.selection.index) || (raw.selection.index as number) < 0))
+      return null;
+    return {
+      ns: BRIDGE_NAMESPACE,
+      v: PROTOCOL_VERSION,
+      t: raw.t,
+      selection: { layer: raw.selection.layer, index: raw.selection.index as number | null },
+    };
+  }
+  if (raw.t === 'editor:canvas') {
+    const box = parseCanvasBox(raw.box);
+    return box ? { ns: BRIDGE_NAMESPACE, v: PROTOCOL_VERSION, t: raw.t, box } : null;
+  }
+  if (raw.t === 'editor:ui-request') {
+    const request = parseUiRequest(raw.id, raw.spec);
+    return request ? { ns: BRIDGE_NAMESPACE, v: PROTOCOL_VERSION, t: raw.t, ...request } : null;
+  }
+  if (raw.t === 'editor:check') {
+    if (
+      typeof raw.ok !== 'boolean' ||
+      !Array.isArray(raw.problems) ||
+      raw.problems.length > 12 ||
+      !raw.problems.every((entry) => typeof entry === 'string')
+    )
+      return null;
+    return { ns: BRIDGE_NAMESPACE, v: PROTOCOL_VERSION, t: raw.t, ok: raw.ok, problems: raw.problems };
+  }
+  if (raw.t === 'editor:ack') {
+    if (typeof raw.ok !== 'boolean' || (raw.error !== undefined && typeof raw.error !== 'string')) return null;
+    return { ns: BRIDGE_NAMESPACE, v: PROTOCOL_VERSION, t: raw.t, ok: raw.ok, ...(raw.error === undefined ? {} : { error: raw.error }) };
+  }
+  if (raw.t === 'editor:controller-error') {
+    if (raw.error !== undefined && typeof raw.error !== 'string') return null;
+    return { ns: BRIDGE_NAMESPACE, v: PROTOCOL_VERSION, t: raw.t, ...(raw.error === undefined ? {} : { error: raw.error }) };
+  }
+  return null;
+}

--- a/apps/web/src/mp/protocol.ts
+++ b/apps/web/src/mp/protocol.ts
@@ -10,10 +10,10 @@
  */
 
 import { INPUT_KEYS, ROOM_PHASES, type InputKey, type RoomPhase } from '@gamedevpl/contract';
-import { BRIDGE_NAMESPACE, PROTOCOL_VERSION } from '../editorControllerProtocol.js';
+import { BRIDGE_NAMESPACE, PROTOCOL_VERSION, type GdpEnvelope } from '../editorControllerProtocol.js';
 
 export { INPUT_KEYS, ROOM_PHASES, type InputKey, type RoomPhase };
-export { BRIDGE_NAMESPACE, PROTOCOL_VERSION };
+export { BRIDGE_NAMESPACE, PROTOCOL_VERSION, type GdpEnvelope };
 
 export interface RosterSlot {
   slot: number;

--- a/apps/web/src/mp/protocol.ts
+++ b/apps/web/src/mp/protocol.ts
@@ -9,13 +9,11 @@
  * the other), so every frame is narrowed by the guards below before it is used.
  */
 
-import { INPUT_KEYS, MP_PROTOCOL_VERSION, ROOM_PHASES, type InputKey, type RoomPhase } from '@gamedevpl/contract';
+import { INPUT_KEYS, ROOM_PHASES, type InputKey, type RoomPhase } from '@gamedevpl/contract';
+import { BRIDGE_NAMESPACE, PROTOCOL_VERSION } from '../editorControllerProtocol.js';
 
 export { INPUT_KEYS, ROOM_PHASES, type InputKey, type RoomPhase };
-
-export const PROTOCOL_VERSION = MP_PROTOCOL_VERSION;
-/** Namespace on the bridge, so a game's own postMessage traffic can't be confused for ours. */
-export const BRIDGE_NAMESPACE = 'gdp';
+export { BRIDGE_NAMESPACE, PROTOCOL_VERSION };
 
 export interface RosterSlot {
   slot: number;


### PR DESCRIPTION
## Summary

- extract the additive `gdp` v1 editor-controller envelope types and hostile-input parser into a focused module
- strictly reject malformed UI, selection, request and canvas messages, including every non-finite or invalid canvas coordinate/size/inset/scale
- keep origin and exact iframe-source checks at the bridge boundary and pin all outbound controller messages to the v1 envelope
- re-export the shared envelope constants and base envelope type from the multiplayer protocol without coupling editor messages to relay frames

## Tests

- GitHub CI [run 32994831816](https://github.com/gamedevpl/www.gamedev.pl/actions/runs/32994831816) — PASS at exact head (all four jobs: lint, type-check, full tests, build, production image, contract and secret scanning)
- `npm run type-check` — PASS
- `npm run lint` — PASS (0 errors; existing warnings only)
- `npm run test -w @gamedevpl/web -- --run src/editorControllerProtocol.test.ts src/editorBridge.controllerProtocol.test.tsx src/editorBridge.test.ts src/mp/protocol.test.ts` — PASS (4 files, 80 tests)
- `npm run build` — PASS
- `npm run module-size -- apps/web/src/editorBridge.ts apps/web/src/editorControllerProtocol.ts apps/web/src/editorControllerProtocol.test.ts apps/web/src/editorBridge.controllerProtocol.test.tsx apps/web/src/mp/protocol.ts` — PASS

Exact head: `667140c7b8c4831ef20db93207804f0458b433e3`

Codex review: clean on exact head.

## Merge blocker

Do not merge until the prerequisite #1041 production rollout has been completed and verified.