### PR TITLE
fix(catalog): allow up to 8 tracker channels in per-game music.json

### DIFF
--- a/apps/api/src/catalog/music-tracks.test.ts
+++ b/apps/api/src/catalog/music-tracks.test.ts
@@ -5,14 +5,9 @@ const validTrack = {
   bpm: 120,
   steps: 8,
   gain: 0.2,
-  channels: [
-    {
-      wave: 'square' as const,
-      gain: 0.5,
-      pattern: ['C4', null, 'E4', null, 'G4', null, 'E4', null],
-    },
-  ],
+  channels: [{ wave: 'square' as const, gain: 0.5, pattern: ['C4', null, 'E4', null, 'G4', null, 'E4', null] }],
 };
+const nCh = (n: number) => ({ ...validTrack, channels: Array(n).fill(validTrack.channels[0]) });
 
 describe('music-tracks', () => {
   it('parses a shared catalog tracks map', () => {
@@ -20,24 +15,28 @@ describe('music-tracks', () => {
     expect(Object.hasOwn(tracks, 'soft-puzzle')).toBe(true);
   });
 
-  it('strictly validates a per-game music.json', () => {
-    const tracks = parseGameMusicTracks(JSON.stringify({ version: 1, tracks: { 'raid-theme': validTrack } }));
-    expect(tracks['raid-theme']).toEqual(validTrack);
+  it('strictly validates a per-game music.json and permits up to 8 channels', () => {
+    expect(
+      parseGameMusicTracks(JSON.stringify({ version: 1, tracks: { 'raid-theme': validTrack } }))['raid-theme'],
+    ).toEqual(validTrack);
+    expect(
+      parseGameMusicTracks(JSON.stringify({ version: 1, tracks: { 'multi-voice': nCh(8) } }))['multi-voice'],
+    ).toEqual(nCh(8));
   });
 
-  it('rejects a per-game catalog with version other than 1', () => {
+  it('rejects version other than 1 and channels > 8', () => {
     expect(() => parseGameMusicTracks(JSON.stringify({ version: 2, tracks: { a: validTrack } }))).toThrow(
       /version must be 1/,
     );
+    expect(() => parseGameMusicTracks(JSON.stringify({ version: 1, tracks: { 'too-many': nCh(9) } }))).toThrow(
+      /too-many needs 1–8 channels/,
+    );
   });
 
-  it('merges game tracks onto the shared catalog', () => {
+  it('merges game tracks onto shared catalog and refuses collision', () => {
     const merged = mergeMusicTrackMaps({ 'soft-puzzle': { loop: true } }, { 'raid-theme': validTrack });
     expect(Object.hasOwn(merged, 'soft-puzzle')).toBe(true);
     expect(Object.hasOwn(merged, 'raid-theme')).toBe(true);
-  });
-
-  it('refuses a game track that collides with the shared catalog', () => {
     expect(() => mergeMusicTrackMaps({ 'soft-puzzle': { loop: true } }, { 'soft-puzzle': validTrack })).toThrow(
       /redefines shared catalog track/,
     );

--- a/apps/api/src/catalog/music-tracks.ts
+++ b/apps/api/src/catalog/music-tracks.ts
@@ -88,8 +88,8 @@ export function parseGameMusicTracks(source: string, label = 'game music.json'):
     ) {
       throw new Error(`${label}: ${name}.gain must be between 0 and 1`);
     }
-    if (!Array.isArray(track.channels) || track.channels.length === 0 || track.channels.length > 4) {
-      throw new Error(`${label}: ${name} needs 1–4 channels`);
+    if (!Array.isArray(track.channels) || track.channels.length === 0 || track.channels.length > 8) {
+      throw new Error(`${label}: ${name} needs 1–8 channels`);
     }
     for (const [channelIndex, channelRaw] of track.channels.entries()) {
       if (!channelRaw || typeof channelRaw !== 'object' || Array.isArray(channelRaw)) {


### PR DESCRIPTION
### Summary

Aligns the website platform's tracker music parser (`apps/api/src/catalog/music-tracks.ts`) with the upgraded GameKit audio engine capability in `gamedevpl/www.gamedev.pl-games` PR #1126.

### Problem
Game snapshot deployment failed during bake because *Rainbow Surfer* ships with a 7-channel tracker score (`rainbow-run`). `parseGameMusicTracks` still capped channel count at 4, throwing `rainbow-run needs 1–4 channels` and blocking snapshot publication.

### Solution
- Increase the maximum allowed channels in `parseGameMusicTracks` from 4 to 8.
- Add unit test coverage in `apps/api/src/catalog/music-tracks.test.ts` asserting that 8 channels are permitted and >8 channels are rejected.
- Verified with dry-run snapshot publish across all 117 games in `www.gamedev.pl-games` at commit `14d3d559049783be0b8aef05da3a31b59276744e`.