### PR TITLE
infra(cloudrun): raise gamedev-app memory limit to 1Gi

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -449,6 +449,7 @@ jobs:
             --min-instances 0 \
             --max-instances "$MAX_INSTANCES" \
             --no-cpu-throttling \
+            --memory 1Gi \
             --port 8080 \
             --set-env-vars "$ENV_VARS" \
             "${SECRET_FLAGS[@]}"

--- a/infra/deploy-api.sh
+++ b/infra/deploy-api.sh
@@ -504,6 +504,7 @@ gcloud run deploy "$SERVICE" \
   --min-instances 0 \
   --max-instances "$MAX_INSTANCES" \
   --no-cpu-throttling \
+  --memory 1Gi \
   --port 8080 \
   --set-env-vars "${ENV_VARS}" \
   ${SECRET_FLAGS[@]+"${SECRET_FLAGS[@]}"}


### PR DESCRIPTION
Prevents Node.js V8 FatalProcessOutOfMemory crashes during concurrent staging uploads, MCP calls, and submission status polling bursts.