### PR TITLE
Reclassify three shared primitives, and enforce the notifications boundary

### DIFF
--- a/apps/api/src/creation/builder.ts
+++ b/apps/api/src/creation/builder.ts
@@ -5,16 +5,10 @@
 import { BUILDERS, isBuilderKind, type BuilderKind } from '@gamedevpl/contract';
 import type { JobState, JobStall, JobTransition } from './job-state.js';
 import { DEFAULT_SELF_BUILD_DELIVERY_CAP, selfBuildDeliveryCap } from '../platform/self-build-delivery-cap.js';
+import { DEFAULT_SELF_BUILD_CONNECT_DAYS, selfBuildConnectDays } from '../platform/self-build-connect-days.js';
 
 export { BUILDERS, isBuilderKind, type BuilderKind, DEFAULT_SELF_BUILD_DELIVERY_CAP, selfBuildDeliveryCap };
-
-/** Default lifetime before a self round with no agent signal is auto-abandoned. */
-export const DEFAULT_SELF_BUILD_CONNECT_DAYS = 14;
-
-export function selfBuildConnectDays(): number {
-  const parsed = Number(process.env.SELF_BUILD_CONNECT_DAYS ?? DEFAULT_SELF_BUILD_CONNECT_DAYS);
-  return Number.isFinite(parsed) && parsed > 0 ? Math.floor(parsed) : DEFAULT_SELF_BUILD_CONNECT_DAYS;
-}
+export { DEFAULT_SELF_BUILD_CONNECT_DAYS, selfBuildConnectDays };
 
 /** Whether the current round is still live. */
 export function isActiveBuildRound(record: { state?: JobState; transitions?: JobTransition[] }): boolean {

--- a/apps/api/src/notifications/notify-sweep-routes.ts
+++ b/apps/api/src/notifications/notify-sweep-routes.ts
@@ -1,6 +1,7 @@
 import type { FastifyInstance } from 'fastify';
 import type { AgentBackend } from '../agent-surface/agent-backend.js';
-import { selfBuildConnectDays, type BuilderKind } from '../creation/builder.js';
+import type { BuilderKind } from '../creation/builder.js';
+import { selfBuildConnectDays } from '../platform/self-build-connect-days.js';
 import { shouldAutoAbandonSelfRound, type JobTransition } from '../creation/job-state.js';
 import type { GamesStore } from '../delivery/games-store.js';
 import type { GitHubClient } from '../catalog/github-client.js';

--- a/apps/api/src/platform/self-build-connect-days.ts
+++ b/apps/api/src/platform/self-build-connect-days.ts
@@ -1,0 +1,10 @@
+// How long a silent self round waits before it is auto-abandoned.
+
+// Split out like the delivery cap: the sweep needs it.
+
+export const DEFAULT_SELF_BUILD_CONNECT_DAYS = 14;
+
+export function selfBuildConnectDays(): number {
+  const parsed = Number(process.env.SELF_BUILD_CONNECT_DAYS ?? DEFAULT_SELF_BUILD_CONNECT_DAYS);
+  return Number.isFinite(parsed) && parsed > 0 ? Math.floor(parsed) : DEFAULT_SELF_BUILD_CONNECT_DAYS;
+}

--- a/eslint-rules/module-boundary-map.mjs
+++ b/eslint-rules/module-boundary-map.mjs
@@ -31,7 +31,7 @@ export const MODULE_BUCKETS = [
  * `eslint .` pass; every other bucket stays warn-only via `npm run module-boundary` until
  * its own turn. Append to this list, never edit its enforcement elsewhere.
  */
-export const ENFORCED_BUCKETS = ['telemetry', 'catalog', 'realtime'];
+export const ENFORCED_BUCKETS = ['telemetry', 'catalog', 'realtime', 'notifications'];
 
 const DEFAULT_BUCKET = 'platform';
 
@@ -104,6 +104,7 @@ const FILE_BUCKET = {
   // agent-surface, and submissions.ts all need the cap without the rest of builder.ts's
   // handoff-authorization logic.
   'self-build-delivery-cap': 'platform',
+  'self-build-connect-days': 'platform',
   // Shared build/serve contract read by delivery, creation, and community alike --
   // pure schema, HTML assembly, or directory/archive-parsing plumbing, not domain
   // business logic of any one bucket.
@@ -113,6 +114,13 @@ const FILE_BUCKET = {
   'kit-registry': 'platform',
   'kit-window': 'platform',
   'round-base-version': 'platform',
+  // Job vocabulary and its transition table, read by eight buckets. Its only
+  // domain import is type-only, so nothing follows it at runtime.
+  'job-state': 'platform',
+  // Signed-URL minting over GCS. No relative imports at all.
+  'gcs-sign': 'platform',
+  // A line counter. No relative imports at all.
+  'module-size': 'platform',
   // A generic HTTP rate-limit classifier with no domain deps at all, and a bare
   // env-flag reader -- neither has business logic tied to any one bucket.
   'github-rate-limit': 'platform',
@@ -122,7 +130,6 @@ const FILE_BUCKET = {
   'draft-lifecycle-routes': 'creation',
   'seed-pipeline': 'creation',
   'creator-self-routes': 'creation',
-  'job-state': 'creation',
   'job-costs': 'creation',
   'job-admin-routes': 'creation',
   'dispatch-reaper': 'creation',
@@ -162,7 +169,6 @@ const FILE_BUCKET = {
   'seed-provider-openai': 'creation',
   'seed-provider-openrouter': 'creation',
   'seed-provider-vertex': 'creation',
-  'module-size': 'creation',
   'game-seed': 'creation',
   'session-crash': 'creation',
   scorecard: 'creation',
@@ -245,7 +251,6 @@ const FILE_BUCKET = {
   'staged-preview': 'delivery',
   'stage-hints': 'delivery',
   'games-store': 'delivery',
-  'gcs-sign': 'delivery',
   'workspace-archive': 'delivery',
   'build-transcript': 'delivery',
   'build-changelog': 'delivery',


### PR DESCRIPTION
Phase 3. Boundary warnings **133 → 112**, and a fourth bucket flips from warn to error.

## Three moves to `platform`

| File | Read by | Its own domain imports |
|---|---|---|
| `creation/job-state` | 8 buckets | one, **type-only** |
| `delivery/gcs-sign` | 3 buckets | **none at all** |
| `creation/module-size` | 2 buckets | **none at all** |

Each is a leaf that many buckets read. All twenty edges into these three files disappear — they were never real coupling, only a bucket label. `job-state`'s single domain import is `import type { ManagedBudgetStop, ManagedSessionUsage }`, and `module-boundary.mjs:105` erases type-only edges, so nothing follows it at runtime.

## `games-store` was a candidate and is deliberately not moved

The scoping list had four files. `games-store` is dropped on evidence:

- It imports `hasPlayableHowToPlay` from `catalog` **as a value**, not a type.
- `module-boundary.mjs:97` **skips platform importers entirely**.

So relabelling it would not resolve that edge — it would *silence* it. That is precisely what the map's own note warns against for `submissions.ts`: *"Do not paper over them by mapping submissions.ts to platform."* Its 1386 lines of upload validation and manifest handling are not a primitive either. It needs its catalog dependency inverted first, which is its own piece of work.

## The one blocker in `notifications` was mine

Flipping `notifications` to error was blocked by a single real edge — introduced by me in #1046, when the notify-sweep extraction pulled `selfBuildConnectDays` out of `creation/builder.ts`.

The precedent was already sitting one line away in the map: `self-build-delivery-cap` was factored out of `creation/builder.ts` into `platform/` for exactly this reason, with `builder.ts` re-exporting it so existing callers never moved. `selfBuildConnectDays` is byte-for-byte the same shape — an env-read with a default — so it gets the same treatment rather than a new invention.

## Enforcement, verified rather than assumed

`notifications` joins `ENFORCED_BUCKETS`. A list entry proves nothing on its own, so I seeded a value import from `creation` into `notifications/notify.ts`:

```
1:36  error  '../creation/builder.js' pulls 'creation' into a 'notifications' module.
✖ 1 problem (1 error, 0 warnings)
```

**error**, not warning. Reverted after.

## Test plan
- [x] `npx tsc --noEmit -p apps/api`
- [x] `npm run lint` — **0 errors** with `notifications` enforced
- [x] `npm run module-boundary` — 133 → 112 warnings; zero edges into the three moved files
- [x] `npx vitest run` on `builder` / `notify-sweep` / `self-build` — **49 passed**
- [x] `comment-prose` / `module-size` clean
- [x] Seeded boundary violation reports as an error; working tree restored and re-verified clean


---
_Generated by [Claude Code](https://claude.ai/code/session_01VaPzGSyNfZ7nvGcJgYNSdL)_