### PR TITLE
Mount the agent channel and the MCP server from buildApp

### DIFF
--- a/apps/api/src/agent-surface/mcp-server.test.ts
+++ b/apps/api/src/agent-surface/mcp-server.test.ts
@@ -189,11 +189,11 @@ async function createApp(
   return await buildApp({
     store,
     sessionSecret: 'dev-session-secret-change-me',
+    ...(platformConnectorSecret ? { platformConnectorSecret } : {}),
     submissionRoutes: {
       githubClient: stubGitHub(),
       githubToken: 'gh-token',
       submissionTokenSecret: secret,
-      ...(platformConnectorSecret ? { platformConnectorSecret } : {}),
       agentChannel: {
         ...(gamesStore ? { gamesStore } : {}),
         ...(objectStore ? { objectStore } : {}),

--- a/apps/api/src/platform/app.ts
+++ b/apps/api/src/platform/app.ts
@@ -63,6 +63,8 @@ import { registerScorecardRoutes, type ScorecardRoutesOptions } from '../creatio
 import { createInternalAuthVerifierFromEnv } from './internal-auth.js';
 import { registerRefineRoute, type SpecRefiner } from '../creation/refine.js';
 import { BOT_UID_PREFIX, InMemoryStore, type Store } from './store.js';
+import { registerAgentChannelRoutes } from '../agent-surface/agent-channel.js';
+import { registerMcpServerRoutes } from '../agent-surface/mcp-server.js';
 import { registerSubmissionRoutes, type SubmissionRoutesOptions } from '../submissions.js';
 import { mintToken } from './submission-token.js';
 import { registerTelemetryRoutes, type TelemetryRoutesOptions } from '../telemetry/telemetry.js';
@@ -132,6 +134,8 @@ export interface BuildAppOptions {
   /** Seam for Sign in with Apple; defaults to JWKS-or-deny-all from APPLE_CLIENT_IDS. */
   appleAuthVerifier?: AppleAuthVerifier;
   submissionRoutes?: SubmissionRoutesOptions;
+  // Shared secret the Copilot MCP connector authenticates with.
+  platformConnectorSecret?: string;
   contentChecker?: ContentChecker;
   specRefiner?: SpecRefiner;
   /** The editor's NL tuning router. Defaults to the Vertex one; stubbed in tests. */
@@ -333,10 +337,8 @@ export async function buildApp(options: BuildAppOptions = {}): Promise<FastifyIn
    * credentials, which degrades the feature to "reviewable but not yet merged back" rather
    * than breaking it.
    *
-   * Assembled here rather than beside the proposal routes because the MCP proposal tools
-   * are registered by `registerSubmissionRoutes` below and need the same base resolver —
-   * one definition, so an agent's proposal and a reviewer's diff cannot disagree about what
-   * a game's current sources are.
+   * One resolver, shared with the MCP proposal tools mounted below, so an agent's proposal
+   * and a reviewer's diff cannot disagree about a game's sources.
    */
   const proposalGithubToken = options.submissionRoutes?.githubToken ?? process.env.GITHUB_TOKEN;
   const snapshotReader = createSnapshotReaderFromEnv();
@@ -368,17 +370,26 @@ export async function buildApp(options: BuildAppOptions = {}): Promise<FastifyIn
   // Env registry selects managed; explicit platform backends still win.
   const resolvedAgentBackends = options.submissionRoutes?.agentBackends;
 
+  const agentChannelOptions = {
+    ...options.submissionRoutes?.agentChannel,
+    // Without a bucket the delivery verb answers 503 rather than accepting an agent's
+    // work and silently dropping it — which is the right behaviour for local
+    // development, where there is no bucket at all.
+    gamesStore,
+    objectStore,
+    knowledgeSearch,
+    // Run the gate as soon as a game is delivered. Without this a candidate is stored
+    // and never verified, so it can never publish — the upload path would end in a
+    // queue nobody drains.
+    onSourcesDelivered: gateTrigger,
+  };
+
+  const platformConnectorSecret = options.platformConnectorSecret ?? process.env.COPILOT_MCP_CONNECTOR_SECRET;
+
   const submissionSeams = await registerSubmissionRoutes(app, {
     ...options.submissionRoutes,
-    resolveProposalBase: resolveBaseForProposal,
-    platformConnectorSecret:
-      options.submissionRoutes?.platformConnectorSecret ?? process.env.COPILOT_MCP_CONNECTOR_SECRET,
     store,
     contentChecker,
-    // So /api/mcp can tell a visitor the product is closed rather than sending them to
-    // hunt for a key that cannot exist yet. Not a gate — the endpoint stays reachable
-    // through the beta wall on purpose.
-    privateBeta,
     // Same allowlist the console is gated on: the people who can see the queue are the
     // people its alerts are addressed to. Two lists would drift, and the failure mode of
     // drift here is an alert nobody receives.
@@ -408,19 +419,28 @@ export async function buildApp(options: BuildAppOptions = {}): Promise<FastifyIn
           }),
     gameSeeder:
       options.submissionRoutes?.gameSeeder ?? createGameSeederFromEnv(app.log, knowledgeSearch, snapshotReader),
-    agentChannel: {
-      ...options.submissionRoutes?.agentChannel,
-      // Without a bucket the delivery verb answers 503 rather than accepting an agent's
-      // work and silently dropping it — which is the right behaviour for local
-      // development, where there is no bucket at all.
-      gamesStore,
-      objectStore,
-      knowledgeSearch,
-      // Run the gate as soon as a game is delivered. Without this a candidate is stored
-      // and never verified, so it can never publish — the upload path would end in a
-      // queue nobody drains.
-      onSourcesDelivered: gateTrigger,
-    },
+    agentChannel: agentChannelOptions,
+  });
+
+  // The agent's wire and the MCP tools over it, mounted where the route table lives.
+
+  const { agentSurface } = submissionSeams;
+
+  await registerAgentChannelRoutes(app, { ...agentChannelOptions, ...agentSurface.channel, store });
+
+  // Remote MCP (BY-05): streamable-HTTP tools wrapping the channel above. Same secret
+  // and store — sessionKey is derived from the round key, never a new creator credential.
+  await registerMcpServerRoutes(app, {
+    ...agentSurface.mcp,
+    store,
+    platformConnectorSecret,
+    // So /api/mcp can say the product is closed. Not a gate.
+    privateBeta,
+    gamesStore,
+    objectStore,
+    // Proposal rounds: an agent contributing to a game its creator does not own.
+    resolveProposalBase: resolveBaseForProposal,
+    onSourcesDelivered: gateTrigger,
   });
 
   // Multiplayer room relay (docs/multiplayer-plan.md). Registered after the auth

--- a/apps/api/src/submissions.ts
+++ b/apps/api/src/submissions.ts
@@ -1,7 +1,7 @@
 import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
 import { z } from 'zod';
-import { registerAgentChannelRoutes, type AgentChannelOptions } from './agent-surface/agent-channel.js';
-import { registerMcpServerRoutes } from './agent-surface/mcp-server.js';
+import type { AgentChannelOptions } from './agent-surface/agent-channel.js';
+import type { McpServerOptions } from './agent-surface/mcp-server.js';
 import { registerNotifySweepRoutes } from './notifications/notify-sweep-routes.js';
 import { createCreationGate, createChatGate, type ChatGate, type CreationGate } from './creation/creation-limits.js';
 import {
@@ -120,25 +120,13 @@ interface CachedStatus {
 export interface SubmissionRoutesOptions {
   githubToken?: string;
   gamesRepo?: string;
-  /**
-   * A game's published sources plus the base to pin a proposal to — the MCP proposal
-   * round's one read. Injected from `buildApp`, which is where the snapshot reader and
-   * games-repo credentials already live.
-   */
-  resolveProposalBase?: (slug: string) => Promise<{
-    base: import('./platform/store.js').ProposalBase;
-    files: import('./delivery/games-store.js').SourceFile[];
-  } | null>;
   submissionTokenSecret?: string;
-  platformConnectorSecret?: string;
   /**
    * Localizes an agent-relayed change request on the write that stores it. Used by the
    * two relay paths and by nothing that serves a read — see the note on the instance.
    * Defaults to createTranslatorFromEnv(); tests inject a stub.
    */
   translator?: Translator;
-  /** Forwarded to the MCP routes so the endpoint can say the product is closed. Copy only. */
-  privateBeta?: boolean;
   githubClient?: GitHubClient;
   fetchImpl?: typeof fetch;
   now?: () => number;
@@ -254,7 +242,37 @@ function checkUserAccess(request: FastifyRequest, reply: FastifyReply): boolean 
 }
 
 /** What `registerSubmissionRoutes` hands back for other route modules to build on. */
+// What the two agent surfaces need that only this registrar can build.
+
+// buildApp mounts both and supplies the rest — store, buckets, gate trigger, flags.
+
+export interface AgentSurfaceSeams {
+  channel: Pick<
+    AgentChannelOptions,
+    | 'agentTokenSecret'
+    | 'now'
+    | 'sourceDelivery'
+    | 'onEvent'
+    | 'onBuilderHandoffAcknowledged'
+    | 'onSourcesStaged'
+    | 'onRegenerateSeed'
+  >;
+  mcp: Pick<
+    McpServerOptions,
+    | 'agentTokenSecret'
+    | 'now'
+    | 'startImprovementRound'
+    | 'continueDraftRound'
+    | 'createGame'
+    | 'contentChecker'
+    | 'dailyImprovementQuota'
+    | 'dailyFeedbackQuota'
+  >;
+}
+
 export interface SubmissionRoutesHandle {
+  // The agent channel and MCP mounts' half of the wiring; buildApp mounts both.
+  agentSurface: AgentSurfaceSeams;
   /** The resolved games-repo client, or null when this deployment cannot reach one. */
   githubClient: GitHubClient | null;
   /** Whether the resolved registry has a platform backend. */
@@ -1628,53 +1646,37 @@ export async function registerSubmissionRoutes(
         })
       : undefined;
 
-  // The agent's side of the wire. Registered here rather than in app.ts so it shares
-  // the store, the token secret, and the caches it has to invalidate.
-  await registerAgentChannelRoutes(app, {
-    ...options.agentChannel,
-    ...(sourceDelivery ? { sourceDelivery } : {}),
-    store,
-    agentTokenSecret: submissionTokenSecret,
-    now,
-    onEvent: (issueNumber) => {
-      buildStatus.invalidateEvents(issueNumber);
-      // Heartbeat / ended / phase move with channel writes; do not keep serving a
-      // minute-old stall next to fresh progress (submit auto-end + continue loop).
-      invalidateStatusCache(issueNumber);
+  const agentSurface: AgentSurfaceSeams = {
+    channel: {
+      ...(sourceDelivery ? { sourceDelivery } : {}),
+      agentTokenSecret: submissionTokenSecret,
+      now,
+      onEvent: (issueNumber) => {
+        buildStatus.invalidateEvents(issueNumber);
+        // Heartbeat / ended / phase move with channel writes; do not keep serving a
+        // minute-old stall next to fresh progress (submit auto-end + continue loop).
+        invalidateStatusCache(issueNumber);
+      },
+      onBuilderHandoffAcknowledged: (input) => acknowledgeBuilderHandoff(input),
+      ...(stagedPreviews
+        ? { onSourcesStaged: ({ issueNumber }: { issueNumber: number }) => stagedPreviews.schedule(issueNumber) }
+        : {}),
+      onRegenerateSeed: regenerateSeed,
     },
-    onBuilderHandoffAcknowledged: (input) => acknowledgeBuilderHandoff(input),
-    ...(stagedPreviews
-      ? { onSourcesStaged: ({ issueNumber }: { issueNumber: number }) => stagedPreviews.schedule(issueNumber) }
-      : {}),
-    onRegenerateSeed: regenerateSeed,
-  });
-
-  // Remote MCP (BY-05): streamable-HTTP tools wrapping the channel above. Same secret
-  // and store — sessionKey is derived from the round key, never a new creator credential.
-  await registerMcpServerRoutes(app, {
-    store,
-    agentTokenSecret: submissionTokenSecret,
-    platformConnectorSecret: options.platformConnectorSecret,
-    now,
-    privateBeta: options.privateBeta,
-    // MCP Apps views (SEP-1865) read MCP_UI directly — off in production until the
-    // Phase 0 host spike lands. No behaviour changes for clients without the extension.
-    gamesStore: options.agentChannel?.gamesStore,
-    objectStore: options.agentChannel?.objectStore,
-    startImprovementRound,
-    continueDraftRound,
-    createGame,
-    contentChecker,
-    dailyImprovementQuota,
-    dailyFeedbackQuota,
-    // Proposal rounds: an agent contributing to a game its creator does not own. Both
-    // seams come from the caller so this module keeps no games-repo or snapshot
-    // dependency; absent means the tools answer "not configured" rather than half-working.
-    resolveProposalBase: options.resolveProposalBase,
-    onSourcesDelivered: options.agentChannel?.onSourcesDelivered,
-  });
+    mcp: {
+      agentTokenSecret: submissionTokenSecret,
+      now,
+      startImprovementRound,
+      continueDraftRound,
+      createGame,
+      contentChecker,
+      dailyImprovementQuota,
+      dailyFeedbackQuota,
+    },
+  };
 
   return {
+    agentSurface,
     githubClient,
     hasPlatformBackend: agentBackends.platformByVendor.size > 0,
     configuredVendors: [...agentBackends.platformByVendor.keys()],

--- a/eslint-rules/comment-prose-baseline.json
+++ b/eslint-rules/comment-prose-baseline.json
@@ -330,7 +330,7 @@
     "apps/api/src/store/records/telemetry.ts": 1136,
     "apps/api/src/store/slices/rounds.ts": 25,
     "apps/api/src/submissions.test.ts": 4637,
-    "apps/api/src/submissions.ts": 8072,
+    "apps/api/src/submissions.ts": 3908,
     "apps/api/src/tab-complete-deploy-flag.test.ts": 13,
     "apps/api/src/telemetry/creator-metrics.test.ts": 81,
     "apps/api/src/telemetry/creator-metrics.ts": 310,

--- a/eslint-rules/module-size-baseline.json
+++ b/eslint-rules/module-size-baseline.json
@@ -335,7 +335,7 @@
     "apps/api/src/platform/admin.test.ts": 1215,
     "apps/api/src/platform/admin.ts": 979,
     "apps/api/src/platform/app.test.ts": 344,
-    "apps/api/src/platform/app.ts": 1067,
+    "apps/api/src/platform/app.ts": 1087,
     "apps/api/src/platform/apple-account.test.ts": 137,
     "apps/api/src/platform/apple-account.ts": 81,
     "apps/api/src/platform/apple-auth.test.ts": 203,


### PR DESCRIPTION
`registerSubmissionRoutes` was awaiting two other modules' registrars as its last act, so the app's route table was decided partly inside a 1,700-line leaf. Both mounts move to `buildApp`, which already owns every other registration. This is the Phase 3 line "the agent channel and MCP server mount from it, not from `submissions.ts`".

## The seam

`registerSubmissionRoutes` returns `agentSurface` — the half of each option object only it can build. `channel` is a `Pick` over `AgentChannelOptions` of: `agentTokenSecret`, `now`, `sourceDelivery`, `onEvent`, `onBuilderHandoffAcknowledged`, `onSourcesStaged`, `onRegenerateSeed`. `mcp` is a `Pick` over `McpServerOptions` of: `agentTokenSecret`, `now`, `startImprovementRound`, `continueDraftRound`, `createGame`, `contentChecker`, `dailyImprovementQuota`, `dailyFeedbackQuota`.

These are closures over the status cache, the staged-preview publisher, the quotas and the round verbs — values with no other way out of that function. Typing them as a `Pick` over the registrars' own option types means the seam list cannot drift from what they accept.

`buildApp` supplies the half it owns (store, buckets, gate trigger, flags) and calls both registrars itself:

    await registerAgentChannelRoutes(app, { ...agentChannelOptions, ...agentSurface.channel, store });
    await registerMcpServerRoutes(app, { ...agentSurface.mcp, store, platformConnectorSecret, privateBeta, ... });

`submissions.ts` now imports both modules type-only.

## Three options that only tunnelled through

`resolveProposalBase`, `privateBeta` and `platformConnectorSecret` were declared on `SubmissionRoutesOptions`, read at exactly one place each — the MCP mount — and never used by the submission routes themselves. All three leave. `platformConnectorSecret` moves to `BuildAppOptions`, which is where its one test seam injects it now; that also removes the `delete agentChannel.platformConnectorSecret` dance the `mcp-server.test.ts` helper needed to keep it off the channel options.

## Behaviour

Both option objects carry the same keys with the same values, and no key appears in both spread groups, so spread order cannot change a value. `store` moves from third position to last in the channel options — nothing after it writes that key.

Nothing runs between the registrar returning and the two mounts, and both were previously the last statements inside it, so route registration order relative to everything else in `buildApp` (the mp relay, the beta wall hook) is unchanged.

`registerSubmissionRoutes` has one other caller, `creator-code.test.ts`, and it goes through `buildApp`.

Full API suite: 226 files, 3550 tests, green.

## Comments corrected rather than carried over

Moving the call sites exposed three comments that were false at the new location:

* The catalog-lane block said the MCP proposal tools "are registered by `registerSubmissionRoutes` below" — after this change they are registered in that same file, twenty lines down.
* A note said the module "keeps no games-repo or snapshot dependency". True of `submissions.ts`; `app.ts` builds `gamesRepoClient` immediately above.
* The `MCP_UI` note described `mcp-server.ts`'s own env read and sat above two unrelated values. Dropped — the flag stays covered by `infra/env-manifest.json` and its own tests.

## Ratchets

`app.ts` grows 20 lines and its module-size ceiling is resealed 1067 → 1087. The composition root gaining the route table is the direction the plan asks for, and `submissions.ts` — the file the freeze protects — did not grow. Its comment-prose baseline reseals 8072 → 3908, locking in the slack the extraction wave left behind.

`npm run lint` exits 0.