### PR TITLE
Extract the notification sweep out of submissions.ts

### DIFF
--- a/apps/api/src/notifications/notify-sweep-routes.ts
+++ b/apps/api/src/notifications/notify-sweep-routes.ts
@@ -1,0 +1,273 @@
+import type { FastifyInstance } from 'fastify';
+import type { AgentBackend } from '../agent-surface/agent-backend.js';
+import { selfBuildConnectDays, type BuilderKind } from '../creation/builder.js';
+import { shouldAutoAbandonSelfRound, type JobTransition } from '../creation/job-state.js';
+import type { GamesStore } from '../delivery/games-store.js';
+import type { GitHubClient } from '../catalog/github-client.js';
+import type { InternalAuthVerifier } from '../platform/internal-auth.js';
+import type { Store, SubmissionRecord } from '../platform/store.js';
+import type { SubmissionStatus, SubmissionStatusResponse } from '../platform/submission-status.js';
+import { mintToken } from '../platform/submission-token.js';
+import { emitOperatorAlert, emitSubmissionNotification, notifyOnTransition, type EmitDeps } from './notify.js';
+import { detectOperatorAlerts, FEEDBACK_STALL_MS } from './operator-alerts.js';
+
+// Max wait for a handoff ack before the sweep forces it.
+const HANDOFF_ACK_STALL_MS = 10 * 60 * 1000;
+
+export interface NotifySweepRoutesDeps {
+  internalAuthVerifier: InternalAuthVerifier;
+  githubClient: GitHubClient | null;
+  submissionTokenSecret: string | undefined;
+  store: Store | undefined;
+  gamesStore: GamesStore | undefined;
+  adminUids: Set<string> | undefined;
+  now: () => number;
+  builderOf: (record: SubmissionRecord | null | undefined) => BuilderKind;
+  backendFor: (builder: BuilderKind | undefined) => Promise<AgentBackend | undefined>;
+  acknowledgeBuilderHandoff: (input: {
+    issueNumber: number;
+    acknowledgedAt: string;
+    log: { error: (context: object, message: string) => void };
+  }) => Promise<{ started: boolean; reason?: string }>;
+  recordDerivedJobState: (record: SubmissionRecord, observed: SubmissionStatus) => Promise<JobTransition | null>;
+  reconcileNativeJob: (record: SubmissionRecord) => Promise<JobTransition | null>;
+  reconcileGateVerdict: (record: SubmissionRecord, sweep?: boolean) => Promise<JobTransition | null>;
+  nativeJobStatus: (record: SubmissionRecord) => Promise<SubmissionStatusResponse>;
+  buildNotifyDeps: () => EmitDeps;
+}
+
+export function registerNotifySweepRoutes(app: FastifyInstance, deps: NotifySweepRoutesDeps): void {
+  const {
+    internalAuthVerifier,
+    githubClient,
+    submissionTokenSecret,
+    store,
+    gamesStore,
+    adminUids,
+    now,
+    builderOf,
+    backendFor,
+    acknowledgeBuilderHandoff,
+    recordDerivedJobState,
+    reconcileNativeJob,
+    reconcileGateVerdict,
+    nativeJobStatus,
+    buildNotifyDeps,
+  } = deps;
+
+  // Closed-tab backstop: Cloud Scheduler POSTs an OIDC token here.
+
+  // Reuses the status poll derivation and its idempotent emit.
+
+  // OIDC authenticates the caller; the hourly ceiling only guards runaways.
+  app.post(
+    '/api/internal/notify-sweep',
+    { config: { rateLimit: { max: 120, timeWindow: '1 hour' } } },
+    async (request, reply) => {
+      if (!(await internalAuthVerifier.verify(request.headers.authorization))) {
+        return reply.status(401).send({ error: 'unauthorized' });
+      }
+      if (!githubClient || !submissionTokenSecret || !store) {
+        return reply.status(503).send({ error: 'submissions are not configured' });
+      }
+
+      const active = await store.listActiveSubmissions();
+      let emitted = 0;
+      const stalledIssues: number[] = [];
+      // Oldest uncollected change request per job, so the alert pass rereads nothing.
+      const pendingFeedback = new Map<number, string>();
+      for (const record of active) {
+        try {
+          // Self round with no agent signal ever: abandon after the connect window.
+          if (
+            shouldAutoAbandonSelfRound({
+              builder: builderOf(record),
+              lastAgentSignalAt: record.lastAgentSignalAt,
+              abandonedAt: record.abandonedAt,
+              state: record.state,
+              roundOpenedAt: record.stateSince ?? record.createdAt,
+              now: now(),
+              connectDays: selfBuildConnectDays(),
+            })
+          ) {
+            const at = new Date(now()).toISOString();
+            const cancelBackend = await backendFor(builderOf(record));
+            const ref = record.dispatch?.refs.at(-1);
+            if (cancelBackend && ref) {
+              try {
+                await cancelBackend.cancel(ref, record.dispatch?.credentialRefs?.[ref]);
+              } catch (cancelError) {
+                request.log.error(
+                  { err: cancelError, issueNumber: record.issueNumber },
+                  'self no-connect cancel failed',
+                );
+              }
+            }
+            await store.recordJobTransition(record.issueNumber, {
+              to: 'abandoned',
+              at,
+              by: 'system',
+              reason: 'no_connect',
+            });
+            await store.setSubmissionAbandoned(record.issueNumber, at);
+            continue;
+          }
+
+          // Stale handoff ack: outgoing agent may be gone.
+          if (
+            record.builderHandoff &&
+            record.builderHandoff.awaitsAgentAck !== false &&
+            !record.builderHandoff.acknowledgedAt &&
+            now() - Date.parse(record.builderHandoff.requestedAt) > HANDOFF_ACK_STALL_MS
+          ) {
+            await acknowledgeBuilderHandoff({
+              issueNumber: record.issueNumber,
+              acknowledgedAt: new Date(now()).toISOString(),
+              log: request.log,
+            });
+            continue;
+          }
+
+          // A dispatched request nobody ever collects errors nowhere; ageing makes it visible.
+          const pending = await store.listPendingCreatorMessages(record.issueNumber);
+          const oldest = pending[0];
+          if (oldest) {
+            pendingFeedback.set(record.issueNumber, oldest.createdAt);
+            if (now() - Date.parse(oldest.createdAt) > FEEDBACK_STALL_MS) {
+              stalledIssues.push(record.issueNumber);
+            }
+          }
+
+          // Same derivation the status poll uses, so sweep and page cannot disagree.
+          const observed = (await reconcileNativeJob(record)) ?? (await reconcileGateVerdict(record, true));
+          const current = observed
+            ? {
+                ...record,
+                state: observed.to,
+                stateSince: observed.at,
+                transitions: [...(record.transitions ?? []), observed],
+              }
+            : record;
+          const status = await nativeJobStatus(current);
+          // Recorded whether or not anyone is notified, so the rail stops deriving.
+          if (record.lastStatus !== status.status) {
+            await store.setSubmissionLastStatus(record.issueNumber, status.status);
+          }
+          // Post-reconcile snapshot: the pre-reconcile record would replan the same destination.
+          await recordDerivedJobState(current, status.status);
+          const statusToken = mintToken(record.issueNumber, submissionTokenSecret);
+          const result = await notifyOnTransition(buildNotifyDeps(), record, status, statusToken);
+          if (result.emitted) emitted += 1;
+        } catch (sweepError) {
+          // One bad submission (deleted issue, GitHub hiccup) must not abort the sweep.
+          request.log.error({ err: sweepError, issueNumber: record.issueNumber }, 'sweep item failed');
+        }
+      }
+      // Operator alerts: a stall is time passing, so no transition writes it.
+
+      // Idempotent per job and kind, so re-running never re-notifies.
+      let alerted = 0;
+      const alerts = detectOperatorAlerts(active, now(), pendingFeedback);
+      // Seeding degradation stays out; the admin summary badge carries it instead.
+      if (adminUids && adminUids.size > 0) {
+        for (const alert of alerts) {
+          try {
+            const { created } = await emitOperatorAlert({ ...buildNotifyDeps(), adminUids }, alert);
+            alerted += created;
+          } catch (alertError) {
+            request.log.error({ err: alertError, alert: alert.id }, 'operator alert emit failed');
+          }
+        }
+      }
+
+      // Reads back re-gate verdicts, one manifest read per pending check.
+      let healthResolved = 0;
+      let unhealthy = 0;
+      const healthGamesStore = gamesStore;
+      if (healthGamesStore) {
+        const publications = await store.listPublications().catch(() => []);
+        for (const publication of publications) {
+          const check = publication.healthCheck;
+          if (!check || check.verdictAt) continue;
+          try {
+            const manifest = await healthGamesStore.getManifest(publication.slug, check.version);
+            const health = manifest?.health;
+            // A verdict older than the request is the previous run's answer.
+            if (!health || Date.parse(health.ranAt) < Date.parse(check.requestedAt)) continue;
+
+            healthResolved += 1;
+            const resolved = { ...check, green: health.green, verdictAt: health.ranAt };
+            if (health.green) {
+              await store.setPublicationHealthCheck(publication.slug, resolved);
+              continue;
+            }
+
+            unhealthy += 1;
+            // Red: the baked bundle still serves, but rebuilding would fail.
+
+            // Notified-at is written after both emits, so failures retry next sweep.
+            const submission = manifest ? await store.getSubmission(manifest.issueNumber) : null;
+            if (submission) {
+              await emitSubmissionNotification(buildNotifyDeps(), {
+                uid: submission.ownerUid,
+                type: 'submission.game_health',
+                issueNumber: submission.issueNumber,
+                gameTitle: submission.title,
+                statusToken: mintToken(submission.issueNumber, submissionTokenSecret),
+              });
+            }
+            if (adminUids && adminUids.size > 0) {
+              await emitOperatorAlert(
+                { ...buildNotifyDeps(), adminUids },
+                {
+                  id: `op-health-${publication.slug}-${check.version}`,
+                  kind: 'game_unhealthy',
+                  issueNumber: manifest?.issueNumber ?? 0,
+                  title: submission?.title ?? publication.slug,
+                  ownerUid: submission?.ownerUid ?? '',
+                  slug: publication.slug,
+                  since: health.ranAt,
+                },
+              );
+            }
+            await store.setPublicationHealthCheck(publication.slug, {
+              ...resolved,
+              notifiedAt: new Date(now()).toISOString(),
+            });
+          } catch (healthError) {
+            // One unreadable manifest must not abort the sweep — same rule as above.
+            request.log.error({ err: healthError, slug: publication.slug }, 'health check read failed');
+          }
+        }
+      }
+
+      // Error level so a job nobody watches cannot fail quietly for weeks.
+      const sweepLog =
+        stalledIssues.length > 0 ? request.log.error.bind(request.log) : request.log.info.bind(request.log);
+      sweepLog(
+        {
+          scanned: active.length,
+          emitted,
+          alerts: alerts.length,
+          alerted,
+          stalled: stalledIssues.length,
+          stalledIssues,
+          healthResolved,
+          unhealthy,
+        },
+        stalledIssues.length > 0
+          ? 'creator feedback undelivered past the stall threshold — no agent has collected it'
+          : 'notify sweep complete',
+      );
+      return reply.send({
+        scanned: active.length,
+        emitted,
+        alerts: alerts.length,
+        alerted,
+        stalled: stalledIssues.length,
+        healthResolved,
+        unhealthy,
+      });
+    },
+  );
+}

--- a/apps/api/src/submissions.ts
+++ b/apps/api/src/submissions.ts
@@ -11,6 +11,7 @@ import { splitConceptBrief } from './agent-surface/agent-build-brief.js';
 import { registerAgentChannelRoutes, type AgentChannelOptions } from './agent-surface/agent-channel.js';
 import { mintAgentToken, mintManagedMcpOpener } from './agent-surface/agent-token.js';
 import { registerMcpServerRoutes } from './agent-surface/mcp-server.js';
+import { registerNotifySweepRoutes } from './notifications/notify-sweep-routes.js';
 import {
   createCreationGate,
   createChatGate,
@@ -63,7 +64,6 @@ import {
   isActiveBuildRound,
   isBuilderKind,
   shouldSteerFeedbackViaInbox,
-  selfBuildConnectDays,
   type BuilderKind,
 } from './creation/builder.js';
 import { DEFAULT_SEED_PROVIDER, type GameSeeder } from './creation/game-seed.js';
@@ -77,7 +77,6 @@ import {
   planObservedStatusTransition,
   reconcileAgentObservation,
   resolveJobState,
-  shouldAutoAbandonSelfRound,
   type JobState,
   type JobTransition,
 } from './creation/job-state.js';
@@ -95,13 +94,7 @@ import { type ChatAgentImage, type StudioChatAgent } from './creation/chat-agent
 import { createLocalGamesClient, resolveLocalGamesDir } from './catalog/local-games-repo.js';
 import { createMailerFromEnv, type Mailer } from './notifications/mailer.js';
 import { createDefaultContentChecker, type ContentChecker } from './platform/moderation.js';
-import {
-  emitOperatorAlert,
-  emitSubmissionNotification,
-  notifyOnTransition,
-  type EmitDeps,
-} from './notifications/notify.js';
-import { detectOperatorAlerts, FEEDBACK_STALL_MS } from './notifications/operator-alerts.js';
+import { notifyOnTransition, type EmitDeps } from './notifications/notify.js';
 import { seedOutcomeFor } from './agent-surface/seed-status.js';
 import { isAdminSession } from './platform/admin-session.js';
 import { peekQuota } from './creation/quota-gate.js';
@@ -272,9 +265,6 @@ const FeedbackRequestSchema = z.object({
     })
     .optional(),
 });
-
-// Max wait for a handoff ack before the sweep forces it.
-const HANDOFF_ACK_STALL_MS = 10 * 60 * 1000;
 
 interface CachedStatus {
   expiresAt: number;
@@ -3370,258 +3360,23 @@ export async function registerSubmissionRoutes(
     return reply.send({ ok: true, state: after?.state ?? 'dispatched', creditsSpent: 1 });
   });
 
-  // The notification sweep (docs/notifications-plan.md N1): the closed-tab backstop
-  // for the opportunistic poll-path detection above. Cloud Scheduler POSTs here with
-  // an OIDC token; we derive the current status of every still-active submission and
-  // emit on transition, reusing the exact same derivation + idempotent emit. No
-  // session — the wall exempts /api/internal and the handler verifies OIDC itself.
-  // Cloud Scheduler hits this every 2–5 minutes (docs/notifications-plan.md N1),
-  // and retries on transient failures; 30/hour sits on that cadence with no headroom.
-  // OIDC already authenticates the caller — this IP ceiling is only a runaway guard.
-  app.post(
-    '/api/internal/notify-sweep',
-    { config: { rateLimit: { max: 120, timeWindow: '1 hour' } } },
-    async (request, reply) => {
-      if (!(await internalAuthVerifier.verify(request.headers.authorization))) {
-        return reply.status(401).send({ error: 'unauthorized' });
-      }
-      if (!githubClient || !submissionTokenSecret || !store) {
-        return reply.status(503).send({ error: 'submissions are not configured' });
-      }
-
-      const active = await store.listActiveSubmissions();
-      let emitted = 0;
-      const stalledIssues: number[] = [];
-      // When each job's oldest uncollected change request arrived, collected as the
-      // loop goes so the alert pass below can see it without reading anything twice.
-      const pendingFeedback = new Map<number, string>();
-      for (const record of active) {
-        try {
-          // Self rounds with no agent signal ever: auto-abandon after the connect window
-          // so a forgotten kickoff does not leave a live channel capability forever.
-          if (
-            shouldAutoAbandonSelfRound({
-              builder: builderOf(record),
-              lastAgentSignalAt: record.lastAgentSignalAt,
-              abandonedAt: record.abandonedAt,
-              state: record.state,
-              roundOpenedAt: record.stateSince ?? record.createdAt,
-              now: now(),
-              connectDays: selfBuildConnectDays(),
-            })
-          ) {
-            const at = new Date(now()).toISOString();
-            const cancelBackend = await backendFor(builderOf(record));
-            const ref = record.dispatch?.refs.at(-1);
-            if (cancelBackend && ref) {
-              try {
-                await cancelBackend.cancel(ref, record.dispatch?.credentialRefs?.[ref]);
-              } catch (cancelError) {
-                request.log.error(
-                  { err: cancelError, issueNumber: record.issueNumber },
-                  'self no-connect cancel failed',
-                );
-              }
-            }
-            await store.recordJobTransition(record.issueNumber, {
-              to: 'abandoned',
-              at,
-              by: 'system',
-              reason: 'no_connect',
-            });
-            await store.setSubmissionAbandoned(record.issueNumber, at);
-            continue;
-          }
-
-          // Stale handoff ack: outgoing agent may be gone.
-          if (
-            record.builderHandoff &&
-            record.builderHandoff.awaitsAgentAck !== false &&
-            !record.builderHandoff.acknowledgedAt &&
-            now() - Date.parse(record.builderHandoff.requestedAt) > HANDOFF_ACK_STALL_MS
-          ) {
-            await acknowledgeBuilderHandoff({
-              issueNumber: record.issueNumber,
-              acknowledgedAt: new Date(now()).toISOString(),
-              log: request.log,
-            });
-            continue;
-          }
-
-          // Unread-request detection. A creator's change request is dispatched to the
-          // agent and queued here; the queue is what an agent already mid-session
-          // drains. If dispatch succeeded but no agent ever collects — a dead session,
-          // a backend that accepted and dropped it — nothing errors anywhere and the
-          // request simply sits. An undelivered message aging past the threshold is
-          // that silence made visible.
-          //
-          // This used to also cover a relay: the request went out as a marked PR
-          // comment that a games-repo workflow re-posted as an `@copilot` mention under
-          // a licensed identity, because bot-authored mentions are dropped. That whole
-          // path is gone along with the jobs that needed it, and so is its failure mode.
-          const pending = await store.listPendingCreatorMessages(record.issueNumber);
-          const oldest = pending[0];
-          if (oldest) {
-            pendingFeedback.set(record.issueNumber, oldest.createdAt);
-            if (now() - Date.parse(oldest.createdAt) > FEEDBACK_STALL_MS) {
-              stalledIssues.push(record.issueNumber);
-            }
-          }
-
-          // Same derivation the status poll uses, so the sweep and the page can never
-          // disagree about what a job's own record says.
-          const observed = (await reconcileNativeJob(record)) ?? (await reconcileGateVerdict(record, true));
-          const current = observed
-            ? {
-                ...record,
-                state: observed.to,
-                stateSince: observed.at,
-                transitions: [...(record.transitions ?? []), observed],
-              }
-            : record;
-          const status = await nativeJobStatus(current);
-          // Every two minutes, for exactly the submissions still in flight — which is
-          // what lets the rail stop deriving its own. Recorded whether or not the
-          // transition is one anybody gets notified about.
-          if (record.lastStatus !== status.status) {
-            await store.setSubmissionLastStatus(record.issueNumber, status.status);
-          }
-          // Use the post-reconcile snapshot: the gate/agent observation above may already
-          // have moved the job, and feeding the pre-reconcile record into the derived-status
-          // planner would plan the same destination again (ready_for_review → ready_for_review)
-          // and reset `stateSince` / overwrite the reason that actually moved it.
-          await recordDerivedJobState(current, status.status);
-          const statusToken = mintToken(record.issueNumber, submissionTokenSecret);
-          const result = await notifyOnTransition(buildNotifyDeps(), record, status, statusToken);
-          if (result.emitted) emitted += 1;
-        } catch (sweepError) {
-          // One bad submission (deleted issue, GitHub hiccup) must not abort the sweep.
-          request.log.error({ err: sweepError, issueNumber: record.issueNumber }, 'sweep item failed');
-        }
-      }
-      // Then the operator's own half of the sweep.
-      //
-      // Raised here rather than at each transition because the alerts are not all
-      // transitions: a stall is time passing, and there is no moment anybody could have
-      // written it. This loop already runs every couple of minutes over exactly the set
-      // of jobs that could be in trouble, so it is the one place all three kinds are
-      // observable. Idempotent per job and kind, so re-running it does not re-notify.
-      let alerted = 0;
-      const alerts = detectOperatorAlerts(active, now(), pendingFeedback);
-      // Seeding degradation is deliberately NOT emitted here, so an alert about the
-      // platform's own plumbing never shares a fate with the sweep, the store, the
-      // notification table and the mail provider it would otherwise travel through. It
-      // still reaches the console badge through /api/admin/summary (detectSeedingDegraded
-      // in operator-alerts.ts), which is where an operator would act on it.
-      if (adminUids && adminUids.size > 0) {
-        for (const alert of alerts) {
-          try {
-            const { created } = await emitOperatorAlert({ ...buildNotifyDeps(), adminUids }, alert);
-            alerted += created;
-          } catch (alertError) {
-            request.log.error({ err: alertError, alert: alert.id }, 'operator alert emit failed');
-          }
-        }
-      }
-
-      // The health half of the sweep: read back verdicts of re-gates in flight. The
-      // gate ran remotely, wrote to the manifest and exited — same read-back pattern as
-      // the acceptance verdict. Bounded: one manifest read per *pending* check, and a
-      // publication with no check (or a resolved one) costs nothing.
-      let healthResolved = 0;
-      let unhealthy = 0;
-      const healthGamesStore = options.agentChannel?.gamesStore;
-      if (healthGamesStore) {
-        const publications = await store.listPublications().catch(() => []);
-        for (const publication of publications) {
-          const check = publication.healthCheck;
-          if (!check || check.verdictAt) continue;
-          try {
-            const manifest = await healthGamesStore.getManifest(publication.slug, check.version);
-            const health = manifest?.health;
-            // A verdict older than the request is the previous run's answer, not this
-            // one's — the run we are waiting for has not written yet.
-            if (!health || Date.parse(health.ranAt) < Date.parse(check.requestedAt)) continue;
-
-            healthResolved += 1;
-            const resolved = { ...check, green: health.green, verdictAt: health.ranAt };
-            if (health.green) {
-              await store.setPublicationHealthCheck(publication.slug, resolved);
-              continue;
-            }
-
-            unhealthy += 1;
-            // Red: the game still serves — its baked bundle froze the engine it shipped
-            // with — but a rebuild would fail. Nudge the creator, whose improvement
-            // round is the fix, and copy the operator. Notified-at is written only
-            // after both, so an emit that dies retries next sweep; the emits themselves
-            // are idempotent by id.
-            const submission = manifest ? await store.getSubmission(manifest.issueNumber) : null;
-            if (submission) {
-              await emitSubmissionNotification(buildNotifyDeps(), {
-                uid: submission.ownerUid,
-                type: 'submission.game_health',
-                issueNumber: submission.issueNumber,
-                gameTitle: submission.title,
-                statusToken: mintToken(submission.issueNumber, submissionTokenSecret),
-              });
-            }
-            if (adminUids && adminUids.size > 0) {
-              await emitOperatorAlert(
-                { ...buildNotifyDeps(), adminUids },
-                {
-                  id: `op-health-${publication.slug}-${check.version}`,
-                  kind: 'game_unhealthy',
-                  issueNumber: manifest?.issueNumber ?? 0,
-                  title: submission?.title ?? publication.slug,
-                  ownerUid: submission?.ownerUid ?? '',
-                  slug: publication.slug,
-                  since: health.ranAt,
-                },
-              );
-            }
-            await store.setPublicationHealthCheck(publication.slug, {
-              ...resolved,
-              notifiedAt: new Date(now()).toISOString(),
-            });
-          } catch (healthError) {
-            // One unreadable manifest must not abort the sweep — same rule as above.
-            request.log.error({ err: healthError, slug: publication.slug }, 'health check read failed');
-          }
-        }
-      }
-
-      // Logged at error level so it surfaces without new infrastructure, the same way
-      // the scorecard sweep reports its failures — a nightly job nobody watches is
-      // exactly the kind that fails quietly for weeks.
-      const sweepLog =
-        stalledIssues.length > 0 ? request.log.error.bind(request.log) : request.log.info.bind(request.log);
-      sweepLog(
-        {
-          scanned: active.length,
-          emitted,
-          alerts: alerts.length,
-          alerted,
-          stalled: stalledIssues.length,
-          stalledIssues,
-          healthResolved,
-          unhealthy,
-        },
-        stalledIssues.length > 0
-          ? 'creator feedback undelivered past the stall threshold — the games-repo @copilot relay may be down'
-          : 'notify sweep complete',
-      );
-      return reply.send({
-        scanned: active.length,
-        emitted,
-        alerts: alerts.length,
-        alerted,
-        stalled: stalledIssues.length,
-        healthResolved,
-        unhealthy,
-      });
-    },
-  );
+  registerNotifySweepRoutes(app, {
+    internalAuthVerifier,
+    githubClient,
+    submissionTokenSecret,
+    store,
+    gamesStore: options.agentChannel?.gamesStore,
+    adminUids,
+    now,
+    builderOf,
+    backendFor,
+    acknowledgeBuilderHandoff,
+    recordDerivedJobState,
+    reconcileNativeJob,
+    reconcileGateVerdict,
+    nativeJobStatus,
+    buildNotifyDeps,
+  });
 
   // Renders the staging buffer while the agent is still filling it, so a creator is not
   // left watching sentences for the minutes between "the game exists" and "the gate

--- a/eslint-rules/comment-prose-baseline.json
+++ b/eslint-rules/comment-prose-baseline.json
@@ -330,7 +330,7 @@
     "apps/api/src/store/records/telemetry.ts": 1136,
     "apps/api/src/store/slices/rounds.ts": 25,
     "apps/api/src/submissions.test.ts": 4637,
-    "apps/api/src/submissions.ts": 8749,
+    "apps/api/src/submissions.ts": 8072,
     "apps/api/src/telemetry/creator-metrics.test.ts": 81,
     "apps/api/src/telemetry/creator-metrics.ts": 310,
     "apps/api/src/telemetry/telemetry-trends.ts": 476,

--- a/eslint-rules/module-boundary-map.mjs
+++ b/eslint-rules/module-boundary-map.mjs
@@ -355,6 +355,7 @@ const FILE_BUCKET = {
   'unsubscribe-token': 'notifications',
   contact: 'notifications',
   'operator-alerts': 'notifications',
+  'notify-sweep-routes': 'notifications',
 
   // submissions.ts is deliberately unmapped: it's the D2 mega-file (registerSubmissionRoutes,
   // ~5,400 lines) Phase 3 Wave B dismantles piece by piece, not a Wave A move target -- every

--- a/eslint-rules/module-size-baseline.json
+++ b/eslint-rules/module-size-baseline.json
@@ -437,7 +437,7 @@
     "apps/api/src/static-serving.test.ts": 95,
     "apps/api/src/store-firestore.test.ts": 710,
     "apps/api/src/submissions.test.ts": 7368,
-    "apps/api/src/submissions.ts": 3723,
+    "apps/api/src/submissions.ts": 3479,
     "apps/api/src/tab-complete-deploy-flag.test.ts": 26,
     "apps/api/src/telemetry-trends.route.test.ts": 75,
     "apps/api/src/telemetry/chat-agent-metrics.test.ts": 53,


### PR DESCRIPTION
Phase 3. Moves `POST /api/internal/notify-sweep` into `notifications/notify-sweep-routes.ts` as `registerNotifySweepRoutes(app, deps)`, along with `HANDOFF_ACK_STALL_MS` — whose only reference in the whole repo was this route.

**`submissions.ts`: 3723 → 3479.** New file: **273 lines** against the 500 cap.

The bucket is `notifications` rather than `creation` because the route's two main collaborators, `notifyOnTransition` and `detectOperatorAlerts`, already live there — so most of its imports become same-bucket edges.

## The scoping note was wrong, and following it would not have compiled

An earlier audit listed **14 seams**. The real number is **15**, and the sets differ: `invalidateDeliveryCaches`, `invalidateStatusCache`, `buildStatus`, `stagedPreviews` and `publishedRef` do not appear anywhere in the route.

`stagedPreviews` is the sharp one — it is declared at line 3632, **after** the extraction point, so it could never have been captured by this route. Wiring the list as given would have been a compile error, not a nit.

`recordDerivedJobState` stays a dep rather than moving with the route: it closes over `store`, `now` and `app.log`, and its JSDoc sits inside `submissions.ts`'s frozen prose baseline, so moving it would force a rewrite for no functional gain.

Six imports went unused in `submissions.ts` once the route left (`selfBuildConnectDays`, `shouldAutoAbandonSelfRound`, `emitOperatorAlert`, `emitSubmissionNotification`, `detectOperatorAlerts`, `FEEDBACK_STALL_MS`) and are dropped — `--max-warnings 0` would have failed on them.

## Proving the move is behaviour-preserving

The two route bodies were compared with comments and blank lines stripped: **183 code lines each, identical**. Only comments differ.

They differ because a new file's prose baseline starts at zero, so every multi-line comment had to become a ≤12-word one-liner. Verified with the real `findCommentProseViolations` rather than by counting words — which mattered, because the checker caught two things hand-counting would have missed: `wordCount` splits on `\w+` so `in-flight` scores 2 and `/api/admin/summary` scores 3, and a bare `//` line does **not** break a stack (only a genuinely empty line does).

## Two pre-existing inaccuracies surfaced while compressing

Neither was introduced here; both were carried forward invisibly inside the old comment block.

1. **The lead comment claimed a `30/hour` rate ceiling. The code says `max: 120`.** The replacement states no number at all, so it cannot drift again.
2. **The stall log line still blamed `"the games-repo @copilot relay"`** — a dispatch path removed months ago, and described as removed by a neighbouring comment in the same block. It now reads *"no agent has collected it"*, which is what actually happened. An operator reading the old line mid-incident would have gone looking for a subsystem that no longer exists.

Fixing an operator-facing log line inside a move is a real behaviour change, so it is called out rather than buried.

## Ratchets

Both baselines lowered to the new sizes (`module-size` 3723 → 3479, `comment-prose` 8749 → 8072) so the gain cannot quietly erode — the same omission that left 7,993 lines of dead slack after Waves B/C/D.

## Test plan
- [x] `npx tsc --noEmit -p apps/api`
- [x] `npx eslint src/submissions.ts src/notifications/notify-sweep-routes.ts --report-unused-disable-directives --max-warnings 0`
- [x] `npm run lint` — 0 errors
- [x] `npx vitest run` on `notify-sweep` / `self-build` / `submissions` / `internal-auth` — **265 passed**, including the whole dedicated `notify-sweep.test.ts` suite. Zero test churn: all four drive the route through `buildApp` + `app.inject`, so the move is transparent to them.
- [x] Code-only diff of the moved body against the original — 183 lines each, identical
- [x] `findCommentProseViolations` on the new file — 0


---
_Generated by [Claude Code](https://claude.ai/code/session_01VaPzGSyNfZ7nvGcJgYNSdL)_