### PR TITLE
Share the one rule for when a round stops accepting edits

### DIFF
--- a/apps/web/src/EditorPanel.tsx
+++ b/apps/web/src/EditorPanel.tsx
@@ -42,6 +42,7 @@ import {
 } from './studioApi.js';
 import { getSubmissionStatus, listMySubmissions } from './submissionApi.js';
 import { pollDelayMs } from './studioStatusPoll.js';
+import { isRoundSealed } from './roundSealed.js';
 
 /**
  * The studio's Edit surface (EditorKit L3): renders a game's own editor
@@ -530,11 +531,7 @@ export function EditorPanel(props: {
         }
         const detail = await getSubmissionStatus(mine.token);
         if (cancelled) return;
-        const sealed =
-          detail.status === 'in_review' ||
-          detail.status === 'published' ||
-          detail.phase === 'ready_for_review' ||
-          detail.phase === 'published';
+        const sealed = isRoundSealed(detail);
         if (sealed) {
           void publishNowRef.current();
           return;

--- a/apps/web/src/StudioWelcomeView.tsx
+++ b/apps/web/src/StudioWelcomeView.tsx
@@ -10,6 +10,7 @@ import { pollDelayMs } from './studioStatusPoll.js';
 import { getSubmissionStatus, type SubmissionStatus } from './submissionApi.js';
 import { recordCreateStep } from './visitTelemetry.js';
 import { welcomeProgressMessage, welcomeStatusLabel } from './welcomeProgress.js';
+import { isRoundSealed } from './roundSealed.js';
 
 // Focusable controls inside the welcome dialog.
 const FOCUSABLE = 'a[href], button:not([disabled]), input:not([disabled]), [tabindex]:not([tabindex="-1"])';
@@ -113,14 +114,7 @@ export function StudioWelcomeView({ game, onOpenStudio }: StudioWelcomeViewProps
     (item) => item.origin !== 'seed' && item.origin !== 'staged',
   );
 
-  const isReady =
-    status != null &&
-    (status.status === 'in_review' ||
-      status.status === 'published' ||
-      status.phase === 'ready_for_review' ||
-      status.phase === 'published' ||
-      hasDeliveredPlayable ||
-      status.preview != null);
+  const isReady = status != null && (isRoundSealed(status) || hasDeliveredPlayable || status.preview != null);
 
   const isNeedsChanges =
     status != null && (status.status === 'needs_changes' || status.phase === 'needs_changes' || status.failure != null);

--- a/apps/web/src/roundSealed.test.ts
+++ b/apps/web/src/roundSealed.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+import { isRoundSealed } from './roundSealed.js';
+
+describe('isRoundSealed', () => {
+  it('seals on either field, because both can carry it', () => {
+    expect(isRoundSealed({ status: 'in_review' })).toBe(true);
+    expect(isRoundSealed({ status: 'published' })).toBe(true);
+    expect(isRoundSealed({ status: 'building', phase: 'ready_for_review' })).toBe(true);
+    expect(isRoundSealed({ status: 'building', phase: 'published' })).toBe(true);
+  });
+
+  it('leaves a round in flight open', () => {
+    expect(isRoundSealed({ status: 'building' })).toBe(false);
+    expect(isRoundSealed({ status: 'queued', phase: 'building' })).toBe(false);
+    expect(isRoundSealed({ status: 'needs_changes' })).toBe(false);
+  });
+
+  it('answers false for an absent status rather than throwing', () => {
+    expect(isRoundSealed(null)).toBe(false);
+    expect(isRoundSealed(undefined)).toBe(false);
+  });
+});

--- a/apps/web/src/roundSealed.ts
+++ b/apps/web/src/roundSealed.ts
@@ -1,0 +1,16 @@
+import type { SubmissionStatus } from './submissionApi.js';
+
+// Past the point where a round still accepts edits.
+
+// `status` is the coarse public state; `phase` is the finer job state.
+
+// Both can carry the seal, so both are asked.
+export function isRoundSealed(status: Pick<SubmissionStatus, 'status' | 'phase'> | null | undefined): boolean {
+  if (!status) return false;
+  return (
+    status.status === 'in_review' ||
+    status.status === 'published' ||
+    status.phase === 'ready_for_review' ||
+    status.phase === 'published'
+  );
+}


### PR DESCRIPTION
Batch 3 of "one meaning for publish", and it came out smaller than I planned it — for a reason worth recording.

## What I expected to find, and what is actually there

I scoped batch 3 as "the third vocabulary": `record.publishedAt` OR'd into a predicate in `job-costs.ts`, plus the `status.status === 'published'` reads. Re-scanning across both workspaces with both operators turned up **33** remaining sites, but they are not one vocabulary with three spellings. They are at least four different questions:

| Question | Shape | Sites |
| --- | --- | --- |
| Is this game live now? | `PublicationRecord.state` / `CatalogEntry.status` | done in [#1058](https://github.com/gamedevpl/www.gamedev.pl/pull/1058) / [#1059](https://github.com/gamedevpl/www.gamedev.pl/pull/1059) |
| Did this job end in a publish? | `JobState === 'published'` | 4 |
| What does the wire say right now? | `SubmissionStatus.status` | ~14 |
| How far has the round got? | `SubmissionStatus.phase` (also a `JobState`) | 2 |

Most of those are a **single field read off a typed response**. There is no second source of truth to drift from, so wrapping `status.status === 'published'` in a helper would add indirection without removing duplication. Collapsing the job lane into the registry lane would be actively wrong: a job that ended `published` is a historical fact, and the game it produced may since have been archived.

So the honest remaining content of batch 3 is one thing, not a sweep.

## The one real duplication

`EditorPanel.tsx` and `StudioWelcomeView.tsx` each carried the same four-clause predicate, spanning two fields:

    status === 'in_review' || status === 'published' || phase === 'ready_for_review' || phase === 'published'

Two copies of a rule over two fields is exactly the drift this item exists to prevent — adding a fifth sealed state means editing one and missing the other, and nothing would fail. `isRoundSealed` in `apps/web/src/roundSealed.ts` now holds it.

Three tests pin the parts that are easy to get wrong when someone edits it later: either field can carry the seal, a round in flight stays open, and an absent status answers `false` rather than throwing.

Both call sites shrink, so no ratchet baseline moves.

## Verification

`tsc` clean. Web suite 199 files / 1752 tests green (three new). `npm run lint` exits 0.

## Where item 6 stands

Batches 1–3 have collapsed the two lanes that genuinely had scattered definitions, plus this one duplicated rule. What remains is batch 4 — the plan's actual end state, the repo lane as an importer writing the same registry entry. That still needs a reconciliation design before any code: today a game removed from `catalog.json` drops out of the gate on the next TTL refresh, but an importer would leave it published forever without tombstones or a reconciliation pass, and `published-slugs.ts` records that the catalog fan-out has already caused one GitHub rate-limit outage.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VaPzGSyNfZ7nvGcJgYNSdL)_