### PR TITLE
Stop 5xx responses echoing the error message to the client

### DIFF
--- a/apps/api/src/platform/app.ts
+++ b/apps/api/src/platform/app.ts
@@ -223,7 +223,8 @@ export async function buildApp(options: BuildAppOptions = {}): Promise<FastifyIn
 
   // Fastify's default 500 echoes err.message; 4xx replies pass through.
   app.setErrorHandler((error: FastifyError, request, reply) => {
-    const statusCode = error.statusCode ?? 500;
+    // Fastify reads both; statusCode wins when an error carries each.
+    const statusCode = error.statusCode ?? (error as { status?: number }).status ?? 500;
     if (statusCode >= 400 && statusCode < 500) {
       void reply.send(error);
       return;

--- a/apps/api/src/platform/app.ts
+++ b/apps/api/src/platform/app.ts
@@ -3,7 +3,12 @@ import fastifyStatic from '@fastify/static';
 import fastifyWebsocket from '@fastify/websocket';
 import { existsSync } from 'node:fs';
 import path from 'node:path';
-import Fastify, { type FastifyInstance, type FastifyRequest, type FastifyServerOptions } from 'fastify';
+import Fastify, {
+  type FastifyError,
+  type FastifyInstance,
+  type FastifyRequest,
+  type FastifyServerOptions,
+} from 'fastify';
 import { registerAccessTokenRoutes } from './access-token-routes.js';
 import { registerJobAdminRoutes } from '../creation/job-admin-routes.js';
 import { createGameSeederFromEnv } from '../agent-surface/agent-backend-env.js';
@@ -215,6 +220,18 @@ export async function buildApp(options: BuildAppOptions = {}): Promise<FastifyIn
     trustProxy: 1,
     routerOptions: { maxParamLength: MAX_REMIX_ID_LENGTH },
   });
+
+  // Fastify's default 500 echoes err.message; 4xx replies pass through.
+  app.setErrorHandler((error: FastifyError, request, reply) => {
+    const statusCode = error.statusCode ?? 500;
+    if (statusCode >= 400 && statusCode < 500) {
+      void reply.send(error);
+      return;
+    }
+    request.log.error({ err: error, method: request.method, url: request.url }, 'unhandled route error');
+    void reply.code(500).send({ error: 'internal' });
+  });
+
   const store = options.store ?? new InMemoryStore();
 
   const isProd = process.env.NODE_ENV === 'production';

--- a/apps/api/src/platform/error-handler.test.ts
+++ b/apps/api/src/platform/error-handler.test.ts
@@ -35,6 +35,19 @@ async function appWithThrowingRoute(logLines?: string[]) {
     throw error;
   });
 
+  // GitHubRequestError, MailerError and friends carry their code in `status`.
+  app.get('/api/test-throw-status-field', async () => {
+    const error = new Error(LEAK) as Error & { status?: number };
+    error.status = 404;
+    throw error;
+  });
+
+  app.get('/api/test-throw-status-field-5xx', async () => {
+    const error = new Error(LEAK) as Error & { status?: number };
+    error.status = 503;
+    throw error;
+  });
+
   app.get('/api/test-throw-redirect', async () => {
     const error = new Error(LEAK) as Error & { statusCode?: number };
     error.statusCode = 302;
@@ -74,6 +87,27 @@ describe('app-wide error handler', () => {
     const response = await app.inject({ method: 'GET', url: '/api/test-throw-redirect' });
 
     // Only a real 4xx is an answer; anything else is failure.
+    expect(response.statusCode).toBe(500);
+    expect(response.json()).toEqual({ error: 'internal' });
+    expect(response.body).not.toContain('gamedev-private-bucket');
+
+    await app.close();
+  });
+
+  it('passes through a 4xx an error carries in status rather than statusCode', async () => {
+    const app = await appWithThrowingRoute();
+    const response = await app.inject({ method: 'GET', url: '/api/test-throw-status-field' });
+
+    expect(response.statusCode).toBe(404);
+    expect(response.json()).toMatchObject({ statusCode: 404, error: 'Not Found' });
+
+    await app.close();
+  });
+
+  it('flattens a 5xx an error carries in status', async () => {
+    const app = await appWithThrowingRoute();
+    const response = await app.inject({ method: 'GET', url: '/api/test-throw-status-field-5xx' });
+
     expect(response.statusCode).toBe(500);
     expect(response.json()).toEqual({ error: 'internal' });
     expect(response.body).not.toContain('gamedev-private-bucket');

--- a/apps/api/src/platform/error-handler.test.ts
+++ b/apps/api/src/platform/error-handler.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from 'vitest';
+import { buildApp } from './app.js';
+import { InMemoryStore } from './store.js';
+
+// A throw carries whatever the failing call put in its message.
+
+const LEAK = 'GAMES_STORE_BUCKET=gamedev-private-bucket /srv/secrets/key.json';
+
+async function appWithThrowingRoute(logLines?: string[]) {
+  const app = await buildApp({
+    store: new InMemoryStore(),
+    sessionSecret: 'dev-session-secret-change-me',
+    ...(logLines
+      ? {
+          logger: {
+            level: 'error',
+            stream: {
+              write(line: string) {
+                logLines.push(line);
+              },
+            },
+          },
+        }
+      : {}),
+  });
+
+  // Registered after build, so it inherits the root error handler.
+  app.get('/api/test-throw', async () => {
+    throw new Error(LEAK);
+  });
+
+  app.get('/api/test-throw-status', async () => {
+    const error = new Error(LEAK) as Error & { statusCode?: number };
+    error.statusCode = 503;
+    throw error;
+  });
+
+  app.get('/api/test-throw-redirect', async () => {
+    const error = new Error(LEAK) as Error & { statusCode?: number };
+    error.statusCode = 302;
+    throw error;
+  });
+
+  await app.ready();
+  return app;
+}
+
+describe('app-wide error handler', () => {
+  it('answers an uncaught throw with a code, never the message', async () => {
+    const app = await appWithThrowingRoute();
+    const response = await app.inject({ method: 'GET', url: '/api/test-throw' });
+
+    expect(response.statusCode).toBe(500);
+    expect(response.json()).toEqual({ error: 'internal' });
+    expect(response.body).not.toContain('gamedev-private-bucket');
+    expect(response.body).not.toContain('/srv/secrets');
+
+    await app.close();
+  });
+
+  it('flattens a thrown 5xx that carries its own status', async () => {
+    const app = await appWithThrowingRoute();
+    const response = await app.inject({ method: 'GET', url: '/api/test-throw-status' });
+
+    // A 503 the route did not send itself is still internal.
+    expect(response.statusCode).toBe(500);
+    expect(response.json()).toEqual({ error: 'internal' });
+
+    await app.close();
+  });
+
+  it('flattens a thrown status outside 4xx rather than passing it through', async () => {
+    const app = await appWithThrowingRoute();
+    const response = await app.inject({ method: 'GET', url: '/api/test-throw-redirect' });
+
+    // Only a real 4xx is an answer; anything else is failure.
+    expect(response.statusCode).toBe(500);
+    expect(response.json()).toEqual({ error: 'internal' });
+    expect(response.body).not.toContain('gamedev-private-bucket');
+
+    await app.close();
+  });
+
+  it('logs the real error so the failure is not lost with the message', async () => {
+    const logLines: string[] = [];
+    const app = await appWithThrowingRoute(logLines);
+    await app.inject({ method: 'GET', url: '/api/test-throw' });
+
+    const logged = logLines.join('\n');
+    expect(logged).toContain('unhandled route error');
+    expect(logged).toContain('gamedev-private-bucket');
+
+    await app.close();
+  });
+
+  it('leaves a route 4xx untouched', async () => {
+    const app = await appWithThrowingRoute();
+
+    // The operator console answers its own 401; do not reshape it.
+    const response = await app.inject({ method: 'GET', url: '/api/admin/submissions' });
+
+    expect(response.statusCode).toBeGreaterThanOrEqual(400);
+    expect(response.statusCode).toBeLessThan(500);
+    expect(response.json()).not.toEqual({ error: 'internal' });
+
+    await app.close();
+  });
+
+  it('leaves Fastify validation 400s in their default shape', async () => {
+    const app = await appWithThrowingRoute();
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/submissions',
+      payload: '{oops',
+      headers: { 'content-type': 'application/json' },
+    });
+
+    expect(response.statusCode).toBe(400);
+    expect(response.json()).toMatchObject({ statusCode: 400, error: 'Bad Request' });
+
+    await app.close();
+  });
+});

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -640,7 +640,8 @@ export function App() {
       } else if (message.includes('blocked')) {
         setSubmissionError(t('auth.accountBlocked'));
       } else {
-        setSubmissionError(message);
+        // Every other code is a machine string (`dispatch_failed`), never a sentence.
+        setSubmissionError(t('errors.generic'));
       }
       setSubmissionStatus('idle');
     }

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -66,6 +66,7 @@ function readLocationRoute(): AppRoute {
   return parsePathRoute(window.location.pathname, window.location.hash);
 }
 import { submitSpec, refineSpec, type SubmissionApiError, type PlatformBuilderAvailability } from './submissionApi.js';
+import { submissionErrorKey } from './submissionErrors.js';
 import { useActiveBuildCount } from './activeBuilds.js';
 import { getSavedSpecs, saveSpec, type SavedSpec } from './mySpecs.js';
 import { saveLastBuilder, type BuilderKind } from './builderKind.js';
@@ -620,29 +621,16 @@ export function App() {
       navigate(builder === 'platform' ? studioWelcomePath(address) : studioConnectPath(address));
     } catch (err) {
       const message = err instanceof Error ? err.message : t('errors.generic');
-      const category = err instanceof Error ? (err as SubmissionApiError).category : undefined;
-      if (message === 'content_rejected') {
-        setSubmissionError(t(`errors.contentRejected.${category ?? 'other'}`));
-      } else if (message === 'creation_paused') {
-        setSubmissionError(t('errors.creationPaused'));
-        // Site-wide limits, not this creator's — checked before the quota branch below
-        // because saying "you've used your allowance" here would be untrue, and the
-        // creator can see their remaining count on the hero to check it.
-      } else if (message === 'creation_over_capacity') {
-        setSubmissionError(t('errors.creationOverCapacity'));
-        // Two submissions of the same title raced for its address and this one lost
-        // twice. Rare, and recoverable by renaming — which is a thing the creator can
-        // now actually do, because they picked the name in the first place.
-      } else if (message === 'name_unavailable') {
-        setSubmissionError(t('errors.nameUnavailable'));
-      } else if (message.includes('quota')) {
-        setSubmissionError(t('auth.quotaExceeded'));
-      } else if (message.includes('blocked')) {
-        setSubmissionError(t('auth.accountBlocked'));
-      } else {
-        // Every other code is a machine string (`dispatch_failed`), never a sentence.
-        setSubmissionError(t('errors.generic'));
-      }
+      const apiErr = err instanceof Error ? (err as SubmissionApiError) : undefined;
+      setSubmissionError(
+        t(
+          submissionErrorKey({
+            message,
+            ...(apiErr?.status !== undefined ? { status: apiErr.status } : {}),
+            ...(apiErr?.category !== undefined ? { category: apiErr.category } : {}),
+          }),
+        ),
+      );
       setSubmissionStatus('idle');
     }
   }

--- a/apps/web/src/SubmissionStatusView.tsx
+++ b/apps/web/src/SubmissionStatusView.tsx
@@ -484,9 +484,7 @@ export function SubmissionStatusView({
         setStatus(null);
         setLoading(false);
         setIsInvalidToken(apiError.status === 400);
-        setErrorMessage(
-          apiError.status === 400 ? t('statusView.invalidToken') : apiError.message || t('errors.generic'),
-        );
+        setErrorMessage(apiError.status === 400 ? t('statusView.invalidToken') : t('errors.generic'));
 
         if (apiError.status !== 400) {
           // Transient failure (network blip, rate limit) — keep trying at the idle cadence.

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -1152,6 +1152,8 @@
   },
   "errors": {
     "generic": "Something went wrong",
+    "signInRequired": "Your sign-in expired. Sign in again and send this once more — your answers are kept.",
+    "tooManyAttempts": "That's a lot of new games at once. Wait a few minutes and try again.",
     "creationPaused": "New games are paused for a moment while we look at something on our side. Your daily allowance hasn't been touched — please try again shortly.",
     "creationOverCapacity": "We've hit today's ceiling on new games across the whole site, so we can't start another one right now. Your own allowance is untouched and still there tomorrow.",
     "nameUnavailable": "That name was taken while we were setting your game up. Give it a different one and try again.",

--- a/apps/web/src/i18n/locales/pl.json
+++ b/apps/web/src/i18n/locales/pl.json
@@ -1166,6 +1166,8 @@
   },
   "errors": {
     "generic": "Coś poszło nie tak",
+    "signInRequired": "Twoja sesja wygasła. Zaloguj się ponownie i wyślij jeszcze raz — odpowiedzi są zachowane.",
+    "tooManyAttempts": "To dużo nowych gier naraz. Odczekaj kilka minut i spróbuj ponownie.",
     "creationPaused": "Tworzenie nowych gier jest na chwilę wstrzymane — sprawdzamy coś u nas. Twój dzienny limit pozostaje nietknięty, spróbuj ponownie za moment.",
     "creationOverCapacity": "Osiągnęliśmy dzisiejszy limit nowych gier w całym serwisie, więc nie możemy teraz zacząć kolejnej. Twój własny limit jest nietknięty i będzie czekał jutro.",
     "nameUnavailable": "Ta nazwa została zajęta, gdy przygotowywaliśmy Twoją grę. Nadaj inną i spróbuj ponownie.",

--- a/apps/web/src/submissionErrors.test.ts
+++ b/apps/web/src/submissionErrors.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest';
+import en from './i18n/locales/en.json';
+import pl from './i18n/locales/pl.json';
+import { submissionErrorKey } from './submissionErrors.js';
+
+function resolve(locale: unknown, key: string): unknown {
+  return key.split('.').reduce<unknown>((node, part) => (node as Record<string, unknown>)?.[part], locale);
+}
+
+describe('submissionErrorKey', () => {
+  it('answers an expired session with sign-in guidance, not a retry', () => {
+    expect(submissionErrorKey({ status: 401, message: 'authentication required' })).toBe('errors.signInRequired');
+  });
+
+  it('keeps the coarse IP limiter distinct from the generic failure', () => {
+    expect(submissionErrorKey({ status: 429, message: 'too many submissions, please try again later' })).toBe(
+      'errors.tooManyAttempts',
+    );
+  });
+
+  it('prefers the truer message for the other two refusals that answer 429', () => {
+    expect(submissionErrorKey({ status: 429, message: 'daily submission quota exceeded' })).toBe('auth.quotaExceeded');
+    expect(submissionErrorKey({ status: 429, message: 'creation_paused' })).toBe('errors.creationPaused');
+    expect(submissionErrorKey({ status: 429, message: 'creation_over_capacity' })).toBe('errors.creationOverCapacity');
+  });
+
+  it('carries the moderation category through', () => {
+    expect(submissionErrorKey({ status: 422, message: 'content_rejected', category: 'sexual' })).toBe(
+      'errors.contentRejected.sexual',
+    );
+    expect(submissionErrorKey({ status: 422, message: 'content_rejected' })).toBe('errors.contentRejected.other');
+  });
+
+  it('answers a blocked account from its 403', () => {
+    expect(submissionErrorKey({ status: 403, message: 'account is blocked' })).toBe('auth.accountBlocked');
+  });
+
+  it('never shows a raw server code', () => {
+    expect(submissionErrorKey({ status: 500, message: 'internal' })).toBe('errors.generic');
+    expect(submissionErrorKey({ status: 503, message: 'submissions are not configured' })).toBe('errors.generic');
+    expect(submissionErrorKey({ message: 'dispatch_failed' })).toBe('errors.generic');
+  });
+
+  it('resolves every key it can return in both locales', () => {
+    const keys = [
+      submissionErrorKey({ status: 401, message: 'authentication required' }),
+      submissionErrorKey({ status: 429, message: 'too many submissions, please try again later' }),
+      submissionErrorKey({ status: 429, message: 'daily submission quota exceeded' }),
+      submissionErrorKey({ status: 429, message: 'creation_paused' }),
+      submissionErrorKey({ status: 429, message: 'creation_over_capacity' }),
+      submissionErrorKey({ status: 409, message: 'name_unavailable' }),
+      submissionErrorKey({ status: 422, message: 'content_rejected', category: 'other' }),
+      submissionErrorKey({ status: 403, message: 'account is blocked' }),
+      submissionErrorKey({ message: 'dispatch_failed' }),
+    ];
+
+    for (const key of keys) {
+      expect(typeof resolve(en, key), `en is missing ${key}`).toBe('string');
+      expect(typeof resolve(pl, key), `pl is missing ${key}`).toBe('string');
+    }
+  });
+});

--- a/apps/web/src/submissionErrors.ts
+++ b/apps/web/src/submissionErrors.ts
@@ -1,0 +1,27 @@
+// Maps a failed submission to the message key the creator should see.
+
+// Order matters: three different refusals all answer 429.
+export function submissionErrorKey(input: { status?: number; message: string; category?: string }): string {
+  const { status, message, category } = input;
+
+  // A session that expired behind the panel; retrying cannot work.
+  if (status === 401) return 'errors.signInRequired';
+
+  if (message === 'content_rejected') return `errors.contentRejected.${category ?? 'other'}`;
+
+  // Site limits, not this creator's; the quota branch would be untrue.
+  if (message === 'creation_paused') return 'errors.creationPaused';
+  if (message === 'creation_over_capacity') return 'errors.creationOverCapacity';
+
+  // Two submissions raced for the address; renaming recovers.
+  if (message === 'name_unavailable') return 'errors.nameUnavailable';
+
+  if (message.includes('quota')) return 'auth.quotaExceeded';
+  if (message.includes('blocked')) return 'auth.accountBlocked';
+
+  // Last of the 429s; the branches above say something truer.
+  if (status === 429) return 'errors.tooManyAttempts';
+
+  // Every other code is a machine string (`dispatch_failed`), never a sentence.
+  return 'errors.generic';
+}

--- a/eslint-rules/module-size-baseline.json
+++ b/eslint-rules/module-size-baseline.json
@@ -335,7 +335,7 @@
     "apps/api/src/platform/admin.test.ts": 1215,
     "apps/api/src/platform/admin.ts": 979,
     "apps/api/src/platform/app.test.ts": 344,
-    "apps/api/src/platform/app.ts": 1104,
+    "apps/api/src/platform/app.ts": 1105,
     "apps/api/src/platform/apple-account.test.ts": 137,
     "apps/api/src/platform/apple-account.ts": 81,
     "apps/api/src/platform/apple-auth.test.ts": 203,

--- a/eslint-rules/module-size-baseline.json
+++ b/eslint-rules/module-size-baseline.json
@@ -335,7 +335,7 @@
     "apps/api/src/platform/admin.test.ts": 1215,
     "apps/api/src/platform/admin.ts": 979,
     "apps/api/src/platform/app.test.ts": 344,
-    "apps/api/src/platform/app.ts": 1087,
+    "apps/api/src/platform/app.ts": 1104,
     "apps/api/src/platform/apple-account.test.ts": 137,
     "apps/api/src/platform/apple-account.ts": 81,
     "apps/api/src/platform/apple-auth.test.ts": 203,


### PR DESCRIPTION
`setErrorHandler` appears nowhere in this repo. Every uncaught throw in every route has been falling through to Fastify's default 500, which puts `err.message` in the response body verbatim. Whatever the failing call put in that message — a bucket name, a filesystem path, a signed URL, a token fragment — went out to the caller with it.

This is the Phase 3 line "add the app-wide error handler mapping typed domain errors to HTTP shapes".

## What throws

21 non-test `.parse(` sites throw rather than `safeParse`. 15 are in route handlers reading `request.params`, spread across `suggestion-inbox.ts` (4), `draft-lifecycle-routes.ts` (3), `handoff-seal-routes.ts` (2) and one each in `game-play-route.ts`, `draft-preview-routes.ts`, `submissions.ts`, `feedback-routes.ts`, `improve-routes.ts`. The other 6 parse model replies inside the LLM call helpers, and a `ZodError` message quotes the input it rejected. Beyond zod, any throw from the GCS client, the GitHub client or the Firestore driver lands the same way.

## The handler

    app.setErrorHandler((error: FastifyError, request, reply) => {
      // Fastify reads both; statusCode wins when an error carries each.
      const statusCode = error.statusCode ?? (error as { status?: number }).status ?? 500;
      if (statusCode >= 400 && statusCode < 500) {
        void reply.send(error);
        return;
      }
      request.log.error({ err: error, method: request.method, url: request.url }, 'unhandled route error');
      void reply.code(500).send({ error: 'internal' });
    });

`{ error: '<code>' }` is what the API already speaks — 81 distinct codes across the routes, and nothing sends a `message` key.

Only a real 4xx passes through. An error carrying a status outside 400–499 (including one carrying none) is treated as a failure and flattened, so a thrown `statusCode: 302` cannot smuggle the message out through the pass-through branch.

Three things I checked against Fastify 5.10 directly rather than assumed:

* `reply.send(error)` inside the handler does **not** re-enter it — four requests, four handler invocations — and reproduces the default body byte for byte.
* The default handler reads `status` as well as `statusCode`, preferring `statusCode` when an error carries both. This repo has four error classes that use `status` — `GitHubRequestError`, `AgentTasksError`, `ManagedAgentError`, `MailerError` — so classifying on `statusCode` alone would have turned a 404 from one of those into a 500. That is a regression, not a missed improvement, and it is why the handler reads both. `tsc` could not have caught it: `status` is not on the `FastifyError` type.
* The default handler logs 5xx itself, so a custom handler that does not log would silently remove every 500 from Cloud Logging. Hence the explicit `request.log.error`, with a test asserting the message reaches the log even though it no longer reaches the client.

No plugin sets its own error handler, so nothing was overridden. `setNotFoundHandler` is untouched.

## The web rendered raw server strings

`throwResponseError` puts the response body's `error` field into `Error.message`. Two call sites then displayed that message to the user directly, so a 503 rendered the literal text `store_unavailable` on screen and a 500 rendered the English `Internal Server Error` to a Polish creator. Pre-existing, but this PR changes what lands there, so both are fixed.

`SubmissionStatusView.tsx` now shows `t('errors.generic')`: its non-400 failures are transient, the poller retries on its own cadence, and there is no recovery action to name.

`App.tsx`'s chain needed more care. An expired session (401 `authentication required`, from `checkUserAccess` in `platform/auth.ts`) and the coarse IP limiter (429 `too many submissions, please try again later`, from `create-game.ts`) match none of the message branches, so folding them into a generic fallback would have replaced recoverable guidance with "Something went wrong" — and for the 401, retrying cannot resolve it. Two new keys in both locales, classified by `status`.

That chain moved to `submissionErrors.ts` as a pure `submissionErrorKey({ status, message, category })`, because the ordering is subtle and nothing covered it: **three** different refusals answer 429 — the creator's daily quota, the two site-wide limits, and the IP limiter — and only the last should say "you went too fast".

## Verification

* 8 tests in `apps/api/src/platform/error-handler.test.ts`. Reverting `app.ts` alone fails the leak assertions and passes the unchanged-behaviour ones, so they discriminate in both directions.
* 7 tests in `apps/web/src/submissionErrors.test.ts`, one of which asserts every key the mapper can return resolves in both `en.json` and `pl.json`.
* API suite 227 files / 3558 tests green. Web suite 199 files / 1749 tests green.
* No test anywhere asserted a 500 status before this PR, and `grep` finds no consumer of the string `Internal Server Error`.
* `npm run lint` exits 0. `app.ts` grows 18 lines; its module-size ceiling reseals 1087 → 1105.

## Deliberately not in this PR

Mapping `ZodError` to a 400 `{ error: 'invalid_request' }`. It is the more correct status for those 15 routes, but it changes a status code rather than removing a leak, and it deserves its own diff.