### PR TITLE
Remove the dead 'gating' job state

### DIFF
--- a/apps/api/src/creation/builder.test.ts
+++ b/apps/api/src/creation/builder.test.ts
@@ -89,7 +89,6 @@ describe('builder helpers', () => {
     expect(shouldSteerFeedbackViaInbox({ state: 'dispatched', ...withRef })).toBe(true);
     expect(shouldSteerFeedbackViaInbox({ state: 'building', ...withRef })).toBe(true);
     expect(shouldSteerFeedbackViaInbox({ state: 'submitted', ...withRef })).toBe(true);
-    expect(shouldSteerFeedbackViaInbox({ state: 'gating', ...withRef })).toBe(true);
     expect(
       shouldSteerFeedbackViaInbox({
         state: 'needs_changes',

--- a/apps/api/src/creation/builder.ts
+++ b/apps/api/src/creation/builder.ts
@@ -18,7 +18,6 @@ export function isActiveBuildRound(record: { state?: JobState; transitions?: Job
     case 'dispatched':
     case 'building':
     case 'submitted':
-    case 'gating':
     case 'publishing':
       return true;
     case 'needs_changes': {

--- a/apps/api/src/creation/job-admin-routes.test.ts
+++ b/apps/api/src/creation/job-admin-routes.test.ts
@@ -86,9 +86,9 @@ describe('buildJobQueue', () => {
   });
 
   it('shows both the internal state and what the creator is being told', () => {
-    const queue = buildJobQueue([record({ issueNumber: 1, state: 'gating', stateSince: ago(MINUTE) })], NOW);
+    const queue = buildJobQueue([record({ issueNumber: 1, state: 'submitted', stateSince: ago(MINUTE) })], NOW);
 
-    expect(queue.jobs[0].state).toBe('gating');
+    expect(queue.jobs[0].state).toBe('submitted');
     expect(queue.jobs[0].creatorStatus).toBe('building');
   });
 
@@ -427,4 +427,3 @@ describe('GET /api/admin/jobs/:issueNumber/preview', () => {
     await app.close();
   });
 });
-

--- a/apps/api/src/creation/job-reconciler.ts
+++ b/apps/api/src/creation/job-reconciler.ts
@@ -250,7 +250,7 @@ export function createJobReconciler(deps: JobReconcilerDeps): JobReconciler {
   async function reconcileGateVerdict(record: SubmissionRecord, sweep = false): Promise<JobTransition | null> {
     if (!gamesStore || !store || !record.slug) return null;
     const state = record.state ?? 'queued';
-    if (state !== 'building' && state !== 'submitted' && state !== 'gating') return null;
+    if (state !== 'building' && state !== 'submitted') return null;
     try {
       const roundGeneration = record.roundGeneration ?? 1;
       // Retained versions may belong to an older round.

--- a/apps/api/src/creation/job-state.test.ts
+++ b/apps/api/src/creation/job-state.test.ts
@@ -30,7 +30,6 @@ describe('job state projection', () => {
   it('hides our own verification behind "building"', () => {
     // Whether the agent or our gate is doing the work is not the creator's business.
     expect(toSubmissionStatus('submitted')).toBe('building');
-    expect(toSubmissionStatus('gating')).toBe('building');
     expect(toSubmissionStatus('building')).toBe('building');
   });
 
@@ -116,7 +115,6 @@ describe('transition rules', () => {
     // `in_progress`. Forcing `building` at dispatch lied about that boot window.
     expect(canTransition('building', 'dispatched')).toBe(true);
     expect(canTransition('submitted', 'dispatched')).toBe(true);
-    expect(canTransition('gating', 'dispatched')).toBe(true);
   });
 
   // A gate-red round is not always over: `mustFixGate` tells the live session to fix the
@@ -132,15 +130,13 @@ describe('transition rules', () => {
 
   // The gate reports by writing its verdict to the version manifest, which we read on a
   // poll — so a delivered job goes straight from `submitted` to the outcome and is never
-  // seen mid-gate. When `gating` was the only exit, that made `submitted` a dead end:
-  // the reconciler computed the right target, canTransition refused it, and the job sat
-  // there telling the creator the gate had never started for as long as they watched.
-  it('lets a delivered job reach the gate verdict without passing through gating', () => {
+  // seen mid-gate. `gating` was that never-taken step, and while it was `submitted`'s
+  // only exit the reconciler computed the right target, canTransition refused it, and
+  // the job sat telling the creator the gate had never started for as long as they
+  // watched. The state is gone; these are the exits that carry the delivery now.
+  it('lets a delivered job reach the gate verdict directly', () => {
     expect(canTransition('submitted', 'ready_for_review')).toBe(true);
     expect(canTransition('submitted', 'needs_changes')).toBe(true);
-    // Still reachable, for records written while it was a step and for a future gate
-    // that reports its start.
-    expect(canTransition('submitted', 'gating')).toBe(true);
     // But not a shortcut past the moderation boundary.
     expect(canTransition('submitted', 'published')).toBe(false);
     expect(canTransition('submitted', 'publishing')).toBe(false);
@@ -208,7 +204,7 @@ describe('reconcileAgentObservation', () => {
   it('ignores agent lifecycle once the work has been delivered', () => {
     // A session reporting failure after a successful upload must not snatch the
     // candidate back from the gate or the reviewer.
-    for (const state of ['submitted', 'gating', 'ready_for_review', 'publishing'] as JobState[]) {
+    for (const state of ['submitted', 'ready_for_review', 'publishing'] as JobState[]) {
       expect(reconcileAgentObservation(state, { state: 'failed', hasCandidate: true })).toBeNull();
       expect(reconcileAgentObservation(state, { state: 'completed', hasCandidate: true })).toBeNull();
     }
@@ -246,10 +242,9 @@ describe('planObservedStatusTransition', () => {
   });
 
   it('does not erase a richer internal state that projects to the same public status', () => {
-    // `submitted`/`gating` both read as `building` to creators — a derived-status
-    // poll must not yank the delivery back to `building` on that lossy match.
+    // `submitted` reads as `building` to creators — a derived-status poll must not
+    // yank the delivery back to `building` on that lossy match.
     expect(planObservedStatusTransition('submitted', 'building', AT)).toBeNull();
-    expect(planObservedStatusTransition('gating', 'building', AT)).toBeNull();
     expect(planObservedStatusTransition('failed', 'needs_changes', AT)).toBeNull();
     expect(planObservedStatusTransition('dispatched', 'queued', AT)).toBeNull();
   });

--- a/apps/api/src/creation/job-state.ts
+++ b/apps/api/src/creation/job-state.ts
@@ -64,8 +64,7 @@ const ALLOWED_TRANSITIONS: Readonly<Record<JobState, readonly JobState[]>> = {
   // `building` here — `toSubmissionStatus(submitted)` is already `building`, and
   // allowing that edge lets the lossy derived-status reconciler yank a delivery back
   // to `building` on every sweep.
-  submitted: ['gating', 'ready_for_review', 'needs_changes', 'failed', 'canceled', 'abandoned', 'dispatched', 'queued'],
-  gating: ['ready_for_review', 'needs_changes', 'failed', 'canceled', 'abandoned', 'dispatched', 'queued'],
+  submitted: ['ready_for_review', 'needs_changes', 'failed', 'canceled', 'abandoned', 'dispatched', 'queued'],
   // `building` (and the queue/dispatch that precede a fresh round) let a creator or
   // their agent continue iterating after a green gate without waiting on publish —
   // Studio feedback and MCP `continue_draft` both land here. Reviewer reject still
@@ -185,7 +184,6 @@ export function toSubmissionStatus(state: JobState): SubmissionStatus {
       return 'queued';
     case 'building':
     case 'submitted':
-    case 'gating':
       return 'building';
     case 'ready_for_review':
       return 'in_review';
@@ -353,7 +351,7 @@ export function reconcileAgentObservation(current: JobState, observation: AgentO
   // Once the work has been delivered, the agent's own lifecycle stops being interesting:
   // the gate and the reviewer own what happens next, and an agent session reporting
   // `completed` (or even `failed`) after a successful upload must not disturb them.
-  const pastAgent: readonly JobState[] = ['submitted', 'gating', 'ready_for_review', 'publishing'];
+  const pastAgent: readonly JobState[] = ['submitted', 'ready_for_review', 'publishing'];
   if (pastAgent.includes(current)) return null;
 
   const next = ((): ReconcileResult | null => {

--- a/apps/api/src/delivery/gate-crash.ts
+++ b/apps/api/src/delivery/gate-crash.ts
@@ -122,7 +122,7 @@ export function createGateCrashProbe(
 ): (record: SubmissionRecord) => Promise<JobTransition | null> {
   return async (record: SubmissionRecord): Promise<JobTransition | null> => {
     const state = record.state ?? 'submitted';
-    if (state !== 'submitted' && state !== 'gating') return null;
+    if (state !== 'submitted') return null;
     if (!record.slug) return null;
 
     const since = Date.parse(record.stateSince ?? record.createdAt ?? '');

--- a/apps/api/src/platform/sweep-scope.test.ts
+++ b/apps/api/src/platform/sweep-scope.test.ts
@@ -6,7 +6,7 @@ describe('isSweepActive', () => {
   it('keeps reaching a delivery the gate still owes a verdict on', () => {
     // An earlier red gate hid later crashed deliveries from the sweep.
     expect(isSweepActive({ lastNotifiedStatus: 'needs_changes', state: 'submitted' })).toBe(true);
-    expect(isSweepActive({ lastNotifiedStatus: 'needs_changes', state: 'gating' })).toBe(true);
+    expect(isSweepActive({ lastNotifiedStatus: 'needs_changes', state: 'submitted' })).toBe(true);
   });
 
   it('does not let gate_crashed disarm the detector that wrote it', () => {

--- a/apps/api/src/platform/sweep-scope.ts
+++ b/apps/api/src/platform/sweep-scope.ts
@@ -13,6 +13,6 @@ export function isSweepActive(record: SweepScopeRecord): boolean {
   if (record.abandonedAt) return false;
   if (record.lastNotifiedStatus === 'published') return false;
   // The gate owes a verdict, so the sweep must reach it.
-  if (record.state === 'submitted' || record.state === 'gating') return true;
+  if (record.state === 'submitted') return true;
   return record.lastNotifiedStatus !== 'needs_changes';
 }

--- a/apps/api/src/store/gating-normalize.test.ts
+++ b/apps/api/src/store/gating-normalize.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import { FirestoreStore } from '../platform/store.js';
+import { fakeFirestore } from './fake-firestore.js';
+
+// Regression coverage for the legacy-'gating' normalization.
+
+// Added when that state was removed from JobState (item 4).
+
+describe('FirestoreStore / legacy gating normalization', () => {
+  it('reads a stored legacy gating record as submitted', async () => {
+    const { db } = fakeFirestore();
+    const store = new FirestoreStore(db);
+    await db.collection('submissions').doc('7').set({
+      issueNumber: 7,
+      createdAt: '2026-01-01T00:00:00Z',
+      state: 'gating',
+    });
+
+    const record = await store.getSubmission(7);
+
+    expect(record?.state).toBe('submitted');
+  });
+
+  it('does not throw when the document is gone by the time it is read', async () => {
+    const { db } = fakeFirestore();
+    const store = new FirestoreStore(db);
+
+    // No document written for this id: the account-deletion race that flagged this.
+    await expect(store.setSubmissionPublishedAt(99, '2026-01-01T00:00:00Z')).resolves.toBeUndefined();
+  });
+});

--- a/apps/api/src/store/records/submission.test.ts
+++ b/apps/api/src/store/records/submission.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import { fromStoredSubmission } from './submission.js';
+
+// A record written before `gating` was removed can still hold it.
+
+describe('fromStoredSubmission', () => {
+  it('reads a legacy gating record as submitted', () => {
+    const record = fromStoredSubmission({ issueNumber: 7, createdAt: '2026-01-01T00:00:00Z', state: 'gating' });
+
+    // Not a cosmetic rename: toSubmissionStatus is exhaustive with no default.
+
+    // An unmapped state would answer undefined on the status route.
+    expect(record.state).toBe('submitted');
+  });
+
+  it('leaves every other state alone', () => {
+    for (const state of ['queued', 'building', 'submitted', 'published', 'failed'] as const) {
+      expect(fromStoredSubmission({ issueNumber: 1, createdAt: '2026-01-01T00:00:00Z', state }).state).toBe(state);
+    }
+  });
+
+  it('passes a record with no state through untouched', () => {
+    const stored = { issueNumber: 3, createdAt: '2026-01-01T00:00:00Z' };
+
+    expect(fromStoredSubmission(stored)).toEqual(stored);
+  });
+
+  it('copies rather than mutating the stored object when it rewrites', () => {
+    const stored = { issueNumber: 9, createdAt: '2026-01-01T00:00:00Z', state: 'gating' };
+    const record = fromStoredSubmission(stored);
+
+    expect(record).not.toBe(stored);
+    expect(stored.state).toBe('gating');
+  });
+});

--- a/apps/api/src/store/records/submission.ts
+++ b/apps/api/src/store/records/submission.ts
@@ -270,3 +270,12 @@ export interface SubmissionRecord {
   // True when `spec` is a machine-assembled brief, not creator words.
   specIsSystemGenerated?: boolean;
 }
+
+// A record stored before `gating` was retired can carry it.
+
+// Nothing entered it deliberately, so `submitted` is where such a job sat.
+export function fromStoredSubmission(data: unknown): SubmissionRecord {
+  const record = data as SubmissionRecord;
+  const stored: string | undefined = record.state;
+  return stored === 'gating' ? { ...record, state: 'submitted' } : record;
+}

--- a/apps/api/src/store/records/submission.ts
+++ b/apps/api/src/store/records/submission.ts
@@ -276,6 +276,9 @@ export interface SubmissionRecord {
 // Nothing entered it deliberately, so `submitted` is where such a job sat.
 export function fromStoredSubmission(data: unknown): SubmissionRecord {
   const record = data as SubmissionRecord;
+  // `gating` no longer typechecks as a JobState.
+
+  // A record written before it was removed can still hold the string.
   const stored: string | undefined = record.state;
   return stored === 'gating' ? { ...record, state: 'submitted' } : record;
 }

--- a/apps/api/src/store/slices/submission-queries.ts
+++ b/apps/api/src/store/slices/submission-queries.ts
@@ -1,6 +1,6 @@
 import type { Firestore } from '@google-cloud/firestore';
 import { isSweepActive } from '../../platform/sweep-scope.js';
-import type { SubmissionRecord } from '../records/submission.js';
+import { fromStoredSubmission, type SubmissionRecord } from '../records/submission.js';
 
 export interface SubmissionQueryStore {
   // Most recently published submissions, newest first -- the build-time sample.
@@ -103,7 +103,7 @@ export class FirestoreSubmissionQueryStore implements SubmissionQueryStore {
   async listRecentlyPublished(limit: number): Promise<SubmissionRecord[]> {
     // Auto-indexed single-field orderBy; docs without publishedAt are excluded by definition.
     const snap = await this.db.collection('submissions').orderBy('publishedAt', 'desc').limit(limit).get();
-    return snap.docs.map((d) => d.data() as SubmissionRecord);
+    return snap.docs.map((d) => fromStoredSubmission(d.data()));
   }
 
   async getSubmissionBySlug(slug: string): Promise<SubmissionRecord | null> {
@@ -114,14 +114,14 @@ export class FirestoreSubmissionQueryStore implements SubmissionQueryStore {
   async listSubmissionsBySlug(slug: string): Promise<SubmissionRecord[]> {
     // Equality-only query, no composite index needed; bounded by jobs per game.
     const snap = await this.db.collection('submissions').where('slug', '==', slug).get();
-    return snap.docs.map((d) => d.data() as SubmissionRecord).sort((a, b) => b.createdAt.localeCompare(a.createdAt));
+    return snap.docs.map((d) => fromStoredSubmission(d.data())).sort((a, b) => b.createdAt.localeCompare(a.createdAt));
   }
 
   async getPublishedSubmissionBySlug(slug: string): Promise<SubmissionRecord | null> {
     // Same query, filtered in memory to avoid a composite index.
     const snap = await this.db.collection('submissions').where('slug', '==', slug).get();
     const records = snap.docs
-      .map((d) => d.data() as SubmissionRecord)
+      .map((d) => fromStoredSubmission(d.data()))
       .filter((record) => record.publishedAt && !record.abandonedAt);
     records.sort((a, b) => b.createdAt.localeCompare(a.createdAt));
     return records[0] ?? null;
@@ -130,14 +130,14 @@ export class FirestoreSubmissionQueryStore implements SubmissionQueryStore {
   async listActiveSubmissions(): Promise<SubmissionRecord[]> {
     // 'in' would need a composite index and miss unset lastNotifiedStatus docs.
     const snap = await this.db.collection('submissions').get();
-    return snap.docs.map((d) => d.data() as SubmissionRecord).filter(isSweepActive);
+    return snap.docs.map((d) => fromStoredSubmission(d.data())).filter(isSweepActive);
   }
 
   async listSubmissionsMissingSlug(): Promise<SubmissionRecord[]> {
     // Firestore can't query for an absent field -- a small full scan.
     const snap = await this.db.collection('submissions').get();
     return snap.docs
-      .map((d) => d.data() as SubmissionRecord)
+      .map((d) => fromStoredSubmission(d.data()))
       .filter((s) => !s.slug && !s.abandonedAt)
       .sort((a, b) => a.createdAt.localeCompare(b.createdAt));
   }
@@ -145,7 +145,7 @@ export class FirestoreSubmissionQueryStore implements SubmissionQueryStore {
   async listSubmissionsWithDelivery(): Promise<SubmissionRecord[]> {
     const snap = await this.db.collection('submissions').get();
     return snap.docs
-      .map((d) => d.data() as SubmissionRecord)
+      .map((d) => fromStoredSubmission(d.data()))
       .filter((s) => Boolean(s.slug && s.deliveredVersion) && !s.abandonedAt)
       .sort((a, b) => a.createdAt.localeCompare(b.createdAt));
   }
@@ -154,13 +154,13 @@ export class FirestoreSubmissionQueryStore implements SubmissionQueryStore {
     // Equality-only, no orderBy -- no composite index; sorted here instead.
     const snap = await this.db.collection('submissions').where('ownerUid', '==', ownerUid).get();
     const sorted = snap.docs
-      .map((d) => d.data() as SubmissionRecord)
+      .map((d) => fromStoredSubmission(d.data()))
       .sort((a, b) => b.createdAt.localeCompare(a.createdAt));
     return opts?.limit !== undefined ? sorted.slice(0, opts.limit) : sorted;
   }
 
   async listQueuedSubmissions(): Promise<SubmissionRecord[]> {
     const snap = await this.db.collection('submissions').where('state', '==', 'queued').get();
-    return snap.docs.map((d) => d.data() as SubmissionRecord).sort((a, b) => a.createdAt.localeCompare(b.createdAt));
+    return snap.docs.map((d) => fromStoredSubmission(d.data())).sort((a, b) => a.createdAt.localeCompare(b.createdAt));
   }
 }

--- a/apps/api/src/store/slices/submission.ts
+++ b/apps/api/src/store/slices/submission.ts
@@ -1,6 +1,6 @@
 import { FieldValue, type Firestore } from '@google-cloud/firestore';
 import type { SubmissionStatus } from '../../platform/submission-status.js';
-import type { SubmissionRecord } from '../records/submission.js';
+import { fromStoredSubmission, type SubmissionRecord } from '../records/submission.js';
 
 export interface SubmissionStore {
   createSubmission(issueNumber: number, ownerUid: string, title: string): Promise<SubmissionRecord>;
@@ -179,7 +179,7 @@ export class FirestoreSubmissionStore implements SubmissionStore {
   async getSubmission(issueNumber: number): Promise<SubmissionRecord | null> {
     const snap = await this.ref(issueNumber).get();
     if (!snap.exists) return null;
-    return snap.data() as SubmissionRecord;
+    return fromStoredSubmission(snap.data());
   }
 
   async setSubmissionNotifiedStatus(issueNumber: number, status: SubmissionStatus): Promise<void> {
@@ -213,7 +213,7 @@ export class FirestoreSubmissionStore implements SubmissionStore {
     return this.db.runTransaction(async (tx) => {
       const snap = await tx.get(ref);
       if (!snap.exists) return 0;
-      const nudges = ((snap.data() as SubmissionRecord).deliveryNudges ?? 0) + 1;
+      const nudges = (fromStoredSubmission(snap.data()).deliveryNudges ?? 0) + 1;
       tx.set(ref, { deliveryNudges: nudges }, { merge: true });
       return nudges;
     });
@@ -223,7 +223,7 @@ export class FirestoreSubmissionStore implements SubmissionStore {
     const ref = this.ref(issueNumber);
     const snap = await ref.get();
     // First observation wins: a later re-derivation must not move the timestamp.
-    if ((snap.data() as SubmissionRecord | undefined)?.publishedAt) return;
+    if (fromStoredSubmission(snap.data())?.publishedAt) return;
     await ref.set({ publishedAt: at }, { merge: true });
   }
 

--- a/apps/api/src/store/slices/submission.ts
+++ b/apps/api/src/store/slices/submission.ts
@@ -223,7 +223,7 @@ export class FirestoreSubmissionStore implements SubmissionStore {
     const ref = this.ref(issueNumber);
     const snap = await ref.get();
     // First observation wins: a later re-derivation must not move the timestamp.
-    if (fromStoredSubmission(snap.data())?.publishedAt) return;
+    if (snap.exists && fromStoredSubmission(snap.data()).publishedAt) return;
     await ref.set({ publishedAt: at }, { merge: true });
   }
 

--- a/apps/web/src/AdminJobsPanel.tsx
+++ b/apps/web/src/AdminJobsPanel.tsx
@@ -443,15 +443,7 @@ export function AdminJobsPanel() {
     for (const list of gameGroups.values()) {
       if (list.some((j) => j.state === 'ready_for_review')) readyGames++;
       if (list.some((j) => j.stall !== null)) stalledCount++;
-      if (
-        list.some(
-          (j) =>
-            j.state === 'building' ||
-            j.state === 'dispatched' ||
-            j.state === 'queued' ||
-            j.state === 'gating',
-        )
-      ) {
+      if (list.some((j) => j.state === 'building' || j.state === 'dispatched' || j.state === 'queued')) {
         inFlightCount++;
       }
     }
@@ -486,13 +478,7 @@ export function AdminJobsPanel() {
           for (const j of stalledJobs) results.push({ job: j, supersededCount: 0 });
         }
       } else if (filter === 'in_flight') {
-        const inFlight = list.filter(
-          (j) =>
-            j.state === 'building' ||
-            j.state === 'dispatched' ||
-            j.state === 'queued' ||
-            j.state === 'gating',
-        );
+        const inFlight = list.filter((j) => j.state === 'building' || j.state === 'dispatched' || j.state === 'queued');
         if (inFlight.length === 0) continue;
         if (latestOnly) {
           results.push({ job: inFlight[0], supersededCount: list.length - 1 });
@@ -624,18 +610,13 @@ export function AdminJobsPanel() {
     [load],
   );
 
-  const selectedEntries = useMemo(
-    () => jobs.filter((j) => selectedIssues.has(j.issueNumber)),
-    [jobs, selectedIssues],
-  );
+  const selectedEntries = useMemo(() => jobs.filter((j) => selectedIssues.has(j.issueNumber)), [jobs, selectedIssues]);
 
   if (state === 'forbidden') return <p className="health-empty">Not found.</p>;
   if (state === 'loading') return <p className="health-empty">Reading the queue…</p>;
   if (state === 'error') return <p className="health-empty">Could not read the queue.</p>;
 
-  const readyJobsToPublish = filteredItems
-    .map(({ job }) => job)
-    .filter((j) => j.state === 'ready_for_review');
+  const readyJobsToPublish = filteredItems.map(({ job }) => job).filter((j) => j.state === 'ready_for_review');
 
   return (
     <section className="admin-jobs">
@@ -694,20 +675,12 @@ export function AdminJobsPanel() {
           />
 
           <label className="admin-jobs-group-toggle" title="Show only the latest valid version per game">
-            <input
-              type="checkbox"
-              checked={latestOnly}
-              onChange={(e) => setLatestOnly(e.target.checked)}
-            />
+            <input type="checkbox" checked={latestOnly} onChange={(e) => setLatestOnly(e.target.checked)} />
             Latest only
           </label>
 
           <label className="admin-jobs-group-toggle">
-            <input
-              type="checkbox"
-              checked={groupByGame}
-              onChange={(e) => setGroupByGame(e.target.checked)}
-            />
+            <input type="checkbox" checked={groupByGame} onChange={(e) => setGroupByGame(e.target.checked)} />
             Group by game
           </label>
         </div>
@@ -721,11 +694,7 @@ export function AdminJobsPanel() {
               : `Batch completed: ${batchProgress.success} succeeded, ${batchProgress.failed} failed.`}
           </div>
           {!batchProgress.running && (
-            <button
-              type="button"
-              className="admin-batch-dismiss"
-              onClick={() => setBatchProgress(null)}
-            >
+            <button type="button" className="admin-batch-dismiss" onClick={() => setBatchProgress(null)}>
               Dismiss
             </button>
           )}
@@ -754,11 +723,7 @@ export function AdminJobsPanel() {
             >
               Cancel selected ({selectedEntries.length})
             </button>
-            <button
-              type="button"
-              className="admin-job-cancel"
-              onClick={() => setSelectedIssues(new Set())}
-            >
+            <button type="button" className="admin-job-cancel" onClick={() => setSelectedIssues(new Set())}>
               Clear selection
             </button>
           </div>
@@ -813,9 +778,7 @@ export function AdminJobsPanel() {
                               <span className="admin-job-group-title">{grp.title}</span>
                               <span className="admin-job-group-badge">{grp.jobs.length} builds</span>
                               {grp.readyCount > 0 && (
-                                <span className="admin-job-group-ready-badge">
-                                  {grp.readyCount} ready to publish
-                                </span>
+                                <span className="admin-job-group-ready-badge">{grp.readyCount} ready to publish</span>
                               )}
                             </button>
                             <div className="admin-job-group-actions">

--- a/apps/web/src/StudioConnectWizard.tsx
+++ b/apps/web/src/StudioConnectWizard.tsx
@@ -39,10 +39,9 @@ function copyInputFromStatus(status: SubmissionStatus | null): SelfBuildCopyInpu
   };
 }
 
-// The round left the agent's hands: delivered, gating, or finished.
+// The round left the agent's hands: delivered or finished.
 const PAST_CONNECT_PHASES: ReadonlySet<string> = new Set([
   'submitted',
-  'gating',
   'ready_for_review',
   'publishing',
   'published',

--- a/apps/web/src/StudioStageCard.tsx
+++ b/apps/web/src/StudioStageCard.tsx
@@ -17,7 +17,7 @@ export function StudioStageCard({ status }: { status?: SubmissionStatus | null }
   // Gate's own timestamp beats a stale pre-delivery agent line.
   const heartbeatAt = gate ? Date.parse(gate.at) || latestAgentActivityAt(status) : latestAgentActivityAt(status);
   // Not ended while the gate still owes a verdict.
-  const awaitingGate = status?.phase === 'submitted' || status?.phase === 'gating';
+  const awaitingGate = status?.phase === 'submitted';
   const ended = !awaitingGate && (status?.stall === 'ended' || Boolean(status?.agentEndedAt));
   const working = gate
     ? {

--- a/apps/web/src/buildLive.ts
+++ b/apps/web/src/buildLive.ts
@@ -5,7 +5,7 @@ const CURRENTLY_MOVING_STATUSES = new Set<SubmissionStatus['status']>(['building
 // The gate owning a delivery outranks an agent stall.
 export function isBuildLive(status: SubmissionStatus): boolean {
   if (status.gateProgress) return true;
-  if (status.phase === 'submitted' || status.phase === 'gating') return true;
+  if (status.phase === 'submitted') return true;
   if (status.stall) return false;
   return CURRENTLY_MOVING_STATUSES.has(status.status);
 }

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -993,7 +993,6 @@
     "phases": {
       "dispatched": "The platform agent has been assigned and is starting up. The first update can take a few minutes while the coding session boots — no need to refresh.",
       "submitted": "The agent delivered your game. We're checking it over now.",
-      "gating": "Automated checks are making sure your game actually runs clean.",
       "ready_for_review": "Your game passed every check. It's waiting for the last look before going live."
     },
     "gateProgress": {

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -993,6 +993,7 @@
     "phases": {
       "dispatched": "The platform agent has been assigned and is starting up. The first update can take a few minutes while the coding session boots — no need to refresh.",
       "submitted": "The agent delivered your game. We're checking it over now.",
+      "gating": "Automated checks are making sure your game actually runs clean.",
       "ready_for_review": "Your game passed every check. It's waiting for the last look before going live."
     },
     "gateProgress": {

--- a/apps/web/src/i18n/locales/pl.json
+++ b/apps/web/src/i18n/locales/pl.json
@@ -1003,6 +1003,7 @@
     "phases": {
       "dispatched": "Agent platformy dostał zadanie i właśnie się uruchamia. Pierwsza aktualizacja może zająć kilka minut, zanim sesja wstanie — nie musisz odświeżać.",
       "submitted": "Agent dostarczył Twoją grę. Właśnie ją sprawdzamy.",
+      "gating": "Automatyczne testy sprawdzają, czy gra działa bez zarzutu.",
       "ready_for_review": "Twoja gra przeszła wszystkie testy. Czeka na ostatnie spojrzenie przed publikacją."
     },
     "gateProgress": {

--- a/apps/web/src/i18n/locales/pl.json
+++ b/apps/web/src/i18n/locales/pl.json
@@ -1003,7 +1003,6 @@
     "phases": {
       "dispatched": "Agent platformy dostał zadanie i właśnie się uruchamia. Pierwsza aktualizacja może zająć kilka minut, zanim sesja wstanie — nie musisz odświeżać.",
       "submitted": "Agent dostarczył Twoją grę. Właśnie ją sprawdzamy.",
-      "gating": "Automatyczne testy sprawdzają, czy gra działa bez zarzutu.",
       "ready_for_review": "Twoja gra przeszła wszystkie testy. Czeka na ostatnie spojrzenie przed publikacją."
     },
     "gateProgress": {

--- a/apps/web/src/welcomeProgress.ts
+++ b/apps/web/src/welcomeProgress.ts
@@ -23,9 +23,6 @@ export function welcomeProgressMessage(status: SubmissionStatus | null, translat
   if (status.phase === 'submitted') {
     return translate('statusView.phases.submitted');
   }
-  if (status.phase === 'gating') {
-    return translate('statusView.phases.gating');
-  }
   if (status.phase === 'ready_for_review') {
     return translate('statusView.phases.ready_for_review');
   }

--- a/eslint-rules/comment-prose-baseline.json
+++ b/eslint-rules/comment-prose-baseline.json
@@ -314,6 +314,7 @@
     "apps/api/src/store/fake-firestore.ts": 328,
     "apps/api/src/store/firestore-util.ts": 163,
     "apps/api/src/store/firestore.ts": 145,
+    "apps/api/src/store/gating-normalize.test.ts": 13,
     "apps/api/src/store/in-memory.ts": 40,
     "apps/api/src/store/records/access-tokens.ts": 204,
     "apps/api/src/store/records/agent-keys.ts": 169,

--- a/packages/contract/src/job-state.test.ts
+++ b/packages/contract/src/job-state.test.ts
@@ -2,13 +2,12 @@ import { describe, expect, it } from 'vitest';
 import { JOB_STALL_VALUES, JOB_STATES } from './job-state.js';
 
 describe('JOB_STATES', () => {
-  it('lists the twelve states the API and web both derive', () => {
+  it('lists the eleven states the API and web both derive', () => {
     expect(JOB_STATES).toEqual([
       'queued',
       'dispatched',
       'building',
       'submitted',
-      'gating',
       'ready_for_review',
       'publishing',
       'published',

--- a/packages/contract/src/job-state.ts
+++ b/packages/contract/src/job-state.ts
@@ -8,8 +8,6 @@ export const JOB_STATES = [
   'building',
   // Agent delivered candidate sources; nothing has verified them yet.
   'submitted',
-  // Our gate runs against delivered sources; never actually observed here.
-  'gating',
   // Gate green; waiting on the human moderation review.
   'ready_for_review',
   // Approved; the snapshot bake is in flight.


### PR DESCRIPTION
Item 4 of the north-star plan.

## Why it was safe to remove

`gating` was `JobState`'s one unreachable value, and the codebase already said so before this PR — a comment on the union itself: *"Our gate runs against delivered sources; never actually observed here."* Another, on the transition table, records the incident that taught this: when `gating` was `submitted`'s only exit, a delivered job's reconciler computed the right target (`ready_for_review` / `needs_changes`), `canTransition` refused it because nothing had ever transitioned *into* `gating`, and the job sat showing "delivered, gate never started" for as long as the creator kept the page open.

The mechanism: the gate reports by writing its verdict straight to the version manifest, which is read on a poll — so a delivered job goes from `submitted` to its outcome without ever being seen mid-gate. `submitted → gating` was the only entry in `ALLOWED_TRANSITIONS`, and nothing wrote it.

## What moved

Removed from `JOB_STATES` (contract package) and every switch, comparison, and transition list that named it — 8 sites in `apps/api`, 5 in `apps/web`. Each was found by `tsc`, not by eye: removing the union member first and fixing exactly the errors it named.

Two matches for the word are deliberately untouched, because they are different vocabularies:

* `community/proposal-state.ts` — `ProposalState` has its own separate `gating`, for proposal review, unrelated to job state.
* `agent-surface/mcp-ui-round-status.html` — a display label the round-status card computes from `gate.deliveryId` ("a delivery in flight reads as gating"), not a read of the job record.

## The one real risk, and how it's covered

`toSubmissionStatus` is an exhaustive switch with no default, and nothing validates a stored record's `state` on read. So a Firestore document written while `gating` still existed — however implausible, given the above — would fall through the switch and answer `undefined` on the status route.

`fromStoredSubmission` (`store/records/submission.ts`) normalizes a legacy `'gating'` to `'submitted'` at every materialization point in the submission store slices — 3 in `submission.ts`, 8 in `submission-queries.ts`, all Firestore reads, confirmed with `grep` before and after. Six tests pin it now: the rewrite itself, that every other state passes through untouched, that a record with no `state` at all is untouched, that the input object isn't mutated, and — added after review — the same rewrite exercised against a real `FirestoreStore` via `fakeFirestore()`, plus a regression test for a document gone by read time (the account-deletion race described below).

## Review round

Codex found three real issues on the first pass, all fixed:

* `packages/contract` has its own test pinning `JOB_STATES`' full membership, which I hadn't run (only `apps/api` and `apps/web`). Updated to the eleven-state list.
* The web locale key `statusView.phases.gating` has a second, live reader I'd missed: `SubmissionStatusView.tsx` and `StudioStageCard.tsx` both use it to label a *running* gate, keyed off `gateProgress`/`gate.stage` — unrelated to the dead `phase === 'gating'` comparisons. Restored in both locales.
* `fromStoredSubmission` crashed on an `undefined` snapshot — a document gone by read time, e.g. an account-deletion race. Rather than widen the function's return type (which `tsc` showed would force every safe `QueryDocumentSnapshot` call site in `submission-queries.ts` to handle a case that can't occur there), the fix guards the one call site that actually lacked the `snap.exists` check its two siblings already had.

## Verification

`tsc` clean on both workspaces, and on the `packages/contract` build. Eight existing tests asserted the old vocabulary directly — including the one written to document the original incident — and are updated to assert the current transitions rather than deleted; none is weaker than before. API suite 229 files / 3563 tests green (6 new). Web suite 200 files / 1752 tests green. Contract package 42 files / 100 tests green. `npm run lint` exits 0.