### PR TITLE
Rename the CLI command to gamedevpl; fence the homemade TUI

### DIFF
--- a/.claude/skills/product-instrumentation/SKILL.md
+++ b/.claude/skills/product-instrumentation/SKILL.md
@@ -193,7 +193,7 @@ adjacent flow, close the gap in the same change or flag it explicitly in the PR:
     `coding` to `VisitFunnel` (`visit-funnel.ts`), rendered as a Code surface block on
     `VisitFunnelPanel` beside Editing. `CODE_STEPS` lives in the shared vocabulary module
     like the others.
-  - **CLI (`gamedev`) funnel write-side shipped, operator panel unread (CL-01 / CL-39):**
+  - **CLI (`gamedevpl`) funnel write-side shipped, operator panel unread (CL-01 / CL-39):**
     `cli_step` (`installed` → `authorized` → `first_turn` → `build_requested` →
     `delivered` → `published`, plus `delegate_offered`/`delegate_used`/`verify_failed`
     beside the ladder) is on the visit stream with closed `channel` / `os` / `adapter` /

--- a/.github/workflows/cli-release.yml
+++ b/.github/workflows/cli-release.yml
@@ -17,7 +17,7 @@ permissions:
 
 jobs:
   release:
-    name: Bundle gamedev Node script
+    name: Bundle gamedevpl Node script
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -45,6 +45,6 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           tag_name: cli-v${{ env.VERSION }}
-          name: gamedev CLI v${{ env.VERSION }}
+          name: gamedevpl CLI v${{ env.VERSION }}
           generate_release_notes: true
           files: apps/cli/dist/release/*

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ playability it does not have.
 The interesting engineering is written up in [`docs/`](./docs) — start with
 [`docs/README.md`](./docs/README.md).
 
-## Connect your agent (MCP or the `gamedev` CLI)
+## Connect your agent (MCP or the `gamedevpl` CLI)
 
 Two doors, same games. The on-site page is
 [`https://www.gamedev.pl/connect`](https://www.gamedev.pl/connect) (also `/mcp`). It lives
@@ -62,8 +62,8 @@ more exist and are deliberately never advertised, so an agent will not discover 
 [`listings/mcp/README.md`](./listings/mcp/README.md) lists every tool with its annotations,
 what each destructive one actually consumes, and why the rest are hidden.
 
-**CLI.** `apps/cli` is the `gamedev` terminal client (no local model). With no verb it
-opens a REPL: describe a game, then iterate. `gamedev checkout <slug>` is the own-editor
+**CLI.** `apps/cli` is the `gamedevpl` terminal client (no local model). With no verb it
+opens a REPL: describe a game, then iterate. `gamedevpl checkout <slug>` is the own-editor
 path. Installers (`/install.sh`) 404 while `CLI_SURFACE` is off. With the flag on, the
 route serves the script even if no `cli-v*` GitHub release exists yet — that download is
 what fails then. Until a release ships, `npm run bundle -w @gamedevpl/cli`. Details:
@@ -110,7 +110,7 @@ it, please report it privately — see [`SECURITY.md`](./SECURITY.md).
 ```
 apps/
   web/               Vite + React + TypeScript — arcade, player, Creator Studio
-  cli/               `gamedev` terminal client (see Connect your agent above)
+  cli/               `gamedevpl` terminal client (see Connect your agent above)
   api/               Fastify + TypeScript — catalog, jobs, auth, agent channel, multiplayer
   api/fixtures/      Games-repo-shaped content so the app runs with no credentials
   e2e/               Playwright checks for critical browser and production flows

--- a/apps/api/src/platform/cli-installers.ts
+++ b/apps/api/src/platform/cli-installers.ts
@@ -2,18 +2,18 @@ export const CLI_VERSION = '0.1.0';
 
 export const CLI_RELEASE_PREFIX = 'cli-v';
 
-export const CLI_ASSET = 'gamedev';
+export const CLI_ASSET = 'gamedevpl';
 
 export function installSh(origin: string): string {
   return `#!/bin/sh
-# gamedev installer — checksum-verifying Node script into ~/.local/bin
+# gamedevpl installer — checksum-verifying Node script into ~/.local/bin
 # Review this file. It is the whole install. No postinstall beyond the copy.
 set -eu
 # Served from ${origin}. The payload is always GitHub Releases, not this origin.
 VERSION="\${GAMEDEV_VERSION:-${CLI_VERSION}}"
 BIN_DIR="\${GAMEDEV_BIN_DIR:-$HOME/.local/bin}"
 if ! command -v node >/dev/null 2>&1; then
-  echo "gamedev needs Node 20+ (same as a game checkout)" >&2
+  echo "gamedevpl needs Node 20+ (same as a game checkout)" >&2
   exit 1
 fi
 major=$(node -p "process.versions.node.split('.')[0]")
@@ -26,13 +26,13 @@ base="https://github.com/gamedevpl/www.gamedev.pl/releases/download/${CLI_RELEAS
 tmp=$(mktemp -d)
 trap 'rm -rf "$tmp"' EXIT
 echo "fetching $asset from GitHub Releases (cli-v$VERSION)"
-curl -fsSL "$base/$asset" -o "$tmp/gamedev"
+curl -fsSL "$base/$asset" -o "$tmp/$asset"
 curl -fsSL "$base/SHA256SUMS" -o "$tmp/SHA256SUMS"
 expected=$(grep " $asset$" "$tmp/SHA256SUMS" | cut -d ' ' -f 1)
 if command -v sha256sum >/dev/null 2>&1; then
-  actual=$(sha256sum "$tmp/gamedev" | cut -d ' ' -f 1)
+  actual=$(sha256sum "$tmp/$asset" | cut -d ' ' -f 1)
 elif command -v shasum >/dev/null 2>&1; then
-  actual=$(shasum -a 256 "$tmp/gamedev" | cut -d ' ' -f 1)
+  actual=$(shasum -a 256 "$tmp/$asset" | cut -d ' ' -f 1)
 else
   echo "need sha256sum or shasum to verify the download" >&2
   exit 1
@@ -42,28 +42,28 @@ if [ "$expected" != "$actual" ]; then
   exit 1
 fi
 mkdir -p "$BIN_DIR"
-install -m 0755 "$tmp/gamedev" "$BIN_DIR/gamedev"
-install -m 0755 "$tmp/gamedev" "$BIN_DIR/git-remote-gamedev"
-echo "installed $BIN_DIR/gamedev (Node script; also git-remote-gamedev)"
+install -m 0755 "$tmp/$asset" "$BIN_DIR/gamedevpl"
+install -m 0755 "$tmp/$asset" "$BIN_DIR/git-remote-gamedev"
+echo "installed $BIN_DIR/gamedevpl (Node script; also git-remote-gamedev)"
 echo "put $BIN_DIR on PATH if it is not already"
 `;
 }
 
 export function installPs1(origin: string): string {
-  return `# gamedev installer for Windows — checksum-verifying Node script into %USERPROFILE%\\.local\\bin
+  return `# gamedevpl installer for Windows — checksum-verifying Node script into %USERPROFILE%\\.local\\bin
 # Review this file. It is the whole install. No postinstall beyond the copy.
 $ErrorActionPreference = "Stop"
 $origin = if ($env:GAMEDEV_ORIGIN) { $env:GAMEDEV_ORIGIN } else { "${origin}" }
 $version = if ($env:GAMEDEV_VERSION) { $env:GAMEDEV_VERSION } else { "${CLI_VERSION}" }
 $binDir = if ($env:GAMEDEV_BIN_DIR) { $env:GAMEDEV_BIN_DIR } else { Join-Path $HOME ".local\\bin" }
 $asset = "${CLI_ASSET}"
-if (-not (Get-Command node -ErrorAction SilentlyContinue)) { throw "gamedev needs Node 20+ (same as a game checkout)" }
+if (-not (Get-Command node -ErrorAction SilentlyContinue)) { throw "gamedevpl needs Node 20+ (same as a game checkout)" }
 $major = [int]((node -p "process.versions.node.split('.')[0]"))
 if ($major -lt 20) { throw "Node $(node -v) is too old; need 20+" }
 $base = "https://github.com/gamedevpl/www.gamedev.pl/releases/download/${CLI_RELEASE_PREFIX}$version"
 $tmp = New-TemporaryFile | ForEach-Object { Remove-Item $_; New-Item -ItemType Directory -Path $_ }
 try {
-  $bin = Join-Path $tmp.FullName "gamedev"
+  $bin = Join-Path $tmp.FullName $asset
   $sums = Join-Path $tmp.FullName "SHA256SUMS"
   Invoke-WebRequest -UseBasicParsing "$base/$asset" -OutFile $bin
   Invoke-WebRequest -UseBasicParsing "$base/SHA256SUMS" -OutFile $sums
@@ -71,17 +71,17 @@ try {
   $actual = (Get-FileHash -Algorithm SHA256 $bin).Hash.ToLower()
   if ($expected -ne $actual) { throw "checksum mismatch for $asset" }
   New-Item -ItemType Directory -Force -Path $binDir | Out-Null
-  Copy-Item $bin (Join-Path $binDir "gamedev")
+  Copy-Item $bin (Join-Path $binDir "gamedevpl")
   Copy-Item $bin (Join-Path $binDir "git-remote-gamedev")
   @(
     '@echo off',
-    'node "%~dp0gamedev" %*'
-  ) | Set-Content -Path (Join-Path $binDir "gamedev.cmd")
+    'node "%~dp0gamedevpl" %*'
+  ) | Set-Content -Path (Join-Path $binDir "gamedevpl.cmd")
   @(
     '@echo off',
     'node "%~dp0git-remote-gamedev" %*'
   ) | Set-Content -Path (Join-Path $binDir "git-remote-gamedev.cmd")
-  Write-Host "installed $binDir\\gamedev (Node script via $origin)"
+  Write-Host "installed $binDir\\gamedevpl (Node script via $origin)"
 } finally {
   Remove-Item -Recurse -Force $tmp
 }

--- a/apps/api/src/platform/cli-installers.ts
+++ b/apps/api/src/platform/cli-installers.ts
@@ -23,7 +23,7 @@ if [ "$major" -lt 20 ]; then
 fi
 asset="${CLI_ASSET}"
 base="https://github.com/gamedevpl/www.gamedev.pl/releases/download/${CLI_RELEASE_PREFIX}\${VERSION}"
-tmp=$(mktemp -d)
+tmp=$(mktemp -d "\${TMPDIR:-/tmp}/gamedevpl.XXXXXX")
 trap 'rm -rf "$tmp"' EXIT
 echo "fetching $asset from GitHub Releases (cli-v$VERSION)"
 curl -fsSL "$base/$asset" -o "$tmp/$asset"

--- a/apps/api/src/platform/cli-installers.ts
+++ b/apps/api/src/platform/cli-installers.ts
@@ -43,8 +43,8 @@ if [ "$expected" != "$actual" ]; then
 fi
 mkdir -p "$BIN_DIR"
 install -m 0755 "$tmp/$asset" "$BIN_DIR/gamedevpl"
-install -m 0755 "$tmp/$asset" "$BIN_DIR/git-remote-gamedev"
-echo "installed $BIN_DIR/gamedevpl (Node script; also git-remote-gamedev)"
+install -m 0755 "$tmp/$asset" "$BIN_DIR/git-remote-gamedevpl"
+echo "installed $BIN_DIR/gamedevpl (Node script; also git-remote-gamedevpl)"
 echo "put $BIN_DIR on PATH if it is not already"
 `;
 }
@@ -72,15 +72,15 @@ try {
   if ($expected -ne $actual) { throw "checksum mismatch for $asset" }
   New-Item -ItemType Directory -Force -Path $binDir | Out-Null
   Copy-Item $bin (Join-Path $binDir "gamedevpl")
-  Copy-Item $bin (Join-Path $binDir "git-remote-gamedev")
+  Copy-Item $bin (Join-Path $binDir "git-remote-gamedevpl")
   @(
     '@echo off',
     'node "%~dp0gamedevpl" %*'
   ) | Set-Content -Path (Join-Path $binDir "gamedevpl.cmd")
   @(
     '@echo off',
-    'node "%~dp0git-remote-gamedev" %*'
-  ) | Set-Content -Path (Join-Path $binDir "git-remote-gamedev.cmd")
+    'node "%~dp0git-remote-gamedevpl" %*'
+  ) | Set-Content -Path (Join-Path $binDir "git-remote-gamedevpl.cmd")
   Write-Host "installed $binDir\\gamedevpl (Node script via $origin)"
 } finally {
   Remove-Item -Recurse -Force $tmp

--- a/apps/api/src/platform/cli-page.ts
+++ b/apps/api/src/platform/cli-page.ts
@@ -21,7 +21,7 @@ export function cliPageHtml(origin: string): string {
     <h2>Journeys</h2>
     <ul class="can">
       <li><code>gamedevpl login</code> then describe a game — refine, watch the gate, open a preview.</li>
-      <li><code>gamedevpl checkout &lt;slug&gt;</code> for your own editor; <code>git push</code> uses <code>git-remote-gamedev</code>.</li>
+      <li><code>gamedevpl checkout &lt;slug&gt;</code> for your own editor; <code>git push</code> uses <code>git-remote-gamedevpl</code>.</li>
       <li>CI: <code>GAMEDEV_TOKEN</code> from secrets, <code>gamedevpl submit --json</code>.</li>
     </ul>
     <h2>Security posture</h2>

--- a/apps/api/src/platform/cli-page.ts
+++ b/apps/api/src/platform/cli-page.ts
@@ -7,22 +7,22 @@ export function cliPageHtml(origin: string): string {
 <head>
   <meta charset="utf-8"/>
   <meta name="viewport" content="width=device-width, initial-scale=1"/>
-  <title>gamedev CLI</title>
+  <title>gamedevpl CLI</title>
   ${OAUTH_PAGE_STYLES}
 </head>
 <body>
   <main>
     <p class="brand">${MASCOT_SVG} gamedev.pl</p>
-    <h1>gamedev, in a terminal</h1>
+    <h1>gamedevpl, in a terminal</h1>
     <p class="lead">A conversational front door for making and iterating games on gamedev.pl. It has no model of its own. Coding happens on the platform, or by a tool you already installed. MCP and this CLI are documented together at <a href="/connect">/connect</a>.</p>
     <h2>Install</h2>
     <pre class="redirect">${install}</pre>
     <p class="hint">Needs Node 20+ — same as a game checkout. Windows: <code>irm ${escapeHtml(origin)}/install.ps1 | iex</code>. The script verifies a SHA-256 before it writes <code>~/.local/bin</code>.</p>
     <h2>Journeys</h2>
     <ul class="can">
-      <li><code>gamedev login</code> then describe a game — refine, watch the gate, open a preview.</li>
-      <li><code>gamedev checkout &lt;slug&gt;</code> for your own editor; <code>git push</code> uses <code>git-remote-gamedev</code>.</li>
-      <li>CI: <code>GAMEDEV_TOKEN</code> from secrets, <code>gamedev submit --json</code>.</li>
+      <li><code>gamedevpl login</code> then describe a game — refine, watch the gate, open a preview.</li>
+      <li><code>gamedevpl checkout &lt;slug&gt;</code> for your own editor; <code>git push</code> uses <code>git-remote-gamedev</code>.</li>
+      <li>CI: <code>GAMEDEV_TOKEN</code> from secrets, <code>gamedevpl submit --json</code>.</li>
     </ul>
     <h2>Security posture</h2>
     <ul class="cannot">

--- a/apps/api/src/platform/cli-surface.test.ts
+++ b/apps/api/src/platform/cli-surface.test.ts
@@ -54,6 +54,7 @@ describe('reserved installer routes', () => {
       expect(sh.body).toContain('Node 20');
       expect(sh.body).toContain('asset="gamedevpl"');
       expect(sh.body).toContain('git-remote-gamedevpl');
+      expect(sh.body).toContain('gamedevpl.XXXXXX');
       expect(sh.body).not.toContain('gamedev-linux');
       const page = await app.inject({ method: 'GET', url: '/cli' });
       expect(page.statusCode).toBe(200);

--- a/apps/api/src/platform/cli-surface.test.ts
+++ b/apps/api/src/platform/cli-surface.test.ts
@@ -52,11 +52,11 @@ describe('reserved installer routes', () => {
       expect(sh.body).toContain('GitHub Releases');
       expect(sh.body).toContain('$HOME/.local/bin');
       expect(sh.body).toContain('Node 20');
-      expect(sh.body).toContain('asset="gamedev"');
+      expect(sh.body).toContain('asset="gamedevpl"');
       expect(sh.body).not.toContain('gamedev-linux');
       const page = await app.inject({ method: 'GET', url: '/cli' });
       expect(page.statusCode).toBe(200);
-      expect(page.body).toContain('gamedev login');
+      expect(page.body).toContain('gamedevpl login');
       expect(page.body).toContain('encrypted file');
       expect(page.body).toContain('Node 20');
       const ps1 = await app.inject({ method: 'GET', url: '/install.ps1' });

--- a/apps/api/src/platform/cli-surface.test.ts
+++ b/apps/api/src/platform/cli-surface.test.ts
@@ -53,6 +53,7 @@ describe('reserved installer routes', () => {
       expect(sh.body).toContain('$HOME/.local/bin');
       expect(sh.body).toContain('Node 20');
       expect(sh.body).toContain('asset="gamedevpl"');
+      expect(sh.body).toContain('git-remote-gamedevpl');
       expect(sh.body).not.toContain('gamedev-linux');
       const page = await app.inject({ method: 'GET', url: '/cli' });
       expect(page.statusCode).toBe(200);
@@ -65,7 +66,7 @@ describe('reserved installer routes', () => {
       expect(ps1.body).toContain('Node 20');
       expect(ps1.body).toContain("process.versions.node.split('.')[0]");
       expect(ps1.body).toContain('too old');
-      expect(ps1.body).toContain('node "%~dp0git-remote-gamedev" %*');
+      expect(ps1.body).toContain('node "%~dp0git-remote-gamedevpl" %*');
       expect(sh.body).not.toContain('ORIGIN=');
       const enabled = await app.inject({ method: 'GET', url: '/api/cli/enabled' });
       expect(enabled.statusCode).toBe(200);

--- a/apps/api/src/platform/oauth-creator-scope.test.ts
+++ b/apps/api/src/platform/oauth-creator-scope.test.ts
@@ -67,7 +67,7 @@ describe('OAuth creator scope (CL-04..CL-07, CL-09)', () => {
     expect(grants.json()).toEqual([
       expect.objectContaining({
         clientId: GAMEDEV_CLI_CLIENT_ID,
-        clientLabel: 'gamedev CLI on studio-mac',
+        clientLabel: 'gamedevpl CLI on studio-mac',
       }),
     ]);
     expect(await store.listOAuthGrantsByOwner('g:boss')).toHaveLength(1);

--- a/apps/api/src/platform/oauth-device.test.ts
+++ b/apps/api/src/platform/oauth-device.test.ts
@@ -141,7 +141,7 @@ describe('OAuth device authorization (CL-08)', () => {
       url: '/api/me/oauth-grants',
       headers: { cookie: sessionCookie('g:boss') },
     });
-    expect(grants.json()).toEqual([expect.objectContaining({ clientLabel: 'gamedev CLI on headless-box' })]);
+    expect(grants.json()).toEqual([expect.objectContaining({ clientLabel: 'gamedevpl CLI on headless-box' })]);
   });
 
   it('does not approve a device code unless action is approve', async () => {

--- a/apps/api/src/platform/oauth-device.ts
+++ b/apps/api/src/platform/oauth-device.ts
@@ -83,13 +83,13 @@ function devicePage(input: { userCode: string; consentToken: string; error?: str
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>gamedev CLI device login</title>
+  <title>gamedevpl CLI device login</title>
   ${OAUTH_PAGE_STYLES}
 </head>
 <body>
   <main>
     <p class="brand">${MASCOT_SVG}<span>gamedev.pl</span></p>
-    <h1>Approve gamedev CLI</h1>
+    <h1>Approve gamedevpl CLI</h1>
     <p class="lead">Enter the code shown in your terminal.</p>
     ${error}
     <form method="post" action="/device">

--- a/apps/api/src/platform/oauth-first-party.ts
+++ b/apps/api/src/platform/oauth-first-party.ts
@@ -9,7 +9,7 @@ export function gamedevCliClient(): OAuthClientRecord {
     clientId: GAMEDEV_CLI_CLIENT_ID,
     registrationType: 'first-party',
     redirectUris: ['http://127.0.0.1/callback', 'http://[::1]/callback'],
-    clientName: 'gamedev CLI',
+    clientName: 'gamedevpl CLI',
     tokenEndpointAuthMethod: 'none',
     createdAt: GAMEDEV_CLI_CREATED_AT,
   };
@@ -28,5 +28,5 @@ export function sanitizeDeviceName(raw: string | undefined): string {
 }
 
 export function gamedevCliGrantLabel(deviceName: string): string {
-  return `gamedev CLI on ${deviceName}`;
+  return `gamedevpl CLI on ${deviceName}`;
 }

--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -1,4 +1,4 @@
-# gamedev CLI (apps/cli)
+# gamedevpl CLI (apps/cli)
 
 Terminal front door for gamedev.pl. **No local model.** Coding happens by delegating to a
 vendor CLI the creator already has, or by the platform builder.
@@ -17,9 +17,9 @@ curl -fsSL https://www.gamedev.pl/install.sh | bash
 ```
 
 The installer is 404 until the `CLI_SURFACE` deploy flag is on. Checksums come from GitHub
-Releases tagged `cli-v*` (one `gamedev` asset). `gamedev update` uses the same channel.
+Releases tagged `cli-v*` (one `gamedevpl` asset). `gamedevpl update` uses the same channel.
 
-Until a release exists: `npm run bundle -w @gamedevpl/cli` and run `apps/cli/dist/gamedev.mjs`.
+Until a release exists: `npm run bundle -w @gamedevpl/cli` and run `apps/cli/dist/gamedevpl.mjs`.
 
 ## Verbs
 

--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -29,4 +29,4 @@ Until a release exists: `npm run bundle -w @gamedevpl/cli` and run `apps/cli/dis
 Exit codes: `0` gate green · `1` gate red · `2` refused · `3` auth · `4` input required.
 
 CI: `GAMEDEV_TOKEN` from secrets. Never pass the creator OAuth token to a sub-agent.
-`git push` / `git pull` against a checkout use `git-remote-gamedev` (same script).
+`git push` / `git pull` against a checkout use `git-remote-gamedevpl` (same script).

--- a/apps/cli/docs/ink-spike.md
+++ b/apps/cli/docs/ink-spike.md
@@ -1,16 +1,20 @@
-# Ink spike (CL-16a)
+# Ink vs the interactive host
 
-Tried: a compiled single-file binary plus Ink (React for terminals).
+Tried (Wave C): a compiled single-file binary plus Ink (React for terminals). **No-go then**
+because that pairing was Node SEA / bun-compile + Ink's reconciler, raw-mode stdin, and
+`SIGWINCH`. That constraint is gone — the shipped file is a Node 20 shebang script.
 
-**No-go for this tree.** The load-bearing design is the two-region renderer (append-only
-transcript + ≤4-row live region), not the framework. Ink's reconciler, raw-mode stdin,
-and `SIGWINCH` under a Node SEA / bun-compiled binary is the pairing the spike was meant
-to prove; this environment cannot exercise macOS Keychain, Windows ConPTY, and a real
-SEA in one pass.
+**Still not Ink in this tree.** The installer is one esbuild file with `dependencies: {}`.
+Ink pulls React and yoga (native or wasm). Bundling yoga into the shebang asset is the
+next trap; taking Ink without bundling it splits npm-run vs installer into two TUIs.
 
-**Go: custom renderer** in `src/renderer.ts` — same glyphs (`◆` / `›`), `NO_COLOR`
-downgrade, width-aware live truncation, transcript never rewritten. Verbs (CL-30) are the
-same functions the REPL calls, so a pipe never blocks on a prompt.
+**Go, and do not grow past this:**
 
-If Ink is revisited, re-run this spike on darwin-arm64, linux-x64, and Windows Terminal
-before replacing `renderer.ts`.
+1. **Sentence prompt** — `node:readline/promises` behind `PromptHost` (`src/host.ts`).
+   Readline is the line editor (history, POSIX). Do not replace it with Ink `useInput`.
+2. **Live region** — `src/live.ts` paints at most a handful of rows (`status --watch`).
+   It is a cursor-up redraw, not a widget kit. No menus, pickers, or layouts here.
+3. **Verbs** — the same functions the REPL calls, so a pipe never blocks on a prompt.
+
+Need a real TUI (pickers, dashboards)? Take Ink and change the installer to a directory
+that can ship yoga. Do not extend `live.ts` into that. Glyphs stay in `src/renderer.ts`.

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "bin": {
-    "gamedev": "./dist/main.js",
+    "gamedevpl": "./dist/main.js",
     "git-remote-gamedev": "./dist/git-remote-main.js"
   },
   "scripts": {

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "bin": {
     "gamedevpl": "./dist/main.js",
-    "git-remote-gamedev": "./dist/git-remote-main.js"
+    "git-remote-gamedevpl": "./dist/git-remote-main.js"
   },
   "scripts": {
     "build": "tsc -p tsconfig.json && node scripts/copy-adapters.mjs",

--- a/apps/cli/scripts/build-binary.mjs
+++ b/apps/cli/scripts/build-binary.mjs
@@ -13,10 +13,10 @@ await build({
   platform: 'node',
   target: 'node20',
   format: 'esm',
-  outfile: join(outDir, 'gamedev.mjs'),
+  outfile: join(outDir, 'gamedevpl.mjs'),
   banner: { js: '#!/usr/bin/env node' },
   packages: 'bundle',
 });
 
-chmodSync(join(outDir, 'gamedev.mjs'), 0o755);
-console.log('bundled dist/gamedev.mjs — shebang Node script, no native binary');
+chmodSync(join(outDir, 'gamedevpl.mjs'), 0o755);
+console.log('bundled dist/gamedevpl.mjs — shebang Node script, no native binary');

--- a/apps/cli/scripts/compile-release.sh
+++ b/apps/cli/scripts/compile-release.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-# Bundle the gamedev Node script for GitHub Releases (cli-v*). No postinstall.
+# Bundle the gamedevpl Node script for GitHub Releases (cli-v*). No postinstall.
 # One asset for every OS — checkout already requires Node 20.
 set -eu
 root=$(CDPATH= cd -- "$(dirname "$0")/.." && pwd)
@@ -8,7 +8,7 @@ out="$root/dist/release"
 rm -rf "$out"
 mkdir -p "$out"
 node "$root/scripts/build-binary.mjs"
-install -m 0755 "$root/dist/gamedev.mjs" "$out/gamedev"
-(cd "$out" && sha256sum gamedev > SHA256SUMS)
+install -m 0755 "$root/dist/gamedevpl.mjs" "$out/gamedevpl"
+(cd "$out" && sha256sum gamedevpl > SHA256SUMS)
 echo "cli-v$version artifact in $out"
 cat "$out/SHA256SUMS"

--- a/apps/cli/src/adapters.ts
+++ b/apps/cli/src/adapters.ts
@@ -34,7 +34,7 @@ function shippedAdapters(): AdapterFile {
 
 export function loadAdapters(env: NodeJS.ProcessEnv = process.env): AdapterFile {
   const shipped = shippedAdapters();
-  const customPath = env.GAMEDEV_ADAPTERS ?? join(env.HOME ?? homedir(), '.config', 'gamedev', 'adapters.json');
+  const customPath = env.GAMEDEV_ADAPTERS ?? join(env.HOME ?? homedir(), '.config', 'gamedevpl', 'adapters.json');
   try {
     const extra = JSON.parse(readFileSync(customPath, 'utf8')) as { adapters?: AdapterSpec[] };
     if (extra.adapters?.length) {

--- a/apps/cli/src/api.ts
+++ b/apps/cli/src/api.ts
@@ -1,3 +1,4 @@
+import { cliUsage } from './bin-name.js';
 import { CliError, EXIT_AUTH, EXIT_INPUT, EXIT_REFUSED } from './exit-codes.js';
 import type { StoredTokens, TokenStore } from './keychain.js';
 
@@ -17,7 +18,7 @@ export function bearerFrom(tokens: StoredTokens | null, env: NodeJS.ProcessEnv):
 
 function throwForStatus(res: Response, errBody: { error?: string; message?: string }): never {
   if (res.status === 401) {
-    throw new CliError('credential expired or revoked — run `gamedev login`', EXIT_AUTH, 'gamedev login');
+    throw new CliError(`credential expired or revoked — run \`${cliUsage('login')}\``, EXIT_AUTH, cliUsage('login'));
   }
   if (res.status === 404) {
     throw new CliError('not found', EXIT_REFUSED);
@@ -37,7 +38,7 @@ export function createApi(input: {
   async function authorized(path: string, init: RequestInit): Promise<Response> {
     const token = bearerFrom(await input.store.get(), env);
     if (!token) {
-      throw new CliError('not signed in — run `gamedev login`', EXIT_AUTH, 'gamedev login');
+      throw new CliError(`not signed in — run \`${cliUsage('login')}\``, EXIT_AUTH, cliUsage('login'));
     }
     return fetchImpl(`${input.origin}${path}`, {
       ...init,

--- a/apps/cli/src/bin-name.ts
+++ b/apps/cli/src/bin-name.ts
@@ -1,0 +1,6 @@
+export const CLI_BIN = 'gamedevpl';
+export const GIT_REMOTE_HELPER = 'git-remote-gamedev';
+
+export function cliUsage(...parts: string[]): string {
+  return [CLI_BIN, ...parts].join(' ');
+}

--- a/apps/cli/src/bin-name.ts
+++ b/apps/cli/src/bin-name.ts
@@ -1,6 +1,11 @@
 export const CLI_BIN = 'gamedevpl';
-export const GIT_REMOTE_HELPER = 'git-remote-gamedev';
+export const GIT_REMOTE_SCHEME = 'gamedevpl';
+export const GIT_REMOTE_HELPER = `git-remote-${GIT_REMOTE_SCHEME}`;
 
 export function cliUsage(...parts: string[]): string {
   return [CLI_BIN, ...parts].join(' ');
+}
+
+export function gitRemoteUrl(slug: string): string {
+  return `${GIT_REMOTE_SCHEME}://${slug}`;
 }

--- a/apps/cli/src/checkout.test.ts
+++ b/apps/cli/src/checkout.test.ts
@@ -35,7 +35,7 @@ describe('checkout', () => {
     mkdirSync(join(dest, 'games', 'ghost-roads'), { recursive: true });
     writeFileSync(join(dest, 'games', 'ghost-roads', 'game.ts'), 'export const n = 1;\n');
     expect(changedPaths([{ path: 'game.ts', content: 'export const n = 1;\n' }], [])).toEqual(['game.ts']);
-    expect(unreconciledMessage()).toContain('gamedev pull');
+    expect(unreconciledMessage()).toContain('gamedevpl pull');
     expect(dirname(join(dest, 'games', 'ghost-roads', 'game.ts'))).toContain('ghost-roads');
   });
 

--- a/apps/cli/src/checkout.test.ts
+++ b/apps/cli/src/checkout.test.ts
@@ -7,7 +7,7 @@ import { createApi } from './api.js';
 import { memoryStore } from './keychain.js';
 
 describe('checkout', () => {
-  it('always inits git with a gamedev:// remote', async () => {
+  it('always inits git with a gamedevpl:// remote', async () => {
     const dest = mkdtempSync(join(tmpdir(), 'gdpl-co-'));
     const commands: string[] = [];
     const result = await checkoutGame({
@@ -23,10 +23,10 @@ describe('checkout', () => {
         commands.push([cmd, ...args].join(' '));
       },
     });
-    expect(result.remote).toBe('gamedev://ghost-roads');
+    expect(result.remote).toBe('gamedevpl://ghost-roads');
     expect(commands).toContain('tar -xzf .gamedev-workspace.tgz');
     expect(commands).toContain('git init');
-    expect(commands).toContain('git remote add origin gamedev://ghost-roads');
+    expect(commands).toContain('git remote add origin gamedevpl://ghost-roads');
     expect(existsSync(join(dest, '.gamedev-workspace.tgz'))).toBe(false);
   });
 

--- a/apps/cli/src/checkout.ts
+++ b/apps/cli/src/checkout.ts
@@ -1,7 +1,7 @@
 import { mkdirSync, readFileSync, writeFileSync, existsSync, readdirSync, rmSync, lstatSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { spawnSync } from 'node:child_process';
-import { cliUsage } from './bin-name.js';
+import { cliUsage, gitRemoteUrl } from './bin-name.js';
 import type { ApiClient } from './api.js';
 import { CliError, EXIT_REFUSED } from './exit-codes.js';
 
@@ -101,11 +101,11 @@ export async function checkoutGame(input: {
     run('tar', ['-xzf', '.gamedev-workspace.tgz'], input.dest);
     writeFileSync(join(input.dest, '.gamedev-slug'), input.slug);
     run('git', ['init'], input.dest);
-    run('git', ['remote', 'add', 'origin', `gamedev://${input.slug}`], input.dest);
+    run('git', ['remote', 'add', 'origin', gitRemoteUrl(input.slug)], input.dest);
   } finally {
     rmSync(tgz, { force: true });
   }
-  return { dest: input.dest, remote: `gamedev://${input.slug}` };
+  return { dest: input.dest, remote: gitRemoteUrl(input.slug) };
 }
 
 export async function pullGame(input: { api: ApiClient; slug: string; dest: string }): Promise<{ version: string }> {

--- a/apps/cli/src/checkout.ts
+++ b/apps/cli/src/checkout.ts
@@ -1,6 +1,7 @@
 import { mkdirSync, readFileSync, writeFileSync, existsSync, readdirSync, rmSync, lstatSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { spawnSync } from 'node:child_process';
+import { cliUsage } from './bin-name.js';
 import type { ApiClient } from './api.js';
 import { CliError, EXIT_REFUSED } from './exit-codes.js';
 
@@ -13,7 +14,7 @@ export type VersionRow = {
 };
 
 export function unreconciledMessage(): string {
-  return 'working copy is unreconciled with the platform — gamedev pull, or pass --force';
+  return `working copy is unreconciled with the platform — ${cliUsage('pull')}, or pass --force`;
 }
 
 export function readCheckoutSlug(cwd: string): string | null {

--- a/apps/cli/src/errors.ts
+++ b/apps/cli/src/errors.ts
@@ -1,3 +1,4 @@
+import { cliUsage } from './bin-name.js';
 import { CliError, EXIT_INPUT, EXIT_REFUSED } from './exit-codes.js';
 
 export function describeError(error: unknown): { message: string; next?: string; code: number } {
@@ -7,7 +8,7 @@ export function describeError(error: unknown): { message: string; next?: string;
   if (error instanceof TypeError) {
     return {
       message: 'offline or proxy failure — check the network and try again',
-      next: 'gamedev whoami',
+      next: cliUsage('whoami'),
       code: EXIT_REFUSED,
     };
   }
@@ -29,7 +30,7 @@ export function moderationRefusal(): CliError {
 
 export function mustFixGate(stage?: string): CliError {
   const where = stage ? ` at ${stage}` : '';
-  return new CliError(`gate red${where} — fix locally, then gamedev submit`, EXIT_REFUSED);
+  return new CliError(`gate red${where} — fix locally, then ${cliUsage('submit')}`, EXIT_REFUSED);
 }
 
 export function otherBuilder(builder: string): CliError {

--- a/apps/cli/src/git-remote-main.ts
+++ b/apps/cli/src/git-remote-main.ts
@@ -7,10 +7,13 @@ import { originFromEnv } from './oauth.js';
 import { diffGame } from './checkout.js';
 import { runRemoteHelper } from './git-remote.js';
 import { readFileSync, existsSync } from 'node:fs';
+import { GIT_REMOTE_SCHEME } from './bin-name.js';
 import { join } from 'node:path';
 
 function slugFromUrl(url: string): string {
-  return url.replace(/^gamedev:\/\//, '').replace(/\/$/, '');
+  const prefix = `${GIT_REMOTE_SCHEME}://`;
+  const stripped = url.startsWith(prefix) ? url.slice(prefix.length) : url;
+  return stripped.replace(/\/$/, '');
 }
 
 export function remoteSlugFromArgv(argv: string[], cwdSlug: string | null): string {

--- a/apps/cli/src/git-remote.test.ts
+++ b/apps/cli/src/git-remote.test.ts
@@ -4,7 +4,7 @@ import { remoteSlugFromArgv } from './git-remote-main.js';
 import { unreconciledMessage } from './checkout.js';
 
 describe('git-remote-gamedev', () => {
-  it('advertises import and push and refuses non-ff like gamedev diff', () => {
+  it('advertises import and push and refuses non-ff like gamedevpl diff', () => {
     expect(handleHelperLine('capabilities', 'ghost-roads')).toContain('import');
     expect(handleHelperLine('capabilities', 'ghost-roads')).toContain('push');
     expect(refuseNonFastForward()).toContain(unreconciledMessage().slice(0, 20));

--- a/apps/cli/src/git-remote.test.ts
+++ b/apps/cli/src/git-remote.test.ts
@@ -3,7 +3,7 @@ import { fastImportScript, handleHelperLine, listRefs, refuseNonFastForward, sha
 import { remoteSlugFromArgv } from './git-remote-main.js';
 import { unreconciledMessage } from './checkout.js';
 
-describe('git-remote-gamedev', () => {
+describe('git-remote-gamedevpl', () => {
   it('advertises import and push and refuses non-ff like gamedevpl diff', () => {
     expect(handleHelperLine('capabilities', 'ghost-roads')).toContain('import');
     expect(handleHelperLine('capabilities', 'ghost-roads')).toContain('push');

--- a/apps/cli/src/git-remote.test.ts
+++ b/apps/cli/src/git-remote.test.ts
@@ -37,9 +37,9 @@ describe('git-remote-gamedevpl', () => {
   });
 
   it('resolves no slug when the remote URL and checkout file are missing', () => {
-    expect(remoteSlugFromArgv(['node', 'git-remote-gamedev'], null)).toBe('');
-    expect(remoteSlugFromArgv(['node', 'git-remote-gamedev'], 'ghost-roads')).toBe('ghost-roads');
-    expect(remoteSlugFromArgv(['node', 'git-remote-gamedev', 'origin', 'gamedev://ghost-roads'], null)).toBe(
+    expect(remoteSlugFromArgv(['node', 'git-remote-gamedevpl'], null)).toBe('');
+    expect(remoteSlugFromArgv(['node', 'git-remote-gamedevpl'], 'ghost-roads')).toBe('ghost-roads');
+    expect(remoteSlugFromArgv(['node', 'git-remote-gamedevpl', 'origin', 'gamedevpl://ghost-roads'], null)).toBe(
       'ghost-roads',
     );
   });

--- a/apps/cli/src/git-remote.ts
+++ b/apps/cli/src/git-remote.ts
@@ -1,4 +1,5 @@
 import { createHash } from 'node:crypto';
+import { cliUsage } from './bin-name.js';
 import { unreconciledMessage } from './checkout.js';
 
 export const GIT_REMOTE_CAPS = ['import', 'push', 'option'] as const;
@@ -95,7 +96,7 @@ export async function runRemoteHelper(slug: string, io: HelperIo): Promise<void>
       const result = await io.pushReconcile();
       const dst = rest.join(' ').split(':')[1] ?? 'refs/heads/main';
       if (result === 'unreconciled') io.write(`${refuseNonFastForward()}\n\n`);
-      else io.write(`error ${dst} git push is not a delivery path — use gamedev submit\n\n`);
+      else io.write(`error ${dst} git push is not a delivery path — use ${cliUsage('submit')}\n\n`);
     } else io.write(`${handleHelperLine(trimmed, slug).join('\n')}\n`);
   }
 }

--- a/apps/cli/src/git-remote.ts
+++ b/apps/cli/src/git-remote.ts
@@ -8,7 +8,7 @@ export type VersionRef = { version: string; createdAt: string };
 export type TreeFile = { path: string; content: string };
 
 export function shaForVersion(version: string): string {
-  return createHash('sha1').update(`gamedev:${version}`).digest('hex');
+  return createHash('sha1').update(`gamedevpl:${version}`).digest('hex');
 }
 
 export function refuseNonFastForward(): string {
@@ -41,7 +41,7 @@ export function fastImportScript(input: {
     const message = row.version;
     chunks.push('commit refs/heads/main');
     chunks.push(`mark :${mark}`);
-    chunks.push(`committer gamedev <cli@gamedev.pl> ${Math.floor(Date.parse(row.createdAt) / 1000)} +0000`);
+    chunks.push(`committer gamedevpl <cli@gamedev.pl> ${Math.floor(Date.parse(row.createdAt) / 1000)} +0000`);
     chunks.push(`data ${Buffer.byteLength(message)}`);
     chunks.push(message);
     if (mark > 1) chunks.push(`from :${mark - 1}`);

--- a/apps/cli/src/host.ts
+++ b/apps/cli/src/host.ts
@@ -1,0 +1,22 @@
+import { createInterface } from 'node:readline/promises';
+
+export type PromptHost = {
+  writeLine: (text: string) => void;
+  prompt: (question: string) => Promise<string>;
+  close: () => void;
+};
+
+export function createReadlineHost(io: { stdin: NodeJS.ReadableStream; stdout: NodeJS.WritableStream }): PromptHost {
+  const rl = createInterface({ input: io.stdin, output: io.stdout });
+  return {
+    writeLine(text) {
+      io.stdout.write(`${text}\n`);
+    },
+    prompt(question) {
+      return rl.question(question);
+    },
+    close() {
+      rl.close();
+    },
+  };
+}

--- a/apps/cli/src/keychain.ts
+++ b/apps/cli/src/keychain.ts
@@ -36,7 +36,7 @@ export function memoryStore(initial?: StoredTokens | null): TokenStore {
 function filePath(env: NodeJS.ProcessEnv): string {
   const override = env.GAMEDEV_TOKEN_FILE;
   if (override) return override;
-  return join(env.HOME ?? homedir(), '.config', 'gamedev', 'credentials.bin');
+  return join(env.HOME ?? homedir(), '.config', 'gamedevpl', 'credentials.bin');
 }
 
 function fileKey(env: NodeJS.ProcessEnv): Buffer {
@@ -81,4 +81,4 @@ export function encryptedFileStore(env: NodeJS.ProcessEnv = process.env): TokenS
 }
 
 export const FILE_FALLBACK_WARNING =
-  'WARNING: OS keychain unavailable; tokens stored in an encrypted file under ~/.config/gamedev. Not plaintext, but weaker than the keychain.';
+  'WARNING: OS keychain unavailable; tokens stored in an encrypted file under ~/.config/gamedevpl. Not plaintext, but weaker than the keychain.';

--- a/apps/cli/src/live.test.ts
+++ b/apps/cli/src/live.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest';
+import { createLiveScreen, renderLive } from './live.js';
+import { formatStatusLines, runStatusVerb, statusWatchDelayMs } from './status-watch.js';
+import { createApi } from './api.js';
+import { memoryStore } from './keychain.js';
+import { EXIT_GREEN } from './exit-codes.js';
+
+describe('live screen', () => {
+  it('truncates live lines to the terminal width', () => {
+    expect(renderLive(['abcdefghij'], 6)).toBe('abcde…');
+  });
+
+  it('repaints by moving the cursor up, never rewriting older rows', () => {
+    const chunks: string[] = [];
+    const stdout = { write: (s: string) => (chunks.push(s), true) } as unknown as NodeJS.WritableStream;
+    const screen = createLiveScreen(stdout, 40);
+    screen.paint(['building']);
+    screen.paint(['building', 'smoke 1/4']);
+    expect(chunks[0]).toBe('building\n');
+    expect(chunks[1]).toBe('\x1b[1A\x1b[Jbuilding\nsmoke 1/4\n');
+  });
+});
+
+describe('status watch', () => {
+  it('uses the Studio cadence, not homemade backoff', () => {
+    expect(statusWatchDelayMs({ status: 'building' })).toBe(3000);
+    expect(statusWatchDelayMs({ status: 'needs_changes' })).toBe(10_000);
+    expect(statusWatchDelayMs({ status: 'queued', stall: 'quiet' })).toBe(3000);
+  });
+
+  it('formats gate progress onto the live block', () => {
+    expect(
+      formatStatusLines(
+        { status: 'building', gateProgress: { stage: 'smoke', index: 1, total: 4 }, preview: { slug: 'sky' } },
+        'https://www.gamedev.pl',
+      ),
+    ).toEqual(['building', 'smoke 1/4', 'https://www.gamedev.pl/play/sky']);
+  });
+
+  it('paints a TTY watch instead of appending status lines', async () => {
+    let calls = 0;
+    const api = createApi({
+      origin: 'https://www.gamedev.pl',
+      store: memoryStore({ accessToken: 'gdpl_pat_x', tokenType: 'Bearer', scope: 'creator' }),
+      fetch: async () => {
+        calls += 1;
+        return new Response(JSON.stringify({ status: calls === 1 ? 'building' : 'published' }), { status: 200 });
+      },
+    });
+    const chunks: string[] = [];
+    const stdout = { write: (s: string) => (chunks.push(s), true), isTTY: true } as unknown as NodeJS.WriteStream;
+    expect(
+      await runStatusVerb({
+        api,
+        token: 'tok',
+        maxPolls: 5,
+        asJson: false,
+        live: true,
+        stdout,
+        sleep: async () => undefined,
+      }),
+    ).toBe(EXIT_GREEN);
+    expect(calls).toBe(2);
+    expect(chunks.join('')).toContain('\x1b[');
+    expect(chunks.join('')).toContain('published');
+  });
+});

--- a/apps/cli/src/live.test.ts
+++ b/apps/cli/src/live.test.ts
@@ -8,6 +8,18 @@ import { EXIT_GREEN } from './exit-codes.js';
 describe('live screen', () => {
   it('truncates live lines to the terminal width', () => {
     expect(renderLive(['abcdefghij'], 6)).toBe('abcde…');
+    expect(renderLive(['abcdefghij'], 1)).toBe('a');
+  });
+
+  it('reads stdout.columns on each paint when width is not fixed', () => {
+    const chunks: string[] = [];
+    const stdout = { write: (s: string) => (chunks.push(s), true), columns: 4 } as unknown as NodeJS.WriteStream;
+    const screen = createLiveScreen(stdout);
+    screen.paint(['abcdefghij']);
+    stdout.columns = 8;
+    screen.paint(['abcdefghij']);
+    expect(chunks[0]).toBe('abc…\n');
+    expect(chunks[1]).toContain('abcdefg…');
   });
 
   it('repaints by moving the cursor up, never rewriting older rows', () => {

--- a/apps/cli/src/live.ts
+++ b/apps/cli/src/live.ts
@@ -1,0 +1,19 @@
+export function renderLive(live: readonly string[], width: number): string {
+  const cap = Math.max(1, width);
+  return live.map((line) => (line.length <= cap ? line : `${line.slice(0, Math.max(1, cap - 1))}…`)).join('\n');
+}
+
+export function createLiveScreen(stdout: NodeJS.WritableStream, width = 80) {
+  let paintedRows = 0;
+  return {
+    paint(lines: readonly string[]) {
+      const text = renderLive(lines, width);
+      const nextRows = text ? text.split('\n').length : 0;
+      let out = '';
+      if (paintedRows > 0) out += `\x1b[${paintedRows}A\x1b[J`;
+      if (text) out += `${text}\n`;
+      stdout.write(out);
+      paintedRows = nextRows;
+    },
+  };
+}

--- a/apps/cli/src/live.ts
+++ b/apps/cli/src/live.ts
@@ -1,13 +1,22 @@
 export function renderLive(live: readonly string[], width: number): string {
-  const cap = Math.max(1, width);
-  return live.map((line) => (line.length <= cap ? line : `${line.slice(0, Math.max(1, cap - 1))}…`)).join('\n');
+  const cap = Math.max(0, width);
+  return live
+    .map((line) => {
+      if (line.length <= cap) return line;
+      if (cap <= 1) return line.slice(0, cap);
+      return `${line.slice(0, cap - 1)}…`;
+    })
+    .join('\n');
 }
 
-export function createLiveScreen(stdout: NodeJS.WritableStream, width = 80) {
+export function createLiveScreen(stdout: NodeJS.WritableStream, width?: number) {
   let paintedRows = 0;
   return {
     paint(lines: readonly string[]) {
-      const text = renderLive(lines, width);
+      const columns =
+        width ??
+        ('columns' in stdout && typeof stdout.columns === 'number' && stdout.columns > 0 ? stdout.columns : 80);
+      const text = renderLive(lines, columns);
       const nextRows = text ? text.split('\n').length : 0;
       let out = '';
       if (paintedRows > 0) out += `\x1b[${paintedRows}A\x1b[J`;

--- a/apps/cli/src/main.test.ts
+++ b/apps/cli/src/main.test.ts
@@ -1,7 +1,7 @@
 import { pathToFileURL } from 'node:url';
 import { PassThrough } from 'node:stream';
 import { describe, expect, it, vi } from 'vitest';
-import { isLaunchedEntry, runCli } from './main.js';
+import { isLaunchedEntry, isGitRemoteHelper, runCli } from './main.js';
 import { EXIT_AUTH, EXIT_GREEN, EXIT_INPUT } from './exit-codes.js';
 
 function io() {
@@ -28,32 +28,32 @@ function io() {
 describe('runCli verbs', () => {
   it('prints help and exits 0', async () => {
     const streams = io();
-    expect(await runCli(['node', 'gamedev', 'help'], {}, streams)).toBe(EXIT_GREEN);
+    expect(await runCli(['node', 'gamedevpl', 'help'], {}, streams)).toBe(EXIT_GREEN);
     expect(streams.read().out).toContain('whoami');
   });
 
   it('exits 4 when repl is run without a TTY', async () => {
     const streams = io();
-    expect(await runCli(['node', 'gamedev'], {}, streams)).toBe(EXIT_INPUT);
+    expect(await runCli(['node', 'gamedevpl'], {}, streams)).toBe(EXIT_INPUT);
   });
 
   it('exits 3 when whoami has no credential', async () => {
     const streams = io();
-    expect(await runCli(['node', 'gamedev', 'whoami'], { HOME: '/tmp/gamedev-cli-empty' }, streams)).toBe(EXIT_AUTH);
+    expect(await runCli(['node', 'gamedevpl', 'whoami'], { HOME: '/tmp/gamedev-cli-empty' }, streams)).toBe(EXIT_AUTH);
   });
 
   it('diff --force skips the platform read', async () => {
     const streams = io();
-    expect(await runCli(['node', 'gamedev', 'diff', '--force'], {}, streams)).toBe(EXIT_GREEN);
+    expect(await runCli(['node', 'gamedevpl', 'diff', '--force'], {}, streams)).toBe(EXIT_GREEN);
   });
 
   it('exits 4 when diff has no slug and no checkout', async () => {
     const streams = io();
-    expect(await runCli(['node', 'gamedev', 'diff'], { HOME: '/tmp/gamedev-cli-empty' }, streams)).toBe(EXIT_INPUT);
+    expect(await runCli(['node', 'gamedevpl', 'diff'], { HOME: '/tmp/gamedev-cli-empty' }, streams)).toBe(EXIT_INPUT);
   });
 
   it('treats the installed script name as a direct launch', () => {
-    const dest = '/home/me/.local/bin/gamedev';
+    const dest = '/home/me/.local/bin/gamedevpl';
     expect(isLaunchedEntry(dest, pathToFileURL(dest).href)).toBe(true);
     expect(isLaunchedEntry(dest, pathToFileURL('/tmp/vitest').href)).toBe(false);
     expect(isLaunchedEntry(undefined)).toBe(false);
@@ -67,10 +67,16 @@ describe('runCli verbs', () => {
     });
     const streams = io();
     expect(
-      await runCli(['node', 'gamedev', 'status', 'tok', '--watch'], { GAMEDEV_TOKEN: 'gdpl_pat_x' }, streams),
+      await runCli(['node', 'gamedevpl', 'status', 'tok', '--watch'], { GAMEDEV_TOKEN: 'gdpl_pat_x' }, streams),
     ).toBe(EXIT_GREEN);
     expect(calls).toBe(1);
     expect(streams.read().out).toContain('published');
     vi.unstubAllGlobals();
+  });
+
+  it('treats a gamedev:// URL as the git remote helper even when argv1 is gamedevpl', () => {
+    expect(isGitRemoteHelper(['node', '/bin/gamedevpl', 'origin', 'gamedev://sky-dodge'])).toBe(true);
+    expect(isGitRemoteHelper(['node', '/bin/gamedevpl', 'status', 'tok'])).toBe(false);
+    expect(isGitRemoteHelper(['node', '/bin/gamedevpl', 'connect', 'gamedev://sky-dodge'])).toBe(false);
   });
 });

--- a/apps/cli/src/main.test.ts
+++ b/apps/cli/src/main.test.ts
@@ -74,9 +74,10 @@ describe('runCli verbs', () => {
     vi.unstubAllGlobals();
   });
 
-  it('treats a gamedev:// URL as the git remote helper even when argv1 is gamedevpl', () => {
-    expect(isGitRemoteHelper(['node', '/bin/gamedevpl', 'origin', 'gamedev://sky-dodge'])).toBe(true);
+  it('treats a gamedevpl:// URL as the git remote helper even when argv1 is gamedevpl', () => {
+    expect(isGitRemoteHelper(['node', '/bin/gamedevpl', 'origin', 'gamedevpl://sky-dodge'])).toBe(true);
     expect(isGitRemoteHelper(['node', '/bin/gamedevpl', 'status', 'tok'])).toBe(false);
-    expect(isGitRemoteHelper(['node', '/bin/gamedevpl', 'connect', 'gamedev://sky-dodge'])).toBe(false);
+    expect(isGitRemoteHelper(['node', '/bin/gamedevpl', 'connect', 'gamedevpl://sky-dodge'])).toBe(false);
+    expect(isGitRemoteHelper(['node', '/bin/git-remote-gamedevpl', 'origin', 'gamedevpl://sky-dodge'])).toBe(true);
   });
 });

--- a/apps/cli/src/main.ts
+++ b/apps/cli/src/main.ts
@@ -132,7 +132,7 @@ export async function runCli(
       return EXIT_GREEN;
     }
     if (verb === 'connect') {
-      io.stdout.write(`${cliUsage('connect', args[0] ?? '')}\n`);
+      io.stdout.write(`${cliUsage('connect', args[0] || '<slug>')}\n`);
       return EXIT_GREEN;
     }
     const read = await dispatchReadVerb({ verb, args, flags, api, io });

--- a/apps/cli/src/main.ts
+++ b/apps/cli/src/main.ts
@@ -1,20 +1,22 @@
 #!/usr/bin/env node
 import { resolve as resolvePath } from 'node:path';
 import { pathToFileURL } from 'node:url';
-import { createInterface } from 'node:readline/promises';
 import { stdin, stdout, stderr } from 'node:process';
 import { parseArgv, jsonMode, SLASH_VERBS } from './argv.js';
+import { CLI_BIN, cliUsage } from './bin-name.js';
 import { createApi, requireTtyFlag } from './api.js';
 import { encryptedFileStore, FILE_FALLBACK_WARNING, memoryStore, type TokenStore } from './keychain.js';
 import { originFromEnv } from './oauth.js';
 import { CliError, EXIT_GREEN, EXIT_INPUT, EXIT_REFUSED } from './exit-codes.js';
 import { describeError, pipeNeedsFlag } from './errors.js';
+import { createReadlineHost } from './host.js';
 import { handleReplLine, replBanner } from './repl.js';
 import type { IntakeDraft } from './create.js';
-import { getStatus, isTerminalStatus, previewUrl } from './turn.js';
 import { checkoutGame, diffGame, pullGame, readCheckoutSlug, unreconciledMessage } from './checkout.js';
 import { runLadder, assertLadderGreen } from './verify.js';
 import { runGitRemoteHelper } from './git-remote-main.js';
+import { glyphs, wantsColor } from './renderer.js';
+import { runStatusVerb } from './status-watch.js';
 import { dispatchReadVerb } from './verbs.js';
 
 function storeFromEnv(env: NodeJS.ProcessEnv): TokenStore {
@@ -27,6 +29,14 @@ function storeFromEnv(env: NodeJS.ProcessEnv): TokenStore {
   return encryptedFileStore(env);
 }
 
+export function isGitRemoteHelper(argv: string[]): boolean {
+  if (/git-remote-gamedev/.test(argv[1] ?? argv[0] ?? '')) return true;
+  if (!argv.some((arg) => arg.startsWith('gamedev://'))) return false;
+  const first = argv[2];
+  if (first && !first.startsWith('-') && (SLASH_VERBS as readonly string[]).includes(first)) return false;
+  return true;
+}
+
 export async function runCli(
   argv: string[],
   env: NodeJS.ProcessEnv,
@@ -36,7 +46,7 @@ export async function runCli(
     stderr,
   },
 ): Promise<number> {
-  if (/git-remote-gamedev/.test(argv[1] ?? argv[0] ?? '')) {
+  if (isGitRemoteHelper(argv)) {
     return runGitRemoteHelper(argv, env);
   }
   const { verb, args, flags } = parseArgv(argv);
@@ -48,7 +58,7 @@ export async function runCli(
 
   try {
     if (verb === 'help' || flags.help) {
-      io.stdout.write(`gamedev <${SLASH_VERBS.join('|')}>\n`);
+      io.stdout.write(`${CLI_BIN} <${SLASH_VERBS.join('|')}>\n`);
       return EXIT_GREEN;
     }
     if (verb === 'login') {
@@ -57,7 +67,7 @@ export async function runCli(
         io.stdout.write('signed in with GAMEDEV_TOKEN\n');
         return EXIT_GREEN;
       }
-      requireTtyFlag(tty, '--token', 'GAMEDEV_TOKEN=… gamedev login');
+      requireTtyFlag(tty, '--token', `GAMEDEV_TOKEN=… ${cliUsage('login')}`);
       io.stdout.write(`open ${origin}/oauth/authorize to sign in, then retry with GAMEDEV_TOKEN set\n`);
       return EXIT_GREEN;
     }
@@ -73,26 +83,20 @@ export async function runCli(
     }
     if (verb === 'status') {
       const token = args[0];
-      if (!token) throw new CliError('gamedev status <token-or-slug>', EXIT_INPUT, '<token>');
+      if (!token) throw new CliError(cliUsage('status', '<token-or-slug>'), EXIT_INPUT, '<token>');
       const max = typeof flags.watch === 'string' ? Number(flags.watch) || 30 : flags.watch ? 30 : 1;
-      let delay = 2000;
-      let status = await getStatus(api, token);
-      for (let i = 1; i <= max; i += 1) {
-        if (asJson) io.stdout.write(`${JSON.stringify(status)}\n`);
-        else {
-          io.stdout.write(`${status.status}${status.stall ? ` (${status.stall})` : ''}\n`);
-          if (status.preview?.slug) io.stdout.write(`${previewUrl(api.origin, status.preview.slug)}\n`);
-        }
-        if (!flags.watch || i === max || isTerminalStatus(status.status)) break;
-        await new Promise((resolve) => setTimeout(resolve, delay));
-        delay = Math.min(Math.round(delay * 1.5), 15_000);
-        status = await getStatus(api, token);
-      }
-      return EXIT_GREEN;
+      return runStatusVerb({
+        api,
+        token,
+        maxPolls: max,
+        asJson,
+        live: Boolean(io.stdout.isTTY) && Boolean(flags.watch) && !asJson,
+        stdout: io.stdout,
+      });
     }
     if (verb === 'checkout') {
       const slug = args[0];
-      if (!slug) throw new CliError('gamedev checkout <slug>', EXIT_INPUT, '<slug>');
+      if (!slug) throw new CliError(cliUsage('checkout', '<slug>'), EXIT_INPUT, '<slug>');
       const dest = args[1] ?? slug;
       const result = await checkoutGame({ api, slug, dest });
       io.stdout.write(`checked out ${slug} → ${result.dest} (origin ${result.remote})\n`);
@@ -100,7 +104,7 @@ export async function runCli(
     }
     if (verb === 'pull') {
       const slug = args[0] ?? readCheckoutSlug(process.cwd());
-      if (!slug) throw new CliError('gamedev pull <slug>', EXIT_INPUT, '<slug>');
+      if (!slug) throw new CliError(cliUsage('pull', '<slug>'), EXIT_INPUT, '<slug>');
       const dest = args[1] ?? process.cwd();
       const pulled = await pullGame({ api, slug, dest });
       io.stdout.write(asJson ? `${JSON.stringify(pulled)}\n` : `pulled ${slug} @ ${pulled.version}\n`);
@@ -109,7 +113,7 @@ export async function runCli(
     if (verb === 'diff') {
       if (flags.force) return EXIT_GREEN;
       const slug = args[0] ?? readCheckoutSlug(process.cwd());
-      if (!slug) throw new CliError('gamedev diff <slug>', EXIT_INPUT, '<slug>');
+      if (!slug) throw new CliError(cliUsage('diff', '<slug>'), EXIT_INPUT, '<slug>');
       const dest = args[1] ?? process.cwd();
       const diff = await diffGame({ api, slug, dest });
       if (asJson) io.stdout.write(`${JSON.stringify(diff)}\n`);
@@ -128,34 +132,38 @@ export async function runCli(
       return EXIT_GREEN;
     }
     if (verb === 'connect') {
-      io.stdout.write(`gamedev connect ${args[0] ?? ''}\n`);
+      io.stdout.write(`${cliUsage('connect', args[0] ?? '')}\n`);
       return EXIT_GREEN;
     }
     const read = await dispatchReadVerb({ verb, args, flags, api, io });
     if (read !== null) return read;
     if (verb === 'repl') {
-      if (!tty) throw pipeNeedsFlag('a verb such as gamedev whoami');
+      if (!tty) throw pipeNeedsFlag(`a verb such as ${cliUsage('whoami')}`);
       io.stdout.write(`${replBanner(true, env)}\n`);
-      const rl = createInterface({ input: io.stdin, output: io.stdout });
+      const host = createReadlineHost(io);
+      const g = glyphs(wantsColor(env, tty));
       let token = typeof flags.token === 'string' ? flags.token : null;
       let draft: IntakeDraft | null = null;
-      for (;;) {
-        const line = await rl.question('› ');
-        const result = await handleReplLine({
-          line,
-          api,
-          token,
-          draft,
-          write: (s) => io.stdout.write(`${s}\n`),
-        });
-        if (result.token !== undefined) token = result.token;
-        if (result.draft !== undefined) draft = result.draft;
-        if (result.next === 'quit') break;
+      try {
+        for (;;) {
+          const line = await host.prompt(`${g.prompt} `);
+          const result = await handleReplLine({
+            line,
+            api,
+            token,
+            draft,
+            write: (s) => host.writeLine(s),
+          });
+          if (result.token !== undefined) token = result.token;
+          if (result.draft !== undefined) draft = result.draft;
+          if (result.next === 'quit') break;
+        }
+      } finally {
+        host.close();
       }
-      rl.close();
       return EXIT_GREEN;
     }
-    io.stderr.write(`unknown verb ${verb} — gamedev help\n`);
+    io.stderr.write(`unknown verb ${verb} — ${cliUsage('help')}\n`);
     return EXIT_INPUT;
   } catch (error) {
     const shown = describeError(error);

--- a/apps/cli/src/main.ts
+++ b/apps/cli/src/main.ts
@@ -3,7 +3,7 @@ import { resolve as resolvePath } from 'node:path';
 import { pathToFileURL } from 'node:url';
 import { stdin, stdout, stderr } from 'node:process';
 import { parseArgv, jsonMode, SLASH_VERBS } from './argv.js';
-import { CLI_BIN, cliUsage } from './bin-name.js';
+import { CLI_BIN, GIT_REMOTE_HELPER, GIT_REMOTE_SCHEME, cliUsage } from './bin-name.js';
 import { createApi, requireTtyFlag } from './api.js';
 import { encryptedFileStore, FILE_FALLBACK_WARNING, memoryStore, type TokenStore } from './keychain.js';
 import { originFromEnv } from './oauth.js';
@@ -30,8 +30,8 @@ function storeFromEnv(env: NodeJS.ProcessEnv): TokenStore {
 }
 
 export function isGitRemoteHelper(argv: string[]): boolean {
-  if (/git-remote-gamedev/.test(argv[1] ?? argv[0] ?? '')) return true;
-  if (!argv.some((arg) => arg.startsWith('gamedev://'))) return false;
+  if ((argv[1] ?? argv[0] ?? '').includes(GIT_REMOTE_HELPER)) return true;
+  if (!argv.some((arg) => arg.startsWith(`${GIT_REMOTE_SCHEME}://`))) return false;
   const first = argv[2];
   if (first && !first.startsWith('-') && (SLASH_VERBS as readonly string[]).includes(first)) return false;
   return true;

--- a/apps/cli/src/renderer.test.ts
+++ b/apps/cli/src/renderer.test.ts
@@ -1,20 +1,7 @@
 import { describe, expect, it } from 'vitest';
-import { createTwoRegion, glyphs, renderLive, wantsColor } from './renderer.js';
+import { glyphs, wantsColor } from './renderer.js';
 
-describe('two-region renderer', () => {
-  it('never rewrites transcript lines', () => {
-    const region = createTwoRegion();
-    region.print('› hello');
-    region.setLive(['▸ building']);
-    region.promote('✓ preview ready');
-    expect(region.transcript).toEqual(['› hello', '✓ preview ready']);
-    expect(region.live).toEqual([]);
-  });
-
-  it('truncates live lines to the terminal width', () => {
-    expect(renderLive(['abcdefghij'], 6)).toBe('abcde…');
-  });
-
+describe('glyphs', () => {
   it('downgrades glyphs when color is off', () => {
     expect(glyphs(false).agent).toBe('*');
     expect(glyphs(true).agent).toBe('◆');

--- a/apps/cli/src/renderer.ts
+++ b/apps/cli/src/renderer.ts
@@ -10,39 +10,3 @@ export function wantsColor(env: NodeJS.ProcessEnv, isTty: boolean): boolean {
   if (env.FORCE_COLOR === '0') return false;
   return isTty;
 }
-
-export interface TwoRegion {
-  transcript: string[];
-  live: string[];
-}
-
-export function createTwoRegion(maxLive = 4): TwoRegion & {
-  print(line: string): void;
-  setLive(lines: string[]): void;
-  promote(line: string): void;
-} {
-  const transcript: string[] = [];
-  let live: string[] = [];
-  return {
-    get transcript() {
-      return transcript;
-    },
-    get live() {
-      return live;
-    },
-    print(line: string) {
-      transcript.push(line);
-    },
-    setLive(lines: string[]) {
-      live = lines.slice(0, maxLive);
-    },
-    promote(line: string) {
-      transcript.push(line);
-      live = [];
-    },
-  };
-}
-
-export function renderLive(live: readonly string[], width: number): string {
-  return live.map((line) => (line.length <= width ? line : `${line.slice(0, Math.max(1, width - 1))}…`)).join('\n');
-}

--- a/apps/cli/src/repl.test.ts
+++ b/apps/cli/src/repl.test.ts
@@ -114,7 +114,7 @@ describe('repl turn loop', () => {
     expect(posts).toBe(0);
   });
 
-  it('tells the user to run known non-REPL verbs as gamedev <verb>', async () => {
+  it('tells the user to run known non-REPL verbs as gamedevpl <verb>', async () => {
     const lines: string[] = [];
     const api = createApi({
       origin: 'https://www.gamedev.pl',
@@ -128,7 +128,7 @@ describe('repl turn loop', () => {
       write: (s) => lines.push(s),
     });
     expect(result.next).toBe('continue');
-    expect(lines.join('\n')).toBe('run it as gamedev status');
+    expect(lines.join('\n')).toBe('run it as gamedevpl status');
   });
 
   it('parses slash-verb flags the same way as argv', async () => {

--- a/apps/cli/src/repl.ts
+++ b/apps/cli/src/repl.ts
@@ -1,4 +1,4 @@
-import { CLI_BIN } from './bin-name.js';
+import { CLI_BIN, cliUsage } from './bin-name.js';
 import { glyphs, wantsColor } from './renderer.js';
 import { completeSlash, parseArgv, SLASH_VERBS, type SlashVerb } from './argv.js';
 import { postTurn } from './turn.js';
@@ -53,7 +53,7 @@ export async function handleReplLine(input: {
         input.write(chunks.join('').trimEnd() || `/${cmd}`);
         return { next: 'continue' };
       }
-      input.write(`run it as gamedev ${cmd}`);
+      input.write(`run it as ${cliUsage(cmd)}`);
       return { next: 'continue' };
     }
     const matches = completeSlash(trimmed);

--- a/apps/cli/src/repl.ts
+++ b/apps/cli/src/repl.ts
@@ -1,4 +1,5 @@
-import { createTwoRegion, glyphs, wantsColor } from './renderer.js';
+import { CLI_BIN } from './bin-name.js';
+import { glyphs, wantsColor } from './renderer.js';
 import { completeSlash, parseArgv, SLASH_VERBS, type SlashVerb } from './argv.js';
 import { postTurn } from './turn.js';
 import type { ApiClient } from './api.js';
@@ -88,7 +89,5 @@ export async function handleReplLine(input: {
 
 export function replBanner(isTty: boolean, env: NodeJS.ProcessEnv): string {
   const g = glyphs(wantsColor(env, isTty));
-  return `${g.agent} gamedev — ${g.prompt} to talk, /help for verbs`;
+  return `${g.agent} ${CLI_BIN} — ${g.prompt} to talk, /help for verbs`;
 }
-
-export { createTwoRegion };

--- a/apps/cli/src/status-watch.ts
+++ b/apps/cli/src/status-watch.ts
@@ -1,0 +1,49 @@
+import { EXIT_GREEN } from './exit-codes.js';
+import { createLiveScreen } from './live.js';
+import { getStatus, isTerminalStatus, previewUrl, type RoundStatus } from './turn.js';
+import type { ApiClient } from './api.js';
+
+export function statusWatchDelayMs(status: Pick<RoundStatus, 'status' | 'phase' | 'stall'>): number {
+  const active =
+    status.status === 'building' ||
+    status.phase === 'dispatched' ||
+    status.stall === 'no_agent_yet' ||
+    status.stall === 'ended' ||
+    status.stall === 'quiet';
+  return active ? 3000 : 10_000;
+}
+
+export function formatStatusLines(status: RoundStatus, origin: string): string[] {
+  const lines = [`${status.status}${status.stall ? ` (${status.stall})` : ''}`];
+  if (status.gateProgress) {
+    lines.push(`${status.gateProgress.stage} ${status.gateProgress.index}/${status.gateProgress.total}`);
+  }
+  if (status.preview?.slug) lines.push(previewUrl(origin, status.preview.slug));
+  if (status.failure?.reason) lines.push(status.failure.reason);
+  return lines;
+}
+
+export async function runStatusVerb(input: {
+  api: ApiClient;
+  token: string;
+  maxPolls: number;
+  asJson: boolean;
+  live: boolean;
+  stdout: NodeJS.WriteStream;
+  sleep?: (ms: number) => Promise<void>;
+}): Promise<number> {
+  const sleep = input.sleep ?? ((ms: number) => new Promise((resolve) => setTimeout(resolve, ms)));
+  const screen = input.live ? createLiveScreen(input.stdout, input.stdout.columns ?? 80) : null;
+  let status = await getStatus(input.api, input.token);
+  for (let i = 1; i <= input.maxPolls; i += 1) {
+    if (input.asJson) input.stdout.write(`${JSON.stringify(status)}\n`);
+    else if (screen) screen.paint(formatStatusLines(status, input.api.origin));
+    else {
+      for (const line of formatStatusLines(status, input.api.origin)) input.stdout.write(`${line}\n`);
+    }
+    if (i === input.maxPolls || isTerminalStatus(status.status)) break;
+    await sleep(statusWatchDelayMs(status));
+    status = await getStatus(input.api, input.token);
+  }
+  return EXIT_GREEN;
+}

--- a/apps/cli/src/status-watch.ts
+++ b/apps/cli/src/status-watch.ts
@@ -33,7 +33,7 @@ export async function runStatusVerb(input: {
   sleep?: (ms: number) => Promise<void>;
 }): Promise<number> {
   const sleep = input.sleep ?? ((ms: number) => new Promise((resolve) => setTimeout(resolve, ms)));
-  const screen = input.live ? createLiveScreen(input.stdout, input.stdout.columns ?? 80) : null;
+  const screen = input.live ? createLiveScreen(input.stdout) : null;
   let status = await getStatus(input.api, input.token);
   for (let i = 1; i <= input.maxPolls; i += 1) {
     if (input.asJson) input.stdout.write(`${JSON.stringify(status)}\n`);

--- a/apps/cli/src/turn.ts
+++ b/apps/cli/src/turn.ts
@@ -14,17 +14,17 @@ export async function getTurns(
   return api.request('GET', `/api/submissions/${encodeURIComponent(token)}/turns`);
 }
 
-export async function getStatus(
-  api: ApiClient,
-  token: string,
-): Promise<{
+export type RoundStatus = {
   status: string;
+  phase?: string;
   gateProgress?: { stage: string; index: number; total: number };
   previewGate?: { green: boolean };
   preview?: { slug: string };
   stall?: string;
   failure?: { reason: string };
-}> {
+};
+
+export async function getStatus(api: ApiClient, token: string): Promise<RoundStatus> {
   return api.request('GET', `/api/submissions/${encodeURIComponent(token)}`);
 }
 

--- a/apps/cli/src/update.test.ts
+++ b/apps/cli/src/update.test.ts
@@ -8,38 +8,45 @@ import { CliError } from './exit-codes.js';
 
 describe('updateCli', () => {
   it('ships one Node-script asset for every platform', () => {
-    expect(assetName()).toBe('gamedev');
+    expect(assetName()).toBe('gamedevpl');
   });
 
   it('parses sha256sum lines', () => {
     expect(expectedHash('abc\n', 'nope')).toBeNull();
     const hash = 'a'.repeat(64);
-    expect(expectedHash(`${hash}  gamedev\n`, 'gamedev')).toBe(hash);
+    expect(expectedHash(`${hash}  gamedevpl\n`, 'gamedevpl')).toBe(hash);
+  });
+
+  it('installs git-remote-gamedevpl beside the CLI binary', () => {
+    expect(helperDest('/home/me/.local/bin/gamedevpl')).toBe('/home/me/.local/bin/git-remote-gamedevpl');
+    expect(helperDest('/home/me/.local/bin/git-remote-gamedevpl')).toBe('/home/me/.local/bin/git-remote-gamedevpl');
+    expect(helperDest('/tmp/gamedevpl.exe')).toBe('/tmp/git-remote-gamedevpl.exe');
+    expect(helperDest('/tmp/GAMEDEVPL.EXE')).toBe('/tmp/git-remote-gamedevpl.exe');
   });
 
   it('writes the verified script and a git-remote helper copy', async () => {
     const bytes = Buffer.from('#!/usr/bin/env node\n');
     const hash = createHash('sha256').update(bytes).digest('hex');
-    const dest = join(mkdtempSync(join(tmpdir(), 'gdpl-upd-')), 'nested', 'gamedev');
+    const dest = join(mkdtempSync(join(tmpdir(), 'gdpl-upd-')), 'nested', 'gamedevpl');
     const result = await updateCli({
       dest,
       version: '0.1.0',
       fetchImpl: async (url) => {
         if (String(url).endsWith('SHA256SUMS')) {
-          return new Response(`${hash}  gamedev\n`, { status: 200 });
+          return new Response(`${hash}  gamedevpl\n`, { status: 200 });
         }
-        if (String(url).endsWith('/gamedev')) {
+        if (String(url).endsWith('/gamedevpl')) {
           return new Response(bytes, { status: 200 });
         }
         return new Response('missing', { status: 404 });
       },
     });
-    expect(result).toEqual({ version: '0.1.0', asset: 'gamedev' });
+    expect(result).toEqual({ version: '0.1.0', asset: 'gamedevpl' });
     expect(readFileSync(dest)).toEqual(bytes);
     expect(readFileSync(helperDest(dest))).toEqual(bytes);
   });
 
-  it('still installs the helper when --dest is not named gamedev', async () => {
+  it('still installs the helper when --dest is not named gamedevpl', async () => {
     const bytes = Buffer.from('#!/usr/bin/env node\n');
     const hash = createHash('sha256').update(bytes).digest('hex');
     const dest = join(mkdtempSync(join(tmpdir(), 'gdpl-upd-')), 'custom-bin');
@@ -47,23 +54,23 @@ describe('updateCli', () => {
       dest,
       version: '0.1.0',
       fetchImpl: async (url) => {
-        if (String(url).endsWith('SHA256SUMS')) return new Response(`${hash}  gamedev\n`, { status: 200 });
-        if (String(url).endsWith('/gamedev')) return new Response(bytes, { status: 200 });
+        if (String(url).endsWith('SHA256SUMS')) return new Response(`${hash}  gamedevpl\n`, { status: 200 });
+        if (String(url).endsWith('/gamedevpl')) return new Response(bytes, { status: 200 });
         return new Response('missing', { status: 404 });
       },
     });
     expect(readFileSync(helperDest(dest))).toEqual(bytes);
-    expect(helperDest(dest)).toMatch(/git-remote-gamedev$/);
+    expect(helperDest(dest)).toMatch(/git-remote-gamedevpl$/);
   });
 
   it('refuses a checksum mismatch', async () => {
     await expect(
       updateCli({
-        dest: join(mkdtempSync(join(tmpdir(), 'gdpl-upd-')), 'gamedev'),
+        dest: join(mkdtempSync(join(tmpdir(), 'gdpl-upd-')), 'gamedevpl'),
         version: '0.1.0',
         fetchImpl: async (url) => {
           if (String(url).endsWith('SHA256SUMS')) {
-            return new Response(`${'b'.repeat(64)}  gamedev\n`, { status: 200 });
+            return new Response(`${'b'.repeat(64)}  gamedevpl\n`, { status: 200 });
           }
           return new Response(Buffer.from('nope'), { status: 200 });
         },

--- a/apps/cli/src/update.ts
+++ b/apps/cli/src/update.ts
@@ -2,11 +2,12 @@ import { createHash } from 'node:crypto';
 import { copyFileSync, mkdirSync, writeFileSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { basename, dirname, join } from 'node:path';
+import { CLI_BIN, GIT_REMOTE_HELPER } from './bin-name.js';
 import { CliError, EXIT_REFUSED } from './exit-codes.js';
 
 export const CLI_VERSION = '0.1.0';
 export const CLI_RELEASE_PREFIX = 'cli-v';
-export const CLI_ASSET = 'gamedev';
+export const CLI_ASSET = CLI_BIN;
 export const CLI_RELEASES_DOWNLOAD = 'https://github.com/gamedevpl/www.gamedev.pl/releases/download';
 export const CLI_RELEASES_API = 'https://api.github.com/repos/gamedevpl/www.gamedev.pl/releases?per_page=100';
 
@@ -34,8 +35,8 @@ export function defaultInstallDest(): string {
 
 export function helperDest(binPath: string): string {
   const ext = /\.exe$/i.test(binPath) ? '.exe' : '';
-  if (basename(binPath).toLowerCase() === `git-remote-gamedev${ext}`) return binPath;
-  return join(dirname(binPath), `git-remote-gamedev${ext}`);
+  if (basename(binPath).toLowerCase() === `${GIT_REMOTE_HELPER}${ext}`.toLowerCase()) return binPath;
+  return join(dirname(binPath), `${GIT_REMOTE_HELPER}${ext}`);
 }
 
 export async function resolveUpdateVersion(input: { version?: string; fetchImpl: FetchLike }): Promise<string> {

--- a/apps/cli/src/verbs.ts
+++ b/apps/cli/src/verbs.ts
@@ -1,4 +1,5 @@
 import type { ApiClient } from './api.js';
+import { cliUsage } from './bin-name.js';
 import { jsonMode } from './argv.js';
 import { CliError, EXIT_GREEN, EXIT_INPUT } from './exit-codes.js';
 import { defaultInstallDest, updateCli } from './update.js';
@@ -46,7 +47,7 @@ export async function dispatchReadVerb(input: {
   }
   if (verb === 'share') {
     const slug = args[0];
-    if (!slug) throw new CliError('gamedev share <slug>', EXIT_INPUT, '<slug>');
+    if (!slug) throw new CliError(cliUsage('share', '<slug>'), EXIT_INPUT, '<slug>');
     const url = `${api.origin}/play/${slug}`;
     emit(io, asJson, { url }, url);
     return EXIT_GREEN;
@@ -64,7 +65,7 @@ export async function dispatchReadVerb(input: {
   }
   if (verb === 'builder') {
     const slug = args[0];
-    if (!slug) throw new CliError('gamedev builder <slug>', EXIT_INPUT, '<slug>');
+    if (!slug) throw new CliError(cliUsage('builder', '<slug>'), EXIT_INPUT, '<slug>');
     const studio = await api.request<{ games?: Array<{ slug?: string; token?: string }> }>(
       'GET',
       `/api/me/studio?game=${encodeURIComponent(slug)}`,

--- a/apps/web/src/CliFunnelBlock.tsx
+++ b/apps/web/src/CliFunnelBlock.tsx
@@ -22,10 +22,10 @@ export function CliFunnelBlock({ funnel }: { funnel: VisitFunnel }) {
   const rows = funnel.cli;
   return (
     <div className="funnel-block" data-testid="cli-funnel">
-      <h3>gamedev CLI</h3>
+      <h3>gamedevpl CLI</h3>
       {rows.every((row) => row.visits === 0) ? (
         <p className="health-empty">
-          Nobody used the gamedev CLI in this window. Pilot verdict needs a live cohort — do not invent one.
+          Nobody used the gamedevpl CLI in this window. Pilot verdict needs a live cohort — do not invent one.
         </p>
       ) : (
         <table className="health-table">

--- a/apps/web/src/VisitFunnelPanel.test.tsx
+++ b/apps/web/src/VisitFunnelPanel.test.tsx
@@ -81,7 +81,7 @@ describe('VisitFunnelPanel', () => {
     const text = render(response({ visits: 4, visitsWithPlay: 3, bounces: 1, plays: 5 }));
     expect(text).toContain('75%');
     expect(text).toContain('reached a game');
-    expect(text).toContain('gamedev CLI');
+    expect(text).toContain('gamedevpl CLI');
   });
 
   it('shows dashes rather than a fake zero when nobody played', () => {

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -1249,7 +1249,7 @@
   },
   "connectAgents": {
     "title": "Connect an agent",
-    "intro": "Two doors, same games. Point a coding agent at gamedev.pl over MCP, or talk in a terminal with the gamedev CLI. Neither has a model of its own — coding happens on the platform or in a tool you already installed.",
+    "intro": "Two doors, same games. Point a coding agent at gamedev.pl over MCP, or talk in a terminal with the gamedevpl CLI. Neither has a model of its own — coding happens on the platform or in a tool you already installed.",
     "back": "Back to the site",
     "jump": "On this page",
     "beta": "Creating games is in closed beta. The connection loads for anyone; the calls need an approved creator account.",
@@ -1264,13 +1264,13 @@
       "registry": "Official MCP Registry"
     },
     "cli": {
-      "nav": "gamedev CLI",
-      "title": "gamedev CLI — a terminal",
+      "nav": "gamedevpl CLI",
+      "title": "gamedevpl CLI — a terminal",
       "lead": "A conversational front door. Type an idea, answer refine questions, watch the gate. Checkout uses your editor; git push is not a delivery path.",
       "installHint": "Needs Node 20+ — same as a game checkout. Windows: irm https://www.gamedev.pl/install.ps1 | iex. The script checksum-verifies before it writes ~/.local/bin.",
       "installPending": "Installers are not public yet. The client lives in this repo at apps/cli; bundle it locally with npm run bundle -w @gamedevpl/cli.",
-      "repl": "gamedev with no verb opens a REPL: describe a game, then iterate.",
-      "checkout": "gamedev checkout <slug> for your own editor. Deliver with gamedev submit.",
+      "repl": "gamedevpl with no verb opens a REPL: describe a game, then iterate.",
+      "checkout": "gamedevpl checkout <slug> for your own editor. Deliver with gamedevpl submit.",
       "ci": "CI: GAMEDEV_TOKEN from secrets. Never pass the creator OAuth token to a sub-agent."
     }
   },
@@ -1672,7 +1672,7 @@
       "cli": "CLI"
     },
     "gamedevCli": {
-      "title": "gamedev CLI",
+      "title": "gamedevpl CLI",
       "hint": "Needs Node 20 — same as a working copy. Then connect this game. Same round as MCP — no extra secret."
     },
     "rotate": {
@@ -1695,7 +1695,7 @@
   },
   "workspaceCheckout": {
     "title": "Work on this game in your own IDE",
-    "hint": "Get a working copy — this game's sources, a setup script and a README, ready for your own editor. Deliver changes back with `gamedev submit`; they go through the usual round, gate and review before anything is published.",
+    "hint": "Get a working copy — this game's sources, a setup script and a README, ready for your own editor. Deliver changes back with `gamedevpl submit`; they go through the usual round, gate and review before anything is published.",
     "action": "Get working copy",
     "pending": "Preparing your working copy…",
     "done": "Your working copy is on its way to your downloads.",
@@ -1709,7 +1709,7 @@
   },
   "oauthClients": {
     "title": "Connected coding agents",
-    "hint": "Agents and the gamedev CLI authorized to access your games. Disconnecting one removes its access immediately.",
+    "hint": "Agents and the gamedevpl CLI authorized to access your games. Disconnecting one removes its access immediately.",
     "loading": "Loading connected clients…",
     "loadError": "We couldn't load connected clients right now.",
     "revokeError": "We couldn't disconnect that client. Try again in a moment.",

--- a/apps/web/src/i18n/locales/pl.json
+++ b/apps/web/src/i18n/locales/pl.json
@@ -1263,7 +1263,7 @@
   },
   "connectAgents": {
     "title": "Podłącz agenta",
-    "intro": "Dwoje drzwi, te same gry. Wskaż agenta kodującego na gamedev.pl przez MCP albo rozmawiaj w terminalu przez gamedev CLI. Żadne nie ma własnego modelu — kod powstaje na platformie albo w narzędziu, które już masz.",
+    "intro": "Dwoje drzwi, te same gry. Wskaż agenta kodującego na gamedev.pl przez MCP albo rozmawiaj w terminalu przez gamedevpl CLI. Żadne nie ma własnego modelu — kod powstaje na platformie albo w narzędziu, które już masz.",
     "back": "Wróć do serwisu",
     "jump": "Na tej stronie",
     "beta": "Tworzenie gier jest w zamkniętej becie. Połączenie ładuje się dla każdego; wywołania wymagają zatwierdzonego konta twórcy.",
@@ -1278,13 +1278,13 @@
       "registry": "Oficjalny rejestr MCP"
     },
     "cli": {
-      "nav": "gamedev CLI",
-      "title": "gamedev CLI — terminal",
+      "nav": "gamedevpl CLI",
+      "title": "gamedevpl CLI — terminal",
       "lead": "Rozmowny front door. Opisz pomysł, odpowiedz na pytania, obserwuj bramkę. Checkout idzie do Twojego edytora; git push nie jest ścieżką oddania.",
       "installHint": "Potrzebujesz Node 20+ — tak jak przy kopii roboczej. Windows: irm https://www.gamedev.pl/install.ps1 | iex. Skrypt weryfikuje sumę kontrolną zanim zapisze ~/.local/bin.",
       "installPending": "Instalatory nie są jeszcze publiczne. Klient jest w tym repozytorium w apps/cli; zbierz go lokalnie: npm run bundle -w @gamedevpl/cli.",
-      "repl": "gamedev bez czasownika otwiera REPL: opisz grę, potem iteruj.",
-      "checkout": "gamedev checkout <slug> do własnego edytora. Oddajesz poleceniem gamedev submit.",
+      "repl": "gamedevpl bez czasownika otwiera REPL: opisz grę, potem iteruj.",
+      "checkout": "gamedevpl checkout <slug> do własnego edytora. Oddajesz poleceniem gamedevpl submit.",
       "ci": "CI: GAMEDEV_TOKEN z secrets. Nigdy nie przekazuj tokenu OAuth twórcy do sub-agenta."
     }
   },
@@ -1686,7 +1686,7 @@
       "cli": "CLI"
     },
     "gamedevCli": {
-      "title": "gamedev CLI",
+      "title": "gamedevpl CLI",
       "hint": "Potrzebujesz Node 20 — tak jak przy kopii roboczej. Potem podłącz tę grę. Ta sama runda co MCP — bez dodatkowego sekretu."
     },
     "rotate": {
@@ -1709,7 +1709,7 @@
   },
   "workspaceCheckout": {
     "title": "Pracuj nad tą grą we własnym IDE",
-    "hint": "Pobierz kopię roboczą — źródła tej gry, skrypt konfiguracyjny i README, gotowe dla Twojego edytora. Oddaj zmiany poleceniem `gamedev submit`; przechodzą zwykłą rundę, bramkę i recenzję, zanim cokolwiek zostanie opublikowane.",
+    "hint": "Pobierz kopię roboczą — źródła tej gry, skrypt konfiguracyjny i README, gotowe dla Twojego edytora. Oddaj zmiany poleceniem `gamedevpl submit`; przechodzą zwykłą rundę, bramkę i recenzję, zanim cokolwiek zostanie opublikowane.",
     "action": "Pobierz kopię roboczą",
     "pending": "Przygotowujemy kopię roboczą…",
     "done": "Kopia robocza trafia do Twoich pobranych plików.",
@@ -1723,7 +1723,7 @@
   },
   "oauthClients": {
     "title": "Podłączone agenty kodujące",
-    "hint": "Agenty i gamedev CLI z dostępem do Twoich gier. Odłączenie natychmiast odbiera dostęp.",
+    "hint": "Agenty i gamedevpl CLI z dostępem do Twoich gier. Odłączenie natychmiast odbiera dostęp.",
     "loading": "Wczytywanie podłączonych klientów…",
     "loadError": "Nie udało się wczytać podłączonych klientów.",
     "revokeError": "Nie udało się odłączyć tego klienta. Spróbuj za chwilę.",

--- a/apps/web/src/surfaces/studio/GamedevCliConnectTab.test.tsx
+++ b/apps/web/src/surfaces/studio/GamedevCliConnectTab.test.tsx
@@ -27,7 +27,7 @@ describe('GamedevCliConnectTab', () => {
       await Promise.resolve();
       await Promise.resolve();
     });
-    expect(host.textContent).toContain('gamedev connect ghost-roads');
+    expect(host.textContent).toContain('gamedevpl connect ghost-roads');
     expect(host.textContent).toContain(`${window.location.origin}/install.sh`);
     await act(async () => root.unmount());
   });

--- a/apps/web/src/surfaces/studio/GamedevCliConnectTab.tsx
+++ b/apps/web/src/surfaces/studio/GamedevCliConnectTab.tsx
@@ -5,7 +5,7 @@ export function GamedevCliConnectTab({ slug }: { slug: string }) {
   const { t } = useTranslation();
   const on = useCliSurfaceEnabled();
   if (!on) return null;
-  const snippet = `curl -fsSL ${window.location.origin}/install.sh | bash\ngamedev connect ${slug}`;
+  const snippet = `curl -fsSL ${window.location.origin}/install.sh | bash\ngamedevpl connect ${slug}`;
   return (
     <div className="studio-connect-step" data-testid="gamedev-cli-connect">
       <h4 className="studio-connect-step-title">{t('connect.gamedevCli.title')}</h4>

--- a/apps/web/src/surfaces/studio/StudioWorkspaceCheckoutPanel.test.tsx
+++ b/apps/web/src/surfaces/studio/StudioWorkspaceCheckoutPanel.test.tsx
@@ -115,7 +115,7 @@ describe('StudioWorkspaceCheckoutPanel', () => {
     const text = container.textContent ?? '';
     expect(text).toContain('Work on this game in your own IDE');
     expect(text).toContain('working copy');
-    expect(text).toMatch(/gamedev submit/i);
+    expect(text).toMatch(/gamedevpl submit/i);
     expect(text).toMatch(/gate and review/i);
     // The feature is explicitly not a way to walk off with the game.
     expect(text).not.toMatch(/export|eject|take your game|download your game/i);

--- a/docs/README.md
+++ b/docs/README.md
@@ -63,7 +63,7 @@ survives only in this repo's early history.
 | [`own-ide-checkout.md`](./own-ide-checkout.md)                     | 🚧 A working copy for creators who prefer their own IDE — checkout, deliver back, one delivery contract |
 | [`cli-status-poll.md`](./cli-status-poll.md)                       | How a non-browser client watches a round: one status read, poll cadence, backoff (CL-12)                |
 | [`cli-pre-job-intake.md`](./cli-pre-job-intake.md)                 | Refine → submit stays client-side for the CLI's first milestone (CL-13)                                 |
-| [`../apps/cli/README.md`](../apps/cli/README.md)                   | `gamedev` terminal client in this repo — public page: `/connect`                                        |
+| [`../apps/cli/README.md`](../apps/cli/README.md)                   | `gamedevpl` terminal client in this repo — public page: `/connect`                                      |
 | [`notifications-plan.md`](./notifications-plan.md)                 | Notify creators/players of transitions: detection sweep, per-user storage, in-app → email → push        |
 | [`creator-qa-plan.md`](./creator-qa-plan.md)                       | Clarifying-questions pass before spec freeze — raises the hit rate of the one-shot agent run            |
 | [`improvement-loop-plan.md`](./improvement-loop-plan.md)           | After publish: player signals → per-game scorecard → agent-assisted fixes and suggestions               |

--- a/docs/cli-pre-job-intake.md
+++ b/docs/cli-pre-job-intake.md
@@ -1,6 +1,6 @@
 # CLI pre-job intake
 
-For the first CLI milestone, refine → submit stays **client-side**. The `gamedev` binary
+For the first CLI milestone, refine → submit stays **client-side**. The `gamedevpl` binary
 drives the existing create routes itself:
 
 1. `POST /api/submissions/refine` — clarifying questions (same flow as Studio).

--- a/docs/contributing-for-agents.md
+++ b/docs/contributing-for-agents.md
@@ -28,7 +28,7 @@ For coding agents (GitHub Copilot, Claude Code, Codex) and humans picking up wor
 ```
 apps/
   web/       Vite + React + TS frontend (prompt form + game player)
-  cli/       `gamedev` terminal client (`/connect` on the site)
+  cli/       `gamedevpl` terminal client (`/connect` on the site)
   api/       Fastify + TS backend (catalog, jobs, agent channel, MCP)
   world/     Zone host (authoritative sims)
 packages/

--- a/eslint-rules/module-boundary-map.mjs
+++ b/eslint-rules/module-boundary-map.mjs
@@ -80,7 +80,7 @@ const FILE_BUCKET = {
   'dev-seed-studio': 'platform',
   'openai-apps-challenge': 'platform',
   'spa-paths': 'platform',
-  // Kill switch + reserved installer routes for the gamedev CLI surface (CL-02).
+  // Kill switch + reserved installer routes for the gamedevpl CLI surface (CL-02).
   'cli-surface': 'platform',
   'cli-installers': 'platform',
   'cli-page': 'platform',

--- a/listings/mcp/README.md
+++ b/listings/mcp/README.md
@@ -11,7 +11,7 @@ an npm package we maintain.
 
 | Path                                        | What                                                                                                                                  |
 | ------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
-| `GET /connect` (alias `/mcp`)               | Human page: MCP URL + gamedev CLI. Header menu, not `/create` or public game pages.                                                   |
+| `GET /connect` (alias `/mcp`)               | Human page: MCP URL + gamedevpl CLI. Header menu, not `/create` or public game pages.                                                 |
 | `GET /.well-known/mcp/server.json`          | Registry-shaped `server.json` (schema `2025-12-11`). Auth points at `/.well-known/oauth-protected-resource` rather than restating it. |
 | `GET /.well-known/oauth-protected-resource` | RFC 9728 protected-resource metadata (BY-18a).                                                                                        |
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -97,7 +97,7 @@
       "name": "@gamedevpl/cli",
       "version": "0.1.0",
       "bin": {
-        "gamedev": "dist/main.js",
+        "gamedevpl": "dist/main.js",
         "git-remote-gamedev": "dist/git-remote-main.js"
       },
       "devDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -98,7 +98,7 @@
       "version": "0.1.0",
       "bin": {
         "gamedevpl": "dist/main.js",
-        "git-remote-gamedev": "dist/git-remote-main.js"
+        "git-remote-gamedevpl": "dist/git-remote-main.js"
       },
       "devDependencies": {
         "@types/node": "^20.14.15",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Stacks on #1088. The command people type is **`gamedevpl`**, not `gamedev`. Unreleased, so there is no shim.

## Command

- npm bin, release asset, `~/.local/bin` dest, installers, `/cli` copy, Studio connect snippet, i18n, and error `next:` hints all say `gamedevpl`.
- **Git matches the command:** helper `git-remote-gamedevpl`, remote `gamedevpl://`. Checkout wires origin to that scheme; installers copy the helper beside the binary under the name git looks up for the scheme.
- OAuth `client_id` remains `gamedev-cli`. Config dir is `~/.config/gamedevpl/` (also unreleased).
- Windows `.cmd` shims invoke `gamedevpl`; helper detection accepts a `gamedevpl://` URL when the first arg is not a verb.

## Interactive I/O (the homemade TUI)

The unused two-region renderer was a widget kit waiting to happen. It is gone.

- **Sentence prompt:** `node:readline/promises` behind `PromptHost`. Do not replace this with Ink `useInput`.
- **Live region:** `status --watch` on a TTY repaints a few rows (cursor-up). Cadence matches Studio (3s active / 10s idle). Pipes still append. No menus or pickers here.
- **Ink** stays out of the shebang bundle (React + yoga). Need a real TUI later: take Ink and ship a directory installer — do not grow `live.ts`. Recorded in `apps/cli/docs/ink-spike.md`.

## Copilot follow-up

`helperDest` matches the helper name case-insensitively (including `.exe`). Git-remote tests invoke `git-remote-gamedevpl`. Live status truncates to the current `stdout.columns` (including width 1). `gamedevpl connect` without a slug prints `gamedevpl connect <slug>`. Installer temp files use `$asset`.

Flag `CLI_SURFACE` stays off. No `cli-v*` tag.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c227c8cb-c1d6-41f1-9f0a-5787614f7ba7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c227c8cb-c1d6-41f1-9f0a-5787614f7ba7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

