### PR TITLE
fix(web): prevent search no-match flicker and stabilize state transitions

### DIFF
--- a/apps/web/src/HeroPromptSection.test.tsx
+++ b/apps/web/src/HeroPromptSection.test.tsx
@@ -802,11 +802,52 @@ describe('HeroPromptSection', () => {
       await flushEffects();
     });
 
-    // Finished search with no match shows creation card.
+    // Finished search with no match shows creation card with CTA button.
     expect(container.querySelector('.searching-card')).toBeNull();
     expect(container.querySelector('.matched-card')).toBeNull();
     expect(container.querySelector('.creation-card')).not.toBeNull();
     expect(container.querySelector('.creation-card')?.textContent).toContain('Opisz swój pomysł na grę');
+    expect(container.querySelector('.creation-card .build-match-btn')?.textContent).toContain('Stwórz taką grę');
+
+    fetchSpy.mockRestore();
+    await act(async () => root.unmount());
+  });
+
+  it('does not show creation card for single-word query when search finds no match', async () => {
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    await i18n.changeLanguage('pl');
+
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(() =>
+      Promise.resolve(new Response(JSON.stringify({ match: null, score: 0 }), { status: 200 })),
+    );
+
+    await act(async () => {
+      root.render(
+        createElement(HeroPromptSection, {
+          initialPrompt: 'miecz',
+          catalogEntries: [],
+          submissionStatus: 'idle',
+          submissionError: null,
+          onSubmitSpec: vi.fn(),
+        }),
+      );
+      await flushEffects();
+    });
+
+    // Advance debounce timer
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 250));
+      await flushEffects();
+    });
+
+    // Single-word search with no match should not propose creation
+    expect(container.querySelector('.searching-card')).toBeNull();
+    expect(container.querySelector('.matched-card')).toBeNull();
+    expect(container.querySelector('.creation-card')).toBeNull();
 
     fetchSpy.mockRestore();
     await act(async () => root.unmount());

--- a/apps/web/src/HeroPromptSection.test.tsx
+++ b/apps/web/src/HeroPromptSection.test.tsx
@@ -853,6 +853,39 @@ describe('HeroPromptSection', () => {
     await act(async () => root.unmount());
   });
 
+  it('renders searching card on the very first synchronous paint when initialPrompt requires search', async () => {
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    await i18n.changeLanguage('pl');
+
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(() =>
+      Promise.resolve(new Response(JSON.stringify({ match: null, score: 0 }), { status: 200 })),
+    );
+
+    // Initial render without flushing effects or advancing timers
+    act(() => {
+      root.render(
+        createElement(HeroPromptSection, {
+          initialPrompt: 'symulator gotowania zupy pomidorowej',
+          catalogEntries: [],
+          submissionStatus: 'idle',
+          submissionError: null,
+          onSubmitSpec: vi.fn(),
+        }),
+      );
+    });
+
+    // Synchronous first paint must already show searching, never creation card
+    expect(container.querySelector('.searching-card')).not.toBeNull();
+    expect(container.querySelector('.creation-card')).toBeNull();
+
+    fetchSpy.mockRestore();
+    await act(async () => root.unmount());
+  });
+
   it('matches Polish sports intent query "chcę pograć w piłkę" to mexico-86', async () => {
     (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
     await i18n.changeLanguage('pl');

--- a/apps/web/src/HeroPromptSection.test.tsx
+++ b/apps/web/src/HeroPromptSection.test.tsx
@@ -733,12 +733,20 @@ describe('HeroPromptSection', () => {
       await flushEffects();
     });
 
+    // In-flight debounce shows search card and no creation flash.
+    expect(container.querySelector('.searching-card')).not.toBeNull();
+    expect(container.querySelector('.searching-spinner')).not.toBeNull();
+    expect(container.querySelector('.creation-card')).toBeNull();
+    expect(container.querySelector('.matched-card')).toBeNull();
+
     // Advance timer for 200ms debounce
     await act(async () => {
       await new Promise((r) => setTimeout(r, 250));
       await flushEffects();
     });
 
+    // Search match replaces search indicator with matched card.
+    expect(container.querySelector('.searching-card')).toBeNull();
     const card = container.querySelector('.matched-card');
     expect(card).not.toBeNull();
 
@@ -747,6 +755,58 @@ describe('HeroPromptSection', () => {
 
     const desc = container.querySelector('.matched-desc');
     expect(desc?.textContent).toBe('Deep space dogfights in a shattered galaxy.');
+
+    fetchSpy.mockRestore();
+    await act(async () => root.unmount());
+  });
+
+  it('shows searching state while debouncing and falls back to creation card when no match is found', async () => {
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    await i18n.changeLanguage('pl');
+
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(async (url) => {
+      if (String(url).includes('/api/catalog/search')) {
+        return {
+          ok: true,
+          json: async () => ({ match: null, score: 0 }),
+        } as Response;
+      }
+      return { ok: false } as Response;
+    });
+
+    await act(async () => {
+      root.render(
+        createElement(HeroPromptSection, {
+          initialPrompt: 'symulator gotowania zupy pomidorowej',
+          catalogEntries: [],
+          submissionStatus: 'idle',
+          submissionError: null,
+          onSubmitSpec: vi.fn(),
+        }),
+      );
+      await flushEffects();
+    });
+
+    // In-flight shows searching indicator, not creation card.
+    expect(container.querySelector('.searching-card')).not.toBeNull();
+    expect(container.querySelector('.searching-card')?.textContent).toContain('Szukanie w katalogu');
+    expect(container.querySelector('.creation-card')).toBeNull();
+
+    // Advance debounce timer
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 250));
+      await flushEffects();
+    });
+
+    // Finished search with no match shows creation card.
+    expect(container.querySelector('.searching-card')).toBeNull();
+    expect(container.querySelector('.matched-card')).toBeNull();
+    expect(container.querySelector('.creation-card')).not.toBeNull();
+    expect(container.querySelector('.creation-card')?.textContent).toContain('Opisz swój pomysł na grę');
 
     fetchSpy.mockRestore();
     await act(async () => root.unmount());
@@ -801,200 +861,5 @@ describe('HeroPromptSection', () => {
 
     await act(async () => root.unmount());
   });
-
-  it('correctly handles negative control queries without false positive matches', async () => {
-    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
-    await i18n.changeLanguage('en');
-
-    const container = document.createElement('div');
-    document.body.appendChild(container);
-    const root = createRoot(container);
-
-    const mockCatalog = [
-      {
-        slug: 'carjack-city',
-        title: 'Carjack City',
-        genre: 'action',
-        controls: 'WASD',
-        media: null,
-        multiplayer: null,
-        saves: null,
-        world: null,
-        sensing: null,
-        orientation: 'landscape' as const,
-        editor: null,
-        status: 'published' as const,
-        submittedBy: null,
-        tagline: { en: 'Top-down driving.', pl: 'Jazda samochodem.' },
-        searchKeywords: ['driving', 'car', 'cars'],
-      },
-      {
-        slug: 'mexico-86',
-        title: "Mexico '86 Arcade Football",
-        genre: 'sports',
-        controls: 'Arrows / Enter',
-        media: null,
-        multiplayer: null,
-        saves: null,
-        world: null,
-        sensing: null,
-        orientation: 'landscape' as const,
-        editor: null,
-        status: 'published' as const,
-        submittedBy: null,
-        tagline: { en: 'Tournament football.', pl: 'Turniej piłkarski.' },
-        searchKeywords: ['football', 'soccer', 'piłka', 'mundial'],
-      },
-      {
-        slug: 'checker-champ',
-        title: 'Checker Champ',
-        genre: 'board',
-        controls: 'Mouse',
-        media: null,
-        multiplayer: null,
-        saves: null,
-        world: null,
-        sensing: null,
-        orientation: 'landscape' as const,
-        editor: null,
-        status: 'published' as const,
-        submittedBy: null,
-        tagline: { en: 'Classic checkers.', pl: 'Klasyczne warcaby.' },
-        searchKeywords: ['checkers', 'warcaby'],
-      },
-      {
-        slug: 'classic-solitaire',
-        title: 'Classic Solitaire',
-        genre: 'cards',
-        controls: 'Mouse',
-        media: null,
-        multiplayer: null,
-        saves: null,
-        world: null,
-        sensing: null,
-        orientation: 'landscape' as const,
-        editor: null,
-        status: 'published' as const,
-        submittedBy: null,
-        tagline: { en: 'Klondike card solitaire.', pl: 'Pasjans karciany.' },
-        searchKeywords: ['cards', 'solitaire', 'karty', 'pasjans'],
-      },
-      {
-        slug: 'starweb-4x',
-        title: 'Starweb 4X',
-        genre: 'strategy',
-        controls: 'Mouse',
-        media: null,
-        multiplayer: null,
-        saves: null,
-        world: null,
-        sensing: null,
-        orientation: 'landscape' as const,
-        editor: null,
-        status: 'published' as const,
-        submittedBy: null,
-        tagline: { en: 'Galactic strategy.', pl: 'Galaktyczna strategia.' },
-        searchKeywords: ['4x', 'space', 'strategy'],
-      },
-    ];
-
-    const checkPrompt = async (prompt: string) => {
-      await act(async () => {
-        root.render(
-          createElement(HeroPromptSection, {
-            key: prompt,
-            initialPrompt: prompt,
-            catalogEntries: mockCatalog,
-            submissionStatus: 'idle',
-            submissionError: null,
-            onSubmitSpec: vi.fn(),
-          }),
-        );
-        await flushEffects();
-      });
-      return container.querySelector('.matched-card');
-    };
-
-    // "card" query should NOT false-match carjack-city
-    const cardMatch = await checkPrompt('I want to play a card game');
-    expect(cardMatch).not.toBeNull();
-    expect(container.querySelector('.matched-title')?.textContent).toBe('Classic Solitaire');
-
-    // Polish cards intent
-    const plCardMatch = await checkPrompt('chcę pograć w karty');
-    expect(plCardMatch).not.toBeNull();
-    expect(container.querySelector('.matched-title')?.textContent).toBe('Classic Solitaire');
-
-    // "gold rush" must NOT false-match mexico-86 via 'gol'
-    const goldRush = await checkPrompt('gold rush');
-    expect(goldRush).toBeNull();
-
-    // "author" and "autumn leaves" must NOT false-match carjack-city via 'aut'
-    const author = await checkPrompt('author');
-    expect(author).toBeNull();
-
-    const autumn = await checkPrompt('autumn leaves');
-    expect(autumn).toBeNull();
-
-    // "chess" / "szachy" must NOT false-match checker-champ
-    const chess = await checkPrompt('chess');
-    expect(chess).toBeNull();
-
-    const szachy = await checkPrompt('szachy');
-    expect(szachy).toBeNull();
-
-    // "web" must NOT false-match a game named starweb-4x by substring
-    const webMatch = await checkPrompt('web');
-    expect(webMatch).toBeNull();
-
-    await act(async () => root.unmount());
-  });
-
-  it('does not match cards game for query "car" via genre substring', async () => {
-    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
-    await i18n.changeLanguage('en');
-
-    const container = document.createElement('div');
-    document.body.appendChild(container);
-    const root = createRoot(container);
-
-    const cardsOnlyCatalog = [
-      {
-        slug: 'classic-solitaire',
-        title: 'Classic Solitaire',
-        genre: 'cards',
-        controls: 'Mouse',
-        media: null,
-        multiplayer: null,
-        saves: null,
-        world: null,
-        sensing: null,
-        orientation: 'landscape' as const,
-        editor: null,
-        status: 'published' as const,
-        submittedBy: null,
-        tagline: { en: 'Klondike card solitaire.', pl: 'Pasjans karciany.' },
-        searchKeywords: ['solitaire', 'pasjans'],
-      },
-    ];
-
-    await act(async () => {
-      root.render(
-        createElement(HeroPromptSection, {
-          key: 'car',
-          initialPrompt: 'car',
-          catalogEntries: cardsOnlyCatalog,
-          submissionStatus: 'idle',
-          submissionError: null,
-          onSubmitSpec: vi.fn(),
-        }),
-      );
-      await flushEffects();
-    });
-
-    const card = container.querySelector('.matched-card');
-    expect(card).toBeNull();
-
-    await act(async () => root.unmount());
-  });
 });
+

--- a/apps/web/src/HeroPromptSection.tsx
+++ b/apps/web/src/HeroPromptSection.tsx
@@ -212,48 +212,45 @@ export function HeroPromptSection({
         : null;
 
   const localMatchedGame = useMemo(() => findMatchingGame(promptText, catalogEntries), [promptText, catalogEntries]);
-  const [vectorMatchedGame, setVectorMatchedGame] = useState<CatalogEntry | null>(null);
-  const [isSearching, setIsSearching] = useState(false);
+  const [vectorMatch, setVectorMatch] = useState<{ query: string; match: CatalogEntry | null }>({
+    query: '',
+    match: null,
+  });
+
+  const trimmedPrompt = promptText.trim();
+  const needsVectorSearch = trimmedPrompt.length >= 3 && !localMatchedGame && !isBusy;
+  const isSearching = needsVectorSearch && vectorMatch.query !== trimmedPrompt;
+  const vectorMatchedGame = needsVectorSearch && vectorMatch.query === trimmedPrompt ? vectorMatch.match : null;
+  const matchedGame = localMatchedGame || vectorMatchedGame;
 
   useEffect(() => {
-    const trimmed = promptText.trim();
-    setVectorMatchedGame(null);
-    if (trimmed.length < 3) {
-      setIsSearching(false);
-      return;
-    }
+    if (!needsVectorSearch) return;
 
-    if (localMatchedGame || isBusy) {
-      setIsSearching(false);
-      return;
-    }
-
-    setIsSearching(true);
     const controller = new AbortController();
     const handle = setTimeout(() => {
-      fetch(`/api/catalog/search?q=${encodeURIComponent(trimmed)}`, { signal: controller.signal })
+      fetch(`/api/catalog/search?q=${encodeURIComponent(trimmedPrompt)}`, { signal: controller.signal })
         .then((res) => (res.ok ? res.json() : null))
         .then((data: { match?: CatalogEntry | null; score?: number } | null) => {
           if (data?.match && typeof data.score === 'number' && data.score >= 0.55) {
             const found = catalogEntries.find((e) => e.slug === data.match?.slug);
             if (found) {
-              setVectorMatchedGame({
-                ...found,
-                tagline: data.match.tagline || found.tagline,
-                shortControls: data.match.shortControls || found.shortControls,
-                searchKeywords: data.match.searchKeywords || found.searchKeywords,
+              setVectorMatch({
+                query: trimmedPrompt,
+                match: {
+                  ...found,
+                  tagline: data.match.tagline || found.tagline,
+                  shortControls: data.match.shortControls || found.shortControls,
+                  searchKeywords: data.match.searchKeywords || found.searchKeywords,
+                },
               });
-              setIsSearching(false);
               return;
             }
           }
-          setVectorMatchedGame(null);
-          setIsSearching(false);
+          setVectorMatch({ query: trimmedPrompt, match: null });
         })
         .catch(() => {
           if (!controller.signal.aborted) {
-            setVectorMatchedGame(null);
-            setIsSearching(false);
+            setVectorMatch({ query: trimmedPrompt, match: null });
           }
         });
     }, 200);
@@ -262,9 +259,7 @@ export function HeroPromptSection({
       clearTimeout(handle);
       controller.abort();
     };
-  }, [promptText, catalogEntries, localMatchedGame, isBusy]);
-
-  const matchedGame = vectorMatchedGame || localMatchedGame;
+  }, [trimmedPrompt, catalogEntries, needsVectorSearch]);
 
   const matchedPoster = useMemo(() => {
     if (!matchedGame?.media?.screenshots?.length) return null;

--- a/apps/web/src/HeroPromptSection.tsx
+++ b/apps/web/src/HeroPromptSection.tsx
@@ -612,6 +612,15 @@ export function HeroPromptSection({
                 </span>
                 <p className="creation-sub">{t('hero.smartNoMatchSub')}</p>
               </div>
+              <div className="creation-actions">
+                <button
+                  type="submit"
+                  className="primary-btn build-match-btn"
+                  disabled={isBusy || pendingAttachmentReads > 0 || (!promptText.trim() && attachments.length === 0)}
+                >
+                  <PixelIcon name="sparkle" size={14} /> {t('hero.smartBuildBtn')}
+                </button>
+              </div>
             </div>
           ) : null}
 

--- a/apps/web/src/HeroPromptSection.tsx
+++ b/apps/web/src/HeroPromptSection.tsx
@@ -273,6 +273,13 @@ export function HeroPromptSection({
     return file ? catalogMediaUrl(matchedGame.slug, file, 320) : null;
   }, [matchedGame]);
 
+  const isCreationIntentEligible = useMemo(() => {
+    const trimmed = promptText.trim();
+    if (attachments.length > 0) return true;
+    const words = trimmed.split(/\s+/).filter(Boolean);
+    return words.length >= 2 && trimmed.length >= 6;
+  }, [promptText, attachments.length]);
+
   const handleFiles = (files: FileList | File[]) => {
     if (submissionStatus !== 'idle') return;
     Array.from(files).forEach((file) => {
@@ -604,7 +611,7 @@ export function HeroPromptSection({
                 <p className="searching-sub">"{promptText.trim()}"</p>
               </div>
             </div>
-          ) : promptText.trim().length >= 3 ? (
+          ) : isCreationIntentEligible ? (
             <div className={`smart-intent-card creation-card${isBusy ? ' is-busy' : ''}`}>
               <div className="creation-info">
                 <span className="smart-badge creation-badge">

--- a/apps/web/src/HeroPromptSection.tsx
+++ b/apps/web/src/HeroPromptSection.tsx
@@ -33,207 +33,7 @@ export type VisualAttachment = {
   dataUrl: string;
 };
 
-const STOP_WORDS = new Set([
-  'chce',
-  'chcę',
-  'chcialbym',
-  'chciałbym',
-  'pograc',
-  'pograć',
-  'zagrac',
-  'zagrać',
-  'gra',
-  'gre',
-  'grę',
-  'grac',
-  'grać',
-  'gry',
-  'gier',
-  'jakas',
-  'jakaś',
-  'fajna',
-  'fajne',
-  'fajną',
-  'super',
-  'dla',
-  'mnie',
-  'w',
-  'z',
-  'na',
-  'do',
-  'o',
-  'i',
-  'oraz',
-  'lub',
-  'albo',
-  'po',
-  'od',
-  'jak',
-  'play',
-  'game',
-  'games',
-  'want',
-  'to',
-  'a',
-  'an',
-  'the',
-  'in',
-  'on',
-  'with',
-  'for',
-  'like',
-  'some',
-]);
-
-// Token-boundary synonyms mapping specific query words to matching catalog game concepts.
-const INTENT_TOKENS: Record<string, string[]> = {
-  // Football / Soccer
-  piłka: ['mexico-86', 'soccer', 'football'],
-  pilka: ['mexico-86', 'soccer', 'football'],
-  piłkę: ['mexico-86', 'soccer', 'football'],
-  pilke: ['mexico-86', 'soccer', 'football'],
-  piłkarski: ['mexico-86', 'soccer', 'football'],
-  pilkarski: ['mexico-86', 'soccer', 'football'],
-  piłkarskie: ['mexico-86', 'soccer', 'football'],
-  pilkarskie: ['mexico-86', 'soccer', 'football'],
-  futbol: ['mexico-86', 'soccer', 'football'],
-  football: ['mexico-86', 'soccer', 'football'],
-  soccer: ['mexico-86', 'soccer', 'football'],
-  mundial: ['mexico-86', 'soccer', 'football'],
-  mecz: ['mexico-86', 'soccer', 'football'],
-
-  // Cars / Racing
-  auto: ['carjack-city', 'racer', 'karts'],
-  auta: ['carjack-city', 'racer', 'karts'],
-  samochód: ['carjack-city', 'racer', 'karts'],
-  samochod: ['carjack-city', 'racer', 'karts'],
-  samochody: ['carjack-city', 'racer', 'karts'],
-  wyścigi: ['carjack-city', 'racer', 'karts'],
-  wyscigi: ['carjack-city', 'racer', 'karts'],
-  wyścig: ['carjack-city', 'racer', 'karts'],
-  wyscig: ['carjack-city', 'racer', 'karts'],
-  racing: ['carjack-city', 'racer', 'karts'],
-  racer: ['carjack-city', 'racer', 'karts'],
-  driving: ['carjack-city', 'racer', 'karts'],
-
-  // Snake
-  wąż: ['serpent-loop', 'snake'],
-  waz: ['serpent-loop', 'snake'],
-  snake: ['serpent-loop', 'snake'],
-  serpent: ['serpent-loop', 'snake'],
-
-  // Cards / Pasjans
-  karty: ['cards', 'solitaire', 'blackjack', 'poker', 'card'],
-  karta: ['cards', 'solitaire', 'blackjack', 'poker', 'card'],
-  karciane: ['cards', 'solitaire', 'blackjack', 'poker', 'card'],
-  karciana: ['cards', 'solitaire', 'blackjack', 'poker', 'card'],
-  cards: ['cards', 'solitaire', 'blackjack', 'poker', 'card'],
-  card: ['cards', 'solitaire', 'blackjack', 'poker', 'card'],
-  pasjans: ['cards', 'solitaire', 'blackjack', 'poker', 'card'],
-  solitaire: ['cards', 'solitaire', 'blackjack', 'poker', 'card'],
-
-  // Farm
-  farma: ['farm'],
-  farm: ['farm'],
-  farming: ['farm'],
-  rolnik: ['farm'],
-
-  // Tanks / Cannon
-  czołg: ['cannon', 'tank'],
-  czolg: ['cannon', 'tank'],
-  czołgi: ['cannon', 'tank'],
-  czolgi: ['cannon', 'tank'],
-  tank: ['cannon', 'tank'],
-  tanks: ['cannon', 'tank'],
-  cannon: ['cannon', 'tank'],
-
-  // Checkers
-  warcaby: ['checker'],
-  warcab: ['checker'],
-  checkers: ['checker'],
-  draughts: ['checker'],
-
-  // Pinball / Flipper
-  flipper: ['pinball'],
-  pinball: ['pinball'],
-
-  // Mario / Plumber
-  mario: ['plumber'],
-
-  // Space
-  kosmos: ['starweb', 'asteroid', 'space'],
-  space: ['starweb', 'asteroid', 'space'],
-  asteroids: ['starweb', 'asteroid', 'space'],
-  asteroidy: ['starweb', 'asteroid', 'space'],
-};
-
-function findMatchingGame(query: string, catalog: CatalogEntry[]): CatalogEntry | null {
-  const normalized = query.trim().toLowerCase();
-  if (!normalized || normalized.length < 2) return null;
-
-  const rawTokens = normalized
-    .replace(/[^a-ząćęłńóśźż0-9\s-]/g, ' ')
-    .split(/\s+/)
-    .filter((t) => t.length > 0);
-  const meaningfulTokens = rawTokens.filter((t) => !STOP_WORDS.has(t) && t.length > 1);
-  const queryTokens = meaningfulTokens.length > 0 ? meaningfulTokens : rawTokens;
-
-  for (const entry of catalog) {
-    const title = entry.title.toLowerCase();
-    const slug = entry.slug.toLowerCase();
-    const genre = entry.genre.toLowerCase();
-    const titleTokens = title.split(/[\s-]+/);
-    const slugTokens = slug.split(/[\s-]+/);
-    const genreTokens = genre.split(/[\s-]+/);
-
-    // 1. Direct exact or whole-word token match in title or slug
-    if (
-      title === normalized ||
-      slug === normalized ||
-      titleTokens.includes(normalized) ||
-      slugTokens.includes(normalized)
-    ) {
-      return entry;
-    }
-
-    // 2. Keyword exact token match
-    if (entry.searchKeywords?.some((k) => queryTokens.includes(k.toLowerCase().trim()))) {
-      return entry;
-    }
-
-    // 3. Exact intent token matching (avoids substring false positives)
-    for (const token of queryTokens) {
-      const targets = INTENT_TOKENS[token];
-      if (targets) {
-        if (
-          targets.some(
-            (target) =>
-              slugTokens.includes(target) ||
-              slug.includes(target) ||
-              titleTokens.includes(target) ||
-              title.includes(target) ||
-              genreTokens.includes(target) ||
-              entry.searchKeywords?.some((k) => k.toLowerCase().includes(target)),
-          )
-        ) {
-          return entry;
-        }
-      }
-    }
-
-    // 4. Word-boundary token match against title / keywords / genre
-    const keywordTokens = (entry.searchKeywords || []).map((k) => k.toLowerCase());
-    const matchedTokenCount = queryTokens.filter(
-      (t) => titleTokens.includes(t) || slugTokens.includes(t) || genreTokens.includes(t) || keywordTokens.includes(t),
-    ).length;
-
-    if (matchedTokenCount > 0 && matchedTokenCount >= Math.ceil(queryTokens.length / 2)) {
-      return entry;
-    }
-  }
-
-  return null;
-}
+import { findMatchingGame } from './findMatchingGame.js';
 
 interface SpeechRecognitionResultItem {
   transcript: string;
@@ -403,16 +203,32 @@ export function HeroPromptSection({
     }
   };
 
+  const isBusy = submissionStatus !== 'idle' || isPreparingAttachments;
+  const busyLabel =
+    submissionStatus === 'refining'
+      ? t('qa.analyzing')
+      : submissionStatus === 'loading'
+        ? t('submit.submitting')
+        : null;
+
   const localMatchedGame = useMemo(() => findMatchingGame(promptText, catalogEntries), [promptText, catalogEntries]);
   const [vectorMatchedGame, setVectorMatchedGame] = useState<CatalogEntry | null>(null);
+  const [isSearching, setIsSearching] = useState(false);
 
   useEffect(() => {
     const trimmed = promptText.trim();
     setVectorMatchedGame(null);
     if (trimmed.length < 3) {
+      setIsSearching(false);
       return;
     }
 
+    if (localMatchedGame || isBusy) {
+      setIsSearching(false);
+      return;
+    }
+
+    setIsSearching(true);
     const controller = new AbortController();
     const handle = setTimeout(() => {
       fetch(`/api/catalog/search?q=${encodeURIComponent(trimmed)}`, { signal: controller.signal })
@@ -427,14 +243,17 @@ export function HeroPromptSection({
                 shortControls: data.match.shortControls || found.shortControls,
                 searchKeywords: data.match.searchKeywords || found.searchKeywords,
               });
+              setIsSearching(false);
               return;
             }
           }
           setVectorMatchedGame(null);
+          setIsSearching(false);
         })
         .catch(() => {
           if (!controller.signal.aborted) {
             setVectorMatchedGame(null);
+            setIsSearching(false);
           }
         });
     }, 200);
@@ -443,7 +262,7 @@ export function HeroPromptSection({
       clearTimeout(handle);
       controller.abort();
     };
-  }, [promptText, catalogEntries]);
+  }, [promptText, catalogEntries, localMatchedGame, isBusy]);
 
   const matchedGame = vectorMatchedGame || localMatchedGame;
 
@@ -486,15 +305,6 @@ export function HeroPromptSection({
       e.target.value = '';
     }
   };
-
-  // Desktop clips Build label; spinner + status must stay visible.
-  const isBusy = submissionStatus !== 'idle' || isPreparingAttachments;
-  const busyLabel =
-    submissionStatus === 'refining'
-      ? t('qa.analyzing')
-      : submissionStatus === 'loading'
-        ? t('submit.submitting')
-        : null;
 
   // Close attach while busy so upload/draw cannot change mid-request.
   useEffect(() => {
@@ -733,7 +543,7 @@ export function HeroPromptSection({
             </div>
           )}
 
-          {matchedGame && (
+          {matchedGame ? (
             <div className="smart-intent-card matched-card">
               {matchedPoster && (
                 <div className="matched-thumb-wrap">
@@ -784,9 +594,17 @@ export function HeroPromptSection({
                 </button>
               </div>
             </div>
-          )}
-
-          {!matchedGame && promptText.trim().length >= 3 && (
+          ) : isSearching ? (
+            <div className="smart-intent-card searching-card" role="status" aria-live="polite">
+              <span className="searching-spinner" aria-hidden="true" />
+              <div className="searching-info">
+                <span className="smart-badge searching-badge">
+                  {t('hero.smartSearching')}
+                </span>
+                <p className="searching-sub">"{promptText.trim()}"</p>
+              </div>
+            </div>
+          ) : promptText.trim().length >= 3 ? (
             <div className={`smart-intent-card creation-card${isBusy ? ' is-busy' : ''}`}>
               <div className="creation-info">
                 <span className="smart-badge creation-badge">
@@ -795,7 +613,7 @@ export function HeroPromptSection({
                 <p className="creation-sub">{t('hero.smartNoMatchSub')}</p>
               </div>
             </div>
-          )}
+          ) : null}
 
           {quota && quota.limit !== null ? (
             <span className={`quota-note${quota.used >= quota.limit ? ' is-spent' : ''}`}>

--- a/apps/web/src/findMatchingGame.test.ts
+++ b/apps/web/src/findMatchingGame.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from "vitest";
+import { findMatchingGame } from "./findMatchingGame.js";
+import type { CatalogEntry } from "./catalog.js";
+
+describe("findMatchingGame", () => {
+  const mockCatalog: CatalogEntry[] = [
+    {
+      slug: "carjack-city",
+      title: "Carjack City",
+      genre: "action",
+      controls: "WASD",
+      media: null,
+      multiplayer: null,
+      saves: null,
+      world: null,
+      sensing: null,
+      orientation: "landscape" as const,
+      editor: null,
+      status: "published" as const,
+      submittedBy: null,
+      tagline: { en: "Top-down driving.", pl: "Jazda samochodem." },
+      searchKeywords: ["driving", "car", "cars"],
+    },
+    {
+      slug: "mexico-86",
+      title: "Mexico '86 Arcade Football",
+      genre: "sports",
+      controls: "Arrows / Enter",
+      media: null,
+      multiplayer: null,
+      saves: null,
+      world: null,
+      sensing: null,
+      orientation: "landscape" as const,
+      editor: null,
+      status: "published" as const,
+      submittedBy: null,
+      tagline: { en: "Tournament football.", pl: "Turniej piłkarski." },
+      searchKeywords: ["football", "soccer", "piłka", "mundial"],
+    },
+    {
+      slug: "checker-champ",
+      title: "Checker Champ",
+      genre: "board",
+      controls: "Mouse",
+      media: null,
+      multiplayer: null,
+      saves: null,
+      world: null,
+      sensing: null,
+      orientation: "landscape" as const,
+      editor: null,
+      status: "published" as const,
+      submittedBy: null,
+      tagline: { en: "Classic checkers.", pl: "Klasyczne warcaby." },
+      searchKeywords: ["checkers", "warcaby"],
+    },
+    {
+      slug: "classic-solitaire",
+      title: "Classic Solitaire",
+      genre: "cards",
+      controls: "Mouse",
+      media: null,
+      multiplayer: null,
+      saves: null,
+      world: null,
+      sensing: null,
+      orientation: "landscape" as const,
+      editor: null,
+      status: "published" as const,
+      submittedBy: null,
+      tagline: { en: "Klondike card solitaire.", pl: "Pasjans karciany." },
+      searchKeywords: ["cards", "solitaire", "karty", "pasjans"],
+    },
+  ];
+
+  it("matches Polish sports intent query to mexico-86", () => {
+    const match = findMatchingGame("chcę pograć w piłkę", mockCatalog);
+    expect(match?.slug).toBe("mexico-86");
+  });
+
+  it("matches card game intent query to classic-solitaire", () => {
+    const match = findMatchingGame("I want to play a card game", mockCatalog);
+    expect(match?.slug).toBe("classic-solitaire");
+  });
+
+  it("matches Polish cards intent to classic-solitaire", () => {
+    const match = findMatchingGame("chcę pograć w karty", mockCatalog);
+    expect(match?.slug).toBe("classic-solitaire");
+  });
+
+  it("does not false-match negative control queries", () => {
+    expect(findMatchingGame("gold rush", mockCatalog)).toBeNull();
+    expect(findMatchingGame("author", mockCatalog)).toBeNull();
+    expect(findMatchingGame("autumn leaves", mockCatalog)).toBeNull();
+    expect(findMatchingGame("chess", mockCatalog)).toBeNull();
+    expect(findMatchingGame("szachy", mockCatalog)).toBeNull();
+    expect(findMatchingGame("web", mockCatalog)).toBeNull();
+    expect(findMatchingGame("car", [{ ...mockCatalog[3] }])).toBeNull();
+  });
+});

--- a/apps/web/src/findMatchingGame.ts
+++ b/apps/web/src/findMatchingGame.ts
@@ -1,0 +1,203 @@
+import type { CatalogEntry } from "./catalog.js";
+
+export const STOP_WORDS = new Set([
+  "chce",
+  "chcę",
+  "chcialbym",
+  "chciałbym",
+  "pograc",
+  "pograć",
+  "zagrac",
+  "zagrać",
+  "gra",
+  "gre",
+  "grę",
+  "grac",
+  "grać",
+  "gry",
+  "gier",
+  "jakas",
+  "jakaś",
+  "fajna",
+  "fajne",
+  "fajną",
+  "super",
+  "dla",
+  "mnie",
+  "w",
+  "z",
+  "na",
+  "do",
+  "o",
+  "i",
+  "oraz",
+  "lub",
+  "albo",
+  "po",
+  "od",
+  "jak",
+  "play",
+  "game",
+  "games",
+  "want",
+  "to",
+  "a",
+  "an",
+  "the",
+  "in",
+  "on",
+  "with",
+  "for",
+  "like",
+  "some",
+]);
+
+// Token-boundary synonyms mapping specific query words to matching catalog game concepts.
+export const INTENT_TOKENS: Record<string, string[]> = {
+  // Football / Soccer
+  piłka: ["mexico-86", "soccer", "football"],
+  pilka: ["mexico-86", "soccer", "football"],
+  piłkę: ["mexico-86", "soccer", "football"],
+  pilke: ["mexico-86", "soccer", "football"],
+  piłkarski: ["mexico-86", "soccer", "football"],
+  pilkarski: ["mexico-86", "soccer", "football"],
+  piłkarskie: ["mexico-86", "soccer", "football"],
+  pilkarskie: ["mexico-86", "soccer", "football"],
+  futbol: ["mexico-86", "soccer", "football"],
+  football: ["mexico-86", "soccer", "football"],
+  soccer: ["mexico-86", "soccer", "football"],
+  mundial: ["mexico-86", "soccer", "football"],
+  mecz: ["mexico-86", "soccer", "football"],
+
+  // Cars / Racing
+  auto: ["carjack-city", "racer", "karts"],
+  auta: ["carjack-city", "racer", "karts"],
+  samochód: ["carjack-city", "racer", "karts"],
+  samochod: ["carjack-city", "racer", "karts"],
+  samochody: ["carjack-city", "racer", "karts"],
+  wyścigi: ["carjack-city", "racer", "karts"],
+  wyscigi: ["carjack-city", "racer", "karts"],
+  wyścig: ["carjack-city", "racer", "karts"],
+  wyscig: ["carjack-city", "racer", "karts"],
+  racing: ["carjack-city", "racer", "karts"],
+  racer: ["carjack-city", "racer", "karts"],
+  driving: ["carjack-city", "racer", "karts"],
+
+  // Snake
+  wąż: ["serpent-loop", "snake"],
+  waz: ["serpent-loop", "snake"],
+  snake: ["serpent-loop", "snake"],
+  serpent: ["serpent-loop", "snake"],
+
+  // Cards / Pasjans
+  karty: ["cards", "solitaire", "blackjack", "poker", "card"],
+  karta: ["cards", "solitaire", "blackjack", "poker", "card"],
+  karciane: ["cards", "solitaire", "blackjack", "poker", "card"],
+  karciana: ["cards", "solitaire", "blackjack", "poker", "card"],
+  cards: ["cards", "solitaire", "blackjack", "poker", "card"],
+  card: ["cards", "solitaire", "blackjack", "poker", "card"],
+  pasjans: ["cards", "solitaire", "blackjack", "poker", "card"],
+  solitaire: ["cards", "solitaire", "blackjack", "poker", "card"],
+
+  // Farm
+  farma: ["farm"],
+  farm: ["farm"],
+  farming: ["farm"],
+  rolnik: ["farm"],
+
+  // Tanks / Cannon
+  czołg: ["cannon", "tank"],
+  czolg: ["cannon", "tank"],
+  czołgi: ["cannon", "tank"],
+  czolgi: ["cannon", "tank"],
+  tank: ["cannon", "tank"],
+  tanks: ["cannon", "tank"],
+  cannon: ["cannon", "tank"],
+
+  // Checkers
+  warcaby: ["checker"],
+  warcab: ["checker"],
+  checkers: ["checker"],
+  draughts: ["checker"],
+
+  // Pinball / Flipper
+  flipper: ["pinball"],
+  pinball: ["pinball"],
+
+  // Mario / Plumber
+  mario: ["plumber"],
+
+  // Space
+  kosmos: ["starweb", "asteroid", "space"],
+  space: ["starweb", "asteroid", "space"],
+  asteroids: ["starweb", "asteroid", "space"],
+  asteroidy: ["starweb", "asteroid", "space"],
+};
+
+export function findMatchingGame(query: string, catalog: CatalogEntry[]): CatalogEntry | null {
+  const normalized = query.trim().toLowerCase();
+  if (!normalized || normalized.length < 2) return null;
+
+  const rawTokens = normalized
+    .replace(/[^a-ząćęłńóśźż0-9\s-]/g, " ")
+    .split(/\s+/)
+    .filter((t) => t.length > 0);
+  const meaningfulTokens = rawTokens.filter((t) => !STOP_WORDS.has(t) && t.length > 1);
+  const queryTokens = meaningfulTokens.length > 0 ? meaningfulTokens : rawTokens;
+
+  for (const entry of catalog) {
+    const title = entry.title.toLowerCase();
+    const slug = entry.slug.toLowerCase();
+    const genre = entry.genre.toLowerCase();
+    const titleTokens = title.split(/[\s-]+/);
+    const slugTokens = slug.split(/[\s-]+/);
+    const genreTokens = genre.split(/[\s-]+/);
+
+    // 1. Direct exact or whole-word token match in title or slug
+    if (
+      title === normalized ||
+      slug === normalized ||
+      titleTokens.includes(normalized) ||
+      slugTokens.includes(normalized)
+    ) {
+      return entry;
+    }
+
+    // 2. Keyword exact token match
+    if (entry.searchKeywords?.some((k) => queryTokens.includes(k.toLowerCase().trim()))) {
+      return entry;
+    }
+
+    // 3. Exact intent token matching (avoids substring false positives)
+    for (const token of queryTokens) {
+      const targets = INTENT_TOKENS[token];
+      if (targets) {
+        if (
+          targets.some(
+            (target) =>
+              slugTokens.includes(target) ||
+              slug.includes(target) ||
+              titleTokens.includes(target) ||
+              title.includes(target) ||
+              genreTokens.includes(target) ||
+              entry.searchKeywords?.some((k) => k.toLowerCase().includes(target)),
+          )
+        ) {
+          return entry;
+        }
+      }
+    }
+
+    // 4. Word-boundary token match against title / keywords / genre
+    const keywordTokens = (entry.searchKeywords || []).map((k) => k.toLowerCase());
+    const matchedTokenCount = queryTokens.filter(
+      (t) => titleTokens.includes(t) || slugTokens.includes(t) || genreTokens.includes(t) || keywordTokens.includes(t),
+    ).length;
+
+    if (matchedTokenCount > 0 && matchedTokenCount >= Math.ceil(queryTokens.length / 2)) {
+      return entry;
+    }
+  }
+
+  return null;
+}

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -128,7 +128,7 @@
     "smartNoMatchTitle": "Describe your game idea: \"{{query}}\"",
     "smartNoMatchSub": "Become the creator — let AI agents build your game idea!",
     "smartSearching": "Searching catalog…",
-    "smartBuildBtn": "Build this game with AI",
+    "smartBuildBtn": "Build this game",
     "keyboardShortcutHint": "Press ⌘+Enter or Ctrl+Enter to submit",
     "micStart": "Speak",
     "micListening": "Listening...",

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -127,6 +127,7 @@
     "smartMatchHint": "Looking for something else? Add more details above to build a new game.",
     "smartNoMatchTitle": "Describe your game idea: \"{{query}}\"",
     "smartNoMatchSub": "Become the creator — let AI agents build your game idea!",
+    "smartSearching": "Searching catalog…",
     "smartBuildBtn": "Build \"{{query}}\" with AI",
     "keyboardShortcutHint": "Press ⌘+Enter or Ctrl+Enter to submit",
     "micStart": "Speak",

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -128,7 +128,7 @@
     "smartNoMatchTitle": "Describe your game idea: \"{{query}}\"",
     "smartNoMatchSub": "Become the creator — let AI agents build your game idea!",
     "smartSearching": "Searching catalog…",
-    "smartBuildBtn": "Build \"{{query}}\" with AI",
+    "smartBuildBtn": "Build this game with AI",
     "keyboardShortcutHint": "Press ⌘+Enter or Ctrl+Enter to submit",
     "micStart": "Speak",
     "micListening": "Listening...",

--- a/apps/web/src/i18n/locales/pl.json
+++ b/apps/web/src/i18n/locales/pl.json
@@ -128,7 +128,7 @@
     "smartNoMatchTitle": "Opisz swój pomysł na grę: \"{{query}}\"",
     "smartNoMatchSub": "Zostań twórcą — pozwól agentom AI stworzyć Twój pomysł!",
     "smartSearching": "Szukanie w katalogu…",
-    "smartBuildBtn": "Stwórz taką grę z AI",
+    "smartBuildBtn": "Stwórz taką grę",
     "keyboardShortcutHint": "Naciśnij ⌘+Enter lub Ctrl+Enter, aby wysłać",
     "micStart": "Mów",
     "micListening": "Słucham...",

--- a/apps/web/src/i18n/locales/pl.json
+++ b/apps/web/src/i18n/locales/pl.json
@@ -127,6 +127,7 @@
     "smartMatchHint": "Chcesz stworzyć coś innego? Dopisz więcej szczegółów powyżej i stwórz nową grę.",
     "smartNoMatchTitle": "Opisz swój pomysł na grę: \"{{query}}\"",
     "smartNoMatchSub": "Zostań twórcą — pozwól agentom AI stworzyć Twój pomysł!",
+    "smartSearching": "Szukanie w katalogu…",
     "smartBuildBtn": "Stwórz \"{{query}}\" z AI",
     "keyboardShortcutHint": "Naciśnij ⌘+Enter lub Ctrl+Enter, aby wysłać",
     "micStart": "Mów",

--- a/apps/web/src/i18n/locales/pl.json
+++ b/apps/web/src/i18n/locales/pl.json
@@ -128,7 +128,7 @@
     "smartNoMatchTitle": "Opisz swój pomysł na grę: \"{{query}}\"",
     "smartNoMatchSub": "Zostań twórcą — pozwól agentom AI stworzyć Twój pomysł!",
     "smartSearching": "Szukanie w katalogu…",
-    "smartBuildBtn": "Stwórz \"{{query}}\" z AI",
+    "smartBuildBtn": "Stwórz taką grę z AI",
     "keyboardShortcutHint": "Naciśnij ⌘+Enter lub Ctrl+Enter, aby wysłać",
     "micStart": "Mów",
     "micListening": "Słucham...",

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -1122,16 +1122,11 @@ a {
   align-items: center;
 }
 
-.play-match-btn {
+.play-match-btn,
+.build-match-btn {
   background: var(--turquoise);
   color: #0b221d;
   font-weight: 700;
-}
-
-.remix-match-btn {
-  background: rgba(255, 255, 255, 0.06);
-  border: 1px solid var(--panel-border);
-  color: var(--text);
 }
 
 .creation-card {
@@ -1153,16 +1148,6 @@ a {
   display: flex;
   gap: 10px;
   align-items: center;
-}
-
-.build-match-btn {
-  background: #38bdf8;
-  color: #0b1a2b;
-  font-weight: 700;
-}
-
-.build-match-btn:hover:not(:disabled) {
-  background: #7dd3fc;
 }
 
 .creation-badge,
@@ -4179,16 +4164,19 @@ body.player-open {
     width: 100%;
   }
 
-  .matched-card {
+  .matched-card,
+  .creation-card {
     flex-direction: column;
     align-items: stretch;
   }
 
-  .matched-actions {
+  .matched-actions,
+  .creation-actions {
     flex-direction: column;
   }
 
-  .matched-actions button {
+  .matched-actions button,
+  .creation-actions button {
     width: 100%;
   }
 

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -985,18 +985,55 @@ a {
   padding: 16px 20px;
   border-radius: 12px;
   text-align: left;
-  animation: fadeIn 0.25s ease-out;
+  min-height: 72px;
+  box-sizing: border-box;
+  animation: fadeIn 0.2s ease-out;
+  transition:
+    background 0.2s ease,
+    border-color 0.2s ease,
+    min-height 0.2s ease;
 }
 
 @keyframes fadeIn {
   from {
     opacity: 0;
-    transform: translateY(-6px);
+    transform: translateY(-4px);
   }
   to {
     opacity: 1;
     transform: translateY(0);
   }
+}
+
+.searching-card {
+  background: rgba(0, 228, 172, 0.04);
+  border: 1px dashed rgba(0, 228, 172, 0.3);
+  display: flex;
+  align-items: center;
+  gap: 14px;
+}
+
+.searching-card .searching-spinner {
+  width: 18px;
+  height: 18px;
+  flex: none;
+  border-radius: 50%;
+  border: 2px solid rgba(0, 228, 172, 0.25);
+  border-top-color: var(--turquoise);
+  animation: status-spin 0.8s linear infinite;
+}
+
+.searching-info {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+
+.searching-sub {
+  margin: 0;
+  font-size: 0.85rem;
+  color: var(--muted);
+  font-style: italic;
 }
 
 .matched-card {
@@ -1102,13 +1139,19 @@ a {
   border: 1px solid rgba(56, 189, 248, 0.25);
 }
 
-.creation-badge {
-  color: var(--accent-blue);
+.creation-badge,
+.searching-badge {
   font-size: 0.85rem;
-  /* This badge quotes the creator's whole prompt back at them; the uppercase the
-     other badges use turned that quote into a full line of shouting. */
   text-transform: none;
   letter-spacing: normal;
+}
+
+.creation-badge {
+  color: var(--accent-blue);
+}
+
+.searching-badge {
+  color: var(--turquoise);
 }
 
 .creation-sub {

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -1137,6 +1137,32 @@ a {
 .creation-card {
   background: rgba(56, 189, 248, 0.08);
   border: 1px solid rgba(56, 189, 248, 0.25);
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+
+.creation-info {
+  flex: 1;
+  min-width: 200px;
+}
+
+.creation-actions {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+}
+
+.build-match-btn {
+  background: #38bdf8;
+  color: #0b1a2b;
+  font-weight: 700;
+}
+
+.build-match-btn:hover:not(:disabled) {
+  background: #7dd3fc;
 }
 
 .creation-badge,


### PR DESCRIPTION
## Summary
- Prevents premature 'no-match' (creation-card) flash while debounce and vector search are in progress.
- Adds an explicit searching indicator state (`searching-card`) with animated spinner and localized 'Searching catalog…' / 'Szukanie w katalogu…' status.
- Stabilizes dimensions and transitions across the 4 search states (empty, searching, matched, no-match) to avoid layout thrashing and catalog jumping.
- Extracts matching logic to `findMatchingGame.ts` with unit tests.

@codex please review.