### PR TITLE
docs(verify-agent-work): record corpse-step vs collapse-pose trap

### DIFF
--- a/.claude/skills/verify-agent-work/SKILL.md
+++ b/.claude/skills/verify-agent-work/SKILL.md
@@ -284,6 +284,15 @@ Two concrete instances of that (observed 2026-07-23):
   functions write the same piece of state, the sequence (A then B then A) is the test,
   not A and B separately. A latch that means “stop trying” is only safe if nothing else
   can raise the value underneath it.
+- **Stepping a corpse with the live combat solver is not the same as advancing a collapse
+  pose.** Observed (bonfire-arena / www.gamedev.pl-games#1198 review, 2026-09-01):
+  `stepFighter()` was the only writer of `fallen`, and runtime skipped it on `e.dead`, so
+  knights vanished standing. A unit test that called `stepFighter` on a dead fighter
+  passed. Wiring the full solver back in left residual `arm.vel` in the still-live
+  clash/strike loop; the capture path then never reached `won`. A/B against the pre-fix
+  commit proved the regression was the corpse step, not the rebase. `trace:classify`
+  on a later fallen-only path was render-only. Advance the pose field the spec names;
+  do not keep a dead blade in the exchange.
 
 ## Read the diff against the spec
 

--- a/.claude/skills/verify-agent-work/SKILL.md
+++ b/.claude/skills/verify-agent-work/SKILL.md
@@ -293,6 +293,15 @@ Two concrete instances of that (observed 2026-07-23):
   commit proved the regression was the corpse step, not the rebase. `trace:classify`
   on a later fallen-only path was render-only. Advance the pose field the spec names;
   do not keep a dead blade in the exchange.
+- **Games-repo `gate-attest` follows CI scope, not the "one game → check:game" heuristic.**
+  Observed (bonfire-arena / www.gamedev.pl-games#1237, 2026-09-01): a game-only read of
+  rule 5b replaced a correct `npm run check:catalog-static` attest with
+  `check:game -- bonfire-arena`. CI still classified the diff as `static` because it also
+  touched `tools/idle-agency.ts` and `tools/tests/` (`isStaticOk` widens scoped → static).
+  The attest job then failed: required command `check:catalog-static`. Ask
+  `node tools/gate-attest.mjs expected` (or the Actions log's `Required command:`) for
+  the SHA you are opening; do not "correct" a static attest down to `check:game` just
+  because a `games/<slug>/` path is in the diff. `check:pr` remains an accepted alias.
 
 ## Read the diff against the spec
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Record verification traps found while reviewing www.gamedev.pl-games#1198 / #1237.

- A unit test that calls `stepFighter` on a dead knight can pass while runtime still skips that call, so the body never collapses. Wiring the *full* solver back in is also wrong: residual blade velocity stays in the live clash/strike loop and the capture path never reaches `won`. Advance the pose field the spec names (`fallen`); do not keep a dead blade in the exchange.
- Games-repo `gate-attest` follows CI *scope*, not the "one game → check:game" heuristic. Touching `tools/idle-agency.ts` or `tools/tests/` widens the diff to `static`, so CI requires `npm run check:catalog-static` even when a `games/<slug>/` path is present. Replacing a static attest with `check:game` fails the attest job.

No product behaviour change.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ebcbb02c-a667-42e4-ace2-e4f560b1adcc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ebcbb02c-a667-42e4-ace2-e4f560b1adcc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

