### PR TITLE
Phase 4: migrate three fixed-cadence Studio pollers onto studioStatusStore

### DIFF
--- a/apps/web/src/surfaces/studio/StudioDetailsBuildProgress.tsx
+++ b/apps/web/src/surfaces/studio/StudioDetailsBuildProgress.tsx
@@ -1,7 +1,8 @@
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { StudioBuildHistory } from './StudioBuildHistory.js';
-import { getSubmissionStatus, type SubmissionStatus } from '../../submissionApi.js';
+import { pokeStudioStatus, subscribeStudioStatus } from './studioStatusStore.js';
+import type { SubmissionStatus } from '../../submissionApi.js';
 
 // Details refreshes slower than the thread's own live pulse.
 const DETAILS_POLL_MS = 10_000;
@@ -24,32 +25,17 @@ export function StudioDetailsBuildProgress({
   const { t, i18n } = useTranslation();
   const [status, setStatus] = useState<SubmissionStatus | null>(null);
   const [loaded, setLoaded] = useState(false);
-  // Bumped to force an immediate re-poll (e.g. right after sealing) instead of waiting
-  // out DETAILS_POLL_MS — canSeal would otherwise read stale for that whole window.
-  const [refreshNonce, setRefreshNonce] = useState(0);
 
   useEffect(() => {
-    let cancelled = false;
-
-    const load = async () => {
-      try {
-        const next = await getSubmissionStatus(token, i18n.language);
-        if (cancelled) return;
+    return subscribeStudioStatus(token, i18n.language, {
+      intervalMs: () => DETAILS_POLL_MS,
+      onUpdate: (next) => {
         setStatus(next);
-      } catch {
-        // Secondary chrome — a failed poll must not toast over the thread.
-      } finally {
-        if (!cancelled) setLoaded(true);
-      }
-    };
-
-    void load();
-    const timer = window.setInterval(() => void load(), DETAILS_POLL_MS);
-    return () => {
-      cancelled = true;
-      window.clearInterval(timer);
-    };
-  }, [token, i18n.language, refreshNonce]);
+        setLoaded(true);
+      },
+      onError: () => setLoaded(true),
+    });
+  }, [token, i18n.language]);
 
   if (!status) {
     return loaded ? null : <p className="studio-rail-empty">{t('statusView.loading')}</p>;
@@ -63,7 +49,7 @@ export function StudioDetailsBuildProgress({
       onSelectPreviewVersion={onSelectPreviewVersion}
       activePreviewVersion={activePreviewVersion}
       onReverted={onReverted}
-      onSealed={() => setRefreshNonce((n) => n + 1)}
+      onSealed={() => pokeStudioStatus(token, i18n.language)}
     />
   );
 }

--- a/apps/web/src/surfaces/studio/StudioDetailsMedia.test.tsx
+++ b/apps/web/src/surfaces/studio/StudioDetailsMedia.test.tsx
@@ -34,13 +34,13 @@ describe('StudioDetailsMedia', () => {
     const root = createRoot(host);
 
     await act(async () => {
-      root.render(<StudioDetailsMedia token="tok" />);
+      root.render(<StudioDetailsMedia token="tok-grid" />);
     });
     await act(async () => {
       await Promise.resolve();
     });
 
-    expect(getSubmissionStatus).toHaveBeenCalledWith('tok', 'en');
+    expect(getSubmissionStatus).toHaveBeenCalledWith('tok-grid', 'en');
     expect(host.querySelector('[data-testid="studio-details-media"]')).not.toBeNull();
     expect(host.querySelectorAll('.studio-details-media-card')).toHaveLength(2);
 
@@ -63,7 +63,7 @@ describe('StudioDetailsMedia', () => {
     const root = createRoot(host);
 
     await act(async () => {
-      root.render(<StudioDetailsMedia token="tok" emptyLabel="Nothing yet" />);
+      root.render(<StudioDetailsMedia token="tok-empty" emptyLabel="Nothing yet" />);
     });
     await act(async () => {
       await Promise.resolve();

--- a/apps/web/src/surfaces/studio/StudioDetailsMedia.tsx
+++ b/apps/web/src/surfaces/studio/StudioDetailsMedia.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { buildMediaUrl, getSubmissionStatus, type BuildMediaItem } from '../../submissionApi.js';
+import { buildMediaUrl, type BuildMediaItem } from '../../submissionApi.js';
+import { subscribeStudioStatus } from './studioStatusStore.js';
 
 /** Details refreshes slower than the thread — the thread already owns the live pulse. */
 const DETAILS_POLL_MS = 10_000;
@@ -16,26 +17,14 @@ export function StudioDetailsMedia({ token, emptyLabel }: { token: string; empty
   const [lightbox, setLightbox] = useState<string | null>(null);
 
   useEffect(() => {
-    let cancelled = false;
-
-    const load = async () => {
-      try {
-        const status = await getSubmissionStatus(token, i18n.language);
-        if (cancelled) return;
+    return subscribeStudioStatus(token, i18n.language, {
+      intervalMs: () => DETAILS_POLL_MS,
+      onUpdate: (status) => {
         setMedia(status.media ?? []);
-      } catch {
-        /* Secondary chrome — a failed poll must not toast over the thread. */
-      } finally {
-        if (!cancelled) setLoaded(true);
-      }
-    };
-
-    void load();
-    const timer = window.setInterval(() => void load(), DETAILS_POLL_MS);
-    return () => {
-      cancelled = true;
-      window.clearInterval(timer);
-    };
+        setLoaded(true);
+      },
+      onError: () => setLoaded(true),
+    });
   }, [token, i18n.language]);
 
   useEffect(() => {

--- a/apps/web/src/surfaces/studio/StudioShotToasts.test.tsx
+++ b/apps/web/src/surfaces/studio/StudioShotToasts.test.tsx
@@ -35,13 +35,13 @@ describe('StudioShotToasts', () => {
     const root = createRoot(host);
 
     await act(async () => {
-      root.render(<StudioShotToasts token="tok" placement="near-play" />);
+      root.render(<StudioShotToasts token="tok-stack" placement="near-play" />);
     });
     await act(async () => {
       await Promise.resolve();
     });
 
-    expect(getSubmissionStatus).toHaveBeenCalledWith('tok', 'en');
+    expect(getSubmissionStatus).toHaveBeenCalledWith('tok-stack', 'en');
     expect(host.querySelector('.studio-shot-toasts.is-near-play')).not.toBeNull();
     expect(host.querySelectorAll('.studio-shot-toast')).toHaveLength(2);
 
@@ -69,7 +69,7 @@ describe('StudioShotToasts', () => {
     const root = createRoot(host);
 
     await act(async () => {
-      root.render(<StudioShotToasts token="tok" placement="near-play" onOpenMedia={onOpenMedia} />);
+      root.render(<StudioShotToasts token="tok-open" placement="near-play" onOpenMedia={onOpenMedia} />);
     });
     await act(async () => {
       await Promise.resolve();
@@ -100,7 +100,7 @@ describe('StudioShotToasts', () => {
     const root = createRoot(host);
 
     await act(async () => {
-      root.render(<StudioShotToasts token="tok" placement="near-play" onOpenMedia={onOpenMedia} />);
+      root.render(<StudioShotToasts token="tok-drag" placement="near-play" onOpenMedia={onOpenMedia} />);
     });
     await act(async () => {
       await Promise.resolve();
@@ -144,12 +144,12 @@ describe('StudioShotToasts', () => {
     const root = createRoot(host);
 
     await act(async () => {
-      root.render(<StudioShotToasts token="tok" />);
+      root.render(<StudioShotToasts token="tok-locale" />);
     });
     await act(async () => {
       await Promise.resolve();
     });
-    expect(getSubmissionStatus).toHaveBeenCalledWith('tok', 'en');
+    expect(getSubmissionStatus).toHaveBeenCalledWith('tok-locale', 'en');
 
     await act(async () => {
       await i18n.changeLanguage('pl');
@@ -157,7 +157,7 @@ describe('StudioShotToasts', () => {
     await act(async () => {
       await Promise.resolve();
     });
-    expect(getSubmissionStatus).toHaveBeenCalledWith('tok', 'pl');
+    expect(getSubmissionStatus).toHaveBeenCalledWith('tok-locale', 'pl');
 
     root.unmount();
     host.remove();
@@ -173,7 +173,7 @@ describe('StudioShotToasts', () => {
     const root = createRoot(host);
 
     await act(async () => {
-      root.render(<StudioShotToasts token="tok" />);
+      root.render(<StudioShotToasts token="tok-empty" />);
     });
     await act(async () => {
       await Promise.resolve();

--- a/apps/web/src/surfaces/studio/StudioShotToasts.tsx
+++ b/apps/web/src/surfaces/studio/StudioShotToasts.tsx
@@ -1,7 +1,8 @@
 import { useEffect, useMemo, useRef, useState, type PointerEvent as ReactPointerEvent } from 'react';
 import { useTranslation } from 'react-i18next';
 import { PixelIcon } from '../../PixelIcon.js';
-import { buildMediaUrl, getSubmissionStatus, type BuildMediaItem } from '../../submissionApi.js';
+import { buildMediaUrl, type BuildMediaItem } from '../../submissionApi.js';
+import { subscribeStudioStatus } from './studioStatusStore.js';
 
 /**
  * Scattered screenshot stack near Play — a dismissable notification.
@@ -89,22 +90,11 @@ export function StudioShotToasts({ token, placement = 'near-play', onOpenMedia }
   const stackRef = useRef<HTMLDivElement | null>(null);
 
   useEffect(() => {
-    let cancelled = false;
-    const load = () => {
-      getSubmissionStatus(token, i18n.language)
-        .then((status) => {
-          if (!cancelled) setMedia(status.media ?? []);
-        })
-        .catch(() => {
-          if (!cancelled) setMedia([]);
-        });
-    };
-    load();
-    const id = window.setInterval(load, POLL_MS);
-    return () => {
-      cancelled = true;
-      window.clearInterval(id);
-    };
+    return subscribeStudioStatus(token, i18n.language, {
+      intervalMs: () => POLL_MS,
+      onUpdate: (status) => setMedia(status.media ?? []),
+      onError: () => setMedia([]),
+    });
   }, [token, i18n.language]);
 
   useEffect(() => {


### PR DESCRIPTION
Phase 4 (item 8) of the north-star plan — web restructure. Follow-up to #1098, which added `studioStatusStore.ts` but wired it into nothing. This PR migrates the three lowest-risk, fixed-cadence consumers onto it — the two remaining (`useStudioStatusPoll.ts`, `SubmissionStatusView.tsx`) are separate follow-up PRs, in risk order.

## What changed

`StudioDetailsBuildProgress`, `StudioDetailsMedia`, and `StudioShotToasts` each ran their own `setInterval` loop calling `getSubmissionStatus` directly (at 10s, 10s, and 12s respectively). All three now subscribe via `subscribeStudioStatus(token, locale, subscriber)` instead — a token/locale with several of these mounted at once (a common case: Details media + the near-Play toast stack + the checklist, all showing the same round) now shares one fetch and one schedule instead of three independent ones.

- `StudioDetailsBuildProgress`'s `refreshNonce` hack (bumped by `onSealed` to force an immediate re-poll instead of waiting out the full interval) is replaced by `pokeStudioStatus(token, locale)` — the store's built-in mechanism for exactly this.
- Per-consumer error handling is preserved exactly as it was: `StudioDetailsMedia` keeps the last-known media on a failed poll; `StudioShotToasts` clears it. Only the polling mechanism changed, not the error-handling semantics.
- `StudioDetailsBuildProgress`'s `status`/`loaded` persistence-across-token-change quirk (a component switching to a new token doesn't reset to a loading state until the new fetch resolves) is preserved unchanged — out of scope for this migration.

## Test changes

The three affected tests' fixtures previously reused the literal token `'tok'` across multiple tests within the same file. Since `studioStatusStore` is a module-level singleton keyed by `(token, locale)`, reusing a token across tests in the same file risks one test's cached poll state leaking into the next (the store doesn't get reset between tests). Gave each test its own unique token to keep them independent — no behavioral assertions changed.

## Verification

- `tsc --noEmit` clean
- `apps/web` suite: 219/219 test files, 1864 tests (all pre-existing tests for the three components pass unchanged in substance)
- Repo `npm run lint`: 0 errors
- Production build succeeds

---
_Generated by [Claude Code](https://claude.ai/code/session_01VaPzGSyNfZ7nvGcJgYNSdL)_