### PR TITLE
fix(catalog): match gfx3d vertical entry in games-repo contract

### DIFF
--- a/apps/api/src/catalog/games-repo-contract-check.test.ts
+++ b/apps/api/src/catalog/games-repo-contract-check.test.ts
@@ -201,7 +201,7 @@ describe('runGamesRepoContractCheck', () => {
     // the bake looked for shared/modules/vehicles.ts and reported the game as missing.
     const assembleWithNewVertical = ASSEMBLE_SOURCE.replace(
       "urban: 'shared/verticals/urban/index.ts',",
-      "urban: 'shared/verticals/urban/index.ts',\n    gfx3d: 'shared/verticals/gfx3d/index.ts',",
+      "urban: 'shared/verticals/urban/index.ts',\n    actors: 'shared/verticals/actors/index.ts',",
     );
     const { fetchImpl } = createFetch({
       ...agreeingPages(),
@@ -211,7 +211,7 @@ describe('runGamesRepoContractCheck', () => {
     const outcome = await runGamesRepoContractCheck({ ...BASE, fetchImpl });
     expect(outcome.kind).toBe('drift');
     expect(outcome.kind === 'drift' && outcome.reason).toContain('GAME_KIT_VERTICALS mismatch');
-    expect(outcome.kind === 'drift' && outcome.reason).toContain('shared/modules/gfx3d.ts');
+    expect(outcome.kind === 'drift' && outcome.reason).toContain('shared/modules/actors.ts');
   });
 
   it('reports drift when a shared vertical resolves to a different entry path', async () => {

--- a/apps/api/src/platform/games-repo-contract.test.ts
+++ b/apps/api/src/platform/games-repo-contract.test.ts
@@ -246,15 +246,14 @@ describe('games-repo source extractors', () => {
   });
 
   it('reads GAME_KIT_VERTICALS from an assemble.ts-shaped source', () => {
-    const source = `
-      const GAME_KIT_VERTICALS = Object.freeze({
-        vehicles: 'shared/verticals/vehicles/index.ts',
-        urban: 'shared/verticals/urban/index.ts',
-        racing: 'shared/verticals/racing/index.ts',
-        football: 'shared/verticals/football/index.ts',
-        platformer: 'shared/verticals/platformer/index.ts',
-      });
-    `;
+    const source = `const GAME_KIT_VERTICALS = Object.freeze({
+      gfx3d: 'shared/modules/gfx3d/index.ts',
+      vehicles: 'shared/verticals/vehicles/index.ts',
+      urban: 'shared/verticals/urban/index.ts',
+      racing: 'shared/verticals/racing/index.ts',
+      football: 'shared/verticals/football/index.ts',
+      platformer: 'shared/verticals/platformer/index.ts',
+    });`;
     expect(extractGameKitVerticals(source)).toEqual(GAME_KIT_VERTICAL_ENTRIES);
   });
 
@@ -265,12 +264,12 @@ describe('games-repo source extractors', () => {
     );
   });
 
-  it('resolves every vertical to a games-repo path, never to shared/modules', () => {
+  it('resolves every vertical to a games-repo path, never to shared/modules root', () => {
     // The regression behind the failed nightly bake: `vehicles` was a name both sides
     // knew, but only the games repo knew it had moved out of shared/modules.
     for (const [name, entry] of Object.entries(GAME_KIT_VERTICAL_ENTRIES)) {
       expect(GAME_KIT_MODULES).toContain(name);
-      expect(entry).toBe(`shared/verticals/${name}/index.ts`);
+      expect(entry).toMatch(/^shared\/(verticals|modules)\/[a-z0-9-]+\/index\.ts$/);
     }
   });
 

--- a/apps/api/src/platform/games-repo-contract.ts
+++ b/apps/api/src/platform/games-repo-contract.ts
@@ -201,6 +201,7 @@ export const MUSIC_CONTRACT = {
  * the nightly bake had to be the thing that noticed.
  */
 export const GAME_KIT_VERTICAL_ENTRIES: Partial<Record<GameKitModuleName, string>> = {
+  gfx3d: 'shared/modules/gfx3d/index.ts',
   vehicles: 'shared/verticals/vehicles/index.ts',
   urban: 'shared/verticals/urban/index.ts',
   racing: 'shared/verticals/racing/index.ts',


### PR DESCRIPTION
Matches the games repo contract where `gfx3d` was moved to `shared/modules/gfx3d/index.ts` and registered in `GAME_KIT_VERTICALS`.