### PR TITLE
Open a browser for gamedevpl login

### DIFF
--- a/apps/api/src/platform/cli-page.ts
+++ b/apps/api/src/platform/cli-page.ts
@@ -20,7 +20,7 @@ export function cliPageHtml(origin: string): string {
     <p class="hint">Needs Node 20+ — same as a game checkout. Windows: <code>irm ${escapeHtml(origin)}/install.ps1 | iex</code>. The script verifies a SHA-256 before it writes <code>~/.local/bin</code>.</p>
     <h2>Journeys</h2>
     <ul class="can">
-      <li><code>gamedevpl login</code> then describe a game — refine, watch the gate, open a preview.</li>
+      <li><code>gamedevpl login</code> opens a browser — approve once, no token to copy. Then describe a game.</li>
       <li><code>gamedevpl checkout &lt;slug&gt;</code> for your own editor; <code>git push</code> uses <code>git-remote-gamedevpl</code>.</li>
       <li>CI: <code>GAMEDEV_TOKEN</code> from secrets, <code>gamedevpl submit --json</code>.</li>
     </ul>

--- a/apps/api/src/platform/cli-page.ts
+++ b/apps/api/src/platform/cli-page.ts
@@ -27,7 +27,7 @@ export function cliPageHtml(origin: string): string {
     <h2>Security posture</h2>
     <ul class="cannot">
       <li>Checksums on every install and update. No postinstall beyond the copy.</li>
-      <li>Tokens in an encrypted file under ~/.config/gamedev.</li>
+      <li>Tokens in an encrypted file under ~/.config/gamedevpl.</li>
       <li>Revoke the grant in Studio to kill CLI access on the next request.</li>
       <li>A sub-agent never receives your OAuth token — round-scoped credentials only.</li>
     </ul>

--- a/apps/api/src/platform/cli-surface.test.ts
+++ b/apps/api/src/platform/cli-surface.test.ts
@@ -59,6 +59,7 @@ describe('reserved installer routes', () => {
       const page = await app.inject({ method: 'GET', url: '/cli' });
       expect(page.statusCode).toBe(200);
       expect(page.body).toContain('gamedevpl login');
+      expect(page.body).toContain('no token to copy');
       expect(page.body).toContain('encrypted file');
       expect(page.body).toContain('Node 20');
       const ps1 = await app.inject({ method: 'GET', url: '/install.ps1' });

--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -28,5 +28,7 @@ Until a release exists: `npm run bundle -w @gamedevpl/cli` and run `apps/cli/dis
 
 Exit codes: `0` gate green · `1` gate red · `2` refused · `3` auth · `4` input required.
 
-CI: `GAMEDEV_TOKEN` from secrets. Never pass the creator OAuth token to a sub-agent.
+`gamedevpl login` opens a browser (loopback OAuth + PKCE). Approve once; the token
+stays on this machine. No paste. CI still uses `GAMEDEV_TOKEN` from secrets.
+Never pass the creator OAuth token to a sub-agent.
 `git push` / `git pull` against a checkout use `git-remote-gamedevpl` (same script).

--- a/apps/cli/src/keychain.test.ts
+++ b/apps/cli/src/keychain.test.ts
@@ -2,7 +2,7 @@ import { mkdtempSync, readFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
-import { encryptedFileStore, memoryStore } from './keychain.js';
+import { encryptedFileStore, FILE_FALLBACK_WARNING, memoryStore } from './keychain.js';
 
 describe('token stores', () => {
   it('round-trips tokens in memory', async () => {
@@ -21,5 +21,10 @@ describe('token stores', () => {
     const bytes = readFileSync(path);
     expect(bytes.toString('utf8')).not.toContain('gdpl_oat_secret');
     expect((await store.get())?.accessToken).toBe('gdpl_oat_secret');
+  });
+
+  it('describes the encrypted file store without claiming a keychain fallback', () => {
+    expect(FILE_FALLBACK_WARNING.toLowerCase()).not.toMatch(/keychain|unavailable|fallback/);
+    expect(FILE_FALLBACK_WARNING).toContain('encrypted file');
   });
 });

--- a/apps/cli/src/keychain.ts
+++ b/apps/cli/src/keychain.ts
@@ -82,3 +82,7 @@ export function encryptedFileStore(env: NodeJS.ProcessEnv = process.env): TokenS
 
 export const FILE_FALLBACK_WARNING =
   'WARNING: OS keychain unavailable; tokens stored in an encrypted file under ~/.config/gamedevpl. Not plaintext, but weaker than the keychain.';
+
+export function fileKeychainOptedIn(env: NodeJS.ProcessEnv): boolean {
+  return env.GAMEDEV_ALLOW_FILE_KEYCHAIN === 'true' || Boolean(env.GAMEDEV_TOKEN_FILE);
+}

--- a/apps/cli/src/keychain.ts
+++ b/apps/cli/src/keychain.ts
@@ -81,7 +81,7 @@ export function encryptedFileStore(env: NodeJS.ProcessEnv = process.env): TokenS
 }
 
 export const FILE_FALLBACK_WARNING =
-  'WARNING: OS keychain unavailable; tokens stored in an encrypted file under ~/.config/gamedevpl. Not plaintext, but weaker than the keychain.';
+  'WARNING: tokens stored in an encrypted file under ~/.config/gamedevpl. Not plaintext.';
 
 export function fileKeychainOptedIn(env: NodeJS.ProcessEnv): boolean {
   return env.GAMEDEV_ALLOW_FILE_KEYCHAIN === 'true' || Boolean(env.GAMEDEV_TOKEN_FILE);

--- a/apps/cli/src/login.test.ts
+++ b/apps/cli/src/login.test.ts
@@ -191,8 +191,12 @@ describe('login verb', () => {
     const stdout = new PassThrough();
     const stderr = new PassThrough();
     let out = '';
+    let err = '';
     stdout.on('data', (chunk: Buffer) => {
       out += chunk.toString();
+    });
+    stderr.on('data', (chunk: Buffer) => {
+      err += chunk.toString();
     });
     const code = await runCli(
       ['node', 'gamedevpl', 'login'],
@@ -205,6 +209,7 @@ describe('login verb', () => {
     );
     expect(code).toBe(EXIT_GREEN);
     expect(out).toContain('signed in with GAMEDEV_TOKEN');
+    expect(err.match(/WARNING: tokens stored/g) ?? []).toHaveLength(1);
     const stored = await encryptedFileStore({ HOME: dir, GAMEDEV_TOKEN_FILE: path }).get();
     expect(stored?.accessToken).toBe('gdpl_pat_import');
   });
@@ -217,8 +222,12 @@ describe('login verb', () => {
     const stdout = new PassThrough();
     const stderr = new PassThrough();
     let out = '';
+    let err = '';
     stdout.on('data', (chunk: Buffer) => {
       out += chunk.toString();
+    });
+    stderr.on('data', (chunk: Buffer) => {
+      err += chunk.toString();
     });
     const code = await runCli(
       ['node', 'gamedevpl', 'login', '--token', 'gdpl_pat_flag'],
@@ -232,6 +241,7 @@ describe('login verb', () => {
     expect(code).toBe(EXIT_GREEN);
     expect(out).toContain('signed in with --token');
     expect(out).not.toContain('GAMEDEV_TOKEN');
+    expect(err.match(/WARNING: tokens stored/g) ?? []).toHaveLength(1);
     const stored = await encryptedFileStore({ HOME: dir, GAMEDEV_TOKEN_FILE: path }).get();
     expect(stored?.accessToken).toBe('gdpl_pat_flag');
   });

--- a/apps/cli/src/login.test.ts
+++ b/apps/cli/src/login.test.ts
@@ -96,6 +96,30 @@ describe('loopback login', () => {
     expect(await store.get()).toBeNull();
   });
 
+  it('surfaces non-cancel OAuth errors instead of calling them cancelled', async () => {
+    const store = memoryStore();
+    const io = sink();
+    await expect(
+      runLoopbackLogin({
+        origin: 'https://www.gamedev.pl',
+        store,
+        stdout: io.stdout,
+        timeoutMs: 4000,
+        fetch: async () => new Response('{}', { status: 500 }),
+        openUrl: async (url) => {
+          const parsed = new URL(url);
+          const redirect = parsed.searchParams.get('redirect_uri');
+          const state = parsed.searchParams.get('state');
+          const hit = await fetch(`${redirect}?error=invalid_request&state=${state}`);
+          expect(hit.status).toBe(200);
+          expect(await hit.text()).toContain('Sign-in failed');
+          return true;
+        },
+      }),
+    ).rejects.toMatchObject({ message: expect.stringContaining('invalid_request'), exitCode: EXIT_AUTH });
+    expect(await store.get()).toBeNull();
+  });
+
   it('prints the URL when the browser cannot be opened', async () => {
     const store = memoryStore();
     const io = sink();

--- a/apps/cli/src/login.test.ts
+++ b/apps/cli/src/login.test.ts
@@ -1,3 +1,4 @@
+import { request as httpRequest } from 'node:http';
 import { mkdtempSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -140,6 +141,44 @@ describe('loopback login', () => {
     });
     expect(io.read().out).toMatch(/^open https:\/\/www\.gamedev\.pl\/oauth\/authorize/m);
   });
+
+  it('parses the callback against a fixed loopback origin, not Host', async () => {
+    const store = memoryStore();
+    const io = sink();
+    await runLoopbackLogin({
+      origin: 'https://www.gamedev.pl',
+      store,
+      stdout: io.stdout,
+      timeoutMs: 4000,
+      fetch: async () =>
+        new Response(JSON.stringify({ access_token: 'gdpl_oat_host', token_type: 'Bearer', scope: 'creator' }), {
+          status: 200,
+        }),
+      openUrl: async (url) => {
+        const parsed = new URL(url);
+        const redirect = new URL(parsed.searchParams.get('redirect_uri') ?? '');
+        const state = parsed.searchParams.get('state');
+        await new Promise<void>((resolve, reject) => {
+          const req = httpRequest(
+            {
+              hostname: redirect.hostname,
+              port: redirect.port,
+              path: `${redirect.pathname}?code=c&state=${state}`,
+              headers: { host: '::::' },
+            },
+            (res) => {
+              res.resume();
+              res.on('end', resolve);
+            },
+          );
+          req.on('error', reject);
+          req.end();
+        });
+        return true;
+      },
+    });
+    expect((await store.get())?.accessToken).toBe('gdpl_oat_host');
+  });
 });
 
 describe('login verb', () => {
@@ -150,6 +189,10 @@ describe('login verb', () => {
     stdin.isTTY = false;
     const stdout = new PassThrough();
     const stderr = new PassThrough();
+    let out = '';
+    stdout.on('data', (chunk: Buffer) => {
+      out += chunk.toString();
+    });
     const code = await runCli(
       ['node', 'gamedevpl', 'login'],
       { HOME: dir, GAMEDEV_TOKEN: 'gdpl_pat_import', GAMEDEV_TOKEN_FILE: path },
@@ -160,6 +203,7 @@ describe('login verb', () => {
       },
     );
     expect(code).toBe(EXIT_GREEN);
+    expect(out).toContain('signed in with GAMEDEV_TOKEN');
     const stored = await encryptedFileStore({ HOME: dir, GAMEDEV_TOKEN_FILE: path }).get();
     expect(stored?.accessToken).toBe('gdpl_pat_import');
   });
@@ -171,6 +215,10 @@ describe('login verb', () => {
     stdin.isTTY = false;
     const stdout = new PassThrough();
     const stderr = new PassThrough();
+    let out = '';
+    stdout.on('data', (chunk: Buffer) => {
+      out += chunk.toString();
+    });
     const code = await runCli(
       ['node', 'gamedevpl', 'login', '--token', 'gdpl_pat_flag'],
       { HOME: dir, GAMEDEV_TOKEN_FILE: path },
@@ -181,6 +229,8 @@ describe('login verb', () => {
       },
     );
     expect(code).toBe(EXIT_GREEN);
+    expect(out).toContain('signed in with --token');
+    expect(out).not.toContain('GAMEDEV_TOKEN');
     const stored = await encryptedFileStore({ HOME: dir, GAMEDEV_TOKEN_FILE: path }).get();
     expect(stored?.accessToken).toBe('gdpl_pat_flag');
   });

--- a/apps/cli/src/login.test.ts
+++ b/apps/cli/src/login.test.ts
@@ -1,0 +1,185 @@
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { PassThrough } from 'node:stream';
+import { describe, expect, it } from 'vitest';
+import { EXIT_AUTH, EXIT_GREEN, EXIT_INPUT } from './exit-codes.js';
+import { encryptedFileStore, memoryStore } from './keychain.js';
+import { runLoopbackLogin } from './login.js';
+import { runCli } from './main.js';
+import { GAMEDEV_CLI_CLIENT_ID } from './oauth.js';
+
+function sink() {
+  const stdout = new PassThrough();
+  const stderr = new PassThrough();
+  let out = '';
+  let err = '';
+  stdout.on('data', (chunk: Buffer) => {
+    out += chunk.toString();
+  });
+  stderr.on('data', (chunk: Buffer) => {
+    err += chunk.toString();
+  });
+  return {
+    stdout: stdout as unknown as NodeJS.WriteStream,
+    stderr: stderr as unknown as NodeJS.WriteStream,
+    read: () => ({ out, err }),
+  };
+}
+
+describe('loopback login', () => {
+  it('opens the authorize URL, exchanges the code, and stores tokens', async () => {
+    const store = memoryStore();
+    const io = sink();
+    let tokenBody = '';
+    await runLoopbackLogin({
+      origin: 'https://www.gamedev.pl',
+      store,
+      stdout: io.stdout,
+      stderr: io.stderr,
+      timeoutMs: 4000,
+      fetch: async (url, init) => {
+        expect(String(url)).toBe('https://www.gamedev.pl/oauth/token');
+        tokenBody = String(init?.body ?? '');
+        return new Response(
+          JSON.stringify({
+            access_token: 'gdpl_oat_loop',
+            refresh_token: 'gdpl_ort_loop',
+            token_type: 'Bearer',
+            scope: 'creator',
+          }),
+          { status: 200 },
+        );
+      },
+      openUrl: async (url) => {
+        const parsed = new URL(url);
+        expect(parsed.searchParams.get('client_id')).toBe(GAMEDEV_CLI_CLIENT_ID);
+        expect(parsed.searchParams.get('code_challenge_method')).toBe('S256');
+        const redirect = parsed.searchParams.get('redirect_uri');
+        const state = parsed.searchParams.get('state');
+        expect(redirect).toMatch(/^http:\/\/127\.0\.0\.1:\d+\/callback$/);
+        const hit = await fetch(`${redirect}?code=auth-code-1&state=${state}`);
+        expect(hit.status).toBe(200);
+        expect(await hit.text()).toContain('Signed in');
+        return true;
+      },
+    });
+    expect(io.read().out).toContain('opening the browser to sign in');
+    expect(io.read().out).toContain('signed in');
+    expect(tokenBody).toContain('grant_type=authorization_code');
+    expect(tokenBody).toContain('code=auth-code-1');
+    expect(tokenBody).toContain('code_verifier=');
+    const saved = await store.get();
+    expect(saved?.accessToken).toBe('gdpl_oat_loop');
+    expect(saved?.refreshToken).toBe('gdpl_ort_loop');
+  });
+
+  it('treats access_denied as a cancelled sign-in', async () => {
+    const store = memoryStore();
+    const io = sink();
+    await expect(
+      runLoopbackLogin({
+        origin: 'https://www.gamedev.pl',
+        store,
+        stdout: io.stdout,
+        timeoutMs: 4000,
+        fetch: async () => new Response('{}', { status: 500 }),
+        openUrl: async (url) => {
+          const parsed = new URL(url);
+          const redirect = parsed.searchParams.get('redirect_uri');
+          const state = parsed.searchParams.get('state');
+          await fetch(`${redirect}?error=access_denied&state=${state}`);
+          return true;
+        },
+      }),
+    ).rejects.toMatchObject({ message: 'sign-in cancelled', exitCode: EXIT_AUTH });
+    expect(await store.get()).toBeNull();
+  });
+
+  it('prints the URL when the browser cannot be opened', async () => {
+    const store = memoryStore();
+    const io = sink();
+    await runLoopbackLogin({
+      origin: 'https://www.gamedev.pl',
+      store,
+      stdout: io.stdout,
+      timeoutMs: 4000,
+      fetch: async () =>
+        new Response(JSON.stringify({ access_token: 'gdpl_oat_x', token_type: 'Bearer', scope: 'creator' }), {
+          status: 200,
+        }),
+      openUrl: async (url) => {
+        const parsed = new URL(url);
+        await fetch(`${parsed.searchParams.get('redirect_uri')}?code=c&state=${parsed.searchParams.get('state')}`);
+        return false;
+      },
+    });
+    expect(io.read().out).toMatch(/^open https:\/\/www\.gamedev\.pl\/oauth\/authorize/m);
+  });
+});
+
+describe('login verb', () => {
+  it('imports GAMEDEV_TOKEN into the encrypted store', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'gamedevpl-login-'));
+    const path = join(dir, 'credentials.bin');
+    const stdin = new PassThrough() as PassThrough & { isTTY?: boolean };
+    stdin.isTTY = false;
+    const stdout = new PassThrough();
+    const stderr = new PassThrough();
+    const code = await runCli(
+      ['node', 'gamedevpl', 'login'],
+      { HOME: dir, GAMEDEV_TOKEN: 'gdpl_pat_import', GAMEDEV_TOKEN_FILE: path },
+      {
+        stdin: stdin as unknown as NodeJS.ReadStream,
+        stdout: stdout as unknown as NodeJS.WriteStream,
+        stderr: stderr as unknown as NodeJS.WriteStream,
+      },
+    );
+    expect(code).toBe(EXIT_GREEN);
+    const stored = await encryptedFileStore({ HOME: dir, GAMEDEV_TOKEN_FILE: path }).get();
+    expect(stored?.accessToken).toBe('gdpl_pat_import');
+  });
+
+  it('imports --token the same way', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'gamedevpl-login-'));
+    const path = join(dir, 'credentials.bin');
+    const stdin = new PassThrough() as PassThrough & { isTTY?: boolean };
+    stdin.isTTY = false;
+    const stdout = new PassThrough();
+    const stderr = new PassThrough();
+    const code = await runCli(
+      ['node', 'gamedevpl', 'login', '--token', 'gdpl_pat_flag'],
+      { HOME: dir, GAMEDEV_TOKEN_FILE: path },
+      {
+        stdin: stdin as unknown as NodeJS.ReadStream,
+        stdout: stdout as unknown as NodeJS.WriteStream,
+        stderr: stderr as unknown as NodeJS.WriteStream,
+      },
+    );
+    expect(code).toBe(EXIT_GREEN);
+    const stored = await encryptedFileStore({ HOME: dir, GAMEDEV_TOKEN_FILE: path }).get();
+    expect(stored?.accessToken).toBe('gdpl_pat_flag');
+  });
+
+  it('refuses a pipe without a token', async () => {
+    const stdin = new PassThrough() as PassThrough & { isTTY?: boolean };
+    stdin.isTTY = false;
+    const stdout = new PassThrough();
+    const stderr = new PassThrough();
+    let err = '';
+    stderr.on('data', (chunk: Buffer) => {
+      err += chunk.toString();
+    });
+    const code = await runCli(
+      ['node', 'gamedevpl', 'login'],
+      { HOME: mkdtempSync(join(tmpdir(), 'gamedevpl-login-')) },
+      {
+        stdin: stdin as unknown as NodeJS.ReadStream,
+        stdout: stdout as unknown as NodeJS.WriteStream,
+        stderr: stderr as unknown as NodeJS.WriteStream,
+      },
+    );
+    expect(code).toBe(EXIT_INPUT);
+    expect(err).toContain('GAMEDEV_TOKEN');
+  });
+});

--- a/apps/cli/src/login.test.ts
+++ b/apps/cli/src/login.test.ts
@@ -67,6 +67,7 @@ describe('loopback login', () => {
     });
     expect(io.read().out).toContain('opening the browser to sign in');
     expect(io.read().out).toContain('signed in');
+    expect(io.read().out).not.toContain('/oauth/authorize');
     expect(tokenBody).toContain('grant_type=authorization_code');
     expect(tokenBody).toContain('code=auth-code-1');
     expect(tokenBody).toContain('code_verifier=');

--- a/apps/cli/src/login.ts
+++ b/apps/cli/src/login.ts
@@ -3,7 +3,7 @@ import { createServer, type IncomingMessage, type ServerResponse } from 'node:ht
 import { hostname as osHostname } from 'node:os';
 import { cliUsage } from './bin-name.js';
 import { CliError, EXIT_AUTH, EXIT_INPUT } from './exit-codes.js';
-import { FILE_FALLBACK_WARNING, fileKeychainOptedIn, type TokenStore } from './keychain.js';
+import type { TokenStore } from './keychain.js';
 import { authorizeUrl, GAMEDEV_CLI_CLIENT_ID, randomVerifier, s256Challenge } from './oauth.js';
 import { openUrl as defaultOpenUrl } from './open-url.js';
 import { glyphs, wantsColor } from './renderer.js';
@@ -216,8 +216,5 @@ export async function runLoopbackLogin(input: LoopbackLoginInput): Promise<void>
     tokenType: tokens.tokenType,
     scope: tokens.scope,
   });
-  if (fileKeychainOptedIn(env) && input.store.kind === 'encrypted-file') {
-    input.stderr?.write(`${FILE_FALLBACK_WARNING}\n`);
-  }
   input.stdout.write(`${g.ok} signed in\n`);
 }

--- a/apps/cli/src/login.ts
+++ b/apps/cli/src/login.ts
@@ -3,7 +3,7 @@ import { createServer, type IncomingMessage, type ServerResponse } from 'node:ht
 import { hostname as osHostname } from 'node:os';
 import { cliUsage } from './bin-name.js';
 import { CliError, EXIT_AUTH, EXIT_INPUT } from './exit-codes.js';
-import { FILE_FALLBACK_WARNING, type TokenStore } from './keychain.js';
+import { FILE_FALLBACK_WARNING, fileKeychainOptedIn, type TokenStore } from './keychain.js';
 import { authorizeUrl, GAMEDEV_CLI_CLIENT_ID, randomVerifier, s256Challenge } from './oauth.js';
 import { openUrl as defaultOpenUrl } from './open-url.js';
 import { glyphs, wantsColor } from './renderer.js';
@@ -16,6 +16,11 @@ const DENY_PAGE =
   '<!doctype html><html lang="en"><head><meta charset="utf-8"><title>gamedevpl</title></head><body><p>Sign-in cancelled. You can close this tab.</p></body></html>';
 const BAD_PAGE =
   '<!doctype html><html lang="en"><head><meta charset="utf-8"><title>gamedevpl</title></head><body><p>This sign-in link is invalid. Return to the terminal.</p></body></html>';
+
+const FAIL_PAGE =
+  '<!doctype html><html lang="en"><head><meta charset="utf-8"><title>gamedevpl</title></head><body><p>Sign-in failed. Return to the terminal.</p></body></html>';
+
+type CallbackResult = { kind: 'code'; code: string } | { kind: 'denied'; error: string };
 
 export type FetchLike = (url: string, init?: RequestInit) => Promise<Response>;
 
@@ -88,12 +93,12 @@ async function exchangeCode(input: {
 
 function listen(expectedState: string): Promise<{
   redirectUri: string;
-  done: Promise<{ kind: 'code'; code: string } | { kind: 'denied' }>;
+  done: Promise<CallbackResult>;
   close: () => Promise<void>;
 }> {
   return new Promise((resolveListen, rejectListen) => {
-    let settle: ((value: { kind: 'code'; code: string } | { kind: 'denied' }) => void) | undefined;
-    const done = new Promise<{ kind: 'code'; code: string } | { kind: 'denied' }>((resolve) => {
+    let settle: ((value: CallbackResult) => void) | undefined;
+    const done = new Promise<CallbackResult>((resolve) => {
       settle = resolve;
     });
     const server = createServer((req: IncomingMessage, res: ServerResponse) => {
@@ -111,8 +116,9 @@ function listen(expectedState: string): Promise<{
       }
       const err = url.searchParams.get('error');
       if (err) {
-        sendHtml(res, 200, DENY_PAGE);
-        settle?.({ kind: 'denied' });
+        const cancelled = err === 'access_denied';
+        sendHtml(res, 200, cancelled ? DENY_PAGE : FAIL_PAGE);
+        settle?.({ kind: 'denied', error: err });
         return;
       }
       const code = url.searchParams.get('code') ?? '';
@@ -162,7 +168,7 @@ export async function runLoopbackLogin(input: LoopbackLoginInput): Promise<void>
   const opened = await open(url);
   if (!opened) input.stdout.write(`open ${url}\n`);
   else input.stdout.write(`${url}\n`);
-  let result: { kind: 'code'; code: string } | { kind: 'denied' };
+  let result: CallbackResult;
   try {
     result = await new Promise((resolve, reject) => {
       const timer = setTimeout(() => {
@@ -183,7 +189,14 @@ export async function runLoopbackLogin(input: LoopbackLoginInput): Promise<void>
     await loop.close();
   }
   if (result.kind === 'denied') {
-    throw new CliError('sign-in cancelled', EXIT_AUTH, cliUsage('login'));
+    if (result.error === 'access_denied') {
+      throw new CliError('sign-in cancelled', EXIT_AUTH, cliUsage('login'));
+    }
+    throw new CliError(
+      `sign-in failed (${result.error}) — run \`${cliUsage('login')}\` again`,
+      EXIT_AUTH,
+      cliUsage('login'),
+    );
   }
   const tokens = await exchangeCode({
     origin: input.origin,
@@ -198,7 +211,7 @@ export async function runLoopbackLogin(input: LoopbackLoginInput): Promise<void>
     tokenType: tokens.tokenType,
     scope: tokens.scope,
   });
-  if (input.store.kind === 'encrypted-file') {
+  if (fileKeychainOptedIn(env) && input.store.kind === 'encrypted-file') {
     input.stderr?.write(`${FILE_FALLBACK_WARNING}\n`);
   }
   input.stdout.write(`${g.ok} signed in\n`);

--- a/apps/cli/src/login.ts
+++ b/apps/cli/src/login.ts
@@ -173,7 +173,6 @@ export async function runLoopbackLogin(input: LoopbackLoginInput): Promise<void>
   input.stdout.write(`${g.work} opening the browser to sign in\n`);
   const opened = await open(url);
   if (!opened) input.stdout.write(`open ${url}\n`);
-  else input.stdout.write(`${url}\n`);
   let result: CallbackResult;
   try {
     result = await new Promise((resolve, reject) => {

--- a/apps/cli/src/login.ts
+++ b/apps/cli/src/login.ts
@@ -1,0 +1,205 @@
+import { timingSafeEqual } from 'node:crypto';
+import { createServer, type IncomingMessage, type ServerResponse } from 'node:http';
+import { hostname as osHostname } from 'node:os';
+import { cliUsage } from './bin-name.js';
+import { CliError, EXIT_AUTH, EXIT_INPUT } from './exit-codes.js';
+import { FILE_FALLBACK_WARNING, type TokenStore } from './keychain.js';
+import { authorizeUrl, GAMEDEV_CLI_CLIENT_ID, randomVerifier, s256Challenge } from './oauth.js';
+import { openUrl as defaultOpenUrl } from './open-url.js';
+import { glyphs, wantsColor } from './renderer.js';
+
+export const LOGIN_TIMEOUT_MS = 5 * 60 * 1000;
+
+const DONE_PAGE =
+  '<!doctype html><html lang="en"><head><meta charset="utf-8"><title>gamedevpl</title></head><body><p>Signed in. You can close this tab.</p></body></html>';
+const DENY_PAGE =
+  '<!doctype html><html lang="en"><head><meta charset="utf-8"><title>gamedevpl</title></head><body><p>Sign-in cancelled. You can close this tab.</p></body></html>';
+const BAD_PAGE =
+  '<!doctype html><html lang="en"><head><meta charset="utf-8"><title>gamedevpl</title></head><body><p>This sign-in link is invalid. Return to the terminal.</p></body></html>';
+
+export type FetchLike = (url: string, init?: RequestInit) => Promise<Response>;
+
+export type LoopbackLoginInput = {
+  origin: string;
+  store: TokenStore;
+  stdout: NodeJS.WritableStream;
+  stderr?: NodeJS.WritableStream;
+  env?: NodeJS.ProcessEnv;
+  isTty?: boolean;
+  fetch?: FetchLike;
+  openUrl?: (url: string) => Promise<boolean>;
+  device?: string;
+  timeoutMs?: number;
+};
+
+function sameSecret(left: string, right: string): boolean {
+  const a = Buffer.from(left);
+  const b = Buffer.from(right);
+  return a.length === b.length && timingSafeEqual(a, b);
+}
+
+function sendHtml(res: ServerResponse, status: number, body: string): void {
+  res.writeHead(status, { 'content-type': 'text/html; charset=utf-8' });
+  res.end(body);
+}
+
+function deviceName(explicit?: string): string {
+  const raw = (explicit ?? osHostname()).trim() || 'this device';
+  return raw.slice(0, 40);
+}
+
+async function exchangeCode(input: {
+  origin: string;
+  code: string;
+  redirectUri: string;
+  verifier: string;
+  fetch: FetchLike;
+}): Promise<{ accessToken: string; refreshToken?: string; tokenType: string; scope: string }> {
+  const res = await input.fetch(`${input.origin}/oauth/token`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/x-www-form-urlencoded' },
+    body: new URLSearchParams({
+      grant_type: 'authorization_code',
+      code: input.code,
+      redirect_uri: input.redirectUri,
+      client_id: GAMEDEV_CLI_CLIENT_ID,
+      code_verifier: input.verifier,
+    }).toString(),
+  });
+  if (!res.ok) {
+    throw new CliError(`sign-in failed — run \`${cliUsage('login')}\` again`, EXIT_AUTH, cliUsage('login'));
+  }
+  const body = (await res.json()) as {
+    access_token?: string;
+    refresh_token?: string;
+    token_type?: string;
+    scope?: string;
+  };
+  if (!body.access_token) {
+    throw new CliError(`sign-in failed — run \`${cliUsage('login')}\` again`, EXIT_AUTH, cliUsage('login'));
+  }
+  return {
+    accessToken: body.access_token,
+    refreshToken: body.refresh_token,
+    tokenType: body.token_type ?? 'Bearer',
+    scope: body.scope ?? 'creator',
+  };
+}
+
+function listen(expectedState: string): Promise<{
+  redirectUri: string;
+  done: Promise<{ kind: 'code'; code: string } | { kind: 'denied' }>;
+  close: () => Promise<void>;
+}> {
+  return new Promise((resolveListen, rejectListen) => {
+    let settle: ((value: { kind: 'code'; code: string } | { kind: 'denied' }) => void) | undefined;
+    const done = new Promise<{ kind: 'code'; code: string } | { kind: 'denied' }>((resolve) => {
+      settle = resolve;
+    });
+    const server = createServer((req: IncomingMessage, res: ServerResponse) => {
+      const host = req.headers.host ?? '127.0.0.1';
+      const url = new URL(req.url ?? '/', `http://${host}`);
+      if (url.pathname !== '/callback') {
+        res.writeHead(404);
+        res.end();
+        return;
+      }
+      const state = url.searchParams.get('state') ?? '';
+      if (!sameSecret(state, expectedState)) {
+        sendHtml(res, 400, BAD_PAGE);
+        return;
+      }
+      const err = url.searchParams.get('error');
+      if (err) {
+        sendHtml(res, 200, DENY_PAGE);
+        settle?.({ kind: 'denied' });
+        return;
+      }
+      const code = url.searchParams.get('code') ?? '';
+      if (!code) {
+        sendHtml(res, 400, BAD_PAGE);
+        return;
+      }
+      sendHtml(res, 200, DONE_PAGE);
+      settle?.({ kind: 'code', code });
+    });
+    server.once('error', rejectListen);
+    server.listen(0, '127.0.0.1', () => {
+      const addr = server.address();
+      if (!addr || typeof addr === 'string') {
+        rejectListen(new Error('loopback listen failed'));
+        return;
+      }
+      resolveListen({
+        redirectUri: `http://127.0.0.1:${addr.port}/callback`,
+        done,
+        close: () =>
+          new Promise((resolve) => {
+            server.close(() => resolve());
+          }),
+      });
+    });
+  });
+}
+
+export async function runLoopbackLogin(input: LoopbackLoginInput): Promise<void> {
+  const env = input.env ?? process.env;
+  const fetchImpl = input.fetch ?? fetch;
+  const open = input.openUrl ?? defaultOpenUrl;
+  const timeoutMs = input.timeoutMs ?? LOGIN_TIMEOUT_MS;
+  const g = glyphs(wantsColor(env, input.isTty ?? false));
+  const verifier = randomVerifier();
+  const state = randomVerifier();
+  const loop = await listen(state);
+  const url = authorizeUrl({
+    origin: input.origin,
+    redirectUri: loop.redirectUri,
+    challenge: s256Challenge(verifier),
+    state,
+    device: deviceName(input.device),
+  });
+  input.stdout.write(`${g.work} opening the browser to sign in\n`);
+  const opened = await open(url);
+  if (!opened) input.stdout.write(`open ${url}\n`);
+  else input.stdout.write(`${url}\n`);
+  let result: { kind: 'code'; code: string } | { kind: 'denied' };
+  try {
+    result = await new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        reject(new CliError(`sign-in timed out — run \`${cliUsage('login')}\` again`, EXIT_INPUT, cliUsage('login')));
+      }, timeoutMs);
+      loop.done.then(
+        (value) => {
+          clearTimeout(timer);
+          resolve(value);
+        },
+        (error: unknown) => {
+          clearTimeout(timer);
+          reject(error);
+        },
+      );
+    });
+  } finally {
+    await loop.close();
+  }
+  if (result.kind === 'denied') {
+    throw new CliError('sign-in cancelled', EXIT_AUTH, cliUsage('login'));
+  }
+  const tokens = await exchangeCode({
+    origin: input.origin,
+    code: result.code,
+    redirectUri: loop.redirectUri,
+    verifier,
+    fetch: fetchImpl,
+  });
+  await input.store.set({
+    accessToken: tokens.accessToken,
+    refreshToken: tokens.refreshToken,
+    tokenType: tokens.tokenType,
+    scope: tokens.scope,
+  });
+  if (input.store.kind === 'encrypted-file') {
+    input.stderr?.write(`${FILE_FALLBACK_WARNING}\n`);
+  }
+  input.stdout.write(`${g.ok} signed in\n`);
+}

--- a/apps/cli/src/login.ts
+++ b/apps/cli/src/login.ts
@@ -74,7 +74,7 @@ async function exchangeCode(input: {
   if (!res.ok) {
     throw new CliError(`sign-in failed — run \`${cliUsage('login')}\` again`, EXIT_AUTH, cliUsage('login'));
   }
-  const body = (await res.json()) as {
+  const body = (await res.json().catch(() => ({}))) as {
     access_token?: string;
     refresh_token?: string;
     token_type?: string;

--- a/apps/cli/src/login.ts
+++ b/apps/cli/src/login.ts
@@ -102,8 +102,14 @@ function listen(expectedState: string): Promise<{
       settle = resolve;
     });
     const server = createServer((req: IncomingMessage, res: ServerResponse) => {
-      const host = req.headers.host ?? '127.0.0.1';
-      const url = new URL(req.url ?? '/', `http://${host}`);
+      let url: URL;
+      try {
+        url = new URL(req.url ?? '/', 'http://127.0.0.1');
+      } catch {
+        res.writeHead(400);
+        res.end();
+        return;
+      }
       if (url.pathname !== '/callback') {
         res.writeHead(404);
         res.end();

--- a/apps/cli/src/main.test.ts
+++ b/apps/cli/src/main.test.ts
@@ -26,10 +26,16 @@ function io() {
 }
 
 describe('runCli verbs', () => {
-  it('prints help and exits 0', async () => {
+  it('writes the file-store warning to injected stderr', async () => {
     const streams = io();
-    expect(await runCli(['node', 'gamedevpl', 'help'], {}, streams)).toBe(EXIT_GREEN);
-    expect(streams.read().out).toContain('whoami');
+    expect(
+      await runCli(
+        ['node', 'gamedevpl', 'help'],
+        { GAMEDEV_ALLOW_FILE_KEYCHAIN: 'true', HOME: '/tmp/gamedev-cli-empty' },
+        streams,
+      ),
+    ).toBe(EXIT_GREEN);
+    expect(streams.read().err).toMatch(/encrypted file/);
   });
 
   it('exits 4 when repl is run without a TTY', async () => {

--- a/apps/cli/src/main.ts
+++ b/apps/cli/src/main.ts
@@ -5,7 +5,13 @@ import { stdin, stdout, stderr } from 'node:process';
 import { parseArgv, jsonMode, SLASH_VERBS } from './argv.js';
 import { CLI_BIN, GIT_REMOTE_HELPER, GIT_REMOTE_SCHEME, cliUsage } from './bin-name.js';
 import { createApi, requireTtyFlag } from './api.js';
-import { encryptedFileStore, FILE_FALLBACK_WARNING, memoryStore, type TokenStore } from './keychain.js';
+import {
+  encryptedFileStore,
+  FILE_FALLBACK_WARNING,
+  fileKeychainOptedIn,
+  memoryStore,
+  type TokenStore,
+} from './keychain.js';
 import { runLoopbackLogin } from './login.js';
 import { originFromEnv } from './oauth.js';
 import { CliError, EXIT_GREEN, EXIT_INPUT, EXIT_REFUSED } from './exit-codes.js';
@@ -24,7 +30,7 @@ function storeFromEnv(env: NodeJS.ProcessEnv): TokenStore {
   if (env.GAMEDEV_TOKEN) {
     return memoryStore({ accessToken: env.GAMEDEV_TOKEN, tokenType: 'Bearer', scope: 'creator' });
   }
-  if (env.GAMEDEV_ALLOW_FILE_KEYCHAIN === 'true' || env.GAMEDEV_TOKEN_FILE) {
+  if (fileKeychainOptedIn(env)) {
     stderr.write(`${FILE_FALLBACK_WARNING}\n`);
   }
   return encryptedFileStore(env);
@@ -67,7 +73,9 @@ export async function runCli(
       const imported = (typeof flags.token === 'string' ? flags.token.trim() : '') || env.GAMEDEV_TOKEN?.trim() || '';
       if (imported) {
         await persist.set({ accessToken: imported, tokenType: 'Bearer', scope: 'creator' });
-        io.stderr.write(`${FILE_FALLBACK_WARNING}\n`);
+        if (fileKeychainOptedIn(env)) {
+          io.stderr.write(`${FILE_FALLBACK_WARNING}\n`);
+        }
         io.stdout.write('signed in with GAMEDEV_TOKEN\n');
         return EXIT_GREEN;
       }

--- a/apps/cli/src/main.ts
+++ b/apps/cli/src/main.ts
@@ -6,6 +6,7 @@ import { parseArgv, jsonMode, SLASH_VERBS } from './argv.js';
 import { CLI_BIN, GIT_REMOTE_HELPER, GIT_REMOTE_SCHEME, cliUsage } from './bin-name.js';
 import { createApi, requireTtyFlag } from './api.js';
 import { encryptedFileStore, FILE_FALLBACK_WARNING, memoryStore, type TokenStore } from './keychain.js';
+import { runLoopbackLogin } from './login.js';
 import { originFromEnv } from './oauth.js';
 import { CliError, EXIT_GREEN, EXIT_INPUT, EXIT_REFUSED } from './exit-codes.js';
 import { describeError, pipeNeedsFlag } from './errors.js';
@@ -62,13 +63,23 @@ export async function runCli(
       return EXIT_GREEN;
     }
     if (verb === 'login') {
-      if (env.GAMEDEV_TOKEN) {
-        await store.set({ accessToken: env.GAMEDEV_TOKEN, tokenType: 'Bearer', scope: 'creator' });
+      const persist = encryptedFileStore(env);
+      const imported = (typeof flags.token === 'string' ? flags.token.trim() : '') || env.GAMEDEV_TOKEN?.trim() || '';
+      if (imported) {
+        await persist.set({ accessToken: imported, tokenType: 'Bearer', scope: 'creator' });
+        io.stderr.write(`${FILE_FALLBACK_WARNING}\n`);
         io.stdout.write('signed in with GAMEDEV_TOKEN\n');
         return EXIT_GREEN;
       }
       requireTtyFlag(tty, '--token', `GAMEDEV_TOKEN=… ${cliUsage('login')}`);
-      io.stdout.write(`open ${origin}/oauth/authorize to sign in, then retry with GAMEDEV_TOKEN set\n`);
+      await runLoopbackLogin({
+        origin,
+        store: persist,
+        stdout: io.stdout,
+        stderr: io.stderr,
+        env,
+        isTty: Boolean(io.stdout.isTTY),
+      });
       return EXIT_GREEN;
     }
     if (verb === 'logout') {

--- a/apps/cli/src/main.ts
+++ b/apps/cli/src/main.ts
@@ -26,12 +26,12 @@ import { glyphs, wantsColor } from './renderer.js';
 import { runStatusVerb } from './status-watch.js';
 import { dispatchReadVerb } from './verbs.js';
 
-function storeFromEnv(env: NodeJS.ProcessEnv): TokenStore {
+function storeFromEnv(env: NodeJS.ProcessEnv, warn: (line: string) => void): TokenStore {
   if (env.GAMEDEV_TOKEN) {
     return memoryStore({ accessToken: env.GAMEDEV_TOKEN, tokenType: 'Bearer', scope: 'creator' });
   }
   if (fileKeychainOptedIn(env)) {
-    stderr.write(`${FILE_FALLBACK_WARNING}\n`);
+    warn(`${FILE_FALLBACK_WARNING}\n`);
   }
   return encryptedFileStore(env);
 }
@@ -59,7 +59,7 @@ export async function runCli(
   const { verb, args, flags } = parseArgv(argv);
   const asJson = jsonMode(flags);
   const origin = originFromEnv(env);
-  const store = storeFromEnv(env);
+  const store = storeFromEnv(env, (line) => io.stderr.write(line));
   const api = createApi({ origin, store, env });
   const tty = Boolean(io.stdin.isTTY);
 

--- a/apps/cli/src/main.ts
+++ b/apps/cli/src/main.ts
@@ -70,13 +70,15 @@ export async function runCli(
     }
     if (verb === 'login') {
       const persist = encryptedFileStore(env);
-      const imported = (typeof flags.token === 'string' ? flags.token.trim() : '') || env.GAMEDEV_TOKEN?.trim() || '';
+      const fromFlag = typeof flags.token === 'string' ? flags.token.trim() : '';
+      const fromEnv = env.GAMEDEV_TOKEN?.trim() ?? '';
+      const imported = fromFlag || fromEnv;
       if (imported) {
         await persist.set({ accessToken: imported, tokenType: 'Bearer', scope: 'creator' });
         if (fileKeychainOptedIn(env)) {
           io.stderr.write(`${FILE_FALLBACK_WARNING}\n`);
         }
-        io.stdout.write('signed in with GAMEDEV_TOKEN\n');
+        io.stdout.write(fromFlag ? 'signed in with --token\n' : 'signed in with GAMEDEV_TOKEN\n');
         return EXIT_GREEN;
       }
       requireTtyFlag(tty, '--token', `GAMEDEV_TOKEN=… ${cliUsage('login')}`);

--- a/apps/cli/src/main.ts
+++ b/apps/cli/src/main.ts
@@ -27,8 +27,9 @@ import { runStatusVerb } from './status-watch.js';
 import { dispatchReadVerb } from './verbs.js';
 
 function storeFromEnv(env: NodeJS.ProcessEnv, warn: (line: string) => void): TokenStore {
-  if (env.GAMEDEV_TOKEN) {
-    return memoryStore({ accessToken: env.GAMEDEV_TOKEN, tokenType: 'Bearer', scope: 'creator' });
+  const token = env.GAMEDEV_TOKEN?.trim();
+  if (token) {
+    return memoryStore({ accessToken: token, tokenType: 'Bearer', scope: 'creator' });
   }
   if (fileKeychainOptedIn(env)) {
     warn(`${FILE_FALLBACK_WARNING}\n`);
@@ -75,7 +76,7 @@ export async function runCli(
       const imported = fromFlag || fromEnv;
       if (imported) {
         await persist.set({ accessToken: imported, tokenType: 'Bearer', scope: 'creator' });
-        if (fileKeychainOptedIn(env)) {
+        if (fileKeychainOptedIn(env) && fromEnv) {
           io.stderr.write(`${FILE_FALLBACK_WARNING}\n`);
         }
         io.stdout.write(fromFlag ? 'signed in with --token\n' : 'signed in with GAMEDEV_TOKEN\n');

--- a/apps/cli/src/open-url.test.ts
+++ b/apps/cli/src/open-url.test.ts
@@ -1,0 +1,9 @@
+import { describe, expect, it } from 'vitest';
+import { openUrl } from './open-url.js';
+
+describe('openUrl', () => {
+  it('refuses non-http URLs', async () => {
+    expect(await openUrl('javascript:alert(1)')).toBe(false);
+    expect(await openUrl('not a url')).toBe(false);
+  });
+});

--- a/apps/cli/src/open-url.ts
+++ b/apps/cli/src/open-url.ts
@@ -1,0 +1,25 @@
+import { spawn } from 'node:child_process';
+
+export function openUrl(url: string): Promise<boolean> {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return Promise.resolve(false);
+  }
+  if (parsed.protocol !== 'https:' && parsed.protocol !== 'http:') return Promise.resolve(false);
+  const [cmd, args] =
+    process.platform === 'darwin'
+      ? (['open', [url]] as const)
+      : process.platform === 'win32'
+        ? (['cmd', ['/c', 'start', '', url]] as const)
+        : (['xdg-open', [url]] as const);
+  return new Promise((resolve) => {
+    const child = spawn(cmd, args, { stdio: 'ignore', detached: true, windowsHide: true });
+    child.once('error', () => resolve(false));
+    child.once('spawn', () => {
+      child.unref();
+      resolve(true);
+    });
+  });
+}

--- a/apps/cli/src/open-url.ts
+++ b/apps/cli/src/open-url.ts
@@ -12,7 +12,7 @@ export function openUrl(url: string): Promise<boolean> {
     process.platform === 'darwin'
       ? (['open', [url]] as const)
       : process.platform === 'win32'
-        ? (['cmd', ['/c', 'start', '', url]] as const)
+        ? (['rundll32', ['url.dll,FileProtocolHandler', url]] as const)
         : (['xdg-open', [url]] as const);
   return new Promise((resolve) => {
     const child = spawn(cmd, args, { stdio: 'ignore', detached: true, windowsHide: true });

--- a/apps/web/src/ConnectAgentsPage.test.tsx
+++ b/apps/web/src/ConnectAgentsPage.test.tsx
@@ -78,6 +78,7 @@ describe('ConnectAgentsPage', () => {
     await draw(true);
     expect(container.textContent).toMatch(/install\.sh/);
     expect(container.textContent).toMatch(/Node 20/);
+    expect(container.textContent).toMatch(/login opens your browser/i);
   });
 
   it('scrolls the hashed section into view on mount', async () => {

--- a/apps/web/src/ConnectAgentsPage.tsx
+++ b/apps/web/src/ConnectAgentsPage.tsx
@@ -89,6 +89,7 @@ export function ConnectAgentsPage({ onBack, onStudio }: { onBack: () => void; on
           <p className="connect-hint">{t('connectAgents.cli.installPending')}</p>
         )}
         <ul className="connect-list">
+          <li>{t('connectAgents.cli.login')}</li>
           <li>{t('connectAgents.cli.repl')}</li>
           <li>{t('connectAgents.cli.checkout')}</li>
           <li>{t('connectAgents.cli.ci')}</li>

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -1269,6 +1269,7 @@
       "lead": "A conversational front door. Type an idea, answer refine questions, watch the gate. Checkout uses your editor; git push is not a delivery path.",
       "installHint": "Needs Node 20+ — same as a game checkout. Windows: irm https://www.gamedev.pl/install.ps1 | iex. The script checksum-verifies before it writes ~/.local/bin.",
       "installPending": "Installers are not public yet. The client lives in this repo at apps/cli; bundle it locally with npm run bundle -w @gamedevpl/cli.",
+      "login": "gamedevpl login opens your browser. Approve once — no token to copy.",
       "repl": "gamedevpl with no verb opens a REPL: describe a game, then iterate.",
       "checkout": "gamedevpl checkout <slug> for your own editor. Deliver with gamedevpl submit.",
       "ci": "CI: GAMEDEV_TOKEN from secrets. Never pass the creator OAuth token to a sub-agent."
@@ -1673,7 +1674,7 @@
     },
     "gamedevCli": {
       "title": "gamedevpl CLI",
-      "hint": "Needs Node 20 — same as a working copy. Then connect this game. Same round as MCP — no extra secret."
+      "hint": "Needs Node 20. Run gamedevpl login (browser opens), then connect this game. Same round as MCP."
     },
     "rotate": {
       "start": "Rotate key",

--- a/apps/web/src/i18n/locales/pl.json
+++ b/apps/web/src/i18n/locales/pl.json
@@ -1283,6 +1283,7 @@
       "lead": "Rozmowny front door. Opisz pomysł, odpowiedz na pytania, obserwuj bramkę. Checkout idzie do Twojego edytora; git push nie jest ścieżką oddania.",
       "installHint": "Potrzebujesz Node 20+ — tak jak przy kopii roboczej. Windows: irm https://www.gamedev.pl/install.ps1 | iex. Skrypt weryfikuje sumę kontrolną zanim zapisze ~/.local/bin.",
       "installPending": "Instalatory nie są jeszcze publiczne. Klient jest w tym repozytorium w apps/cli; zbierz go lokalnie: npm run bundle -w @gamedevpl/cli.",
+      "login": "gamedevpl login otwiera przeglądarkę. Zatwierdzasz raz — bez kopiowania tokenu.",
       "repl": "gamedevpl bez czasownika otwiera REPL: opisz grę, potem iteruj.",
       "checkout": "gamedevpl checkout <slug> do własnego edytora. Oddajesz poleceniem gamedevpl submit.",
       "ci": "CI: GAMEDEV_TOKEN z secrets. Nigdy nie przekazuj tokenu OAuth twórcy do sub-agenta."
@@ -1687,7 +1688,7 @@
     },
     "gamedevCli": {
       "title": "gamedevpl CLI",
-      "hint": "Potrzebujesz Node 20 — tak jak przy kopii roboczej. Potem podłącz tę grę. Ta sama runda co MCP — bez dodatkowego sekretu."
+      "hint": "Potrzebujesz Node 20. gamedevpl login otwiera przeglądarkę, potem podłącz tę grę. Ta sama runda co MCP."
     },
     "rotate": {
       "start": "Obróć klucz",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
`gamedevpl login` was a stub: print an authorize URL and tell you to set `GAMEDEV_TOKEN`. That is the CI path, not the creator path.

This matches Codex / Claude / agy: the CLI binds `http://127.0.0.1:/callback`, opens the browser, you approve the first-party `gamedev-cli` client (PKCE, no secret), the code comes back on loopback, tokens go into the encrypted store. No paste.

`GAMEDEV_TOKEN` and `gamedevpl login --token` still import a secret for CI and pipes.

The REPL is still a line CLI (readline + a few-row live region), not a TUI. That is the Ink fence from the previous PR — boxes and pickers wait for Ink plus an installer directory.

## Copilot follow-up

Loopback callback parsing uses a fixed `http://127.0.0.1` base (Host is ignored, bad URLs 400). The file-store warning no longer claims an OS keychain fallback. Import success says `--token` or `GAMEDEV_TOKEN` to match the source. When the browser opens, the authorize URL (including CSRF `state`) is not printed to stdout; `open $url` remains only if launch fails.

Stacked on the `gamedevpl` rename (#1091). Does not enable `CLI_SURFACE`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c227c8cb-c1d6-41f1-9f0a-5787614f7ba7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c227c8cb-c1d6-41f1-9f0a-5787614f7ba7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

