### PR TITLE
Phase 4: core/persistence.ts — one localStorage wrapper for the web

### DIFF
--- a/apps/web/src/builderKind.ts
+++ b/apps/web/src/builderKind.ts
@@ -2,6 +2,7 @@
 // without waiting on a status field the API may not yet echo.
 
 import { BUILDERS, isBuilderKind, type BuilderKind } from '@gamedevpl/contract';
+import { readStorageItem, writeStorageItem } from './core/persistence.js';
 
 export { BUILDERS, isBuilderKind, type BuilderKind };
 
@@ -10,21 +11,13 @@ const STORAGE_PREFIX = 'gamedev_last_builder:';
 /** Last builder the creator picked for this game (status token), if any. */
 export function loadLastBuilder(token: string): BuilderKind | null {
   if (!token) return null;
-  try {
-    const raw = localStorage.getItem(`${STORAGE_PREFIX}${token}`);
-    return isBuilderKind(raw) ? raw : null;
-  } catch {
-    return null;
-  }
+  const raw = readStorageItem(`${STORAGE_PREFIX}${token}`);
+  return isBuilderKind(raw) ? raw : null;
 }
 
 export function saveLastBuilder(token: string, builder: BuilderKind): void {
   if (!token) return;
-  try {
-    localStorage.setItem(`${STORAGE_PREFIX}${token}`, builder);
-  } catch {
-    // Persistence is a convenience — never a precondition.
-  }
+  writeStorageItem(`${STORAGE_PREFIX}${token}`, builder);
 }
 
 /** Default for a new round: remembered choice, else platform. */

--- a/apps/web/src/connectCollapse.ts
+++ b/apps/web/src/connectCollapse.ts
@@ -3,22 +3,16 @@
  * thread. Expand restores it; Details also mounts the card when available.
  */
 
+import { readStorageItem, removeStorageItem, writeStorageItem } from './core/persistence.js';
+
 const STORAGE_PREFIX = 'gamedev_connect_collapsed:';
 
 export function isConnectCollapsed(token: string): boolean {
-  try {
-    return localStorage.getItem(`${STORAGE_PREFIX}${token}`) === '1';
-  } catch {
-    return false;
-  }
+  return readStorageItem(`${STORAGE_PREFIX}${token}`) === '1';
 }
 
 export function setConnectCollapsed(token: string, collapsed: boolean): void {
-  try {
-    const key = `${STORAGE_PREFIX}${token}`;
-    if (collapsed) localStorage.setItem(key, '1');
-    else localStorage.removeItem(key);
-  } catch {
-    // Preference only — a private mode block must not break the thread.
-  }
+  const key = `${STORAGE_PREFIX}${token}`;
+  if (collapsed) writeStorageItem(key, '1');
+  else removeStorageItem(key);
 }

--- a/apps/web/src/core/persistence.test.ts
+++ b/apps/web/src/core/persistence.test.ts
@@ -4,6 +4,7 @@ import {
   readStorageItem,
   readStorageJSON,
   removeStorageItem,
+  resolveWebStorage,
   writeStorageItem,
   writeStorageJSON,
 } from './persistence.js';
@@ -90,5 +91,28 @@ describe('readStorageJSON / writeStorageJSON', () => {
     expect(readStorageJSON('missing', fakeStorage)).toBeNull();
     fakeStorage.setItem('bad', '{not json');
     expect(readStorageJSON('bad', fakeStorage)).toBeNull();
+  });
+
+  it('degrades to a no-op when the value cannot be serialized', () => {
+    const storage = new Map<string, string>();
+    const fakeStorage: Storage = {
+      getItem: (key) => storage.get(key) ?? null,
+      setItem: (key, value) => void storage.set(key, value),
+      removeItem: (key) => void storage.delete(key),
+      clear: () => storage.clear(),
+      key: () => null,
+      length: storage.size,
+    };
+    const circular: Record<string, unknown> = {};
+    circular.self = circular;
+    expect(() => writeStorageJSON('k', circular, fakeStorage)).not.toThrow();
+    expect(fakeStorage.getItem('k')).toBeNull();
+  });
+});
+
+describe('resolveWebStorage', () => {
+  it('returns the requested Storage object', () => {
+    expect(resolveWebStorage('local')).toBe(window.localStorage);
+    expect(resolveWebStorage('session')).toBe(window.sessionStorage);
   });
 });

--- a/apps/web/src/core/persistence.test.ts
+++ b/apps/web/src/core/persistence.test.ts
@@ -1,0 +1,94 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  readStorageItem,
+  readStorageJSON,
+  removeStorageItem,
+  writeStorageItem,
+  writeStorageJSON,
+} from './persistence.js';
+
+function throwingStorage(): Storage {
+  return {
+    getItem: () => {
+      throw new Error('blocked');
+    },
+    setItem: () => {
+      throw new Error('blocked');
+    },
+    removeItem: () => {
+      throw new Error('blocked');
+    },
+    clear: () => {},
+    key: () => null,
+    length: 0,
+  };
+}
+
+describe('readStorageItem / writeStorageItem / removeStorageItem', () => {
+  afterEach(() => {
+    window.localStorage.removeItem('gdpl.persistence-test');
+  });
+
+  it('round-trips through the given storage', () => {
+    const storage = new Map<string, string>();
+    const fakeStorage: Storage = {
+      getItem: (key) => storage.get(key) ?? null,
+      setItem: (key, value) => void storage.set(key, value),
+      removeItem: (key) => void storage.delete(key),
+      clear: () => storage.clear(),
+      key: () => null,
+      length: storage.size,
+    };
+    writeStorageItem('k', 'v', fakeStorage);
+    expect(readStorageItem('k', fakeStorage)).toBe('v');
+    removeStorageItem('k', fakeStorage);
+    expect(readStorageItem('k', fakeStorage)).toBeNull();
+  });
+
+  it('degrades to null / no-op when storage throws', () => {
+    const storage = throwingStorage();
+    expect(readStorageItem('k', storage)).toBeNull();
+    expect(() => writeStorageItem('k', 'v', storage)).not.toThrow();
+    expect(() => removeStorageItem('k', storage)).not.toThrow();
+  });
+
+  it('defaults to window.localStorage', () => {
+    writeStorageItem('gdpl.persistence-test', 'v');
+    expect(window.localStorage.getItem('gdpl.persistence-test')).toBe('v');
+    expect(readStorageItem('gdpl.persistence-test')).toBe('v');
+    removeStorageItem('gdpl.persistence-test');
+    expect(window.localStorage.getItem('gdpl.persistence-test')).toBeNull();
+  });
+});
+
+describe('readStorageJSON / writeStorageJSON', () => {
+  it('round-trips structured data', () => {
+    const storage = new Map<string, string>();
+    const fakeStorage: Storage = {
+      getItem: (key) => storage.get(key) ?? null,
+      setItem: (key, value) => void storage.set(key, value),
+      removeItem: (key) => void storage.delete(key),
+      clear: () => storage.clear(),
+      key: () => null,
+      length: storage.size,
+    };
+    writeStorageJSON('k', { a: 1, b: ['x'] }, fakeStorage);
+    expect(readStorageJSON<{ a: number; b: string[] }>('k', fakeStorage)).toEqual({ a: 1, b: ['x'] });
+  });
+
+  it('returns null for a missing key or malformed JSON', () => {
+    const storage = new Map<string, string>();
+    const fakeStorage: Storage = {
+      getItem: (key) => storage.get(key) ?? null,
+      setItem: (key, value) => void storage.set(key, value),
+      removeItem: (key) => void storage.delete(key),
+      clear: () => storage.clear(),
+      key: () => null,
+      length: storage.size,
+    };
+    expect(readStorageJSON('missing', fakeStorage)).toBeNull();
+    fakeStorage.setItem('bad', '{not json');
+    expect(readStorageJSON('bad', fakeStorage)).toBeNull();
+  });
+});

--- a/apps/web/src/core/persistence.ts
+++ b/apps/web/src/core/persistence.ts
@@ -44,5 +44,26 @@ export function readStorageJSON<T>(key: string, storage?: Storage): T | null {
 }
 
 export function writeStorageJSON(key: string, value: unknown, storage?: Storage): void {
-  writeStorageItem(key, JSON.stringify(value), storage);
+  // A circular value or bigint throws here, not in writeStorageItem —
+  // this API promises fail-silent persistence, not a thrown exception.
+  let raw: string;
+  try {
+    raw = JSON.stringify(value);
+  } catch {
+    return;
+  }
+  writeStorageItem(key, raw, storage);
+}
+
+/**
+ * The `window.localStorage` / `window.sessionStorage` object itself can
+ * throw or be absent outside a browser, same as access to it.
+ * Resolved here so every caller shares one guarded lookup, not its own copy.
+ */
+export function resolveWebStorage(kind: 'local' | 'session'): Storage | undefined {
+  try {
+    return kind === 'local' ? window.localStorage : window.sessionStorage;
+  } catch {
+    return undefined;
+  }
 }

--- a/apps/web/src/core/persistence.ts
+++ b/apps/web/src/core/persistence.ts
@@ -1,0 +1,48 @@
+/**
+ * The one place apps/web touches Storage (localStorage/sessionStorage).
+ * Private/blocked browsers throw on access instead of returning null;
+ * every read/write here degrades to "best effort" instead of throwing.
+ */
+
+// Resolved inside each try, not as a parameter default: a bare
+// `localStorage` reference throws ReferenceError outside a browser
+// (SSR, a plain Node test) — a parameter default evaluates too
+// early for that function's own try/catch to catch it.
+
+export function readStorageItem(key: string, storage?: Storage): string | null {
+  try {
+    return (storage ?? localStorage).getItem(key);
+  } catch {
+    return null;
+  }
+}
+
+export function writeStorageItem(key: string, value: string, storage?: Storage): void {
+  try {
+    (storage ?? localStorage).setItem(key, value);
+  } catch {
+    // Quota exceeded or storage blocked — best-effort only.
+  }
+}
+
+export function removeStorageItem(key: string, storage?: Storage): void {
+  try {
+    (storage ?? localStorage).removeItem(key);
+  } catch {
+    // Best-effort only.
+  }
+}
+
+export function readStorageJSON<T>(key: string, storage?: Storage): T | null {
+  const raw = readStorageItem(key, storage);
+  if (!raw) return null;
+  try {
+    return JSON.parse(raw) as T;
+  } catch {
+    return null;
+  }
+}
+
+export function writeStorageJSON(key: string, value: unknown, storage?: Storage): void {
+  writeStorageItem(key, JSON.stringify(value), storage);
+}

--- a/apps/web/src/i18n/index.ts
+++ b/apps/web/src/i18n/index.ts
@@ -1,6 +1,7 @@
 import { LOCALES, type Locale } from '@gamedevpl/contract';
 import i18n from 'i18next';
 import { initReactI18next } from 'react-i18next';
+import { readStorageItem, writeStorageItem } from '../core/persistence.js';
 
 export const SUPPORTED_LANGUAGES = LOCALES;
 export type SupportedLanguage = Locale;
@@ -17,18 +18,14 @@ const STORAGE_KEY = 'gamedevpl:lang';
  * language ourselves lets `resources` below name only the one JSON that's actually needed.
  */
 function detectLanguage(): SupportedLanguage {
-  try {
-    const stored = localStorage.getItem(STORAGE_KEY);
-    // Normalized the same way navigator candidates are below: a value cached by the
-    // removed i18next-browser-languagedetector (pre-dating this module) can be
-    // region-qualified, e.g. 'pl-PL' or 'en-US' — an exact match against
-    // SUPPORTED_LANGUAGES would silently discard a still-valid stored preference.
-    const storedBase = stored?.split(/[-_]/)[0]?.toLowerCase();
-    if (storedBase && (SUPPORTED_LANGUAGES as readonly string[]).includes(storedBase)) {
-      return storedBase as SupportedLanguage;
-    }
-  } catch {
-    // localStorage unavailable (private mode, disabled) — fall through to navigator.
+  const stored = readStorageItem(STORAGE_KEY);
+  // Normalized the same way navigator candidates are below: a value cached by the
+  // removed i18next-browser-languagedetector (pre-dating this module) can be
+  // region-qualified, e.g. 'pl-PL' or 'en-US' — an exact match against
+  // SUPPORTED_LANGUAGES would silently discard a still-valid stored preference.
+  const storedBase = stored?.split(/[-_]/)[0]?.toLowerCase();
+  if (storedBase && (SUPPORTED_LANGUAGES as readonly string[]).includes(storedBase)) {
+    return storedBase as SupportedLanguage;
   }
   const candidates = typeof navigator !== 'undefined' ? (navigator.languages ?? [navigator.language]) : [];
   for (const candidate of candidates) {
@@ -120,11 +117,7 @@ export const i18nReady: Promise<void> = (async () => {
         // Persisted on every successful switch, not only the first time a bundle
         // loads — otherwise switching back to an already-loaded language (EN -> PL
         // -> EN) never updates the stored choice, and the next reload reverts to PL.
-        try {
-          localStorage.setItem(STORAGE_KEY, lng);
-        } catch {
-          // best-effort persistence only
-        }
+        writeStorageItem(STORAGE_KEY, lng);
       }
       return nativeChangeLanguage(lng, callback);
     })();

--- a/apps/web/src/mySpecs.ts
+++ b/apps/web/src/mySpecs.ts
@@ -1,3 +1,5 @@
+import { readStorageJSON, writeStorageJSON } from './core/persistence.js';
+
 export type SavedSpec = {
   token: string;
   title: string;
@@ -13,14 +15,8 @@ export type SavedSpec = {
 const STORAGE_KEY = 'gamedev_saved_specs';
 
 export function getSavedSpecs(): SavedSpec[] {
-  try {
-    const raw = localStorage.getItem(STORAGE_KEY);
-    if (!raw) return [];
-    const parsed = JSON.parse(raw) as SavedSpec[];
-    return Array.isArray(parsed) ? parsed : [];
-  } catch {
-    return [];
-  }
+  const parsed = readStorageJSON<SavedSpec[]>(STORAGE_KEY);
+  return Array.isArray(parsed) ? parsed : [];
 }
 
 export function saveSpec(spec: SavedSpec): SavedSpec[] {
@@ -28,21 +24,13 @@ export function saveSpec(spec: SavedSpec): SavedSpec[] {
   // Filter out any duplicate token
   const filtered = current.filter((item) => item.token !== spec.token);
   const updated = [spec, ...filtered];
-  try {
-    localStorage.setItem(STORAGE_KEY, JSON.stringify(updated));
-  } catch {
-    // ignore quota errors
-  }
+  writeStorageJSON(STORAGE_KEY, updated);
   return updated;
 }
 
 export function removeSpec(token: string): SavedSpec[] {
   const current = getSavedSpecs();
   const updated = current.filter((item) => item.token !== token);
-  try {
-    localStorage.setItem(STORAGE_KEY, JSON.stringify(updated));
-  } catch {
-    // ignore
-  }
+  writeStorageJSON(STORAGE_KEY, updated);
   return updated;
 }

--- a/apps/web/src/pendingQa.ts
+++ b/apps/web/src/pendingQa.ts
@@ -1,6 +1,7 @@
 import type { BuilderKind } from './builderKind.js';
 import { isBuilderKind } from './builderKind.js';
 import type { QAQuestion } from './CreatorQA.js';
+import { readStorageJSON, removeStorageItem, writeStorageJSON } from './core/persistence.js';
 
 /**
  * The clarifying-questions session, parked in localStorage.
@@ -44,50 +45,37 @@ const STORAGE_KEY = 'gamedev_pending_qa';
 const MAX_AGE_MS = 24 * 60 * 60_000;
 
 export function loadPendingQa(): PendingQaSession | null {
-  try {
-    const raw = localStorage.getItem(STORAGE_KEY);
-    if (!raw) return null;
-    const parsed = JSON.parse(raw) as PendingQaSession;
-    // An empty question list is a real session now, not a corrupt one: the confirm
-    // panel opens for every concept so the game can be named, and a clean concept
-    // reaches it with nothing to clarify. The concept is what makes a session
-    // meaningful; the title may legitimately be blank while the creator picks one.
-    if (
-      !parsed?.spec?.concept ||
-      !Array.isArray(parsed.questions) ||
-      typeof parsed.savedAt !== 'number' ||
-      Date.now() - parsed.savedAt > MAX_AGE_MS
-    ) {
-      clearPendingQa();
-      return null;
-    }
-    return {
-      ...parsed,
-      // displayName is optional to the creator, so tolerate its absence in older blobs.
-      spec: { ...parsed.spec, title: parsed.spec.title ?? '', displayName: parsed.spec.displayName ?? '' },
-      answers: { selected: parsed.answers?.selected ?? {}, custom: parsed.answers?.custom ?? {} },
-      ...(typeof parsed.locale === 'string' && parsed.locale ? { locale: parsed.locale } : {}),
-      ...(isBuilderKind(parsed.builder) ? { builder: parsed.builder } : {}),
-    };
-  } catch {
-    // Corrupt or unreadable (private mode, disabled storage): start clean rather than
-    // letting a bad blob wedge the creation flow on every load.
+  // Corrupt or unreadable (private mode, disabled storage): readStorageJSON returns
+  // null, and starting clean beats wedging the creation flow on every load.
+  const parsed = readStorageJSON<PendingQaSession>(STORAGE_KEY);
+  if (!parsed) return null;
+  // An empty question list is a real session now, not a corrupt one: the confirm
+  // panel opens for every concept so the game can be named, and a clean concept
+  // reaches it with nothing to clarify. The concept is what makes a session
+  // meaningful; the title may legitimately be blank while the creator picks one.
+  if (
+    !parsed?.spec?.concept ||
+    !Array.isArray(parsed.questions) ||
+    typeof parsed.savedAt !== 'number' ||
+    Date.now() - parsed.savedAt > MAX_AGE_MS
+  ) {
+    clearPendingQa();
     return null;
   }
+  return {
+    ...parsed,
+    // displayName is optional to the creator, so tolerate its absence in older blobs.
+    spec: { ...parsed.spec, title: parsed.spec.title ?? '', displayName: parsed.spec.displayName ?? '' },
+    answers: { selected: parsed.answers?.selected ?? {}, custom: parsed.answers?.custom ?? {} },
+    ...(typeof parsed.locale === 'string' && parsed.locale ? { locale: parsed.locale } : {}),
+    ...(isBuilderKind(parsed.builder) ? { builder: parsed.builder } : {}),
+  };
 }
 
 export function savePendingQa(session: Omit<PendingQaSession, 'savedAt'>): void {
-  try {
-    localStorage.setItem(STORAGE_KEY, JSON.stringify({ ...session, savedAt: Date.now() }));
-  } catch {
-    // Storage full or blocked — persistence is a convenience, never a precondition.
-  }
+  writeStorageJSON(STORAGE_KEY, { ...session, savedAt: Date.now() });
 }
 
 export function clearPendingQa(): void {
-  try {
-    localStorage.removeItem(STORAGE_KEY);
-  } catch {
-    // ignore
-  }
+  removeStorageItem(STORAGE_KEY);
 }

--- a/apps/web/src/priorRoundDismiss.ts
+++ b/apps/web/src/priorRoundDismiss.ts
@@ -3,6 +3,8 @@
  * Dismiss is local only — the store still keeps the messages.
  */
 
+import { readStorageItem, removeStorageItem, writeStorageItem } from './core/persistence.js';
+
 const STORAGE_PREFIX = 'gamedev_prior_round_hide:';
 
 function storageKey(slug: string, roundId: string): string {
@@ -10,19 +12,11 @@ function storageKey(slug: string, roundId: string): string {
 }
 
 export function isPriorRoundDismissed(slug: string, roundId: string): boolean {
-  try {
-    return localStorage.getItem(storageKey(slug, roundId)) === '1';
-  } catch {
-    return false;
-  }
+  return readStorageItem(storageKey(slug, roundId)) === '1';
 }
 
 export function setPriorRoundDismissed(slug: string, roundId: string, dismissed: boolean): void {
-  try {
-    const key = storageKey(slug, roundId);
-    if (dismissed) localStorage.setItem(key, '1');
-    else localStorage.removeItem(key);
-  } catch {
-    // Preference only — private mode must not break the thread.
-  }
+  const key = storageKey(slug, roundId);
+  if (dismissed) writeStorageItem(key, '1');
+  else removeStorageItem(key);
 }

--- a/apps/web/src/pwa.ts
+++ b/apps/web/src/pwa.ts
@@ -21,7 +21,7 @@
  *   changed (they have games of their own now, and notifications to want).
  */
 
-import { readStorageItem, writeStorageItem } from './core/persistence.js';
+import { readStorageItem, resolveWebStorage, writeStorageItem } from './core/persistence.js';
 
 const VISITS_KEY = 'gamedev_pwa_visits';
 const VISIT_COUNTED_KEY = 'gamedev_pwa_visit_counted';
@@ -33,26 +33,13 @@ export const MIN_VISITS_BEFORE_PROMPT = 2;
 /** How long a dismissal holds before the offer may return. */
 export const DISMISSAL_TTL_MS = 30 * 24 * 60 * 60_000;
 
-/**
- * An install nudge is the last thing that should be able to break a page render.
- * `window` itself may not exist (SSR, a plain Node test) — resolved inside a try,
- * same as readStorageItem/writeStorageItem guard the storage object itself.
- */
-function resolveStorage(storage: 'local' | 'session'): Storage | undefined {
-  try {
-    return storage === 'local' ? window.localStorage : window.sessionStorage;
-  } catch {
-    return undefined;
-  }
-}
-
 function readStorage(storage: 'local' | 'session', key: string): string | null {
-  const target = resolveStorage(storage);
+  const target = resolveWebStorage(storage);
   return target ? readStorageItem(key, target) : null;
 }
 
 function writeStorage(storage: 'local' | 'session', key: string, value: string): void {
-  const target = resolveStorage(storage);
+  const target = resolveWebStorage(storage);
   if (target) writeStorageItem(key, value, target);
 }
 

--- a/apps/web/src/pwa.ts
+++ b/apps/web/src/pwa.ts
@@ -21,6 +21,8 @@
  *   changed (they have games of their own now, and notifications to want).
  */
 
+import { readStorageItem, writeStorageItem } from './core/persistence.js';
+
 const VISITS_KEY = 'gamedev_pwa_visits';
 const VISIT_COUNTED_KEY = 'gamedev_pwa_visit_counted';
 const DISMISSED_KEY = 'gamedev_pwa_install_dismissed_at';
@@ -32,27 +34,26 @@ export const MIN_VISITS_BEFORE_PROMPT = 2;
 export const DISMISSAL_TTL_MS = 30 * 24 * 60 * 60_000;
 
 /**
- * Storage access that cannot throw.
- *
- * Safari in private browsing, and any browser with site data blocked, throw on
- * `localStorage` access rather than returning null. An install nudge is the last thing
- * in this app that should be able to break a page render, so every read and write here
- * degrades to "we know nothing", which the rules below treat as "do not prompt".
+ * An install nudge is the last thing that should be able to break a page render.
+ * `window` itself may not exist (SSR, a plain Node test) — resolved inside a try,
+ * same as readStorageItem/writeStorageItem guard the storage object itself.
  */
-function readStorage(storage: 'local' | 'session', key: string): string | null {
+function resolveStorage(storage: 'local' | 'session'): Storage | undefined {
   try {
-    return (storage === 'local' ? window.localStorage : window.sessionStorage).getItem(key);
+    return storage === 'local' ? window.localStorage : window.sessionStorage;
   } catch {
-    return null;
+    return undefined;
   }
 }
 
+function readStorage(storage: 'local' | 'session', key: string): string | null {
+  const target = resolveStorage(storage);
+  return target ? readStorageItem(key, target) : null;
+}
+
 function writeStorage(storage: 'local' | 'session', key: string, value: string): void {
-  try {
-    (storage === 'local' ? window.localStorage : window.sessionStorage).setItem(key, value);
-  } catch {
-    /* private mode / blocked storage — the counter just never advances */
-  }
+  const target = resolveStorage(storage);
+  if (target) writeStorageItem(key, value, target);
 }
 
 /**

--- a/apps/web/src/recentPlays.ts
+++ b/apps/web/src/recentPlays.ts
@@ -6,19 +6,15 @@
  * published catalog and never stores them on an account from this path.
  */
 
+import { readStorageJSON, writeStorageJSON } from './core/persistence.js';
+
 const STORAGE_KEY = 'gdpl.recentPlays';
 const MAX_RECENT = 8;
 
 function readRaw(): string[] {
-  try {
-    const raw = localStorage.getItem(STORAGE_KEY);
-    if (!raw) return [];
-    const parsed = JSON.parse(raw) as unknown;
-    if (!Array.isArray(parsed)) return [];
-    return parsed.filter((entry): entry is string => typeof entry === 'string' && /^[a-z0-9][a-z0-9-]*$/.test(entry));
-  } catch {
-    return [];
-  }
+  const parsed = readStorageJSON<unknown>(STORAGE_KEY);
+  if (!Array.isArray(parsed)) return [];
+  return parsed.filter((entry): entry is string => typeof entry === 'string' && /^[a-z0-9][a-z0-9-]*$/.test(entry));
 }
 
 export function getRecentPlays(): string[] {
@@ -28,9 +24,5 @@ export function getRecentPlays(): string[] {
 export function rememberRecentPlay(slug: string): void {
   if (!/^[a-z0-9][a-z0-9-]*$/.test(slug)) return;
   const next = [slug, ...readRaw().filter((entry) => entry !== slug)].slice(0, MAX_RECENT);
-  try {
-    localStorage.setItem(STORAGE_KEY, JSON.stringify(next));
-  } catch {
-    // Quota / private mode — recommendations simply stay cold-start.
-  }
+  writeStorageJSON(STORAGE_KEY, next);
 }

--- a/apps/web/src/surfaces/catalog/catalogSort.ts
+++ b/apps/web/src/surfaces/catalog/catalogSort.ts
@@ -1,4 +1,5 @@
 import type { CatalogEntry } from '../../catalog.js';
+import { readStorageItem, removeStorageItem, writeStorageItem } from '../../core/persistence.js';
 import { getRecentPlays } from '../../recentPlays.js';
 
 export type CatalogSortMode = 'recommended' | 'newest' | 'most_played' | 'last_played' | 'alpha';
@@ -28,21 +29,13 @@ export function isCatalogFilterId(value: unknown): value is CatalogFilterId {
 }
 
 export function readCatalogSortMode(): CatalogSortMode {
-  try {
-    const raw = localStorage.getItem(SORT_STORAGE_KEY);
-    if (raw === LEGACY_NOT_PLAYED_SORT) return DEFAULT_CATALOG_SORT;
-    return isCatalogSortMode(raw) ? raw : DEFAULT_CATALOG_SORT;
-  } catch {
-    return DEFAULT_CATALOG_SORT;
-  }
+  const raw = readStorageItem(SORT_STORAGE_KEY);
+  if (raw === LEGACY_NOT_PLAYED_SORT) return DEFAULT_CATALOG_SORT;
+  return isCatalogSortMode(raw) ? raw : DEFAULT_CATALOG_SORT;
 }
 
 export function writeCatalogSortMode(mode: CatalogSortMode): void {
-  try {
-    localStorage.setItem(SORT_STORAGE_KEY, mode);
-  } catch {
-    // Private mode — preference simply does not persist.
-  }
+  writeStorageItem(SORT_STORAGE_KEY, mode);
 }
 
 /**
@@ -50,39 +43,35 @@ export function writeCatalogSortMode(mode: CatalogSortMode): void {
  */
 export function readCatalogFilters(): Set<CatalogFilterId> {
   const filters = new Set<CatalogFilterId>();
-  try {
-    const raw = localStorage.getItem(FILTERS_STORAGE_KEY);
-    if (raw) {
+  const raw = readStorageItem(FILTERS_STORAGE_KEY);
+  if (raw) {
+    try {
       const parsed: unknown = JSON.parse(raw);
       if (Array.isArray(parsed)) {
         for (const item of parsed) {
           if (isCatalogFilterId(item)) filters.add(item);
         }
       }
-      return filters;
+    } catch {
+      // Bad JSON — empty set.
     }
-
-    // One-shot migrations from older persistence shapes.
-    if (localStorage.getItem(LEGACY_NOT_PLAYED_FILTER_KEY) === '1') {
-      filters.add('not_played');
-    } else if (localStorage.getItem(SORT_STORAGE_KEY) === LEGACY_NOT_PLAYED_SORT) {
-      filters.add('not_played');
-      localStorage.setItem(SORT_STORAGE_KEY, DEFAULT_CATALOG_SORT);
-    }
-    if (filters.size > 0) writeCatalogFilters(filters);
-    localStorage.removeItem(LEGACY_NOT_PLAYED_FILTER_KEY);
-  } catch {
-    // Private mode / bad JSON — empty set.
+    return filters;
   }
+
+  // One-shot migrations from older persistence shapes.
+  if (readStorageItem(LEGACY_NOT_PLAYED_FILTER_KEY) === '1') {
+    filters.add('not_played');
+  } else if (readStorageItem(SORT_STORAGE_KEY) === LEGACY_NOT_PLAYED_SORT) {
+    filters.add('not_played');
+    writeStorageItem(SORT_STORAGE_KEY, DEFAULT_CATALOG_SORT);
+  }
+  if (filters.size > 0) writeCatalogFilters(filters);
+  removeStorageItem(LEGACY_NOT_PLAYED_FILTER_KEY);
   return filters;
 }
 
 export function writeCatalogFilters(filters: ReadonlySet<CatalogFilterId>): void {
-  try {
-    localStorage.setItem(FILTERS_STORAGE_KEY, JSON.stringify([...filters]));
-  } catch {
-    // Private mode — preference simply does not persist.
-  }
+  writeStorageItem(FILTERS_STORAGE_KEY, JSON.stringify([...filters]));
 }
 
 export interface CatalogSortSignals {

--- a/apps/web/src/surfaces/studio/StudioConnectCard.tsx
+++ b/apps/web/src/surfaces/studio/StudioConnectCard.tsx
@@ -12,6 +12,7 @@ import {
   type ConnectPayload,
 } from './connectApi.js';
 import { isConnectCollapsed, setConnectCollapsed } from '../../connectCollapse.js';
+import { readStorageItem, writeStorageItem } from '../../core/persistence.js';
 import type { ConnectCardMode } from '../../selfBuildCopy.js';
 import { recordStudioStep } from '../../visitTelemetry.js';
 
@@ -36,21 +37,12 @@ type ConnectAuthMode = 'key' | 'oauth';
 const QUIET_UNAVAILABLE = new Set(['not_self_round', 'inactive_round']);
 
 function loadAuthMode(): ConnectAuthMode {
-  try {
-    const raw = localStorage.getItem(AUTH_MODE_STORAGE_KEY);
-    // Sign-in is the default path — paste-header is the escape hatch (Cursor bugs, CLI).
-    return raw === 'key' ? 'key' : 'oauth';
-  } catch {
-    return 'oauth';
-  }
+  // Sign-in is the default path — paste-header is the escape hatch (Cursor bugs, CLI).
+  return readStorageItem(AUTH_MODE_STORAGE_KEY) === 'key' ? 'key' : 'oauth';
 }
 
 function saveAuthMode(mode: ConnectAuthMode): void {
-  try {
-    localStorage.setItem(AUTH_MODE_STORAGE_KEY, mode);
-  } catch {
-    // Convenience only.
-  }
+  writeStorageItem(AUTH_MODE_STORAGE_KEY, mode);
 }
 
 type StudioConnectCardProps = {

--- a/apps/web/src/surfaces/studio/SubmissionStatusView.tsx
+++ b/apps/web/src/surfaces/studio/SubmissionStatusView.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
 import { useTranslation } from 'react-i18next';
 import { latestAgentActivityAt } from '../../agentActivity.js';
 import { BuilderModeBadge } from '../../BuilderModeBadge.js';
+import { readStorageItem, writeStorageItem } from '../../core/persistence.js';
 import type { BuilderUnavailableReason } from '../../BuilderChoice.js';
 import { defaultBuilderFor, isBuilderKind, saveLastBuilder, type BuilderKind } from '../../builderKind.js';
 import { GameTheater } from '../../GameTheater.js';
@@ -246,11 +247,7 @@ const STATUS_CHIP_DISMISSAL_PREFIX = 'gamedev_status_chip_dismissed:';
 
 function hasDismissedStatusChip(chipKey: string): boolean {
   if (chipKey !== REMEMBERED_STATUS_CHIP) return false;
-  try {
-    return window.localStorage.getItem(`${STATUS_CHIP_DISMISSAL_PREFIX}${chipKey}`) === '1';
-  } catch {
-    return false;
-  }
+  return readStorageItem(`${STATUS_CHIP_DISMISSAL_PREFIX}${chipKey}`) === '1';
 }
 
 /** Dismissible status chip above the composer. */
@@ -261,11 +258,7 @@ function ThreadStatusChip({ chipKey, children }: { chipKey: string; children: Re
   const dismiss = () => {
     setDismissed(true);
     if (chipKey !== REMEMBERED_STATUS_CHIP) return;
-    try {
-      window.localStorage.setItem(`${STATUS_CHIP_DISMISSAL_PREFIX}${chipKey}`, '1');
-    } catch {
-      // Storage unavailable.
-    }
+    writeStorageItem(`${STATUS_CHIP_DISMISSAL_PREFIX}${chipKey}`, '1');
   };
 
   if (dismissed) return null;

--- a/apps/web/src/surfaces/studio/studioWelcome.ts
+++ b/apps/web/src/surfaces/studio/studioWelcome.ts
@@ -1,22 +1,15 @@
+import { readStorageItem, writeStorageItem } from '../../core/persistence.js';
 import { getSavedSpecs } from '../../mySpecs.js';
 import { listMySubmissions } from '../../submissionApi.js';
 
 const ONBOARDED_KEY = 'gamedev_studio_onboarded';
 
 export function isStudioOnboarded(): boolean {
-  try {
-    return localStorage.getItem(ONBOARDED_KEY) === '1';
-  } catch {
-    return false;
-  }
+  return readStorageItem(ONBOARDED_KEY) === '1';
 }
 
 export function markStudioOnboarded(): void {
-  try {
-    localStorage.setItem(ONBOARDED_KEY, '1');
-  } catch {
-    // Convenience only.
-  }
+  writeStorageItem(ONBOARDED_KEY, '1');
 }
 
 // Resolve status token from slug or token.

--- a/eslint-rules/comment-prose-baseline.json
+++ b/eslint-rules/comment-prose-baseline.json
@@ -388,7 +388,7 @@
     "apps/web/src/connectCollapse.ts": 26,
     "apps/web/src/ContactPage.tsx": 64,
     "apps/web/src/ContributionsSetting.tsx": 197,
-    "apps/web/src/core/persistence.ts": 69,
+    "apps/web/src/core/persistence.ts": 122,
     "apps/web/src/core/router.test.ts": 451,
     "apps/web/src/core/router.ts": 2406,
     "apps/web/src/creatorGames.test.ts": 13,

--- a/eslint-rules/comment-prose-baseline.json
+++ b/eslint-rules/comment-prose-baseline.json
@@ -388,6 +388,7 @@
     "apps/web/src/connectCollapse.ts": 26,
     "apps/web/src/ContactPage.tsx": 64,
     "apps/web/src/ContributionsSetting.tsx": 197,
+    "apps/web/src/core/persistence.ts": 69,
     "apps/web/src/core/router.test.ts": 451,
     "apps/web/src/core/router.ts": 2406,
     "apps/web/src/creatorGames.test.ts": 13,

--- a/eslint-rules/module-size-baseline.json
+++ b/eslint-rules/module-size-baseline.json
@@ -662,7 +662,7 @@
     "apps/web/src/PullToRefresh.tsx": 41,
     "apps/web/src/pushApi.ts": 144,
     "apps/web/src/pwa.test.ts": 161,
-    "apps/web/src/pwa.ts": 199,
+    "apps/web/src/pwa.ts": 200,
     "apps/web/src/recentPlays.test.ts": 41,
     "apps/web/src/recentPlays.ts": 36,
     "apps/web/src/recommendationsApi.test.ts": 71,


### PR DESCRIPTION
Phase 4 (item 8) of the north-star plan — web restructure. `core/`'s data-layer bullet: "localStorage access goes through one persistence module." This is that module — first batch of the post-Wave-A `core/` work, ahead of the fetch-cache data layer and the studio-poller consolidation (both scoped as separate follow-up PRs).

## What changed

`apps/web/src/core/persistence.ts` wraps `localStorage`/`sessionStorage` access (`readStorageItem`/`writeStorageItem`/`removeStorageItem` + JSON convenience wrappers), matching the fail-silent try/catch convention every one of the 12 modules that touched storage directly had already independently reinvented. Migrated: `builderKind.ts`, `connectCollapse.ts`, `i18n/index.ts`, `mySpecs.ts`, `pendingQa.ts`, `priorRoundDismiss.ts`, `pwa.ts`, `recentPlays.ts`, `surfaces/catalog/catalogSort.ts`, `surfaces/studio/StudioConnectCard.tsx`, `surfaces/studio/SubmissionStatusView.tsx`, `surfaces/studio/studioWelcome.ts`. Each call site is a mechanical swap — same keys, same fail-silent semantics.

**A real bug caught along the way**: a naive `storage: Storage = localStorage` parameter default evaluates *before* the function body's `try` runs, so it doesn't catch the `ReferenceError` thrown by referencing the bare `localStorage` identifier outside a browser (81 test files run in vitest's default Node environment, not jsdom, where `localStorage` isn't a global at all). The full test suite caught this immediately (81 failing files) — fixed by resolving the storage object *inside* the `try`, matching what every migrated call site already did.

## Verification

- `tsc --noEmit` clean
- `apps/web` suite: 217/217 test files, 1830 tests
- Repo `npm run lint`: 0 errors (comment-prose and module-size baselines resealed)
- Production build succeeds

## Scope note

The fetch-cache data layer (`core/dataLayer.ts`, request dedup + invalidation) and the five-Studio-pollers-into-one consolidation are separate follow-up PRs — this is just the persistence piece.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VaPzGSyNfZ7nvGcJgYNSdL)_