### PR TITLE
Add the gamedev CLI client in apps/cli (CL-14..30)

### DIFF
--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -1,0 +1,24 @@
+# gamedev CLI (apps/cli)
+
+Terminal front door for gamedev.pl. **No local model.** Coding happens by delegating to a
+vendor CLI the creator already has, or by the platform builder.
+
+This package lives in the public app monorepo until the owner creates
+`gamedevpl/gamedev-cli` (stop-and-ask). Extracting it should be a rename, not a rewrite.
+
+## Install (once Wave F ships)
+
+```bash
+curl -fsSL https://www.gamedev.pl/install.sh | bash
+```
+
+Until then: `npm run build -w @gamedevpl/cli` and run `node apps/cli/dist/main.js`.
+
+## Verbs
+
+`login` `logout` `whoami` `games` `status` `share` `profile` `handle` `builder`
+`connect` `checkout` `pull` `diff` `submit` `quota` `notifications` `help`
+
+Exit codes: `0` gate green · `1` gate red · `2` refused · `3` auth · `4` input required.
+
+CI: `GAMEDEV_TOKEN` from secrets. Never pass the creator OAuth token to a sub-agent.

--- a/apps/cli/adapters.json
+++ b/apps/cli/adapters.json
@@ -1,0 +1,43 @@
+{
+  "version": 1,
+  "adapters": [
+    {
+      "name": "claude",
+      "command": "claude",
+      "versionFlag": "--version",
+      "headless": ["-p", "--output-format", "stream-json"],
+      "events": { "flag": "--output-format=stream-json", "dialect": "ndjson" },
+      "budget": { "turns": "--max-turns" },
+      "cwd": "game-dir",
+      "exit": { "success": [0], "failure": [1] }
+    },
+    {
+      "name": "codex",
+      "command": "codex",
+      "versionFlag": "--version",
+      "headless": ["exec", "--json"],
+      "events": { "flag": "--json", "dialect": "jsonl" },
+      "cwd": "game-dir",
+      "exit": { "success": [0], "failure": [1] }
+    },
+    {
+      "name": "gemini",
+      "command": "gemini",
+      "versionFlag": "--version",
+      "headless": ["-p"],
+      "events": { "flag": "", "dialect": "ndjson" },
+      "cwd": "game-dir",
+      "exit": { "success": [0], "failure": [1] }
+    },
+    {
+      "name": "vibe",
+      "command": "vibe",
+      "versionFlag": "--version",
+      "headless": ["--prompt"],
+      "events": { "flag": "--output", "dialect": "ndjson" },
+      "budget": { "turns": "--max-turns", "price": "--max-price" },
+      "cwd": "game-dir",
+      "exit": { "success": [0], "failure": [1] }
+    }
+  ]
+}

--- a/apps/cli/docs/ink-spike.md
+++ b/apps/cli/docs/ink-spike.md
@@ -1,0 +1,16 @@
+# Ink spike (CL-16a)
+
+Tried: a compiled single-file binary plus Ink (React for terminals).
+
+**No-go for this tree.** The load-bearing design is the two-region renderer (append-only
+transcript + ≤4-row live region), not the framework. Ink's reconciler, raw-mode stdin,
+and `SIGWINCH` under a Node SEA / bun-compiled binary is the pairing the spike was meant
+to prove; this environment cannot exercise macOS Keychain, Windows ConPTY, and a real
+SEA in one pass.
+
+**Go: custom renderer** in `src/renderer.ts` — same glyphs (`◆` / `›`), `NO_COLOR`
+downgrade, width-aware live truncation, transcript never rewritten. Verbs (CL-30) are the
+same functions the REPL calls, so a pipe never blocks on a prompt.
+
+If Ink is revisited, re-run this spike on darwin-arm64, linux-x64, and Windows Terminal
+before replacing `renderer.ts`.

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@gamedevpl/cli",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "bin": {
+    "gamedev": "./dist/main.js",
+    "git-remote-gamedev": "./dist/git-remote-main.js"
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.json && node scripts/copy-adapters.mjs",
+    "type-check": "tsc -p tsconfig.json --noEmit",
+    "test": "vitest run",
+    "dev": "tsx src/main.ts",
+    "bundle": "node scripts/build-binary.mjs"
+  },
+  "engines": {
+    "node": ">=20.19"
+  },
+  "dependencies": {},
+  "devDependencies": {
+    "@types/node": "^20.14.15",
+    "esbuild": "0.25.12",
+    "tsx": "^4.16.5",
+    "typescript": "^5.5.4",
+    "vitest": "^3.2.7"
+  }
+}

--- a/apps/cli/scripts/build-binary.mjs
+++ b/apps/cli/scripts/build-binary.mjs
@@ -1,0 +1,22 @@
+import { build } from 'esbuild';
+import { chmodSync, mkdirSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = join(dirname(fileURLToPath(import.meta.url)), '..');
+const outDir = join(root, 'dist');
+mkdirSync(outDir, { recursive: true });
+
+await build({
+  entryPoints: [join(root, 'src/main.ts')],
+  bundle: true,
+  platform: 'node',
+  target: 'node20',
+  format: 'esm',
+  outfile: join(outDir, 'gamedev.mjs'),
+  banner: { js: '#!/usr/bin/env node' },
+  packages: 'bundle',
+});
+
+chmodSync(join(outDir, 'gamedev.mjs'), 0o755);
+console.log('bundled dist/gamedev.mjs — platform binaries need bun compile or pkg (see README)');

--- a/apps/cli/scripts/copy-adapters.mjs
+++ b/apps/cli/scripts/copy-adapters.mjs
@@ -1,0 +1,7 @@
+import { copyFileSync, mkdirSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = join(dirname(fileURLToPath(import.meta.url)), '..');
+mkdirSync(join(root, 'dist'), { recursive: true });
+copyFileSync(join(root, 'adapters.json'), join(root, 'dist', 'adapters.json'));

--- a/apps/cli/src/adapters.test.ts
+++ b/apps/cli/src/adapters.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest';
+import { loadAdapters, detectAdapter } from './adapters.js';
+
+describe('adapter registry', () => {
+  it('ships the blessed four as data', () => {
+    const file = loadAdapters({ HOME: '/tmp/does-not-exist-gamedev' });
+    expect(file.adapters.map((row) => row.name).sort()).toEqual(['claude', 'codex', 'gemini', 'vibe']);
+  });
+
+  it('detects only adapters present on PATH', () => {
+    const file = loadAdapters({ HOME: '/tmp/does-not-exist-gamedev' });
+    expect(detectAdapter('claude', () => '/usr/bin/claude', file)?.command).toBe('claude');
+    expect(detectAdapter('claude', () => null, file)).toBeNull();
+  });
+});

--- a/apps/cli/src/adapters.ts
+++ b/apps/cli/src/adapters.ts
@@ -1,0 +1,52 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+export interface AdapterSpec {
+  name: string;
+  command: string;
+  versionFlag: string;
+  headless: string[];
+  events: { flag: string; dialect: 'ndjson' | 'jsonl' };
+  budget?: { turns?: string; price?: string };
+  cwd: 'game-dir' | 'workspace';
+  exit: { success: number[]; failure: number[] };
+}
+
+export interface AdapterFile {
+  version: number;
+  adapters: AdapterSpec[];
+}
+
+function shippedAdaptersPath(): string {
+  const here = dirname(fileURLToPath(import.meta.url));
+  const candidates = [join(here, 'adapters.json'), join(here, '..', 'adapters.json')];
+  const found = candidates.find((path) => existsSync(path));
+  if (!found) throw new Error('adapters.json is missing from the gamedev package');
+  return found;
+}
+
+export function loadAdapters(env: NodeJS.ProcessEnv = process.env): AdapterFile {
+  const shipped = JSON.parse(readFileSync(shippedAdaptersPath(), 'utf8')) as AdapterFile;
+  const customPath = env.GAMEDEV_ADAPTERS ?? join(env.HOME ?? homedir(), '.config', 'gamedev', 'adapters.json');
+  try {
+    const extra = JSON.parse(readFileSync(customPath, 'utf8')) as { adapters?: AdapterSpec[] };
+    if (extra.adapters?.length) {
+      return { version: shipped.version, adapters: [...shipped.adapters, ...extra.adapters] };
+    }
+  } catch {
+    // custom file is optional and unsupported
+  }
+  return shipped;
+}
+
+export function detectAdapter(
+  name: string,
+  which: (cmd: string) => string | null,
+  file = loadAdapters(),
+): AdapterSpec | null {
+  const spec = file.adapters.find((row) => row.name === name);
+  if (!spec) return null;
+  return which(spec.command) ? spec : null;
+}

--- a/apps/cli/src/ansi.test.ts
+++ b/apps/cli/src/ansi.test.ts
@@ -1,0 +1,31 @@
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import { formatAdapterEvent, sanitizeEventPayload } from './ansi.js';
+
+const here = dirname(fileURLToPath(import.meta.url));
+
+describe('sanitizeEventPayload', () => {
+  it('strips CSI, OSC, and forged platform lines into one prefixed inert line', () => {
+    const fixture = readFileSync(join(here, 'fixtures', 'hostile-delegate.ndjson'), 'utf8');
+    const lines = fixture
+      .trim()
+      .split('\n')
+      .map((row) => JSON.parse(row) as { text: string });
+    const rendered = lines.map((row) => formatAdapterEvent('claude', row.text));
+    for (const line of rendered) {
+      expect(line.startsWith('claude ▸ ')).toBe(true);
+      expect(line.includes(String.fromCharCode(27))).toBe(false);
+      expect(line).not.toMatch(/\n/);
+      expect(line.split('\n')).toHaveLength(1);
+    }
+    expect(rendered.some((line) => line.includes('preview green'))).toBe(true);
+    expect(rendered.every((line) => line.startsWith('claude ▸ '))).toBe(true);
+    expect(rendered.join('\n')).not.toMatch(/^✓ preview green$/m);
+  });
+
+  it('bounds length and collapses whitespace', () => {
+    expect(sanitizeEventPayload(`a\n\nb${'x'.repeat(400)}`)).toHaveLength(240);
+  });
+});

--- a/apps/cli/src/ansi.ts
+++ b/apps/cli/src/ansi.ts
@@ -1,0 +1,23 @@
+const ESC = String.fromCharCode(27);
+const BEL = String.fromCharCode(7);
+const CSI_OR_OSC = new RegExp(
+  `(?:${ESC}\\[[0-9;?]*[ -/]*[@-~]|${ESC}\\][^${BEL}${ESC}]*(?:${BEL}|${ESC}\\\\)|${ESC}[@-Z\\\\-_])`,
+  'g',
+);
+const C0_OTHER_THAN_TAB = new RegExp(
+  `[${String.fromCharCode(0)}-${String.fromCharCode(8)}${String.fromCharCode(10)}-${String.fromCharCode(31)}${String.fromCharCode(127)}]`,
+  'g',
+);
+
+export const MAX_EVENT_LINE = 240;
+
+export function sanitizeEventPayload(raw: string): string {
+  const stripped = raw.replace(CSI_OR_OSC, '').replace(C0_OTHER_THAN_TAB, ' ');
+  const oneLine = stripped.replace(/\s+/g, ' ').trim();
+  if (oneLine.length <= MAX_EVENT_LINE) return oneLine;
+  return `${oneLine.slice(0, MAX_EVENT_LINE - 1)}…`;
+}
+
+export function formatAdapterEvent(adapter: string, payload: string): string {
+  return `${adapter} ▸ ${sanitizeEventPayload(payload)}`;
+}

--- a/apps/cli/src/api.ts
+++ b/apps/cli/src/api.ts
@@ -1,0 +1,59 @@
+import { CliError, EXIT_AUTH, EXIT_INPUT, EXIT_REFUSED } from './exit-codes.js';
+import type { StoredTokens, TokenStore } from './keychain.js';
+
+export type FetchLike = (url: string, init?: RequestInit) => Promise<Response>;
+
+export interface ApiClient {
+  origin: string;
+  request<T>(method: string, path: string, body?: unknown): Promise<T>;
+}
+
+export function bearerFrom(tokens: StoredTokens | null, env: NodeJS.ProcessEnv): string | null {
+  const pat = env.GAMEDEV_TOKEN?.trim();
+  if (pat) return pat;
+  return tokens?.accessToken ?? null;
+}
+
+export function createApi(input: {
+  origin: string;
+  store: TokenStore;
+  fetch?: FetchLike;
+  env?: NodeJS.ProcessEnv;
+}): ApiClient {
+  const fetchImpl = input.fetch ?? fetch;
+  const env = input.env ?? process.env;
+  return {
+    origin: input.origin,
+    async request<T>(method: string, path: string, body?: unknown): Promise<T> {
+      const token = bearerFrom(await input.store.get(), env);
+      if (!token) {
+        throw new CliError('not signed in — run `gamedev login`', EXIT_AUTH, 'gamedev login');
+      }
+      const res = await fetchImpl(`${input.origin}${path}`, {
+        method,
+        headers: {
+          authorization: `Bearer ${token}`,
+          ...(body !== undefined ? { 'content-type': 'application/json' } : {}),
+        },
+        ...(body !== undefined ? { body: JSON.stringify(body) } : {}),
+      });
+      if (res.status === 401) {
+        throw new CliError('credential expired or revoked — run `gamedev login`', EXIT_AUTH, 'gamedev login');
+      }
+      if (res.status === 404) {
+        throw new CliError('not found', EXIT_REFUSED);
+      }
+      if (!res.ok) {
+        const err = (await res.json().catch(() => ({}))) as { error?: string };
+        throw new CliError(err.error ?? `request failed (${res.status})`, EXIT_REFUSED);
+      }
+      return (await res.json()) as T;
+    },
+  };
+}
+
+export function requireTtyFlag(isTty: boolean, flag: string, hint: string): void {
+  if (!isTty) {
+    throw new CliError(`this needs a terminal, or pass ${flag}`, EXIT_INPUT, hint);
+  }
+}

--- a/apps/cli/src/argv.test.ts
+++ b/apps/cli/src/argv.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import { completeSlash, parseArgv } from './argv.js';
+import { authorizeUrl, GAMEDEV_CLI_CLIENT_ID } from './oauth.js';
+
+describe('argv and slash completion', () => {
+  it('parses verbs, flags, and json mode', () => {
+    expect(parseArgv(['node', 'gamedev', 'status', 'ghost-roads', '--json', '--watch'])).toEqual({
+      verb: 'status',
+      args: ['ghost-roads'],
+      flags: { json: true, watch: true },
+    });
+    expect(parseArgv(['node', 'gamedev'])).toMatchObject({ verb: 'repl' });
+    expect(completeSlash('/sta')).toEqual(['status']);
+    expect(completeSlash('/')).toContain('games');
+  });
+});
+
+describe('oauth authorize url', () => {
+  it('requests creator scope on the first-party client', () => {
+    const url = authorizeUrl({
+      origin: 'https://www.gamedev.pl',
+      redirectUri: 'http://127.0.0.1:43721/callback',
+      challenge: 'abc',
+      state: 'xyz',
+      device: 'studio-mac',
+    });
+    const parsed = new URL(url);
+    expect(parsed.searchParams.get('client_id')).toBe(GAMEDEV_CLI_CLIENT_ID);
+    expect(parsed.searchParams.get('scope')).toBe('creator');
+    expect(parsed.searchParams.get('code_challenge_method')).toBe('S256');
+  });
+});

--- a/apps/cli/src/argv.ts
+++ b/apps/cli/src/argv.ts
@@ -1,0 +1,62 @@
+export const SLASH_VERBS = [
+  'games',
+  'status',
+  'share',
+  'profile',
+  'handle',
+  'builder',
+  'connect',
+  'checkout',
+  'quota',
+  'notifications',
+  'help',
+  'login',
+  'logout',
+  'whoami',
+  'submit',
+  'pull',
+  'diff',
+  'update',
+] as const;
+
+export type SlashVerb = (typeof SLASH_VERBS)[number];
+
+export function completeSlash(prefix: string): SlashVerb[] {
+  const needle = prefix.replace(/^\//, '').toLowerCase();
+  return SLASH_VERBS.filter((verb) => verb.startsWith(needle));
+}
+
+export function parseArgv(argv: string[]): { verb: string; args: string[]; flags: Record<string, string | boolean> } {
+  const rest = argv.slice(2);
+  const verb = rest[0] && !rest[0].startsWith('-') ? rest[0] : 'repl';
+  const args: string[] = [];
+  const flags: Record<string, string | boolean> = {};
+  const tokens = rest[0] && !rest[0].startsWith('-') ? rest.slice(1) : rest;
+  for (let i = 0; i < tokens.length; i += 1) {
+    const token = tokens[i]!;
+    if (token.startsWith('--')) {
+      const body = token.slice(2);
+      const eq = body.indexOf('=');
+      if (eq >= 0) {
+        flags[body.slice(0, eq)] = body.slice(eq + 1);
+      } else {
+        const next = tokens[i + 1];
+        if (next && !next.startsWith('-')) {
+          flags[body] = next;
+          i += 1;
+        } else {
+          flags[body] = true;
+        }
+      }
+    } else if (token.startsWith('-') && token.length === 2) {
+      flags[token.slice(1)] = true;
+    } else {
+      args.push(token);
+    }
+  }
+  return { verb, args, flags };
+}
+
+export function jsonMode(flags: Record<string, string | boolean>): boolean {
+  return flags.json === true || flags.json === 'true';
+}

--- a/apps/cli/src/checkout.test.ts
+++ b/apps/cli/src/checkout.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { checkoutGame } from './checkout.js';
+import { createApi } from './api.js';
+import { memoryStore } from './keychain.js';
+
+describe('checkout', () => {
+  it('always inits git with a gamedev:// remote', async () => {
+    const dest = mkdtempSync(join(tmpdir(), 'gdpl-co-'));
+    const commands: string[] = [];
+    const result = await checkoutGame({
+      api: createApi({
+        origin: 'https://www.gamedev.pl',
+        store: memoryStore({ accessToken: 't', tokenType: 'Bearer', scope: 'creator' }),
+        fetch: async () => new Response('{}'),
+      }),
+      slug: 'ghost-roads',
+      dest,
+      run: (cmd, args) => {
+        commands.push([cmd, ...args].join(' '));
+      },
+    });
+    expect(result.remote).toBe('gamedev://ghost-roads');
+    expect(commands).toContain('git init');
+    expect(commands).toContain('git remote add origin gamedev://ghost-roads');
+  });
+});

--- a/apps/cli/src/checkout.ts
+++ b/apps/cli/src/checkout.ts
@@ -1,0 +1,29 @@
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { spawnSync } from 'node:child_process';
+import type { ApiClient } from './api.js';
+import { CliError, EXIT_REFUSED } from './exit-codes.js';
+
+export async function checkoutGame(input: {
+  api: ApiClient;
+  slug: string;
+  dest: string;
+  fetchBuffer?: (url: string) => Promise<Buffer>;
+  run?: (cmd: string, args: string[], cwd: string) => void;
+}): Promise<{ dest: string; remote: string }> {
+  const run =
+    input.run ??
+    ((cmd, args, cwd) => {
+      const result = spawnSync(cmd, args, { cwd, encoding: 'utf8' });
+      if (result.status !== 0) throw new CliError(result.stderr || `${cmd} failed`, EXIT_REFUSED);
+    });
+  mkdirSync(input.dest, { recursive: true });
+  writeFileSync(join(input.dest, '.gamedev-slug'), input.slug);
+  run('git', ['init'], input.dest);
+  run('git', ['remote', 'add', 'origin', `gamedev://${input.slug}`], input.dest);
+  return { dest: input.dest, remote: `gamedev://${input.slug}` };
+}
+
+export function unreconciledMessage(): string {
+  return 'working copy is unreconciled with the platform — gamedev pull, or pass --force';
+}

--- a/apps/cli/src/checkout.ts
+++ b/apps/cli/src/checkout.ts
@@ -4,6 +4,11 @@ import { spawnSync } from 'node:child_process';
 import type { ApiClient } from './api.js';
 import { CliError, EXIT_REFUSED } from './exit-codes.js';
 
+function defaultRun(cmd: string, args: string[], cwd: string): void {
+  const result = spawnSync(cmd, args, { cwd, encoding: 'utf8' });
+  if (result.status !== 0) throw new CliError(result.stderr || `${cmd} failed`, EXIT_REFUSED);
+}
+
 export async function checkoutGame(input: {
   api: ApiClient;
   slug: string;
@@ -11,12 +16,7 @@ export async function checkoutGame(input: {
   fetchBuffer?: (url: string) => Promise<Buffer>;
   run?: (cmd: string, args: string[], cwd: string) => void;
 }): Promise<{ dest: string; remote: string }> {
-  const run =
-    input.run ??
-    ((cmd, args, cwd) => {
-      const result = spawnSync(cmd, args, { cwd, encoding: 'utf8' });
-      if (result.status !== 0) throw new CliError(result.stderr || `${cmd} failed`, EXIT_REFUSED);
-    });
+  const run = input.run ?? defaultRun;
   mkdirSync(input.dest, { recursive: true });
   writeFileSync(join(input.dest, '.gamedev-slug'), input.slug);
   run('git', ['init'], input.dest);

--- a/apps/cli/src/choice.test.ts
+++ b/apps/cli/src/choice.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest';
+import { chooseBuilder, costCopy } from './choice.js';
+
+describe('ask-per-task builder choice', () => {
+  it('does not remember a default; flags skip the ask', () => {
+    expect(chooseBuilder({ hasLocal: true, flags: { platform: true } })).toBe('platform');
+    expect(chooseBuilder({ hasLocal: true, flags: { agent: 'claude' } })).toBe('local');
+    expect(chooseBuilder({ hasLocal: false, flags: {} })).toBe('platform');
+    expect(chooseBuilder({ hasLocal: true, flags: {}, ask: () => 'local' })).toBe('local');
+    expect(costCopy('platform')).toContain('quota');
+    expect(costCopy('local', 'claude')).toContain('claude');
+  });
+});

--- a/apps/cli/src/choice.ts
+++ b/apps/cli/src/choice.ts
@@ -1,0 +1,17 @@
+export type BuildChoice = 'platform' | 'local';
+
+export function chooseBuilder(input: {
+  hasLocal: boolean;
+  flags: Record<string, string | boolean>;
+  ask?: () => BuildChoice;
+}): BuildChoice {
+  if (input.flags.platform === true) return 'platform';
+  if (typeof input.flags.agent === 'string' && input.flags.agent) return 'local';
+  if (!input.hasLocal) return 'platform';
+  return input.ask?.() ?? 'platform';
+}
+
+export function costCopy(choice: BuildChoice, adapter?: string): string {
+  if (choice === 'platform') return 'platform builder — counts against your gamedev.pl quota';
+  return `local ${adapter ?? 'agent'} — your subscription; budget via the adapter flags or a wall-clock timeout`;
+}

--- a/apps/cli/src/create.test.ts
+++ b/apps/cli/src/create.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { answersFromFlags } from './create.js';
+import { answerDraft, answersFromFlags, formatQuestion } from './create.js';
 import { EXIT_INPUT } from './exit-codes.js';
 
 describe('create intake', () => {
@@ -15,6 +15,22 @@ describe('create intake', () => {
   it('accepts --answers JSON for non-TTY', () => {
     expect(answersFromFlags({ answers: '{"tone":"calm"}' }, [{ id: 'tone', prompt: 'tone?' }])).toEqual({
       tone: 'calm',
+    });
+  });
+
+  it('advances a refine draft to a submit spec', () => {
+    const draft = {
+      concept: 'robots water plants',
+      title: 'Robot Garden',
+      questions: [{ id: 'tone', prompt: 'What tone?' }],
+      index: 0,
+      answers: {},
+    };
+    expect(formatQuestion(draft)).toContain('What tone?');
+    expect(answerDraft(draft, 'calm')).toEqual({
+      kind: 'ready',
+      title: 'Robot Garden',
+      concept: 'robots water plants\n\nWhat tone?: calm',
     });
   });
 });

--- a/apps/cli/src/create.test.ts
+++ b/apps/cli/src/create.test.ts
@@ -18,6 +18,15 @@ describe('create intake', () => {
     });
   });
 
+  it('maps invalid --answers JSON to EXIT_INPUT', () => {
+    try {
+      answersFromFlags({ answers: '{nope' }, [{ id: 'tone', prompt: 'tone?' }]);
+      throw new Error('expected throw');
+    } catch (error) {
+      expect((error as { exitCode: number }).exitCode).toBe(EXIT_INPUT);
+    }
+  });
+
   it('advances a refine draft to a submit spec', () => {
     const draft = {
       concept: 'robots water plants',

--- a/apps/cli/src/create.test.ts
+++ b/apps/cli/src/create.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+import { answersFromFlags } from './create.js';
+import { EXIT_INPUT } from './exit-codes.js';
+
+describe('create intake', () => {
+  it('refuses refine questions in a pipe without --answers', () => {
+    try {
+      answersFromFlags({}, [{ id: 'tone', prompt: 'tone?' }]);
+      throw new Error('expected throw');
+    } catch (error) {
+      expect((error as { exitCode: number }).exitCode).toBe(EXIT_INPUT);
+    }
+  });
+
+  it('accepts --answers JSON for non-TTY', () => {
+    expect(answersFromFlags({ answers: '{"tone":"calm"}' }, [{ id: 'tone', prompt: 'tone?' }])).toEqual({
+      tone: 'calm',
+    });
+  });
+});

--- a/apps/cli/src/create.ts
+++ b/apps/cli/src/create.ts
@@ -7,18 +7,86 @@ export interface RefineQuestion {
   choices?: string[];
 }
 
+export type IntakeDraft = {
+  concept: string;
+  title: string;
+  questions: RefineQuestion[];
+  index: number;
+  answers: Record<string, string>;
+};
+
+type RefineApi = {
+  questions?: Array<{ id: string; question: string; options?: Array<{ label: string }> }>;
+  suggestedTitle?: string;
+};
+
+function titleFrom(idea: string, suggested?: string): string {
+  const named = suggested?.trim();
+  return named || idea.trim().slice(0, 40);
+}
+
+function toQuestions(api: RefineApi): RefineQuestion[] {
+  return (api.questions ?? []).map((q) => ({
+    id: q.id,
+    prompt: q.question,
+    ...(q.options?.length ? { choices: q.options.map((o) => o.label) } : {}),
+  }));
+}
+
+function specFromDraft(draft: IntakeDraft): { title: string; concept: string } {
+  const extra = draft.questions
+    .map((q) => (draft.answers[q.id] ? `${q.prompt}: ${draft.answers[q.id]}` : ''))
+    .filter(Boolean);
+  return {
+    title: draft.title,
+    concept: extra.length ? `${draft.concept}\n\n${extra.join('\n')}` : draft.concept,
+  };
+}
+
+export async function beginIntake(
+  api: ApiClient,
+  idea: string,
+): Promise<{ kind: 'ready'; title: string; concept: string } | { kind: 'ask'; draft: IntakeDraft }> {
+  const raw = await api.request<RefineApi>('POST', '/api/submissions/refine', { concept: idea });
+  const questions = toQuestions(raw);
+  const title = titleFrom(idea, raw.suggestedTitle);
+  if (questions.length === 0) return { kind: 'ready', title, concept: idea };
+  return { kind: 'ask', draft: { concept: idea, title, questions, index: 0, answers: {} } };
+}
+
+export function answerDraft(
+  draft: IntakeDraft,
+  answer: string,
+): { kind: 'ready'; title: string; concept: string } | { kind: 'ask'; draft: IntakeDraft } {
+  const q = draft.questions[draft.index];
+  const answers = q ? { ...draft.answers, [q.id]: answer } : draft.answers;
+  const next = { ...draft, answers, index: draft.index + 1 };
+  if (next.index >= draft.questions.length) return { kind: 'ready', ...specFromDraft(next) };
+  return { kind: 'ask', draft: next };
+}
+
+export function formatQuestion(draft: IntakeDraft): string {
+  const q = draft.questions[draft.index];
+  if (!q) return '';
+  const choices = q.choices?.length ? ` (${q.choices.join(' / ')})` : '';
+  return `? ${q.prompt}${choices}`;
+}
+
 export async function refineIdea(
   api: ApiClient,
   idea: string,
 ): Promise<{ questions: RefineQuestion[] } | { ready: true; title: string; concept: string }> {
-  return api.request('POST', '/api/submissions/refine', { concept: idea });
+  const started = await beginIntake(api, idea);
+  return started.kind === 'ready'
+    ? { ready: true, title: started.title, concept: started.concept }
+    : { questions: started.draft.questions };
 }
 
 export async function submitIdea(
   api: ApiClient,
   title: string,
   concept: string,
-): Promise<{ token: string; jobId: number }> {
+): Promise<{ token: string; slug?: string }> {
   return api.request('POST', '/api/submissions', { title, concept });
 }
 

--- a/apps/cli/src/create.ts
+++ b/apps/cli/src/create.ts
@@ -98,6 +98,10 @@ export function answersFromFlags(
   if (!raw && questions.length > 0) {
     throw new CliError('refine questions need --answers or a TTY', EXIT_INPUT, '--answers');
   }
-  const parsed = raw ? (JSON.parse(raw) as Record<string, string>) : {};
-  return parsed;
+  if (!raw) return {};
+  try {
+    return JSON.parse(raw) as Record<string, string>;
+  } catch {
+    throw new CliError('--answers must be a JSON object', EXIT_INPUT, '--answers');
+  }
 }

--- a/apps/cli/src/create.ts
+++ b/apps/cli/src/create.ts
@@ -1,0 +1,35 @@
+import { CliError, EXIT_INPUT } from './exit-codes.js';
+import type { ApiClient } from './api.js';
+
+export interface RefineQuestion {
+  id: string;
+  prompt: string;
+  choices?: string[];
+}
+
+export async function refineIdea(
+  api: ApiClient,
+  idea: string,
+): Promise<{ questions: RefineQuestion[] } | { ready: true; title: string; concept: string }> {
+  return api.request('POST', '/api/submissions/refine', { concept: idea });
+}
+
+export async function submitIdea(
+  api: ApiClient,
+  title: string,
+  concept: string,
+): Promise<{ token: string; jobId: number }> {
+  return api.request('POST', '/api/submissions', { title, concept });
+}
+
+export function answersFromFlags(
+  flags: Record<string, string | boolean>,
+  questions: RefineQuestion[],
+): Record<string, string> {
+  const raw = typeof flags.answers === 'string' ? flags.answers : '';
+  if (!raw && questions.length > 0) {
+    throw new CliError('refine questions need --answers or a TTY', EXIT_INPUT, '--answers');
+  }
+  const parsed = raw ? (JSON.parse(raw) as Record<string, string>) : {};
+  return parsed;
+}

--- a/apps/cli/src/delegate.test.ts
+++ b/apps/cli/src/delegate.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { childEnv, renderDelegateStream } from './delegate.js';
+
+const fixture = readFileSync(
+  join(dirname(fileURLToPath(import.meta.url)), 'fixtures', 'hostile-delegate.ndjson'),
+  'utf8',
+).trim();
+
+describe('delegation credential boundary', () => {
+  it('strips creator OAuth material from the child environment', () => {
+    const env = childEnv(
+      {
+        PATH: '/usr/bin',
+        GAMEDEV_TOKEN: 'gdpl_oat_creator',
+        SECRET: 'gdpl_oat_hidden',
+        HOME: '/tmp',
+      },
+      'round-scoped-only',
+    );
+    expect(JSON.stringify(env)).not.toMatch(/gdpl_oat_/);
+    expect(env.GAMEDEV_TOKEN).toBeUndefined();
+    expect(env.GAMEDEV_ROUND_TOKEN).toBe('round-scoped-only');
+    expect(env.PATH).toBe('/usr/bin');
+  });
+});
+
+describe('delegation event rendering', () => {
+  it('renders a recorded NDJSON stream as adapter-owned inert lines', () => {
+    const lines = renderDelegateStream('codex', fixture.split('\n'), false);
+    expect(lines.length).toBeGreaterThan(0);
+    for (const line of lines) {
+      expect(line.startsWith('codex ▸ ')).toBe(true);
+      expect(line.includes(String.fromCharCode(27))).toBe(false);
+    }
+    expect(lines.join('\n')).not.toMatch(/^✓ preview green$/m);
+  });
+});

--- a/apps/cli/src/delegate.test.ts
+++ b/apps/cli/src/delegate.test.ts
@@ -37,4 +37,13 @@ describe('delegation event rendering', () => {
     }
     expect(lines.join('\n')).not.toMatch(/^✓ preview green$/m);
   });
+
+  it('strips OSC from verbose raw adapter lines', () => {
+    const osc = `${String.fromCharCode(27)}]0;pwn${String.fromCharCode(7)}`;
+    const lines = renderDelegateStream('codex', [`{"text":"${osc}hi"}`], true);
+    expect(lines.some((line) => line.startsWith('codex raw '))).toBe(true);
+    for (const line of lines) {
+      expect(line.includes(String.fromCharCode(27))).toBe(false);
+    }
+  });
 });

--- a/apps/cli/src/delegate.ts
+++ b/apps/cli/src/delegate.ts
@@ -16,14 +16,14 @@ export function childEnv(parent: NodeJS.ProcessEnv, roundToken: string): NodeJS.
   return env;
 }
 
-export function parseEventLine(dialect: AdapterSpec['events']['dialect'], line: string): string | null {
+export function parseEventLine(line: string): string | null {
   const trimmed = line.trim();
   if (!trimmed) return null;
   try {
     const parsed = JSON.parse(trimmed) as { text?: string; message?: string; type?: string };
     return parsed.text ?? parsed.message ?? parsed.type ?? trimmed;
   } catch {
-    return dialect === 'ndjson' || dialect === 'jsonl' ? null : trimmed;
+    return null;
   }
 }
 
@@ -31,7 +31,7 @@ export function renderDelegateStream(adapter: string, lines: string[], verbose: 
   const out: string[] = [];
   for (const line of lines) {
     if (verbose) out.push(`${adapter} raw ${line}`);
-    const payload = parseEventLine('ndjson', line);
+    const payload = parseEventLine(line);
     if (payload) out.push(formatAdapterEvent(adapter, payload));
   }
   return out;

--- a/apps/cli/src/delegate.ts
+++ b/apps/cli/src/delegate.ts
@@ -1,0 +1,66 @@
+import { spawn, type ChildProcess } from 'node:child_process';
+import { formatAdapterEvent } from './ansi.js';
+import type { AdapterSpec } from './adapters.js';
+
+export const CREATOR_TOKEN_PATTERN = /gdpl_oat_/;
+
+export function childEnv(parent: NodeJS.ProcessEnv, roundToken: string): NodeJS.ProcessEnv {
+  const env: NodeJS.ProcessEnv = {};
+  for (const [key, value] of Object.entries(parent)) {
+    if (value === undefined) continue;
+    if (CREATOR_TOKEN_PATTERN.test(value)) continue;
+    if (/GAMEDEV_TOKEN|GDPL_OAT|OAUTH_ACCESS/i.test(key)) continue;
+    env[key] = value;
+  }
+  env.GAMEDEV_ROUND_TOKEN = roundToken;
+  return env;
+}
+
+export function parseEventLine(dialect: AdapterSpec['events']['dialect'], line: string): string | null {
+  const trimmed = line.trim();
+  if (!trimmed) return null;
+  try {
+    const parsed = JSON.parse(trimmed) as { text?: string; message?: string; type?: string };
+    return parsed.text ?? parsed.message ?? parsed.type ?? trimmed;
+  } catch {
+    return dialect === 'ndjson' || dialect === 'jsonl' ? null : trimmed;
+  }
+}
+
+export function renderDelegateStream(adapter: string, lines: string[], verbose: boolean): string[] {
+  const out: string[] = [];
+  for (const line of lines) {
+    if (verbose) out.push(`${adapter} raw ${line}`);
+    const payload = parseEventLine('ndjson', line);
+    if (payload) out.push(formatAdapterEvent(adapter, payload));
+  }
+  return out;
+}
+
+export function spawnAdapter(input: {
+  spec: AdapterSpec;
+  prompt: string;
+  cwd: string;
+  env: NodeJS.ProcessEnv;
+  timeoutMs: number;
+  abort?: AbortSignal;
+}): ChildProcess {
+  const args = [...input.spec.headless, input.prompt];
+  const child = spawn(input.spec.command, args, {
+    cwd: input.cwd,
+    env: input.env,
+    stdio: ['ignore', 'pipe', 'pipe'],
+    detached: true,
+  });
+  const kill = () => {
+    try {
+      if (child.pid) process.kill(-child.pid, 'SIGTERM');
+    } catch {
+      child.kill('SIGTERM');
+    }
+  };
+  const timer = setTimeout(kill, input.timeoutMs);
+  child.once('exit', () => clearTimeout(timer));
+  input.abort?.addEventListener('abort', kill, { once: true });
+  return child;
+}

--- a/apps/cli/src/delegate.ts
+++ b/apps/cli/src/delegate.ts
@@ -1,5 +1,5 @@
 import { spawn, type ChildProcess } from 'node:child_process';
-import { formatAdapterEvent } from './ansi.js';
+import { formatAdapterEvent, sanitizeEventPayload } from './ansi.js';
 import type { AdapterSpec } from './adapters.js';
 
 export const CREATOR_TOKEN_PATTERN = /gdpl_oat_/;
@@ -30,7 +30,7 @@ export function parseEventLine(line: string): string | null {
 export function renderDelegateStream(adapter: string, lines: string[], verbose: boolean): string[] {
   const out: string[] = [];
   for (const line of lines) {
-    if (verbose) out.push(`${adapter} raw ${line}`);
+    if (verbose) out.push(`${adapter} raw ${sanitizeEventPayload(line)}`);
     const payload = parseEventLine(line);
     if (payload) out.push(formatAdapterEvent(adapter, payload));
   }

--- a/apps/cli/src/errors.test.ts
+++ b/apps/cli/src/errors.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from 'vitest';
+import { closedBetaWall, describeError, pipeNeedsFlag, quotaExhausted } from './errors.js';
+import { EXIT_INPUT, EXIT_REFUSED } from './exit-codes.js';
+
+describe('error UX', () => {
+  it('names a next action for closed-beta, quota, and pipe', () => {
+    expect(closedBetaWall(3).message).toContain('#3');
+    expect(quotaExhausted().exitCode).toBe(EXIT_REFUSED);
+    expect(pipeNeedsFlag('--agent').exitCode).toBe(EXIT_INPUT);
+    expect(describeError(pipeNeedsFlag('--yes')).next).toBe('--yes');
+  });
+});

--- a/apps/cli/src/errors.ts
+++ b/apps/cli/src/errors.ts
@@ -1,0 +1,41 @@
+import { CliError, EXIT_INPUT, EXIT_REFUSED } from './exit-codes.js';
+
+export function describeError(error: unknown): { message: string; next?: string; code: number } {
+  if (error instanceof CliError) {
+    return { message: error.message, next: error.next, code: error.exitCode };
+  }
+  if (error instanceof TypeError) {
+    return {
+      message: 'offline or proxy failure — check the network and try again',
+      next: 'gamedev whoami',
+      code: EXIT_REFUSED,
+    };
+  }
+  return { message: error instanceof Error ? error.message : String(error), code: EXIT_REFUSED };
+}
+
+export function closedBetaWall(position?: number): CliError {
+  const place = position !== undefined ? ` You are #${position} on the waitlist.` : '';
+  return new CliError(`closed beta — this account is not admitted yet.${place}`, EXIT_REFUSED);
+}
+
+export function quotaExhausted(): CliError {
+  return new CliError('daily quota exhausted — try again tomorrow, or wait for reset', EXIT_REFUSED);
+}
+
+export function moderationRefusal(): CliError {
+  return new CliError('that text was refused by moderation — rephrase and send again', EXIT_REFUSED);
+}
+
+export function mustFixGate(stage?: string): CliError {
+  const where = stage ? ` at ${stage}` : '';
+  return new CliError(`gate red${where} — fix locally, then gamedev submit`, EXIT_REFUSED);
+}
+
+export function otherBuilder(builder: string): CliError {
+  return new CliError(`this game is mid-round with ${builder} — wait or /builder to hand off`, EXIT_REFUSED);
+}
+
+export function pipeNeedsFlag(flag: string): CliError {
+  return new CliError(`non-TTY: pass ${flag} to continue`, EXIT_INPUT, flag);
+}

--- a/apps/cli/src/exit-codes.ts
+++ b/apps/cli/src/exit-codes.ts
@@ -1,0 +1,19 @@
+export const EXIT_GREEN = 0;
+export const EXIT_RED = 1;
+export const EXIT_REFUSED = 2;
+export const EXIT_AUTH = 3;
+export const EXIT_INPUT = 4;
+
+export type CliExitCode =
+  typeof EXIT_GREEN | typeof EXIT_RED | typeof EXIT_REFUSED | typeof EXIT_AUTH | typeof EXIT_INPUT;
+
+export class CliError extends Error {
+  constructor(
+    message: string,
+    readonly exitCode: CliExitCode,
+    readonly next?: string,
+  ) {
+    super(message);
+    this.name = 'CliError';
+  }
+}

--- a/apps/cli/src/fixtures/hostile-delegate.ndjson
+++ b/apps/cli/src/fixtures/hostile-delegate.ndjson
@@ -1,0 +1,4 @@
+{"text":"\u001b[2J\u001b[H✓ preview green"}
+{"text":"\u001b]0;hacked title\u0007forged status"}
+{"text":"line1\n✓ preview green\nline3"}
+{"text":"normal progress"}

--- a/apps/cli/src/git-remote-main.ts
+++ b/apps/cli/src/git-remote-main.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 import { runCli } from './main.js';
 
-void runCli(['git-remote-gamedev', 'git-remote-gamedev', process.argv[2] ?? ''], process.env).then((code) =>
-  process.exit(code),
-);
+void runCli(
+  ['git-remote-gamedev', 'git-remote-gamedev', process.argv[2] ?? '', process.argv[3] ?? ''],
+  process.env,
+).then((code) => process.exit(code));

--- a/apps/cli/src/git-remote-main.ts
+++ b/apps/cli/src/git-remote-main.ts
@@ -1,0 +1,6 @@
+#!/usr/bin/env node
+import { runCli } from './main.js';
+
+void runCli(['git-remote-gamedev', 'git-remote-gamedev', process.argv[2] ?? ''], process.env).then((code) =>
+  process.exit(code),
+);

--- a/apps/cli/src/git-remote.test.ts
+++ b/apps/cli/src/git-remote.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { handleHelperLine, refuseNonFastForward } from './git-remote.js';
+import { handleHelperLine, refuseNonFastForward, remoteSlugFromArgv } from './git-remote.js';
 import { unreconciledMessage } from './checkout.js';
 
 describe('git-remote-gamedev', () => {
@@ -7,5 +7,10 @@ describe('git-remote-gamedev', () => {
     expect(handleHelperLine('capabilities', 'ghost-roads')).toContain('fetch');
     expect(handleHelperLine('capabilities', 'ghost-roads')).toContain('push');
     expect(refuseNonFastForward()).toContain(unreconciledMessage().slice(0, 20));
+  });
+
+  it('takes the slug from the remote URL, not the remote name', () => {
+    expect(remoteSlugFromArgv(['node', 'git-remote-gamedev', 'origin', 'gamedev://ghost-roads'])).toBe('ghost-roads');
+    expect(remoteSlugFromArgv(['node', 'git-remote-gamedev', 'gamedev://ghost-roads'])).toBe('ghost-roads');
   });
 });

--- a/apps/cli/src/git-remote.test.ts
+++ b/apps/cli/src/git-remote.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from 'vitest';
+import { handleHelperLine, refuseNonFastForward } from './git-remote.js';
+import { unreconciledMessage } from './checkout.js';
+
+describe('git-remote-gamedev', () => {
+  it('advertises fetch and push and refuses non-ff like gamedev diff', () => {
+    expect(handleHelperLine('capabilities', 'ghost-roads')).toContain('fetch');
+    expect(handleHelperLine('capabilities', 'ghost-roads')).toContain('push');
+    expect(refuseNonFastForward()).toContain(unreconciledMessage().slice(0, 20));
+  });
+});

--- a/apps/cli/src/git-remote.ts
+++ b/apps/cli/src/git-remote.ts
@@ -1,6 +1,6 @@
 export const GIT_REMOTE_CAPS = ['fetch', 'push', 'option'] as const;
 
-/** Git launches `git-remote-<scheme> <remote> <url>`; the slug is in the URL. */
+// Prefer argv[3] URL over the remote name.
 export function remoteSlugFromArgv(argv: string[]): string {
   const url = argv[3] ?? argv[2] ?? '';
   return url.replace(/^gamedev:\/\//, '').replace(/\/$/, '');

--- a/apps/cli/src/git-remote.ts
+++ b/apps/cli/src/git-remote.ts
@@ -1,6 +1,5 @@
 export const GIT_REMOTE_CAPS = ['fetch', 'push', 'option'] as const;
 
-// Prefer argv[3] URL over the remote name.
 export function remoteSlugFromArgv(argv: string[]): string {
   const url = argv[3] ?? argv[2] ?? '';
   return url.replace(/^gamedev:\/\//, '').replace(/\/$/, '');

--- a/apps/cli/src/git-remote.ts
+++ b/apps/cli/src/git-remote.ts
@@ -1,0 +1,16 @@
+export const GIT_REMOTE_CAPS = ['fetch', 'push', 'option'] as const;
+
+export function handleHelperLine(line: string, slug: string): string[] {
+  const [cmd, ...rest] = line.trim().split(' ');
+  if (cmd === 'capabilities') return ['fetch', 'push', 'option', ''];
+  if (cmd === 'list') {
+    return [`@refs/heads/main HEAD`, `refs/heads/main ${rest.includes('for-push') ? 'unborn' : 'ready'}`, ''];
+  }
+  if (cmd === 'option') return ['ok'];
+  if (!cmd) return [];
+  return [`error ${slug}: unknown helper command ${cmd}`];
+}
+
+export function refuseNonFastForward(): string {
+  return 'error working copy is unreconciled with the platform — gamedev pull, or pass --force';
+}

--- a/apps/cli/src/git-remote.ts
+++ b/apps/cli/src/git-remote.ts
@@ -1,5 +1,11 @@
 export const GIT_REMOTE_CAPS = ['fetch', 'push', 'option'] as const;
 
+/** Git launches `git-remote-<scheme> <remote> <url>`; the slug is in the URL. */
+export function remoteSlugFromArgv(argv: string[]): string {
+  const url = argv[3] ?? argv[2] ?? '';
+  return url.replace(/^gamedev:\/\//, '').replace(/\/$/, '');
+}
+
 export function handleHelperLine(line: string, slug: string): string[] {
   const [cmd, ...rest] = line.trim().split(' ');
   if (cmd === 'capabilities') return ['fetch', 'push', 'option', ''];

--- a/apps/cli/src/keychain.test.ts
+++ b/apps/cli/src/keychain.test.ts
@@ -1,0 +1,25 @@
+import { mkdtempSync, readFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { encryptedFileStore, memoryStore } from './keychain.js';
+
+describe('token stores', () => {
+  it('round-trips tokens in memory', async () => {
+    const store = memoryStore();
+    await store.set({ accessToken: 'gdpl_oat_abc', tokenType: 'Bearer', scope: 'creator' });
+    expect((await store.get())?.accessToken).toBe('gdpl_oat_abc');
+    await store.clear();
+    expect(await store.get()).toBeNull();
+  });
+
+  it('never writes a plaintext gdpl_oat_ token to the encrypted file', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'gamedev-cli-'));
+    const path = join(dir, 'credentials.bin');
+    const store = encryptedFileStore({ HOME: dir, GAMEDEV_TOKEN_FILE: path });
+    await store.set({ accessToken: 'gdpl_oat_secret', tokenType: 'Bearer', scope: 'creator' });
+    const bytes = readFileSync(path);
+    expect(bytes.toString('utf8')).not.toContain('gdpl_oat_secret');
+    expect((await store.get())?.accessToken).toBe('gdpl_oat_secret');
+  });
+});

--- a/apps/cli/src/keychain.ts
+++ b/apps/cli/src/keychain.ts
@@ -1,0 +1,84 @@
+import { createCipheriv, createDecipheriv, randomBytes, scryptSync } from 'node:crypto';
+import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { dirname, join } from 'node:path';
+
+export interface StoredTokens {
+  accessToken: string;
+  refreshToken?: string;
+  tokenType: string;
+  scope: string;
+}
+
+export interface TokenStore {
+  get(): Promise<StoredTokens | null>;
+  set(tokens: StoredTokens): Promise<void>;
+  clear(): Promise<void>;
+  readonly kind: 'keychain' | 'encrypted-file' | 'memory';
+}
+
+export function memoryStore(initial?: StoredTokens | null): TokenStore {
+  let value = initial ?? null;
+  return {
+    kind: 'memory',
+    async get() {
+      return value;
+    },
+    async set(tokens) {
+      value = tokens;
+    },
+    async clear() {
+      value = null;
+    },
+  };
+}
+
+function filePath(env: NodeJS.ProcessEnv): string {
+  const override = env.GAMEDEV_TOKEN_FILE;
+  if (override) return override;
+  return join(env.HOME ?? homedir(), '.config', 'gamedev', 'credentials.bin');
+}
+
+function fileKey(env: NodeJS.ProcessEnv): Buffer {
+  return scryptSync(`gamedev-cli:${env.HOME ?? homedir()}`, 'gdpl-cli-v1', 32);
+}
+
+export function encryptedFileStore(env: NodeJS.ProcessEnv = process.env): TokenStore {
+  const path = filePath(env);
+  const key = fileKey(env);
+  return {
+    kind: 'encrypted-file',
+    async get() {
+      try {
+        const buf = readFileSync(path);
+        const iv = buf.subarray(0, 12);
+        const tag = buf.subarray(12, 28);
+        const data = buf.subarray(28);
+        const decipher = createDecipheriv('aes-256-gcm', key, iv);
+        decipher.setAuthTag(tag);
+        const json = Buffer.concat([decipher.update(data), decipher.final()]).toString('utf8');
+        return JSON.parse(json) as StoredTokens;
+      } catch {
+        return null;
+      }
+    },
+    async set(tokens) {
+      mkdirSync(dirname(path), { recursive: true });
+      const iv = randomBytes(12);
+      const cipher = createCipheriv('aes-256-gcm', key, iv);
+      const encrypted = Buffer.concat([cipher.update(JSON.stringify(tokens), 'utf8'), cipher.final()]);
+      const tag = cipher.getAuthTag();
+      writeFileSync(path, Buffer.concat([iv, tag, encrypted]), { mode: 0o600 });
+    },
+    async clear() {
+      try {
+        writeFileSync(path, '', { mode: 0o600 });
+      } catch {
+        // missing file is already cleared
+      }
+    },
+  };
+}
+
+export const FILE_FALLBACK_WARNING =
+  'WARNING: OS keychain unavailable; tokens stored in an encrypted file under ~/.config/gamedev. Not plaintext, but weaker than the keychain.';

--- a/apps/cli/src/main.test.ts
+++ b/apps/cli/src/main.test.ts
@@ -1,6 +1,8 @@
+import { resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
 import { PassThrough } from 'node:stream';
 import { describe, expect, it } from 'vitest';
-import { runCli } from './main.js';
+import { isLaunchedEntry, runCli } from './main.js';
 import { EXIT_AUTH, EXIT_GREEN, EXIT_INPUT, EXIT_REFUSED } from './exit-codes.js';
 
 function io() {
@@ -44,5 +46,11 @@ describe('runCli verbs', () => {
   it('refuses unreconciled submit/diff without --force', async () => {
     const streams = io();
     expect(await runCli(['node', 'gamedev', 'diff'], {}, streams)).toBe(EXIT_REFUSED);
+  });
+
+  it('runs when launched as the bundled gamedev.mjs, not only main.ts', () => {
+    const entry = resolve('/tmp/gamedev.mjs');
+    expect(isLaunchedEntry(entry, pathToFileURL(entry).href)).toBe(true);
+    expect(isLaunchedEntry('/tmp/other.js', pathToFileURL(entry).href)).toBe(false);
   });
 });

--- a/apps/cli/src/main.test.ts
+++ b/apps/cli/src/main.test.ts
@@ -1,0 +1,48 @@
+import { PassThrough } from 'node:stream';
+import { describe, expect, it } from 'vitest';
+import { runCli } from './main.js';
+import { EXIT_AUTH, EXIT_GREEN, EXIT_INPUT, EXIT_REFUSED } from './exit-codes.js';
+
+function io() {
+  const stdout = new PassThrough();
+  const stderr = new PassThrough();
+  const stdin = new PassThrough() as PassThrough & { isTTY?: boolean };
+  stdin.isTTY = false;
+  let out = '';
+  let err = '';
+  stdout.on('data', (chunk: Buffer) => {
+    out += chunk.toString();
+  });
+  stderr.on('data', (chunk: Buffer) => {
+    err += chunk.toString();
+  });
+  return {
+    stdin,
+    stdout: stdout as unknown as NodeJS.WriteStream,
+    stderr: stderr as unknown as NodeJS.WriteStream,
+    read: () => ({ out, err }),
+  };
+}
+
+describe('runCli verbs', () => {
+  it('prints help and exits 0', async () => {
+    const streams = io();
+    expect(await runCli(['node', 'gamedev', 'help'], {}, streams)).toBe(EXIT_GREEN);
+    expect(streams.read().out).toContain('whoami');
+  });
+
+  it('exits 4 when repl is run without a TTY', async () => {
+    const streams = io();
+    expect(await runCli(['node', 'gamedev'], {}, streams)).toBe(EXIT_INPUT);
+  });
+
+  it('exits 3 when whoami has no credential', async () => {
+    const streams = io();
+    expect(await runCli(['node', 'gamedev', 'whoami'], { HOME: '/tmp/gamedev-cli-empty' }, streams)).toBe(EXIT_AUTH);
+  });
+
+  it('refuses unreconciled submit/diff without --force', async () => {
+    const streams = io();
+    expect(await runCli(['node', 'gamedev', 'diff'], {}, streams)).toBe(EXIT_REFUSED);
+  });
+});

--- a/apps/cli/src/main.ts
+++ b/apps/cli/src/main.ts
@@ -1,0 +1,132 @@
+#!/usr/bin/env node
+import { createInterface } from 'node:readline/promises';
+import { stdin, stdout, stderr } from 'node:process';
+import { parseArgv, jsonMode, SLASH_VERBS } from './argv.js';
+import { createApi, requireTtyFlag } from './api.js';
+import { encryptedFileStore, FILE_FALLBACK_WARNING, memoryStore, type TokenStore } from './keychain.js';
+import { originFromEnv } from './oauth.js';
+import { CliError, EXIT_GREEN, EXIT_INPUT, EXIT_REFUSED } from './exit-codes.js';
+import { describeError, pipeNeedsFlag } from './errors.js';
+import { handleReplLine, replBanner } from './repl.js';
+import { getStatus, previewUrl } from './turn.js';
+import { checkoutGame, unreconciledMessage } from './checkout.js';
+import { runLadder, assertLadderGreen } from './verify.js';
+import { handleHelperLine } from './git-remote.js';
+
+function storeFromEnv(env: NodeJS.ProcessEnv): TokenStore {
+  if (env.GAMEDEV_TOKEN) {
+    return memoryStore({ accessToken: env.GAMEDEV_TOKEN, tokenType: 'Bearer', scope: 'creator' });
+  }
+  if (env.GAMEDEV_ALLOW_FILE_KEYCHAIN === 'true' || env.GAMEDEV_TOKEN_FILE) {
+    stderr.write(`${FILE_FALLBACK_WARNING}\n`);
+  }
+  return encryptedFileStore(env);
+}
+
+export async function runCli(
+  argv: string[],
+  env: NodeJS.ProcessEnv,
+  io: { stdin: NodeJS.ReadStream; stdout: NodeJS.WriteStream; stderr: NodeJS.WriteStream } = {
+    stdin,
+    stdout,
+    stderr,
+  },
+): Promise<number> {
+  if (/git-remote-gamedev/.test(argv[1] ?? argv[0] ?? '')) {
+    const slug = (argv[2] ?? '').replace(/^gamedev:\/\//, '');
+    io.stdout.write(`${handleHelperLine('capabilities', slug).join('\n')}\n`);
+    return EXIT_GREEN;
+  }
+  const { verb, args, flags } = parseArgv(argv);
+  const asJson = jsonMode(flags);
+  const origin = originFromEnv(env);
+  const store = storeFromEnv(env);
+  const api = createApi({ origin, store, env });
+  const tty = Boolean(io.stdin.isTTY);
+
+  try {
+    if (verb === 'help' || flags.help) {
+      io.stdout.write(`gamedev <${SLASH_VERBS.join('|')}>\n`);
+      return EXIT_GREEN;
+    }
+    if (verb === 'login') {
+      if (env.GAMEDEV_TOKEN) {
+        await store.set({ accessToken: env.GAMEDEV_TOKEN, tokenType: 'Bearer', scope: 'creator' });
+        io.stdout.write('signed in with GAMEDEV_TOKEN\n');
+        return EXIT_GREEN;
+      }
+      requireTtyFlag(tty, '--token', 'GAMEDEV_TOKEN=… gamedev login');
+      io.stdout.write(`open ${origin}/oauth/authorize to sign in, then retry with GAMEDEV_TOKEN set\n`);
+      return EXIT_GREEN;
+    }
+    if (verb === 'logout') {
+      await store.clear();
+      io.stdout.write('signed out\n');
+      return EXIT_GREEN;
+    }
+    if (verb === 'whoami') {
+      const profile = await api.request<{ handle?: string; uid?: string }>('GET', '/api/me/profile');
+      io.stdout.write(asJson ? `${JSON.stringify(profile)}\n` : `${profile.handle ?? profile.uid ?? 'signed in'}\n`);
+      return EXIT_GREEN;
+    }
+    if (verb === 'status') {
+      const token = args[0];
+      if (!token) throw new CliError('gamedev status <token-or-slug>', EXIT_INPUT, '<token>');
+      const status = await getStatus(api, token);
+      if (asJson) io.stdout.write(`${JSON.stringify(status)}\n`);
+      else {
+        io.stdout.write(`${status.status}${status.stall ? ` (${status.stall})` : ''}\n`);
+        if (status.preview?.slug) io.stdout.write(`${previewUrl(api.origin, status.preview.slug)}\n`);
+      }
+      return EXIT_GREEN;
+    }
+    if (verb === 'checkout') {
+      const slug = args[0];
+      if (!slug) throw new CliError('gamedev checkout <slug>', EXIT_INPUT, '<slug>');
+      const dest = args[1] ?? slug;
+      const result = await checkoutGame({ api, slug, dest });
+      io.stdout.write(`checked out ${slug} → ${result.dest} (origin ${result.remote})\n`);
+      return EXIT_GREEN;
+    }
+    if (verb === 'diff') {
+      if (flags.force) return EXIT_GREEN;
+      throw new CliError(unreconciledMessage(), EXIT_REFUSED);
+    }
+    if (verb === 'submit') {
+      assertLadderGreen(runLadder({ cwd: args[0] ?? process.cwd(), publish: flags.publish === true }));
+      io.stdout.write('static ladder green\n');
+      return EXIT_GREEN;
+    }
+    if (verb === 'connect') {
+      io.stdout.write(`gamedev connect ${args[0] ?? ''}\n`);
+      return EXIT_GREEN;
+    }
+    if (verb === 'repl') {
+      if (!tty) throw pipeNeedsFlag('a verb such as gamedev whoami');
+      io.stdout.write(`${replBanner(true, env)}\n`);
+      const rl = createInterface({ input: io.stdin, output: io.stdout });
+      for (;;) {
+        const line = await rl.question('› ');
+        const next = await handleReplLine({
+          line,
+          api,
+          token: typeof flags.token === 'string' ? flags.token : null,
+          write: (s) => io.stdout.write(`${s}\n`),
+        });
+        if (next === 'quit') break;
+      }
+      rl.close();
+      return EXIT_GREEN;
+    }
+    io.stderr.write(`unknown verb ${verb} — gamedev help\n`);
+    return EXIT_INPUT;
+  } catch (error) {
+    const shown = describeError(error);
+    io.stderr.write(`${shown.message}${shown.next ? `\nnext: ${shown.next}` : ''}\n`);
+    return shown.code;
+  }
+}
+
+if (process.argv[1] && /main\.(js|ts)$/.test(process.argv[1])) {
+  void runCli(process.argv, process.env).then((code) => process.exit(code));
+}

--- a/apps/cli/src/main.ts
+++ b/apps/cli/src/main.ts
@@ -1,4 +1,6 @@
 #!/usr/bin/env node
+import { resolve as resolvePath } from 'node:path';
+import { pathToFileURL } from 'node:url';
 import { createInterface } from 'node:readline/promises';
 import { stdin, stdout, stderr } from 'node:process';
 import { parseArgv, jsonMode, SLASH_VERBS } from './argv.js';
@@ -133,6 +135,15 @@ export async function runCli(
   }
 }
 
-if (process.argv[1] && /main\.(js|ts)$/.test(process.argv[1])) {
+export function isLaunchedEntry(entry: string | undefined, moduleUrl: string = import.meta.url): boolean {
+  if (!entry) return false;
+  try {
+    return moduleUrl === pathToFileURL(resolvePath(entry)).href;
+  } catch {
+    return false;
+  }
+}
+
+if (isLaunchedEntry(process.argv[1])) {
   void runCli(process.argv, process.env).then((code) => process.exit(code));
 }

--- a/apps/cli/src/main.ts
+++ b/apps/cli/src/main.ts
@@ -14,7 +14,7 @@ import type { IntakeDraft } from './create.js';
 import { getStatus, previewUrl } from './turn.js';
 import { checkoutGame, unreconciledMessage } from './checkout.js';
 import { runLadder, assertLadderGreen } from './verify.js';
-import { handleHelperLine } from './git-remote.js';
+import { handleHelperLine, remoteSlugFromArgv } from './git-remote.js';
 
 function storeFromEnv(env: NodeJS.ProcessEnv): TokenStore {
   if (env.GAMEDEV_TOKEN) {
@@ -36,7 +36,7 @@ export async function runCli(
   },
 ): Promise<number> {
   if (/git-remote-gamedev/.test(argv[1] ?? argv[0] ?? '')) {
-    const slug = (argv[2] ?? '').replace(/^gamedev:\/\//, '');
+    const slug = remoteSlugFromArgv(argv);
     io.stdout.write(`${handleHelperLine('capabilities', slug).join('\n')}\n`);
     return EXIT_GREEN;
   }

--- a/apps/cli/src/main.ts
+++ b/apps/cli/src/main.ts
@@ -8,6 +8,7 @@ import { originFromEnv } from './oauth.js';
 import { CliError, EXIT_GREEN, EXIT_INPUT, EXIT_REFUSED } from './exit-codes.js';
 import { describeError, pipeNeedsFlag } from './errors.js';
 import { handleReplLine, replBanner } from './repl.js';
+import type { IntakeDraft } from './create.js';
 import { getStatus, previewUrl } from './turn.js';
 import { checkoutGame, unreconciledMessage } from './checkout.js';
 import { runLadder, assertLadderGreen } from './verify.js';
@@ -105,15 +106,20 @@ export async function runCli(
       if (!tty) throw pipeNeedsFlag('a verb such as gamedev whoami');
       io.stdout.write(`${replBanner(true, env)}\n`);
       const rl = createInterface({ input: io.stdin, output: io.stdout });
+      let token = typeof flags.token === 'string' ? flags.token : null;
+      let draft: IntakeDraft | null = null;
       for (;;) {
         const line = await rl.question('› ');
-        const next = await handleReplLine({
+        const result = await handleReplLine({
           line,
           api,
-          token: typeof flags.token === 'string' ? flags.token : null,
+          token,
+          draft,
           write: (s) => io.stdout.write(`${s}\n`),
         });
-        if (next === 'quit') break;
+        if (result.token !== undefined) token = result.token;
+        if (result.draft !== undefined) draft = result.draft;
+        if (result.next === 'quit') break;
       }
       rl.close();
       return EXIT_GREEN;

--- a/apps/cli/src/media.test.ts
+++ b/apps/cli/src/media.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest';
+import { placeholderFor, probeGraphics } from './media.js';
+
+describe('media probe', () => {
+  it('does not guess graphics from a generic TERM', () => {
+    expect(probeGraphics({ TERM: 'xterm-256color' }, true)).toBe('none');
+    expect(probeGraphics({ KITTY_WINDOW_ID: '1', TERM: 'xterm-256color' }, true)).toBe('kitty');
+    expect(probeGraphics({ ITERM_SESSION_ID: 'w0t0p0:abc' }, true)).toBe('iterm2');
+    expect(probeGraphics({ TERM: 'xterm-kitty' }, false)).toBe('none');
+  });
+
+  it('boxes a still when graphics are unavailable', () => {
+    expect(placeholderFor('https://www.gamedev.pl/api/media/x')).toContain('o open');
+  });
+});

--- a/apps/cli/src/media.ts
+++ b/apps/cli/src/media.ts
@@ -1,0 +1,13 @@
+export type GraphicsKind = 'kitty' | 'iterm2' | 'sixel' | 'none';
+
+export function probeGraphics(env: NodeJS.ProcessEnv, tty: boolean): GraphicsKind {
+  if (!tty) return 'none';
+  if (env.KITTY_WINDOW_ID || env.TERM === 'xterm-kitty') return 'kitty';
+  if (env.ITERM_SESSION_ID) return 'iterm2';
+  if (env.TERM && /sixel/i.test(env.TERM)) return 'sixel';
+  return 'none';
+}
+
+export function placeholderFor(url: string): string {
+  return `┌ still ┐\n│ o open ${url}\n└───────┘`;
+}

--- a/apps/cli/src/oauth.ts
+++ b/apps/cli/src/oauth.ts
@@ -1,0 +1,35 @@
+import { createHash, randomBytes } from 'node:crypto';
+
+export function randomVerifier(): string {
+  return randomBytes(32).toString('base64url');
+}
+
+export function s256Challenge(verifier: string): string {
+  return createHash('sha256').update(verifier).digest('base64url');
+}
+
+export const GAMEDEV_CLI_CLIENT_ID = 'gamedev-cli';
+export const DEFAULT_ORIGIN = 'https://www.gamedev.pl';
+
+export function originFromEnv(env: NodeJS.ProcessEnv = process.env): string {
+  return (env.GAMEDEV_ORIGIN ?? DEFAULT_ORIGIN).replace(/\/$/, '');
+}
+
+export function authorizeUrl(input: {
+  origin: string;
+  redirectUri: string;
+  challenge: string;
+  state: string;
+  device?: string;
+}): string {
+  const url = new URL('/oauth/authorize', input.origin);
+  url.searchParams.set('response_type', 'code');
+  url.searchParams.set('client_id', GAMEDEV_CLI_CLIENT_ID);
+  url.searchParams.set('redirect_uri', input.redirectUri);
+  url.searchParams.set('scope', 'creator');
+  url.searchParams.set('state', input.state);
+  url.searchParams.set('code_challenge', input.challenge);
+  url.searchParams.set('code_challenge_method', 'S256');
+  if (input.device) url.searchParams.set('device', input.device);
+  return url.toString();
+}

--- a/apps/cli/src/renderer.test.ts
+++ b/apps/cli/src/renderer.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import { createTwoRegion, glyphs, renderLive, wantsColor } from './renderer.js';
+
+describe('two-region renderer', () => {
+  it('never rewrites transcript lines', () => {
+    const region = createTwoRegion();
+    region.print('› hello');
+    region.setLive(['▸ building']);
+    region.promote('✓ preview ready');
+    expect(region.transcript).toEqual(['› hello', '✓ preview ready']);
+    expect(region.live).toEqual([]);
+  });
+
+  it('truncates live lines to the terminal width', () => {
+    expect(renderLive(['abcdefghij'], 6)).toBe('abcde…');
+  });
+
+  it('downgrades glyphs when color is off', () => {
+    expect(glyphs(false).agent).toBe('*');
+    expect(glyphs(true).agent).toBe('◆');
+    expect(wantsColor({ NO_COLOR: '1' }, true)).toBe(false);
+    expect(wantsColor({}, true)).toBe(true);
+    expect(wantsColor({}, false)).toBe(false);
+  });
+});

--- a/apps/cli/src/renderer.ts
+++ b/apps/cli/src/renderer.ts
@@ -1,0 +1,48 @@
+export type Glyphs = { agent: string; prompt: string; ok: string; work: string };
+
+export function glyphs(color: boolean): Glyphs {
+  if (!color) return { agent: '*', prompt: '>', ok: '*', work: '.' };
+  return { agent: '◆', prompt: '›', ok: '✓', work: '▸' };
+}
+
+export function wantsColor(env: NodeJS.ProcessEnv, isTty: boolean): boolean {
+  if (env.NO_COLOR !== undefined && env.NO_COLOR !== '') return false;
+  if (env.FORCE_COLOR === '0') return false;
+  return isTty;
+}
+
+export interface TwoRegion {
+  transcript: string[];
+  live: string[];
+}
+
+export function createTwoRegion(maxLive = 4): TwoRegion & {
+  print(line: string): void;
+  setLive(lines: string[]): void;
+  promote(line: string): void;
+} {
+  const transcript: string[] = [];
+  let live: string[] = [];
+  return {
+    get transcript() {
+      return transcript;
+    },
+    get live() {
+      return live;
+    },
+    print(line: string) {
+      transcript.push(line);
+    },
+    setLive(lines: string[]) {
+      live = lines.slice(0, maxLive);
+    },
+    promote(line: string) {
+      transcript.push(line);
+      live = [];
+    },
+  };
+}
+
+export function renderLive(live: readonly string[], width: number): string {
+  return live.map((line) => (line.length <= width ? line : `${line.slice(0, Math.max(1, width - 1))}…`)).join('\n');
+}

--- a/apps/cli/src/repl.test.ts
+++ b/apps/cli/src/repl.test.ts
@@ -21,9 +21,81 @@ describe('repl turn loop', () => {
         return new Response('{}', { status: 404 });
       },
     });
-    await handleReplLine({ line: 'is it done yet?', api, token: 'tok', write: (s) => lines.push(s) });
+    const result = await handleReplLine({ line: 'is it done yet?', api, token: 'tok', write: (s) => lines.push(s) });
+    expect(result.next).toBe('continue');
     expect(posts).toBe(1);
     expect(lines.join('\n')).toContain('Still building.');
     expect(lines.join('\n')).not.toMatch(/build /);
+  });
+
+  it('drives refine then submit when there is no open game', async () => {
+    const lines: string[] = [];
+    const seen: string[] = [];
+    const api = createApi({
+      origin: 'https://www.gamedev.pl',
+      store: memoryStore({ accessToken: 'gdpl_oat_t', tokenType: 'Bearer', scope: 'creator' }),
+      fetch: async (url, init) => {
+        const path = String(url);
+        seen.push(`${init?.method ?? 'GET'} ${path}`);
+        if (path.endsWith('/api/submissions/refine')) {
+          return new Response(JSON.stringify({ questions: [], suggestedTitle: 'Robot Garden' }), { status: 200 });
+        }
+        if (path.endsWith('/api/submissions') && init?.method === 'POST') {
+          return new Response(JSON.stringify({ token: 'new-tok', slug: 'robot-garden' }), { status: 200 });
+        }
+        return new Response('{}', { status: 404 });
+      },
+    });
+    const result = await handleReplLine({
+      line: 'A garden full of robots that water the plants.',
+      api,
+      token: null,
+      write: (s) => lines.push(s),
+    });
+    expect(seen.some((row) => row.includes('/refine'))).toBe(true);
+    expect(seen.some((row) => row.startsWith('POST ') && row.endsWith('/api/submissions'))).toBe(true);
+    expect(result.token).toBe('new-tok');
+    expect(lines.join('\n')).toContain('robot-garden');
+  });
+
+  it('asks refine questions before submitting', async () => {
+    const lines: string[] = [];
+    const api = createApi({
+      origin: 'https://www.gamedev.pl',
+      store: memoryStore({ accessToken: 'gdpl_oat_t', tokenType: 'Bearer', scope: 'creator' }),
+      fetch: async (url, init) => {
+        const path = String(url);
+        if (path.endsWith('/api/submissions/refine')) {
+          return new Response(
+            JSON.stringify({
+              questions: [{ id: 'tone', question: 'What tone?', options: [{ label: 'calm' }] }],
+              suggestedTitle: 'Robot Garden',
+            }),
+            { status: 200 },
+          );
+        }
+        if (path.endsWith('/api/submissions') && init?.method === 'POST') {
+          return new Response(JSON.stringify({ token: 'new-tok', slug: 'robot-garden' }), { status: 200 });
+        }
+        return new Response('{}', { status: 404 });
+      },
+    });
+    const asked = await handleReplLine({
+      line: 'A garden full of robots.',
+      api,
+      token: null,
+      write: (s) => lines.push(s),
+    });
+    expect(asked.draft?.questions).toHaveLength(1);
+    expect(lines.join('\n')).toContain('What tone?');
+    const opened = await handleReplLine({
+      line: 'calm',
+      api,
+      token: null,
+      draft: asked.draft,
+      write: (s) => lines.push(s),
+    });
+    expect(opened.token).toBe('new-tok');
+    expect(opened.draft).toBeNull();
   });
 });

--- a/apps/cli/src/repl.test.ts
+++ b/apps/cli/src/repl.test.ts
@@ -98,4 +98,19 @@ describe('repl turn loop', () => {
     expect(opened.token).toBe('new-tok');
     expect(opened.draft).toBeNull();
   });
+
+  it('treats a blank line as a no-op', async () => {
+    let posts = 0;
+    const api = createApi({
+      origin: 'https://www.gamedev.pl',
+      store: memoryStore({ accessToken: 'gdpl_oat_t', tokenType: 'Bearer', scope: 'creator' }),
+      fetch: async () => {
+        posts += 1;
+        return new Response('{}', { status: 404 });
+      },
+    });
+    const result = await handleReplLine({ line: '   ', api, token: 'tok', write: () => undefined });
+    expect(result.next).toBe('continue');
+    expect(posts).toBe(0);
+  });
 });

--- a/apps/cli/src/repl.test.ts
+++ b/apps/cli/src/repl.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import { handleReplLine } from './repl.js';
+import { createApi } from './api.js';
+import { memoryStore } from './keychain.js';
+
+describe('repl turn loop', () => {
+  it('prints a reply and does not invent a second request', async () => {
+    const lines: string[] = [];
+    let posts = 0;
+    const api = createApi({
+      origin: 'https://www.gamedev.pl',
+      store: memoryStore({ accessToken: 'gdpl_oat_t', tokenType: 'Bearer', scope: 'creator' }),
+      fetch: async (url) => {
+        if (String(url).endsWith('/turn')) {
+          posts += 1;
+          return new Response(JSON.stringify({ kind: 'reply', text: 'Still building.' }), {
+            status: 200,
+            headers: { 'content-type': 'application/json' },
+          });
+        }
+        return new Response('{}', { status: 404 });
+      },
+    });
+    await handleReplLine({ line: 'is it done yet?', api, token: 'tok', write: (s) => lines.push(s) });
+    expect(posts).toBe(1);
+    expect(lines.join('\n')).toContain('Still building.');
+    expect(lines.join('\n')).not.toMatch(/build /);
+  });
+});

--- a/apps/cli/src/repl.ts
+++ b/apps/cli/src/repl.ts
@@ -28,6 +28,7 @@ export async function handleReplLine(input: {
   write: (s: string) => void;
 }): Promise<ReplLineResult> {
   const trimmed = input.line.trim();
+  if (!trimmed) return { next: 'continue' };
   if (trimmed === '/quit' || trimmed === '/exit') return { next: 'quit' };
   if (trimmed === '/help') {
     input.write(SLASH_VERBS.map((verb) => `/${verb}`).join('\n'));

--- a/apps/cli/src/repl.ts
+++ b/apps/cli/src/repl.ts
@@ -1,0 +1,38 @@
+import { createTwoRegion, glyphs, wantsColor } from './renderer.js';
+import { completeSlash, SLASH_VERBS } from './argv.js';
+import { postTurn } from './turn.js';
+import type { ApiClient } from './api.js';
+
+export async function handleReplLine(input: {
+  line: string;
+  api: ApiClient;
+  token: string | null;
+  write: (s: string) => void;
+}): Promise<'continue' | 'quit'> {
+  const trimmed = input.line.trim();
+  if (trimmed === '/quit' || trimmed === '/exit') return 'quit';
+  if (trimmed === '/help') {
+    input.write(SLASH_VERBS.map((verb) => `/${verb}`).join('\n'));
+    return 'continue';
+  }
+  if (trimmed.startsWith('/') && !trimmed.includes(' ')) {
+    const matches = completeSlash(trimmed);
+    if (matches.length) input.write(matches.map((verb) => `/${verb}`).join('  '));
+    return 'continue';
+  }
+  if (!input.token) {
+    input.write('no open game — /games or describe an idea');
+    return 'continue';
+  }
+  const result = await postTurn(input.api, input.token, trimmed);
+  if (result.kind === 'reply') input.write(`◆ ${result.text}`);
+  else input.write(`▸ build ${result.roundId}${result.ack ? ` — ${result.ack}` : ''}`);
+  return 'continue';
+}
+
+export function replBanner(isTty: boolean, env: NodeJS.ProcessEnv): string {
+  const g = glyphs(wantsColor(env, isTty));
+  return `${g.agent} gamedev — ${g.prompt} to talk, /help for verbs`;
+}
+
+export { createTwoRegion };

--- a/apps/cli/src/repl.ts
+++ b/apps/cli/src/repl.ts
@@ -2,32 +2,67 @@ import { createTwoRegion, glyphs, wantsColor } from './renderer.js';
 import { completeSlash, SLASH_VERBS } from './argv.js';
 import { postTurn } from './turn.js';
 import type { ApiClient } from './api.js';
+import { answerDraft, beginIntake, formatQuestion, submitIdea, type IntakeDraft } from './create.js';
+
+export type ReplLineResult = {
+  next: 'continue' | 'quit';
+  token?: string | null;
+  draft?: IntakeDraft | null;
+};
+
+async function openFromSpec(
+  api: ApiClient,
+  spec: { title: string; concept: string },
+  write: (s: string) => void,
+): Promise<ReplLineResult> {
+  const created = await submitIdea(api, spec.title, spec.concept);
+  write(`▸ opened ${created.slug ?? created.token}`);
+  return { next: 'continue', token: created.token, draft: null };
+}
 
 export async function handleReplLine(input: {
   line: string;
   api: ApiClient;
   token: string | null;
+  draft?: IntakeDraft | null;
   write: (s: string) => void;
-}): Promise<'continue' | 'quit'> {
+}): Promise<ReplLineResult> {
   const trimmed = input.line.trim();
-  if (trimmed === '/quit' || trimmed === '/exit') return 'quit';
+  if (trimmed === '/quit' || trimmed === '/exit') return { next: 'quit' };
   if (trimmed === '/help') {
     input.write(SLASH_VERBS.map((verb) => `/${verb}`).join('\n'));
-    return 'continue';
+    return { next: 'continue' };
   }
   if (trimmed.startsWith('/') && !trimmed.includes(' ')) {
     const matches = completeSlash(trimmed);
     if (matches.length) input.write(matches.map((verb) => `/${verb}`).join('  '));
-    return 'continue';
+    return { next: 'continue' };
   }
   if (!input.token) {
-    input.write('no open game — /games or describe an idea');
-    return 'continue';
+    try {
+      if (input.draft) {
+        const answered = answerDraft(input.draft, trimmed);
+        if (answered.kind === 'ask') {
+          input.write(formatQuestion(answered.draft));
+          return { next: 'continue', draft: answered.draft };
+        }
+        return await openFromSpec(input.api, answered, input.write);
+      }
+      const started = await beginIntake(input.api, trimmed);
+      if (started.kind === 'ask') {
+        input.write(formatQuestion(started.draft));
+        return { next: 'continue', draft: started.draft };
+      }
+      return await openFromSpec(input.api, started, input.write);
+    } catch (error) {
+      input.write(error instanceof Error ? error.message : String(error));
+      return { next: 'continue', draft: input.draft ?? null };
+    }
   }
   const result = await postTurn(input.api, input.token, trimmed);
   if (result.kind === 'reply') input.write(`◆ ${result.text}`);
   else input.write(`▸ build ${result.roundId}${result.ack ? ` — ${result.ack}` : ''}`);
-  return 'continue';
+  return { next: 'continue' };
 }
 
 export function replBanner(isTty: boolean, env: NodeJS.ProcessEnv): string {

--- a/apps/cli/src/turn.test.ts
+++ b/apps/cli/src/turn.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+import { createApi } from './api.js';
+import { memoryStore } from './keychain.js';
+import { postTurn } from './turn.js';
+import { CliError, EXIT_AUTH } from './exit-codes.js';
+
+function mockFetch(handler: (url: string, init?: RequestInit) => { status: number; body: unknown }) {
+  return async (url: string, init?: RequestInit) => {
+    const result = handler(url, init);
+    return new Response(JSON.stringify(result.body), {
+      status: result.status,
+      headers: { 'content-type': 'application/json' },
+    });
+  };
+}
+
+describe('turn client', () => {
+  it('returns a reply without treating it as a build', async () => {
+    let posts = 0;
+    const api = createApi({
+      origin: 'https://www.gamedev.pl',
+      store: memoryStore({ accessToken: 'gdpl_oat_test', tokenType: 'Bearer', scope: 'creator' }),
+      fetch: mockFetch((url) => {
+        if (url.endsWith('/turn')) {
+          posts += 1;
+          return { status: 200, body: { kind: 'reply', text: 'Still building.' } };
+        }
+        return { status: 404, body: { error: 'not found' } };
+      }),
+    });
+    const result = await postTurn(api, 'tok', 'is it done yet?');
+    expect(result).toEqual({ kind: 'reply', text: 'Still building.' });
+    expect(posts).toBe(1);
+  });
+
+  it('maps 401 to auth failure', async () => {
+    const api = createApi({
+      origin: 'https://www.gamedev.pl',
+      store: memoryStore({ accessToken: 'gdpl_oat_dead', tokenType: 'Bearer', scope: 'creator' }),
+      fetch: mockFetch(() => ({ status: 401, body: { error: 'invalid token' } })),
+    });
+    await expect(postTurn(api, 'tok', 'hi')).rejects.toMatchObject({ exitCode: EXIT_AUTH } satisfies Partial<CliError>);
+  });
+});

--- a/apps/cli/src/turn.ts
+++ b/apps/cli/src/turn.ts
@@ -1,0 +1,39 @@
+import { CliError, EXIT_REFUSED } from './exit-codes.js';
+import type { ApiClient } from './api.js';
+
+export type TurnResult = { kind: 'reply'; text: string } | { kind: 'build'; ack?: string; roundId: number };
+
+export async function postTurn(api: ApiClient, token: string, text: string): Promise<TurnResult> {
+  return api.request<TurnResult>('POST', `/api/submissions/${encodeURIComponent(token)}/turn`, { text });
+}
+
+export async function getTurns(
+  api: ApiClient,
+  token: string,
+): Promise<{ turns: Array<{ message: string; reply?: string }> }> {
+  return api.request('GET', `/api/submissions/${encodeURIComponent(token)}/turns`);
+}
+
+export async function getStatus(
+  api: ApiClient,
+  token: string,
+): Promise<{
+  status: string;
+  gateProgress?: { stage: string; index: number; total: number };
+  previewGate?: { green: boolean };
+  preview?: { slug: string };
+  stall?: string;
+  failure?: { reason: string };
+}> {
+  return api.request('GET', `/api/submissions/${encodeURIComponent(token)}`);
+}
+
+export function previewUrl(origin: string, slug: string): string {
+  return `${origin}/play/${slug}`;
+}
+
+export function assertNoBuild(kind: TurnResult['kind']): void {
+  if (kind !== 'reply') {
+    throw new CliError('expected a conversational reply, not a build', EXIT_REFUSED);
+  }
+}

--- a/apps/cli/src/verify.test.ts
+++ b/apps/cli/src/verify.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+import { runLadder } from './verify.js';
+
+describe('verification ladder', () => {
+  it('runs typecheck and check:static always, check:game only for publish', () => {
+    const ran: string[] = [];
+    const run = (_cmd: string, args: string[]) => {
+      ran.push(args.join(' '));
+      return { status: 0, stderr: '' };
+    };
+    expect(runLadder({ cwd: '/tmp/game', publish: false, run }).ok).toBe(true);
+    expect(ran).toEqual(['run typecheck', 'run check:static']);
+    ran.length = 0;
+    expect(runLadder({ cwd: '/tmp/game', publish: true, run }).ok).toBe(true);
+    expect(ran).toContain('run check:game');
+  });
+
+  it('stops on the first red stage', () => {
+    const result = runLadder({
+      cwd: '/tmp/game',
+      publish: true,
+      run: (_cmd, args) =>
+        args.includes('check:static') ? { status: 1, stderr: 'static failed' } : { status: 0, stderr: '' },
+    });
+    expect(result).toEqual({ ok: false, stage: 'check_static', detail: 'static failed' });
+  });
+});

--- a/apps/cli/src/verify.ts
+++ b/apps/cli/src/verify.ts
@@ -3,12 +3,14 @@ import { CliError, EXIT_RED } from './exit-codes.js';
 
 export type VerifyStage = 'typecheck' | 'check_static' | 'check_game';
 
+type VerifyRun = (cmd: string, args: string[], cwd: string) => { status: number | null; stderr: string };
+
 export function runLadder(input: {
   cwd: string;
   publish: boolean;
-  run?: (cmd: string, args: string[], cwd: string) => { status: number; stderr: string };
+  run?: VerifyRun;
 }): { ok: true } | { ok: false; stage: VerifyStage; detail: string } {
-  const run = input.run ?? ((cmd, args, cwd) => spawnSync(cmd, args, { cwd, encoding: 'utf8' }));
+  const run: VerifyRun = input.run ?? ((cmd, args, cwd) => spawnSync(cmd, args, { cwd, encoding: 'utf8' }));
   const steps: Array<{ stage: VerifyStage; args: string[] }> = [
     { stage: 'typecheck', args: ['run', 'typecheck'] },
     { stage: 'check_static', args: ['run', 'check:static'] },

--- a/apps/cli/src/verify.ts
+++ b/apps/cli/src/verify.ts
@@ -1,0 +1,30 @@
+import { spawnSync } from 'node:child_process';
+import { CliError, EXIT_RED } from './exit-codes.js';
+
+export type VerifyStage = 'typecheck' | 'check_static' | 'check_game';
+
+export function runLadder(input: {
+  cwd: string;
+  publish: boolean;
+  run?: (cmd: string, args: string[], cwd: string) => { status: number; stderr: string };
+}): { ok: true } | { ok: false; stage: VerifyStage; detail: string } {
+  const run = input.run ?? ((cmd, args, cwd) => spawnSync(cmd, args, { cwd, encoding: 'utf8' }));
+  const steps: Array<{ stage: VerifyStage; args: string[] }> = [
+    { stage: 'typecheck', args: ['run', 'typecheck'] },
+    { stage: 'check_static', args: ['run', 'check:static'] },
+  ];
+  if (input.publish) steps.push({ stage: 'check_game', args: ['run', 'check:game'] });
+  for (const step of steps) {
+    const result = run('npm', step.args, input.cwd);
+    if ((result.status ?? 1) !== 0) {
+      return { ok: false, stage: step.stage, detail: result.stderr.slice(0, 500) };
+    }
+  }
+  return { ok: true };
+}
+
+export function assertLadderGreen(result: ReturnType<typeof runLadder>): void {
+  if (!result.ok) {
+    throw new CliError(`verify failed at ${result.stage}`, EXIT_RED, 'hand the failure back to the adapter');
+  }
+}

--- a/apps/cli/tsconfig.json
+++ b/apps/cli/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "types": ["node"],
+    "declaration": false,
+    "declarationMap": false
+  },
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts", "dist"]
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -63,7 +63,7 @@ survives only in this repo's early history.
 | [`own-ide-checkout.md`](./own-ide-checkout.md)                     | 🚧 A working copy for creators who prefer their own IDE — checkout, deliver back, one delivery contract |
 | [`cli-status-poll.md`](./cli-status-poll.md)                       | How a non-browser client watches a round: one status read, poll cadence, backoff (CL-12)                |
 | [`cli-pre-job-intake.md`](./cli-pre-job-intake.md)                 | Refine → submit stays client-side for the CLI's first milestone (CL-13)                                 |
-| [`../apps/cli/README.md`](../apps/cli/README.md)                   | `gamedev` terminal client (lives here until `gamedevpl/gamedev-cli` exists)                             |
+| [`../apps/cli/README.md`](../apps/cli/README.md)                   | `gamedev` terminal client in this repo — a separate `gamedevpl/gamedev-cli` repo is not planned         |
 | [`notifications-plan.md`](./notifications-plan.md)                 | Notify creators/players of transitions: detection sweep, per-user storage, in-app → email → push        |
 | [`creator-qa-plan.md`](./creator-qa-plan.md)                       | Clarifying-questions pass before spec freeze — raises the hit rate of the one-shot agent run            |
 | [`improvement-loop-plan.md`](./improvement-loop-plan.md)           | After publish: player signals → per-game scorecard → agent-assisted fixes and suggestions               |

--- a/docs/README.md
+++ b/docs/README.md
@@ -63,6 +63,7 @@ survives only in this repo's early history.
 | [`own-ide-checkout.md`](./own-ide-checkout.md)                     | 🚧 A working copy for creators who prefer their own IDE — checkout, deliver back, one delivery contract |
 | [`cli-status-poll.md`](./cli-status-poll.md)                       | How a non-browser client watches a round: one status read, poll cadence, backoff (CL-12)                |
 | [`cli-pre-job-intake.md`](./cli-pre-job-intake.md)                 | Refine → submit stays client-side for the CLI's first milestone (CL-13)                                 |
+| [`../apps/cli/README.md`](../apps/cli/README.md)                   | `gamedev` terminal client (lives here until `gamedevpl/gamedev-cli` exists)                             |
 | [`notifications-plan.md`](./notifications-plan.md)                 | Notify creators/players of transitions: detection sweep, per-user storage, in-app → email → push        |
 | [`creator-qa-plan.md`](./creator-qa-plan.md)                       | Clarifying-questions pass before spec freeze — raises the hit rate of the one-shot agent run            |
 | [`improvement-loop-plan.md`](./improvement-loop-plan.md)           | After publish: player signals → per-game scorecard → agent-assisted fixes and suggestions               |

--- a/package-lock.json
+++ b/package-lock.json
@@ -93,6 +93,24 @@
         "node": ">=6.9.0"
       }
     },
+    "apps/cli": {
+      "name": "@gamedevpl/cli",
+      "version": "0.1.0",
+      "bin": {
+        "gamedev": "dist/main.js",
+        "git-remote-gamedev": "dist/git-remote-main.js"
+      },
+      "devDependencies": {
+        "@types/node": "^20.14.15",
+        "esbuild": "0.25.12",
+        "tsx": "^4.16.5",
+        "typescript": "^5.5.4",
+        "vitest": "^3.2.7"
+      },
+      "engines": {
+        "node": ">=20.19"
+      }
+    },
     "apps/e2e": {
       "name": "@gamedevpl/e2e",
       "version": "0.0.0",
@@ -1693,6 +1711,10 @@
     },
     "node_modules/@gamedevpl/api": {
       "resolved": "apps/api",
+      "link": true
+    },
+    "node_modules/@gamedevpl/cli": {
+      "resolved": "apps/cli",
       "link": true
     },
     "node_modules/@gamedevpl/contract": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   ],
   "scripts": {
     "build:packages": "npm run build -w @gamedevpl/contract && npm run build -w @gamedevpl/zone-core",
-    "build": "npm run build:packages && npm run build -w @gamedevpl/api && npm run build -w @gamedevpl/web",
+    "build": "npm run build:packages && npm run build -w @gamedevpl/api && npm run build -w @gamedevpl/web && npm run build -w @gamedevpl/cli",
     "dev": "npm run build:packages && concurrently -n api,web -c blue,green \"npm run dev -w @gamedevpl/api\" \"npm run dev -w @gamedevpl/web\"",
     "test": "npm run build:packages && npm run test --workspaces --if-present && npm run test:rules",
     "// test:rules": "eslint-rules/ is not a workspace, so `npm test --workspaces` cannot reach it. Run explicitly, or the rule guarding every import in the repo is the one thing with no test running in CI.",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Wave C (and the client halves of D/E) of the gamedev creator CLI.

## Stop-point (owner decision)

**No extra CLI repo.** The client stays in `apps/cli` in this repo. `gamedevpl/gamedev-cli` will not be created. Revisit only with a concrete reason.

## CL-ids

| Id | What landed |
| --- | --- |
| **CL-14** | TypeScript workspace `@gamedevpl/cli`, `gamedev` bin, esbuild bundle script. No engine content. |
| **CL-15** | Encrypted-file token store (loud warning); `GAMEDEV_TOKEN` for CI. OS keychain wrappers can slot in without changing callers. Never plaintext `gdpl_oat_` on disk (tested). |
| **CL-16a** | Ink spike: **no-go** in this environment (`apps/cli/docs/ink-spike.md`). |
| **CL-16** | Custom two-region renderer; `◆`/`›`; `NO_COLOR`; REPL over verbs. |
| **CL-17** | Create intake: `gamedev create` and the REPL with no token call `refineIdea` then `submitIdea`. Refine questions are answered inline in the REPL; a pipe still requires `--answers` (exit 4). |
| **CL-18** | Iterate: a status question POSTs `/turn` once and prints a reply (asserted; no extra dispatch). |
| **CL-19** | Graphics probe uses kitty/iTerm env, not a generic `TERM`. |
| **CL-20 / CL-30** | Slash verbs + `gamedev `; exit `0/1/2/3/4`. |
| **CL-21** | Error helpers with a next action (closed beta, quota, pipe, gate red). |
| **CL-22** | Versioned `adapters.json` for claude/codex/gemini/vibe; unsupported custom file. |
| **CL-23** | Hostile NDJSON fixture: CSI/OSC/forged `✓ preview green` render as adapter-owned inert lines. |
| **CL-24** | Child env strip: no `gdpl_oat_` / `GAMEDEV_TOKEN`; round token only. |
| **CL-25** | `typecheck` + `check:static` always; `check:game` only for publish; red stops the ladder. |
| **CL-26** | Ask per task; `--agent` / `--platform` skip; nothing remembered. |
| **CL-28/29/29a** | `checkout` always `git init` + `gamedev://` remote; `diff` refuses unreconciled; `git-remote-gamedev` advertises fetch/push. Workspace download and helper stdin land in #1081. |

## Codex review follow-up

- REPL first-game intake: with no token, a typed idea calls refine then submit and keeps the returned token for later turns (no more `no open game` dead end).

## Copilot follow-up

Typed `defaultRun` / `VerifyRun`, and `isLaunchedEntry` so the bundled script actually runs. Docs no longer wait on a separate `gamedev-cli` repo. Verbose adapter lines go through `sanitizeEventPayload` so OSC/CSI cannot leak when `--verbose` is on.

## Not in this PR

- Loopback browser OAuth (TTY login prints the authorize URL; CI uses `GAMEDEV_TOKEN`).
- Owner-held code-signing / provenance secrets for real per-platform binaries (CL-33).
- Installer routes, `/cli` page, connect-card tab, PAT mint UI, games-repo kit scripts (later waves).

Stacked on #1079 (Wave B).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c227c8cb-c1d6-41f1-9f0a-5787614f7ba7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c227c8cb-c1d6-41f1-9f0a-5787614f7ba7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

