### PR TITLE
fix(web): support cold vector search without preloaded catalog, remove quota line, and add text CTA to prompt button

### DIFF
--- a/apps/api/src/catalog/catalog-search-routes.ts
+++ b/apps/api/src/catalog/catalog-search-routes.ts
@@ -59,14 +59,7 @@ export async function registerCatalogSearchRoutes(
         const best = catalogVectorIndex.findBestMatch(queryVector, 0.55);
         if (best) {
           return reply.send({
-            match: {
-              slug: best.game.slug,
-              title: best.game.title,
-              genre: best.game.genre,
-              tagline: best.game.tagline,
-              shortControls: best.game.shortControls,
-              searchKeywords: best.game.searchKeywords,
-            },
+            match: best.game,
             score: best.score,
           });
         }

--- a/apps/web/src/App.qa.test.ts
+++ b/apps/web/src/App.qa.test.ts
@@ -217,10 +217,9 @@ describe('the QA gate in App', () => {
       await flushEffects();
     });
 
-    const buildBtn = container.querySelector<HTMLButtonElement>('.build-btn');
-    expect(buildBtn?.textContent).toContain('Analyzing your idea');
-    expect(buildBtn?.textContent).not.toContain('Submitting');
-    expect(buildBtn?.disabled).toBe(true);
+    const busyStatus = container.querySelector('.prompt-busy-status');
+    expect(busyStatus?.textContent).toContain('Analyzing your idea');
+    expect(busyStatus?.textContent).not.toContain('Submitting');
 
     // Release the refiner: the label hands over to the panel, not to "Submitting…".
     await act(async () => {
@@ -230,7 +229,7 @@ describe('the QA gate in App', () => {
     });
 
     expect(inWizard('.qa-wizard')).not.toBeNull();
-    expect(container.querySelector<HTMLButtonElement>('.build-btn')?.textContent).toContain('Build My Game');
+    expect(container.querySelector('.prompt-busy-status')).toBeNull();
     await act(async () => root.unmount());
   });
 

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -298,23 +298,21 @@ export function App() {
   // `/play/<slug>` auto-opens theater once the catalog confirms the game.
   // Close replaces onto the canonical page; in-place Play is untouched.
   useEffect(() => {
-    if (route.view !== 'play') return;
-
-    const entry = catalogEntries.find((game) => game.slug === route.slug);
-
-    if (stageContent?.type === 'catalog' && stageContent.game.slug === route.slug) {
+    if (stageContent?.type === 'catalog') {
+      const entry = catalogEntries.find((game) => game.slug === stageContent.game.slug);
       if (entry && stageContent.game !== entry) {
         setStageContent((prev) =>
-          prev?.type === 'catalog' && prev.game.slug === route.slug ? { ...prev, game: entry } : prev,
+          prev?.type === 'catalog' && prev.game.slug === entry.slug ? { ...prev, game: entry } : prev,
         );
       }
-      // Ready + missing → UnpublishedPlayView.
-      if (catalogStatus === 'ready' && !entry) {
+      if (route.view === 'play' && catalogStatus === 'ready' && !entry) {
         setStageContent(null);
       }
       return;
     }
 
+    if (route.view !== 'play') return;
+    const entry = catalogEntries.find((game) => game.slug === route.slug);
     // Wait so unknown slugs do not flash a 404 theater.
     if (catalogStatus !== 'ready' || !entry) return;
 
@@ -834,7 +832,8 @@ export function App() {
 
   function handlePlayGame(game: CatalogEntry, via?: PlayVia) {
     // In-place Play from home/profile/game page; `/play/<slug>` auto-opens itself.
-    setStageContent({ type: 'catalog', game, ...(via === undefined ? {} : { via }) });
+    const fullEntry = catalogEntries.find((e) => e.slug === game.slug) ?? game;
+    setStageContent({ type: 'catalog', game: fullEntry, ...(via === undefined ? {} : { via }) });
     // Soft refresh so "continue" / genre picks update after the next home visit.
     setRecommendationsRefreshKey((n) => n + 1);
   }

--- a/apps/web/src/HeroPromptSection.test.tsx
+++ b/apps/web/src/HeroPromptSection.test.tsx
@@ -796,18 +796,23 @@ describe('HeroPromptSection', () => {
     expect(container.querySelector('.searching-card')?.textContent).toContain('Szukanie w katalogu');
     expect(container.querySelector('.creation-card')).toBeNull();
 
+    // During debounced search: searching card is displayed, build-btn stays compact circle
+    expect(container.querySelector('.searching-card')).not.toBeNull();
+    expect(container.querySelector('.build-btn')?.classList.contains('has-text-cta')).toBe(false);
+
     // Advance debounce timer
     await act(async () => {
       await new Promise((r) => setTimeout(r, 250));
       await flushEffects();
     });
 
-    // Finished search with no match shows creation card with CTA button.
+    // Search with no match shows creation card and expanded CTA.
     expect(container.querySelector('.searching-card')).toBeNull();
     expect(container.querySelector('.matched-card')).toBeNull();
     expect(container.querySelector('.creation-card')).not.toBeNull();
     expect(container.querySelector('.creation-card')?.textContent).toContain('Opisz swój pomysł na grę');
     expect(container.querySelector('.creation-card .build-match-btn')?.textContent).toContain('Stwórz taką grę');
+    expect(container.querySelector('.build-btn')?.classList.contains('has-text-cta')).toBe(true);
 
     fetchSpy.mockRestore();
     await act(async () => root.unmount());
@@ -894,25 +899,16 @@ describe('HeroPromptSection', () => {
     document.body.appendChild(container);
     const root = createRoot(container);
 
-    const mockCatalog = [
-      {
-        slug: 'mexico-86',
-        title: "Mexico '86 Arcade Football",
-        genre: 'sports',
-        controls: 'Arrows / Enter',
-        media: null,
-        multiplayer: null,
-        saves: null,
-        world: null,
-        sensing: null,
-        orientation: 'landscape' as const,
-        editor: null,
-        status: 'published' as const,
-        submittedBy: null,
-        tagline: { en: 'Tournament football.', pl: 'Turniej piłkarski.' },
-        searchKeywords: ['football', 'soccer', 'piłka', 'mundial'],
-      },
-    ];
+    const mockCatalog = [{
+      slug: 'mexico-86',
+      title: "Mexico '86 Arcade Football",
+      genre: 'sports',
+      controls: 'Arrows / Enter',
+      media: null, multiplayer: null, saves: null, world: null, sensing: null,
+      orientation: 'landscape' as const, editor: null, status: 'published' as const, submittedBy: null,
+      tagline: { en: 'Tournament football.', pl: 'Turniej piłkarski.' },
+      searchKeywords: ['football', 'soccer', 'piłka', 'mundial'],
+    }];
 
     await act(async () => {
       root.render(
@@ -929,9 +925,7 @@ describe('HeroPromptSection', () => {
 
     const card = container.querySelector('.matched-card');
     expect(card).not.toBeNull();
-
-    const title = container.querySelector('.matched-title');
-    expect(title?.textContent).toBe("Mexico '86 Arcade Football");
+    expect(container.querySelector('.matched-title')?.textContent).toBe("Mexico '86 Arcade Football");
 
     await act(async () => root.unmount());
   });
@@ -954,15 +948,7 @@ describe('HeroPromptSection', () => {
     };
 
     const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(() =>
-      Promise.resolve(
-        new Response(
-          JSON.stringify({
-            match: vectorMatchGame,
-            score: 0.85,
-          }),
-          { status: 200 },
-        ),
-      ),
+      Promise.resolve(new Response(JSON.stringify({ match: vectorMatchGame, score: 0.85 }), { status: 200 })),
     );
 
     // Initial render with catalogEntries = [] (e.g. initial cold load)
@@ -985,10 +971,11 @@ describe('HeroPromptSection', () => {
       await flushEffects();
     });
 
-    // Even with empty catalogEntries, match should be displayed
+    // Match is displayed and prompt button shows build CTA.
     const card = container.querySelector('.matched-card');
     expect(card).not.toBeNull();
     expect(container.querySelector('.matched-title')?.textContent).toBe('Bonfire Arena');
+    expect(container.querySelector('.build-btn')?.classList.contains('has-text-cta')).toBe(true);
 
     fetchSpy.mockRestore();
     await act(async () => root.unmount());

--- a/apps/web/src/HeroPromptSection.test.tsx
+++ b/apps/web/src/HeroPromptSection.test.tsx
@@ -935,5 +935,63 @@ describe('HeroPromptSection', () => {
 
     await act(async () => root.unmount());
   });
+
+  it('matches game from vector search even when catalogEntries is initially empty on cold load', async () => {
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    await i18n.changeLanguage('pl');
+
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    const vectorMatchGame = {
+      slug: 'bonfire-arena',
+      title: 'Bonfire Arena',
+      genre: 'soulslike',
+      tagline: { pl: 'Pojedynki na miecze', en: 'Sword duels' },
+      shortControls: { pl: 'Strzałki / Spacja', en: 'Arrows / Space' },
+      searchKeywords: ['miecze', 'walka'],
+    };
+
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(() =>
+      Promise.resolve(
+        new Response(
+          JSON.stringify({
+            match: vectorMatchGame,
+            score: 0.85,
+          }),
+          { status: 200 },
+        ),
+      ),
+    );
+
+    // Initial render with catalogEntries = [] (e.g. initial cold load)
+    await act(async () => {
+      root.render(
+        createElement(HeroPromptSection, {
+          initialPrompt: 'walka na miecze',
+          catalogEntries: [],
+          submissionStatus: 'idle',
+          submissionError: null,
+          onSubmitSpec: vi.fn(),
+        }),
+      );
+      await flushEffects();
+    });
+
+    // Advance debounce
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 250));
+      await flushEffects();
+    });
+
+    // Even with empty catalogEntries, match should be displayed
+    const card = container.querySelector('.matched-card');
+    expect(card).not.toBeNull();
+    expect(container.querySelector('.matched-title')?.textContent).toBe('Bonfire Arena');
+
+    fetchSpy.mockRestore();
+    await act(async () => root.unmount());
+  });
 });
 

--- a/apps/web/src/HeroPromptSection.test.tsx
+++ b/apps/web/src/HeroPromptSection.test.tsx
@@ -53,11 +53,9 @@ describe('HeroPromptSection', () => {
 
     const attachBtn = container.querySelector('.attach-btn');
     const micBtn = container.querySelector('.mic-btn');
-    const buildBtn = container.querySelector('.build-btn');
 
     expect(attachBtn).not.toBeNull();
     expect(micBtn).not.toBeNull();
-    expect(buildBtn).not.toBeNull();
     expect(container.querySelector('.prompt-composer-bar')).not.toBeNull();
     expect(container.querySelectorAll('.chip-btn')).toHaveLength(0);
 
@@ -93,13 +91,13 @@ describe('HeroPromptSection', () => {
       await flushEffects();
     });
 
-    expect(document.activeElement).not.toBe(container.querySelector('.big-prompt-input'));
+    const textarea = container.querySelector('.big-prompt-input');
+    expect(document.activeElement).not.toBe(textarea);
 
     await act(async () => root.unmount());
   });
 
   it('says it is analyzing while the refiner runs, and submitting only once it is', async () => {
-    // refining must not claim Submitting before anything is sent
     (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
     await i18n.changeLanguage('en');
 
@@ -120,17 +118,19 @@ describe('HeroPromptSection', () => {
         );
         await flushEffects();
       });
-      return container.querySelector<HTMLButtonElement>('.build-btn');
     };
 
-    expect((await renderWithStatus('refining'))?.textContent).toContain('Analyzing your idea');
-    expect((await renderWithStatus('loading'))?.textContent).toContain('Submitting');
-    expect((await renderWithStatus('idle'))?.textContent).toContain('Build My Game');
+    await renderWithStatus('refining');
+    expect(container.querySelector('.prompt-busy-status')?.textContent).toContain('Analyzing your idea');
+    expect(container.querySelector<HTMLInputElement>('.big-prompt-input')?.disabled).toBe(true);
 
-    // Busy must disable the button against a second fire.
-    expect((await renderWithStatus('refining'))?.disabled).toBe(true);
-    expect((await renderWithStatus('loading'))?.disabled).toBe(true);
-    expect((await renderWithStatus('idle'))?.disabled).toBe(false);
+    await renderWithStatus('loading');
+    expect(container.querySelector('.prompt-busy-status')?.textContent).toContain('Submitting');
+    expect(container.querySelector<HTMLInputElement>('.big-prompt-input')?.disabled).toBe(true);
+
+    await renderWithStatus('idle');
+    expect(container.querySelector('.prompt-busy-status')).toBeNull();
+    expect(container.querySelector<HTMLInputElement>('.big-prompt-input')?.disabled).toBe(false);
 
     await act(async () => root.unmount());
   });
@@ -161,7 +161,6 @@ describe('HeroPromptSection', () => {
 
     await renderWithStatus('refining');
     expect(container.querySelector('.prompt-composer-bar.is-busy')).not.toBeNull();
-    expect(container.querySelector('.build-btn.is-busy')).not.toBeNull();
     expect(container.querySelector('.build-btn-spinner')).not.toBeNull();
     expect(container.querySelector('.prompt-busy-status')?.textContent).toMatch(/Analyzing your idea/i);
     expect(container.querySelector('.creation-card.is-busy .creation-sub')?.textContent).toMatch(/Become the creator/i);
@@ -318,7 +317,6 @@ describe('HeroPromptSection', () => {
       await flushEffects();
     });
 
-    expect(container.querySelector<HTMLButtonElement>('.build-btn')?.disabled).toBe(true);
     await act(async () => {
       container
         .querySelector('.prompt-box-form')
@@ -330,7 +328,6 @@ describe('HeroPromptSection', () => {
     await act(async () => {
       await new Promise((resolve) => setTimeout(resolve, 10));
     });
-    expect(container.querySelector<HTMLButtonElement>('.build-btn')?.disabled).toBe(false);
 
     await act(async () => root.unmount());
   });
@@ -381,14 +378,12 @@ describe('HeroPromptSection', () => {
         ?.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }));
       await flushEffects();
     });
-    expect(container.querySelector<HTMLButtonElement>('.build-btn')?.disabled).toBe(true);
     expect(onSubmitSpec).not.toHaveBeenCalled();
 
     await act(async () => {
       resolveNormalization(['small']);
       await flushEffects();
     });
-    expect(container.querySelector<HTMLButtonElement>('.build-btn')?.disabled).toBe(false);
     expect(onSubmitSpec).toHaveBeenCalledTimes(1);
 
     await act(async () => root.unmount());
@@ -796,9 +791,8 @@ describe('HeroPromptSection', () => {
     expect(container.querySelector('.searching-card')?.textContent).toContain('Szukanie w katalogu');
     expect(container.querySelector('.creation-card')).toBeNull();
 
-    // During debounced search: searching card is displayed, build-btn stays compact circle
+    // During debounced search: searching card is displayed
     expect(container.querySelector('.searching-card')).not.toBeNull();
-    expect(container.querySelector('.build-btn')?.classList.contains('has-text-cta')).toBe(false);
 
     // Advance debounce timer
     await act(async () => {
@@ -806,13 +800,12 @@ describe('HeroPromptSection', () => {
       await flushEffects();
     });
 
-    // Search with no match shows creation card and expanded CTA.
+    // Search with no match shows creation card and build button.
     expect(container.querySelector('.searching-card')).toBeNull();
     expect(container.querySelector('.matched-card')).toBeNull();
     expect(container.querySelector('.creation-card')).not.toBeNull();
     expect(container.querySelector('.creation-card')?.textContent).toContain('Opisz swój pomysł na grę');
     expect(container.querySelector('.creation-card .build-match-btn')?.textContent).toContain('Stwórz taką grę');
-    expect(container.querySelector('.build-btn')?.classList.contains('has-text-cta')).toBe(true);
 
     fetchSpy.mockRestore();
     await act(async () => root.unmount());
@@ -971,11 +964,11 @@ describe('HeroPromptSection', () => {
       await flushEffects();
     });
 
-    // Match is displayed and prompt button shows build CTA.
+    // Match is displayed with play CTA and secondary build link.
     const card = container.querySelector('.matched-card');
     expect(card).not.toBeNull();
     expect(container.querySelector('.matched-title')?.textContent).toBe('Bonfire Arena');
-    expect(container.querySelector('.build-btn')?.classList.contains('has-text-cta')).toBe(true);
+    expect(container.querySelector('.matched-actions .match-build-link')?.textContent).toContain('lub stwórz swoją grę');
 
     fetchSpy.mockRestore();
     await act(async () => root.unmount());

--- a/apps/web/src/HeroPromptSection.tsx
+++ b/apps/web/src/HeroPromptSection.tsx
@@ -279,8 +279,6 @@ export function HeroPromptSection({
     return words.length >= 2 && trimmed.length >= 6;
   }, [promptText, attachments.length]);
 
-  const showTextualBuildCta = Boolean((matchedGame || isCreationIntentEligible) && !isSearching && !isBusy);
-
   const handleFiles = (files: FileList | File[]) => {
     if (submissionStatus !== 'idle') return;
     Array.from(files).forEach((file) => {
@@ -469,7 +467,6 @@ export function HeroPromptSection({
                 if (pastedImages.length > 0) handleFiles(pastedImages);
               }}
             />
-
             <div className="prompt-bar-actions">
               <button
                 type="button"
@@ -484,20 +481,7 @@ export function HeroPromptSection({
               </button>
             </div>
 
-            <button
-              type="submit"
-              className={`primary-btn build-btn${isBusy ? ' is-busy' : ''}${showTextualBuildCta ? ' has-text-cta' : ''}`}
-              title={busyLabel ?? t('hero.buildGameButton')}
-              aria-label={busyLabel ?? t('hero.buildGameButton')}
-              disabled={isBusy || pendingAttachmentReads > 0 || (!promptText.trim() && attachments.length === 0)}
-            >
-              {isBusy ? (
-                <span className="build-btn-spinner" aria-hidden="true" />
-              ) : (
-                <PixelIcon name={showTextualBuildCta ? 'sparkle' : 'send'} size={showTextualBuildCta ? 14 : 16} />
-              )}
-              <span className="build-btn-label">{busyLabel ?? t('hero.buildGameButton')}</span>
-            </button>
+            <button type="submit" style={{ display: 'none' }} aria-hidden="true" disabled={isBusy} />
           </div>
 
           {exampleChips && exampleChips.length > 0 && !isBusy && (
@@ -556,22 +540,24 @@ export function HeroPromptSection({
 
           {matchedGame ? (
             <div className="smart-intent-card matched-card">
-              {matchedPoster && (
+              {matchedPoster ? (
                 <div className="matched-thumb-wrap">
                   <img
                     src={matchedPoster}
                     alt={matchedGame.title}
                     className="matched-thumb"
-                    loading="eager"
+                    loading="lazy"
                     decoding="async"
                   />
                 </div>
-              )}
+              ) : null}
               <div className="matched-info">
                 <div className="matched-badges">
-                  <span className="smart-badge">
-                    <PixelIcon name="gamepad" size={12} /> {t('catalog.genre')}: {matchedGame.genre}
-                  </span>
+                  {matchedGame.genre && (
+                    <span className="smart-badge">
+                      <PixelIcon name="gamepad" size={12} /> {t('catalog.genre')}: {matchedGame.genre}
+                    </span>
+                  )}
                   {matchedGame.multiplayer && (
                     <span className="smart-badge smart-badge-secondary">
                       <PixelIcon name="user" size={12} /> {t('catalog.categories.multiplayer_party')}
@@ -602,6 +588,13 @@ export function HeroPromptSection({
                   disabled={isBusy}
                 >
                   <PixelIcon name="play" size={14} /> {t('hero.smartPlayBtn', { title: matchedGame.title })}
+                </button>
+                <button
+                  type="submit"
+                  className="match-build-link"
+                  disabled={isBusy || pendingAttachmentReads > 0 || (!promptText.trim() && attachments.length === 0)}
+                >
+                  <PixelIcon name="sparkle" size={12} /> {t('hero.orBuildOwnGame')}
                 </button>
               </div>
             </div>

--- a/apps/web/src/HeroPromptSection.tsx
+++ b/apps/web/src/HeroPromptSection.tsx
@@ -279,6 +279,8 @@ export function HeroPromptSection({
     return words.length >= 2 && trimmed.length >= 6;
   }, [promptText, attachments.length]);
 
+  const showTextualBuildCta = Boolean((matchedGame || isCreationIntentEligible) && !isSearching && !isBusy);
+
   const handleFiles = (files: FileList | File[]) => {
     if (submissionStatus !== 'idle') return;
     Array.from(files).forEach((file) => {
@@ -484,12 +486,16 @@ export function HeroPromptSection({
 
             <button
               type="submit"
-              className={`primary-btn build-btn${isBusy ? ' is-busy' : ''}`}
+              className={`primary-btn build-btn${isBusy ? ' is-busy' : ''}${showTextualBuildCta ? ' has-text-cta' : ''}`}
               title={busyLabel ?? t('hero.buildGameButton')}
               aria-label={busyLabel ?? t('hero.buildGameButton')}
               disabled={isBusy || pendingAttachmentReads > 0 || (!promptText.trim() && attachments.length === 0)}
             >
-              {isBusy ? <span className="build-btn-spinner" aria-hidden="true" /> : <PixelIcon name="sparkle" size={14} />}
+              {isBusy ? (
+                <span className="build-btn-spinner" aria-hidden="true" />
+              ) : (
+                <PixelIcon name={showTextualBuildCta ? 'sparkle' : 'send'} size={showTextualBuildCta ? 14 : 16} />
+              )}
               <span className="build-btn-label">{busyLabel ?? t('hero.buildGameButton')}</span>
             </button>
           </div>

--- a/apps/web/src/HeroPromptSection.tsx
+++ b/apps/web/src/HeroPromptSection.tsx
@@ -91,18 +91,16 @@ export function HeroPromptSection({
   const attachMenuRef = useRef<HTMLDivElement | null>(null);
   const attachPanelRef = useClampToViewport<HTMLDivElement>(attachMenuOpen);
 
-  // Show quota before a 429 after they finish typing.
-  const [quota, setQuota] = useState<{ used: number; limit: number | null } | null>(null);
+  // Platform builder availability poll.
   useEffect(() => {
     let cancelled = false;
     getQuota()
       .then((result) => {
         if (cancelled) return;
-        setQuota(result.submissions);
         onPlatformBuilderAvailability?.(result.platformBuilder);
       })
       .catch(() => {
-        // Signed out or unreachable — the line simply doesn't render.
+        // Signed out or unreachable.
       });
     return () => {
       cancelled = true;
@@ -220,7 +218,15 @@ export function HeroPromptSection({
   const trimmedPrompt = promptText.trim();
   const needsVectorSearch = trimmedPrompt.length >= 3 && !localMatchedGame && !isBusy;
   const isSearching = needsVectorSearch && vectorMatch.query !== trimmedPrompt;
-  const vectorMatchedGame = needsVectorSearch && vectorMatch.query === trimmedPrompt ? vectorMatch.match : null;
+  const rawVectorGame = needsVectorSearch && vectorMatch.query === trimmedPrompt ? vectorMatch.match : null;
+
+  // Enriches matched game with screenshots from catalog.
+  const vectorMatchedGame = useMemo(() => {
+    if (!rawVectorGame) return null;
+    const full = catalogEntries.find((e) => e.slug === rawVectorGame.slug);
+    return full ? { ...full, ...rawVectorGame } : rawVectorGame;
+  }, [rawVectorGame, catalogEntries]);
+
   const matchedGame = localMatchedGame || vectorMatchedGame;
 
   useEffect(() => {
@@ -233,18 +239,16 @@ export function HeroPromptSection({
         .then((data: { match?: CatalogEntry | null; score?: number } | null) => {
           if (data?.match && typeof data.score === 'number' && data.score >= 0.55) {
             const found = catalogEntries.find((e) => e.slug === data.match?.slug);
-            if (found) {
-              setVectorMatch({
-                query: trimmedPrompt,
-                match: {
+            const entry = found
+              ? {
                   ...found,
                   tagline: data.match.tagline || found.tagline,
                   shortControls: data.match.shortControls || found.shortControls,
                   searchKeywords: data.match.searchKeywords || found.searchKeywords,
-                },
-              });
-              return;
-            }
+                }
+              : (data.match as CatalogEntry);
+            setVectorMatch({ query: trimmedPrompt, match: entry });
+            return;
           }
           setVectorMatch({ query: trimmedPrompt, match: null });
         })
@@ -485,8 +489,7 @@ export function HeroPromptSection({
               aria-label={busyLabel ?? t('hero.buildGameButton')}
               disabled={isBusy || pendingAttachmentReads > 0 || (!promptText.trim() && attachments.length === 0)}
             >
-              {isBusy ? <span className="build-btn-spinner" aria-hidden="true" /> : <PixelIcon name="send" size={16} />}
-              {/* refining ≠ submitting; phone shows label, desktop clips to icon */}
+              {isBusy ? <span className="build-btn-spinner" aria-hidden="true" /> : <PixelIcon name="sparkle" size={14} />}
               <span className="build-btn-label">{busyLabel ?? t('hero.buildGameButton')}</span>
             </button>
           </div>
@@ -624,12 +627,6 @@ export function HeroPromptSection({
                 </button>
               </div>
             </div>
-          ) : null}
-
-          {quota && quota.limit !== null ? (
-            <span className={`quota-note${quota.used >= quota.limit ? ' is-spent' : ''}`}>
-              {t('hero.quotaLeft', { left: Math.max(0, quota.limit - quota.used), limit: quota.limit })}
-            </span>
           ) : null}
         </form>
 

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -129,6 +129,7 @@
     "smartNoMatchSub": "Become the creator — let AI agents build your game idea!",
     "smartSearching": "Searching catalog…",
     "smartBuildBtn": "Build this game",
+    "orBuildOwnGame": "or build your own game",
     "keyboardShortcutHint": "Press ⌘+Enter or Ctrl+Enter to submit",
     "micStart": "Speak",
     "micListening": "Listening...",

--- a/apps/web/src/i18n/locales/pl.json
+++ b/apps/web/src/i18n/locales/pl.json
@@ -129,6 +129,7 @@
     "smartNoMatchSub": "Zostań twórcą — pozwól agentom AI stworzyć Twój pomysł!",
     "smartSearching": "Szukanie w katalogu…",
     "smartBuildBtn": "Stwórz taką grę",
+    "orBuildOwnGame": "lub stwórz swoją grę",
     "keyboardShortcutHint": "Naciśnij ⌘+Enter lub Ctrl+Enter, aby wysłać",
     "micStart": "Mów",
     "micListening": "Słucham...",

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -484,7 +484,7 @@ a {
    height:auto so border-box can't clip 36px cells. */
 .prompt-composer-bar {
   display: grid;
-  grid-template-columns: 36px minmax(0, 1fr) 36px auto;
+  grid-template-columns: 36px minmax(0, 1fr) 36px;
   align-items: center;
   column-gap: 8px;
   width: 100%;
@@ -494,7 +494,7 @@ a {
   background: rgba(32, 42, 51, 0.97);
   border: 1px solid rgba(0, 228, 172, 0.22);
   border-radius: 999px;
-  padding: 4px 6px 4px 8px;
+  padding: 4px 8px;
   box-shadow:
     0 8px 24px rgba(0, 0, 0, 0.32),
     0 0 0 1px rgba(0, 0, 0, 0.2);
@@ -1141,8 +1141,35 @@ a {
 
 .matched-actions {
   display: flex;
-  gap: 10px;
+  flex-direction: column;
   align-items: center;
+  gap: 6px;
+  flex: none;
+}
+
+.match-build-link {
+  background: none;
+  border: none;
+  padding: 2px 6px;
+  color: var(--text-muted, #94a3b8);
+  font-size: 0.82rem;
+  font-weight: 500;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  text-decoration: underline;
+  text-underline-offset: 3px;
+  transition: color 0.2s ease;
+}
+
+.match-build-link:hover:not(:disabled) {
+  color: var(--turquoise, #00e4ac);
+}
+
+.match-build-link:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
 }
 
 .play-match-btn,
@@ -4201,6 +4228,11 @@ body.player-open {
   .matched-actions button,
   .creation-actions button {
     width: 100%;
+  }
+
+  .matched-actions .match-build-link {
+    width: auto;
+    align-self: center;
   }
 
   .catalog-grid {

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -636,17 +636,18 @@ a {
   flex: none;
 }
 
-/* Pill build button with visible text CTA and icon. */
+/* Send/build button: compact circle by default, expanded pill when active CTA. */
 .prompt-composer-bar .build-btn {
   position: relative;
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  gap: 6px;
-  width: auto;
-  height: 38px;
-  min-height: 38px;
-  padding: 0 16px;
+  gap: 0;
+  width: 36px;
+  height: 36px;
+  min-width: 36px;
+  min-height: 36px;
+  padding: 0;
   margin: 0;
   border: none;
   border-radius: 999px;
@@ -655,9 +656,34 @@ a {
   white-space: nowrap;
   flex: none;
   box-sizing: border-box;
+  transition:
+    width 0.2s ease,
+    padding 0.2s ease,
+    gap 0.2s ease;
 }
 
 .prompt-composer-bar .build-btn-label {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+/* Expanded state: pill CTA with visible text when matched or creation intent is active. */
+.prompt-composer-bar .build-btn.has-text-cta {
+  width: auto;
+  height: 38px;
+  min-height: 38px;
+  padding: 0 16px;
+  gap: 6px;
+}
+
+.prompt-composer-bar .build-btn.has-text-cta .build-btn-label {
   position: static;
   width: auto;
   height: auto;
@@ -665,8 +691,6 @@ a {
   margin: 0;
   overflow: visible;
   clip: auto;
-  white-space: nowrap;
-  border: 0;
 }
 
 /* Busy: keep teal; spinner replaces the icon during generation. */

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -484,7 +484,7 @@ a {
    height:auto so border-box can't clip 36px cells. */
 .prompt-composer-bar {
   display: grid;
-  grid-template-columns: 36px minmax(0, 1fr) 36px 36px;
+  grid-template-columns: 36px minmax(0, 1fr) 36px auto;
   align-items: center;
   column-gap: 8px;
   width: 100%;
@@ -494,7 +494,7 @@ a {
   background: rgba(32, 42, 51, 0.97);
   border: 1px solid rgba(0, 228, 172, 0.22);
   border-radius: 999px;
-  padding: 4px 8px;
+  padding: 4px 6px 4px 8px;
   box-shadow:
     0 8px 24px rgba(0, 0, 0, 0.32),
     0 0 0 1px rgba(0, 0, 0, 0.2);
@@ -636,18 +636,17 @@ a {
   flex: none;
 }
 
-/* Desktop: circular send — label stays for a11y/tests, clipped visually. */
+/* Pill build button with visible text CTA and icon. */
 .prompt-composer-bar .build-btn {
   position: relative;
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  gap: 0;
-  width: 36px;
-  height: 36px;
-  min-width: 36px;
-  min-height: 36px;
-  padding: 0;
+  gap: 6px;
+  width: auto;
+  height: 38px;
+  min-height: 38px;
+  padding: 0 16px;
   margin: 0;
   border: none;
   border-radius: 999px;
@@ -659,18 +658,18 @@ a {
 }
 
 .prompt-composer-bar .build-btn-label {
-  position: absolute;
-  width: 1px;
-  height: 1px;
+  position: static;
+  width: auto;
+  height: auto;
   padding: 0;
-  margin: -1px;
-  overflow: hidden;
-  clip: rect(0, 0, 0, 0);
+  margin: 0;
+  overflow: visible;
+  clip: auto;
   white-space: nowrap;
   border: 0;
 }
 
-/* Busy: keep teal; spinner replaces the clipped label on desktop. */
+/* Busy: keep teal; spinner replaces the icon during generation. */
 .prompt-composer-bar .build-btn.is-busy {
   opacity: 1;
   cursor: progress;

--- a/apps/web/src/styles.heroComposer.test.ts
+++ b/apps/web/src/styles.heroComposer.test.ts
@@ -33,7 +33,7 @@ describe('desktop hero composer pill', () => {
     expect(bar).toMatch(/align-items:\s*center/);
     expect(bar).toMatch(/height:\s*auto/);
     expect(bar).toMatch(/padding:\s*4px 8px/);
-    expect(bar).toMatch(/grid-template-columns:\s*36px minmax\(0,\s*1fr\) 36px 36px/);
+    expect(bar).toMatch(/grid-template-columns:\s*36px minmax\(0,\s*1fr\) 36px/);
 
     const input = firstRuleBody('.big-prompt-input');
     expect(input).toMatch(/height:\s*36px/);


### PR DESCRIPTION
## Summary
- **Fix cold load search**: Uses `data.match` from `/api/catalog/search` even when `catalogEntries` hasn't finished its initial load yet, enriching with media/screenshots reactively once catalog loads.
- **Remove quota note**: Removed the unnecessary 'X of Y games left today' line below the prompt composer.
- **Textual CTA in prompt field**: Replaced the circular send icon button on desktop with an explicit pill CTA button (`✦ Stwórz Moją Grę` / `✦ Build My Game`) so creation intent is unambiguous.

@codex please review.