### PR TITLE
Fix stale byte-budget figure in game-asset-generation skill

### DIFF
--- a/.claude/skills/game-asset-generation/SKILL.md
+++ b/.claude/skills/game-asset-generation/SKILL.md
@@ -37,8 +37,12 @@ not left to taste.
    `npm run check:gfx`.
 3. **Never hand-roll `new AudioContext()` or oscillators in game code.** All audio goes
    through the `audio` module (`GameKit.createAudio`). Enforced by validate Checks 9 and 17.
-4. **Byte budget is real.** 200 KiB author budget per game; platform ceiling and serve cap
-   are contract-locked across two repos. Assets are not free.
+4. **Byte budget is real.** ~936 KiB author budget per game (`authorBudgetBytes` in
+   `shared/assemble-contract.json`, mirrored in `tools/validate.ts`'s `GAME_BUDGET_BYTES`),
+   plus a 410 KB platform/GameKit reserve not billed to the author (`GAMEKIT_PLATFORM_BYTES`)
+   — contract-locked across two repos. Assets are not free, but the ceiling is far higher
+   than the old "200 KiB" figure this line used to give; verify against `tools/validate.ts`
+   before assuming a feature won't fit.
 5. **Reference art packs are study-only.** `references/packs/` (CC0 Kenney/itch material)
    must never be shipped into a bundle or inlined as `data:image` — validate Checks 15/16.
 


### PR DESCRIPTION
## Summary

The `game-asset-generation` skill stated a 200 KiB author budget per game. The games
repo's actual contract (`shared/assemble-contract.json`, `tools/validate.ts`) is
`authorBudgetBytes` = 936 KiB, plus a separate 410 KB platform reserve not billed to the
author. The old figure was nearly 5x too low and would wrongly rule out features during
planning — found while scoping an unrelated character-rig proposal in the games repo
(paired context: `gamedevpl/www.gamedev.pl-games#1152`).

## Why a separate PR

This fix was originally committed on `claude/creatorqa-option-images-ol45jg`, a shared
working branch with no PR of its own yet. Split out here as its own isolated,
independently reviewable change.

## Test plan

- [x] Diffed against `gamedevpl/www.gamedev.pl-games`'s `shared/assemble-contract.json`
      and `tools/validate.ts` to confirm the corrected numbers
- Docs-only change, no code affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QE2A4wNt2vBD22o4Ujj1wc)_