### PR TITLE
Remove dead GitHubClient.createIssue/closePullRequest, fix doc comment

### DIFF
--- a/apps/api/src/agent-build-media.test.ts
+++ b/apps/api/src/agent-build-media.test.ts
@@ -25,13 +25,11 @@ const PNG = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x01, 0
 
 function stubGitHub(): GitHubClient {
   return {
-    createIssue: async () => ({ number: ISSUE }),
     getIssueState: async () => ({ state: 'open' as const }),
     findLinkedPR: async (): Promise<LinkedPullRequest | null> => null,
     createIssueComment: async () => ({ id: 1 }),
     updateIssueBody: async () => {},
     closeIssue: async () => {},
-    closePullRequest: async () => {},
     ensureOpenPullRequest: async () => ({ number: 1 }),
     deleteBranch: async () => {},
     getGameSources: async (): Promise<GameSources | null> => null,

--- a/apps/api/src/agent-build-reads.test.ts
+++ b/apps/api/src/agent-build-reads.test.ts
@@ -37,13 +37,11 @@ function packedKitTarball(files: Record<string, string | Buffer>): Buffer {
 
 function stubGitHub(): GitHubClient {
   return {
-    createIssue: async () => ({ number: ISSUE }),
     getIssueState: async () => ({ state: 'open' as const }),
     findLinkedPR: async (): Promise<LinkedPullRequest | null> => null,
     createIssueComment: async () => ({ id: 1 }),
     updateIssueBody: async () => {},
     closeIssue: async () => {},
-    closePullRequest: async () => {},
     ensureOpenPullRequest: async () => ({ number: 1 }),
     deleteBranch: async () => {},
     getGameSources: async (): Promise<GameSources | null> => null,

--- a/apps/api/src/agent-surface/agent-channel.test.ts
+++ b/apps/api/src/agent-surface/agent-channel.test.ts
@@ -20,13 +20,11 @@ const ISSUE = 42;
 
 function stubGitHub(overrides: Partial<GitHubClient> = {}): GitHubClient {
   return {
-    createIssue: async () => ({ number: ISSUE }),
     getIssueState: async () => ({ state: 'open' as const }),
     findLinkedPR: async (): Promise<LinkedPullRequest | null> => null,
     createIssueComment: async () => ({ id: 1 }),
     updateIssueBody: async () => {},
     closeIssue: async () => {},
-    closePullRequest: async () => {},
     ensureOpenPullRequest: async () => ({ number: 1 }),
     deleteBranch: async () => {},
     getGameSources: async (): Promise<GameSources | null> => null,

--- a/apps/api/src/agent-surface/creator-agent-key-routes.test.ts
+++ b/apps/api/src/agent-surface/creator-agent-key-routes.test.ts
@@ -27,13 +27,11 @@ const CONCEPT = 'A tactics game about careful timing and cover.';
 
 function stubGitHub(): GitHubClient {
   return {
-    createIssue: async () => ({ number: 1 }),
     getIssueState: async () => ({ state: 'open' as const }),
     findLinkedPR: async (): Promise<LinkedPullRequest | null> => null,
     createIssueComment: async () => ({ id: 1 }),
     updateIssueBody: async () => {},
     closeIssue: async () => {},
-    closePullRequest: async () => {},
     ensureOpenPullRequest: async () => ({ number: 1 }),
     deleteBranch: async () => {},
     getGameSources: async (): Promise<GameSources | null> => null,

--- a/apps/api/src/agent-surface/mcp-debug-log.test.ts
+++ b/apps/api/src/agent-surface/mcp-debug-log.test.ts
@@ -112,13 +112,11 @@ describe('mcp tool refusal logging', () => {
       sessionSecret: 'dev-session-secret-change-me',
       submissionRoutes: {
         githubClient: {
-          createIssue: async () => ({ number: 42 }),
           getIssueState: async () => ({ state: 'open' as const }),
           findLinkedPR: async () => null,
           createIssueComment: async () => ({ id: 1 }),
           updateIssueBody: async () => {},
           closeIssue: async () => {},
-          closePullRequest: async () => {},
           ensureOpenPullRequest: async () => ({ number: 1 }),
           deleteBranch: async () => {},
           getGameSources: async () => null,

--- a/apps/api/src/agent-surface/mcp-oauth-metadata.test.ts
+++ b/apps/api/src/agent-surface/mcp-oauth-metadata.test.ts
@@ -160,13 +160,11 @@ describe('MCP OAuth 401 challenge (BY-18a)', () => {
       sessionSecret: 'dev-session-secret-change-me',
       submissionRoutes: {
         githubClient: {
-          createIssue: async () => ({ number: 42 }),
           getIssueState: async () => ({ state: 'open' as const }),
           findLinkedPR: async () => null,
           createIssueComment: async () => ({ id: 1 }),
           updateIssueBody: async () => {},
           closeIssue: async () => {},
-          closePullRequest: async () => {},
           ensureOpenPullRequest: async () => ({ number: 1 }),
           deleteBranch: async () => {},
           getGameSources: async () => null,
@@ -234,13 +232,11 @@ describe('MCP OAuth 401 challenge (BY-18a)', () => {
       sessionSecret: 'dev-session-secret-change-me',
       submissionRoutes: {
         githubClient: {
-          createIssue: async () => ({ number: 42 }),
           getIssueState: async () => ({ state: 'open' as const }),
           findLinkedPR: async () => null,
           createIssueComment: async () => ({ id: 1 }),
           updateIssueBody: async () => {},
           closeIssue: async () => {},
-          closePullRequest: async () => {},
           ensureOpenPullRequest: async () => ({ number: 1 }),
           deleteBranch: async () => {},
           getGameSources: async () => null,
@@ -306,13 +302,11 @@ describe('MCP OAuth challenge regressions (BY-18a)', () => {
       sessionSecret: 'dev-session-secret-change-me',
       submissionRoutes: {
         githubClient: {
-          createIssue: async () => ({ number: ISSUE }),
           getIssueState: async () => ({ state: 'open' as const }),
           findLinkedPR: async () => null,
           createIssueComment: async () => ({ id: 1 }),
           updateIssueBody: async () => {},
           closeIssue: async () => {},
-          closePullRequest: async () => {},
           ensureOpenPullRequest: async () => ({ number: 1 }),
           deleteBranch: async () => {},
           getGameSources: async () => null,

--- a/apps/api/src/agent-surface/mcp-server.test.ts
+++ b/apps/api/src/agent-surface/mcp-server.test.ts
@@ -65,13 +65,11 @@ const MINIMAL_FILES = [
 
 function stubGitHub(): GitHubClient {
   return {
-    createIssue: async () => ({ number: ISSUE }),
     getIssueState: async () => ({ state: 'open' as const }),
     findLinkedPR: async (): Promise<LinkedPullRequest | null> => null,
     createIssueComment: async () => ({ id: 1 }),
     updateIssueBody: async () => {},
     closeIssue: async () => {},
-    closePullRequest: async () => {},
     ensureOpenPullRequest: async () => ({ number: 1 }),
     deleteBranch: async () => {},
     getGameSources: async (): Promise<GameSources | null> => null,

--- a/apps/api/src/agent-surface/self-build-connect.test.ts
+++ b/apps/api/src/agent-surface/self-build-connect.test.ts
@@ -39,13 +39,11 @@ const MASKED_AUTH = 'Authorization: Bearer ····9a10e';
 
 function stubGitHub(): GitHubClient {
   return {
-    createIssue: async () => ({ number: 1 }),
     getIssueState: async () => ({ state: 'open' as const }),
     findLinkedPR: async (): Promise<LinkedPullRequest | null> => null,
     createIssueComment: async () => ({ id: 1 }),
     updateIssueBody: async () => {},
     closeIssue: async () => {},
-    closePullRequest: async () => {},
     ensureOpenPullRequest: async () => ({ number: 1 }),
     deleteBranch: async () => {},
     getGameSources: async (): Promise<GameSources | null> => null,

--- a/apps/api/src/catalog/github-client.ts
+++ b/apps/api/src/catalog/github-client.ts
@@ -308,13 +308,9 @@ export interface GitHubClient {
   closeIssue(issueNumber: number): Promise<void>;
   /**
    * Opens a pull request for an existing branch, or returns the open one if there
-   * already is one.
-   *
-   * Exists for one narrow reason: GitHub's agent tasks API can only resume work on a
-   * branch that has an **open pull request** — without one, the `head_ref` asking it to
-   * resume is silently ignored and the agent branches fresh instead. So a revision round
-   * has to guarantee the PR exists first. The PR is never merged and nothing reads it;
-   * it is resumption context, left open for the life of the build.
+   * already is one. The sole production caller, `proposal-apply-bot.ts`, uses this for
+   * the repo-lane merge-back: the PR it opens goes through the games repo's normal
+   * CODEOWNERS review and merge, same as any other PR.
    */
   ensureOpenPullRequest(input: { headRef: string; baseRef: string; title: string; body: string }): Promise<{
     number: number;

--- a/apps/api/src/catalog/github-client.ts
+++ b/apps/api/src/catalog/github-client.ts
@@ -304,7 +304,7 @@ export interface GitHubClient {
   createIssueComment(issueOrPrNumber: number, body: string): Promise<{ id: number }>;
   /** Rewrites an issue body. No production caller — the issue-first flow is retired. */
   updateIssueBody(issueNumber: number, body: string): Promise<void>;
-  /** Closes an issue — a creator abandoning their build. */
+  /** Closes an issue. No production caller — the issue-first flow is retired. */
   closeIssue(issueNumber: number): Promise<void>;
   /**
    * Opens a pull request for an existing branch, or returns the open one if there

--- a/apps/api/src/catalog/github-client.ts
+++ b/apps/api/src/catalog/github-client.ts
@@ -38,12 +38,6 @@ import { generateStyleCss, type Theme } from '../platform/theme-css-generator.js
 
 export type { CatalogGameTouch } from './catalog-touch.js';
 
-interface CreateIssueInput {
-  title: string;
-  body: string;
-  labels: string[];
-}
-
 export interface PullRequestCommit {
   /** First line of the commit message — a human-readable step in the build. */
   message: string;
@@ -299,7 +293,6 @@ export function parseSubmittedBy(raw: string | undefined | null): string | null 
 }
 
 export interface GitHubClient {
-  createIssue(input: CreateIssueInput): Promise<{ number: number }>;
   getIssueState(issueNumber: number): Promise<{ state: 'open' | 'closed' }>;
   findLinkedPR(issueNumber: number): Promise<LinkedPullRequest | null>;
   /**
@@ -315,13 +308,8 @@ export interface GitHubClient {
    * when the issue already exists.
    */
   updateIssueBody(issueNumber: number, body: string): Promise<void>;
-  /**
-   * Closes an issue (a creator abandoning their build) or an open pull request.
-   * The REST issues endpoint covers both — a PR is an issue for state purposes —
-   * but PRs are closed through the pulls endpoint so GitHub records it as such.
-   */
+  /** Closes an issue — a creator abandoning their build. */
   closeIssue(issueNumber: number): Promise<void>;
-  closePullRequest(pullNumber: number): Promise<void>;
   /**
    * Opens a pull request for an existing branch, or returns the open one if there
    * already is one.
@@ -330,7 +318,7 @@ export interface GitHubClient {
    * branch that has an **open pull request** — without one, the `head_ref` asking it to
    * resume is silently ignored and the agent branches fresh instead. So a revision round
    * has to guarantee the PR exists first. The PR is never merged and nothing reads it;
-   * it is resumption context, and the adapter closes it when the job finishes.
+   * it is resumption context, left open for the life of the build.
    */
   ensureOpenPullRequest(input: { headRef: string; baseRef: string; title: string; body: string }): Promise<{
     number: number;
@@ -988,14 +976,6 @@ export function createGitHubClient(options: GitHubClientOptions): GitHubClient {
   }
 
   return {
-    async createIssue(input) {
-      const result = await requestJson<{ number: number }>(`https://api.github.com/repos/${repo}/issues`, {
-        method: 'POST',
-        body: JSON.stringify(input),
-      });
-      return { number: result.number };
-    },
-
     async getIssueState(issueNumber) {
       const result = await requestJson<{ state: 'open' | 'closed' }>(
         `https://api.github.com/repos/${repo}/issues/${issueNumber}`,
@@ -1105,13 +1085,6 @@ export function createGitHubClient(options: GitHubClientOptions): GitHubClient {
 
     async closeIssue(issueNumber) {
       await requestJson(`https://api.github.com/repos/${repo}/issues/${issueNumber}`, {
-        method: 'PATCH',
-        body: JSON.stringify({ state: 'closed' }),
-      });
-    },
-
-    async closePullRequest(pullNumber) {
-      await requestJson(`https://api.github.com/repos/${repo}/pulls/${pullNumber}`, {
         method: 'PATCH',
         body: JSON.stringify({ state: 'closed' }),
       });

--- a/apps/api/src/catalog/github-client.ts
+++ b/apps/api/src/catalog/github-client.ts
@@ -302,11 +302,7 @@ export interface GitHubClient {
    * on its open PR.
    */
   createIssueComment(issueOrPrNumber: number, body: string): Promise<{ id: number }>;
-  /**
-   * Rewrites an issue body. Used once, right after creation, to add the build-channel
-   * credentials — they are derived from the issue number, which GitHub only assigns
-   * when the issue already exists.
-   */
+  /** Rewrites an issue body. No production caller — the issue-first flow is retired. */
   updateIssueBody(issueNumber: number, body: string): Promise<void>;
   /** Closes an issue — a creator abandoning their build. */
   closeIssue(issueNumber: number): Promise<void>;

--- a/apps/api/src/catalog/local-games-repo.test.ts
+++ b/apps/api/src/catalog/local-games-repo.test.ts
@@ -131,21 +131,15 @@ describe('local games repo', () => {
     expect(await client.getProgressNotes('main', '../../package.json')).toBeNull();
   });
 
-  it('invents issue state in memory so the creation flow can complete', async () => {
-    const issue = await client.createIssue({
-      title: 'A local game idea',
-      body: 'concept',
-      labels: [],
-    });
-    expect(issue.number).toBeGreaterThan(0);
+  it('invents issue state in memory', async () => {
+    const issueNumber = 1234;
+    expect(await client.getIssueState(issueNumber)).toEqual({ state: 'open' });
 
-    expect(await client.getIssueState(issue.number)).toEqual({ state: 'open' });
-
-    await client.closeIssue(issue.number);
-    expect(await client.getIssueState(issue.number)).toEqual({ state: 'closed' });
+    await client.closeIssue(issueNumber);
+    expect(await client.getIssueState(issueNumber)).toEqual({ state: 'closed' });
 
     // No agent runs locally, so there is never a linked pull request.
-    expect(await client.findLinkedPR(issue.number)).toBeNull();
+    expect(await client.findLinkedPR(issueNumber)).toBeNull();
   });
 
   it('falls back to the bundled fixtures when the configured directory is empty', async () => {

--- a/apps/api/src/game-snapshot-serve.test.ts
+++ b/apps/api/src/game-snapshot-serve.test.ts
@@ -41,13 +41,11 @@ function createGithubStub(catalog: CatalogGameEntry[]) {
   const getGameSources = vi.fn(async () => gameSources());
   const getGameMedia = vi.fn(async () => new Uint8Array([0x67, 0x69, 0x74]));
   const githubClient = {
-    createIssue: vi.fn(async () => ({ number: 1 })),
     getIssueState: vi.fn(async () => ({ state: 'open' as const })),
     findLinkedPR: vi.fn(async () => null),
     createIssueComment: vi.fn(async () => ({ id: 1 })),
     updateIssueBody: vi.fn(async () => {}),
     closeIssue: vi.fn(async () => {}),
-    closePullRequest: vi.fn(async () => {}),
     getGameSources,
     getGameMedia,
     getCatalog,

--- a/apps/api/src/mcp-continue-draft.test.ts
+++ b/apps/api/src/mcp-continue-draft.test.ts
@@ -21,13 +21,11 @@ const DRAFT_ISSUE = 1000018;
 
 function stubGitHub(): GitHubClient {
   return {
-    createIssue: async () => ({ number: DRAFT_ISSUE }),
     getIssueState: async () => ({ state: 'open' as const }),
     findLinkedPR: async (): Promise<LinkedPullRequest | null> => null,
     createIssueComment: async () => ({ id: 1 }),
     updateIssueBody: async () => {},
     closeIssue: async () => {},
-    closePullRequest: async () => {},
     ensureOpenPullRequest: async () => ({ number: 1 }),
     deleteBranch: async () => {},
     getGameSources: async (): Promise<GameSources | null> => null,

--- a/apps/api/src/mcp-oauth-handshake.test.ts
+++ b/apps/api/src/mcp-oauth-handshake.test.ts
@@ -22,13 +22,11 @@ async function buildMcpApp(store: InMemoryStore) {
     sessionSecret: 'dev-session-secret-change-me',
     submissionRoutes: {
       githubClient: {
-        createIssue: async () => ({ number: ISSUE }),
         getIssueState: async () => ({ state: 'open' as const }),
         findLinkedPR: async () => null,
         createIssueComment: async () => ({ id: 1 }),
         updateIssueBody: async () => {},
         closeIssue: async () => {},
-        closePullRequest: async () => {},
         ensureOpenPullRequest: async () => ({ number: 1 }),
         deleteBranch: async () => {},
         getGameSources: async () => null,

--- a/apps/api/src/mcp-open-round.test.ts
+++ b/apps/api/src/mcp-open-round.test.ts
@@ -24,13 +24,11 @@ const PUBLISHED_ISSUE = 10;
 
 function stubGitHub(): GitHubClient {
   return {
-    createIssue: async () => ({ number: PUBLISHED_ISSUE }),
     getIssueState: async () => ({ state: 'open' as const }),
     findLinkedPR: async (): Promise<LinkedPullRequest | null> => null,
     createIssueComment: async () => ({ id: 1 }),
     updateIssueBody: async () => {},
     closeIssue: async () => {},
-    closePullRequest: async () => {},
     ensureOpenPullRequest: async () => ({ number: 1 }),
     deleteBranch: async () => {},
     getGameSources: async (): Promise<GameSources | null> => null,

--- a/apps/api/src/notify-sweep.test.ts
+++ b/apps/api/src/notify-sweep.test.ts
@@ -32,7 +32,6 @@ function publishedGithubClient(): GitHubClient {
     },
   ];
   return {
-    createIssue: async () => ({ number: 42 }),
     getIssueState: async () => ({ state: 'open' }),
     findLinkedPR: async () => mergedPr,
     getGameSources: async () => null,
@@ -53,7 +52,6 @@ function buildingGithubClient(): GitHubClient {
     changedFiles: ['games/sky-dodge/index.html'],
   };
   return {
-    createIssue: async () => ({ number: 42 }),
     getIssueState: async () => ({ state: 'open' }),
     findLinkedPR: async () => openPr,
     getGameSources: async () => null,

--- a/apps/api/src/platform/oauth-as.test.ts
+++ b/apps/api/src/platform/oauth-as.test.ts
@@ -23,13 +23,11 @@ async function buildOAuthApp(store: InMemoryStore) {
     sessionSecret: SESSION_SECRET,
     submissionRoutes: {
       githubClient: {
-        createIssue: async () => ({ number: 42 }),
         getIssueState: async () => ({ state: 'open' as const }),
         findLinkedPR: async () => null,
         createIssueComment: async () => ({ id: 1 }),
         updateIssueBody: async () => {},
         closeIssue: async () => {},
-        closePullRequest: async () => {},
         ensureOpenPullRequest: async () => ({ number: 1 }),
         deleteBranch: async () => {},
         getGameSources: async () => null,
@@ -870,13 +868,11 @@ describe('oauth token helpers', () => {
       sessionSecretPrev: PREV,
       submissionRoutes: {
         githubClient: {
-          createIssue: async () => ({ number: 42 }),
           getIssueState: async () => ({ state: 'open' as const }),
           findLinkedPR: async () => null,
           createIssueComment: async () => ({ id: 1 }),
           updateIssueBody: async () => {},
           closeIssue: async () => {},
-          closePullRequest: async () => {},
           ensureOpenPullRequest: async () => ({ number: 1 }),
           deleteBranch: async () => {},
           getGameSources: async () => null,

--- a/apps/api/src/self-build.test.ts
+++ b/apps/api/src/self-build.test.ts
@@ -15,13 +15,11 @@ const CONCEPT = 'A squad tactics game about clearing rooms with careful timing a
 
 function stubGitHub(): GitHubClient {
   return {
-    createIssue: async () => ({ number: 1 }),
     getIssueState: async () => ({ state: 'open' as const }),
     findLinkedPR: async (): Promise<LinkedPullRequest | null> => null,
     createIssueComment: async () => ({ id: 1 }),
     updateIssueBody: async () => {},
     closeIssue: async () => {},
-    closePullRequest: async () => {},
     ensureOpenPullRequest: async () => ({ number: 1 }),
     deleteBranch: async () => {},
     getGameSources: async (): Promise<GameSources | null> => null,

--- a/apps/api/src/submissions.test.ts
+++ b/apps/api/src/submissions.test.ts
@@ -51,7 +51,6 @@ function createGithubClientStub(params: {
   catalog?: CatalogGameEntry[];
   progressNotes?: string | null;
 }) {
-  const createIssue = vi.fn(async () => ({ number: params.jobId ?? 123 }));
   const getIssueState = vi.fn(async () => ({ state: params.issueState ?? 'open' }));
   const findLinkedPR = vi.fn(async () => params.linkedPr ?? null);
   const getGameSources = vi.fn(async () => params.gameSources ?? null);
@@ -60,16 +59,13 @@ function createGithubClientStub(params: {
   const createIssueComment = vi.fn(async () => ({ id: 1 }));
   const updateIssueBody = vi.fn(async () => {});
   const closeIssue = vi.fn(async () => {});
-  const closePullRequest = vi.fn(async () => {});
   const getProgressNotes = vi.fn(async () => params.progressNotes ?? null);
   const githubClient: GitHubClient = {
-    createIssue,
     getIssueState,
     findLinkedPR,
     createIssueComment,
     updateIssueBody,
     closeIssue,
-    closePullRequest,
     getGameSources,
     getGameMedia,
     getCatalog,
@@ -78,13 +74,11 @@ function createGithubClientStub(params: {
   };
   return {
     githubClient,
-    createIssue,
     getIssueState,
     findLinkedPR,
     createIssueComment,
     updateIssueBody,
     closeIssue,
-    closePullRequest,
     getGameSources,
     getGameMedia,
     getCatalog,
@@ -497,8 +491,8 @@ describe('submission routes', () => {
     await app.close();
   });
 
-  it('rejects a submission that trips content moderation with 422, before creating an issue or spending quota', async () => {
-    const { githubClient, createIssue } = createGithubClientStub({});
+  it('rejects a submission that trips content moderation with 422, before spending quota', async () => {
+    const { githubClient } = createGithubClientStub({});
     const { app, store, authHeaders } = await createApp({ githubClient, submissionTokenSecret: secret });
 
     const response = await app.inject({
@@ -510,7 +504,6 @@ describe('submission routes', () => {
 
     expect(response.statusCode).toBe(422);
     expect(response.json()).toEqual({ error: 'content_rejected', category: 'adult' });
-    expect(createIssue).not.toHaveBeenCalled();
 
     const quota = await store.checkAndIncrementQuota(
       'g:test-user',
@@ -525,7 +518,7 @@ describe('submission routes', () => {
   it('files nothing on GitHub, and sends the sanitized spec straight to an agent', async () => {
     // Job identity is ours: no issue is created, so a build no longer waits on a work
     // item existing in someone else's system before it can be named.
-    const { githubClient, createIssue } = createGithubClientStub({ jobId: 77 });
+    const { githubClient } = createGithubClientStub({ jobId: 77 });
     const { backend, briefs } = createBackendStub();
     const { app, authHeaders, store } = await createApp({
       githubClient,
@@ -545,7 +538,6 @@ describe('submission routes', () => {
     });
 
     expect(response.statusCode).toBe(200);
-    expect(createIssue).not.toHaveBeenCalled();
 
     // The token addresses a job id of ours, allocated above the floor that separates
     // them from the era when identity came from an issue number.
@@ -2909,7 +2901,7 @@ describe('submission routes', () => {
   });
 
   it('abandons a native job without closing anything on GitHub', async () => {
-    const { githubClient, closeIssue, closePullRequest } = createGithubClientStub({ jobId: 77 });
+    const { githubClient, closeIssue } = createGithubClientStub({ jobId: 77 });
     const { backend } = createBackendStub();
     const { app, authHeaders, store } = await createApp({
       githubClient,
@@ -2933,7 +2925,6 @@ describe('submission routes', () => {
 
     expect(response.statusCode).toBe(200);
     expect(closeIssue).not.toHaveBeenCalled();
-    expect(closePullRequest).not.toHaveBeenCalled();
     expect((await store.getSubmission(job.jobId))?.state).toBe('canceled');
 
     await app.close();
@@ -4348,7 +4339,7 @@ describe('POST /api/submissions/:token/improve', () => {
     // last caller of that path after #347 moved dispatch in-house — and nothing collects
     // such an issue any more, so the request went nowhere. An improvement is now a new
     // job carrying the game's slug.
-    const { githubClient, createIssue } = createGithubClientStub({ jobId: 501 });
+    const { githubClient } = createGithubClientStub({ jobId: 501 });
     const store = new InMemoryStore();
     const { backend, briefs } = createBackendStub();
     const { app, authHeaders } = await createApp({
@@ -4370,7 +4361,6 @@ describe('POST /api/submissions/:token/improve', () => {
 
     expect(res.statusCode).toBe(200);
     expect(res.json()).toMatchObject({ ok: true, slug: 'sky-dodge' });
-    expect(createIssue).not.toHaveBeenCalled();
     const dispatched = briefs.at(-1)!;
     expect(dispatched.slug).toBe('sky-dodge');
     expect(dispatched.feedback).toContain('Make level two less punishing');
@@ -4379,7 +4369,7 @@ describe('POST /api/submissions/:token/improve', () => {
   });
 
   it('refuses unpublished games — those still use the draft feedback path', async () => {
-    const { githubClient, createIssue } = createGithubClientStub({});
+    const { githubClient } = createGithubClientStub({});
     const store = new InMemoryStore();
     const { app, authHeaders } = await createApp({ githubClient, submissionTokenSecret: secret, store });
     await store.createSubmission(123, 'g:test-user', 'Not live yet');
@@ -4393,12 +4383,11 @@ describe('POST /api/submissions/:token/improve', () => {
     });
 
     expect(res.statusCode).toBe(409);
-    expect(createIssue).not.toHaveBeenCalled();
     await app.close();
   });
 
   it('refuses someone else’s published game even with a valid token', async () => {
-    const { githubClient, createIssue } = createGithubClientStub({});
+    const { githubClient } = createGithubClientStub({});
     const store = new InMemoryStore();
     const { app, authHeaders } = await createApp({ githubClient, submissionTokenSecret: secret, store });
     await store.createSubmission(123, 'g:someone-else', 'Not yours');
@@ -4413,13 +4402,12 @@ describe('POST /api/submissions/:token/improve', () => {
     });
 
     expect(res.statusCode).toBe(403);
-    expect(createIssue).not.toHaveBeenCalled();
     await app.close();
   });
 
   describe('the Studio mini chat agent', () => {
     it('a conversational reply answers on the current job and opens no new one', async () => {
-      const { githubClient, createIssue } = createGithubClientStub({ jobId: 501 });
+      const { githubClient } = createGithubClientStub({ jobId: 501 });
       const store = new InMemoryStore();
       const { backend, briefs } = createBackendStub();
       const decide = vi.fn(async () => ({ kind: 'reply' as const, text: 'You can tune difficulty from Settings.' }));
@@ -4443,7 +4431,6 @@ describe('POST /api/submissions/:token/improve', () => {
 
       expect(res.statusCode).toBe(200);
       expect(res.json()).toEqual({ ok: true });
-      expect(createIssue).not.toHaveBeenCalled();
       // No new job: the reply lives on the published job's thread.
       expect(briefs).toHaveLength(0);
       const all = await store.listCreatorMessages(123);
@@ -4485,7 +4472,7 @@ describe('POST /api/submissions/:token/improve', () => {
     });
 
     it('a conversational reply does not spend the daily improvement quota', async () => {
-      const { githubClient, createIssue } = createGithubClientStub({ jobId: 501 });
+      const { githubClient } = createGithubClientStub({ jobId: 501 });
       const store = new InMemoryStore();
       const { backend, briefs } = createBackendStub();
       const responses: Array<{ kind: 'reply'; text: string } | { kind: 'build' }> = [
@@ -4518,7 +4505,6 @@ describe('POST /api/submissions/:token/improve', () => {
         expect(res.statusCode).toBe(200);
         expect(res.json()).toEqual({ ok: true });
       }
-      expect(createIssue).not.toHaveBeenCalled();
 
       const build = await app.inject({
         method: 'POST',

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -241,18 +241,16 @@ flowchart LR
 > `by: 'operator'`. That human step is the moderation boundary; do not automate past it.
 
 A round is **dispatched to an agent backend** and the agent delivers back over the **build
-channel**, calling `submit_sources`. It does not travel as a merged pull request: nothing in
-`apps/api` calls `createIssue`, and the managed Copilot provider passes
+channel**, calling `submit_sources`. It does not travel as a merged pull request:
+`GitHubClient` has no issue-creation method at all (the issue-first flow was retired — see
+`docs/steel-thread-plan.md`'s M4 history), and the managed Copilot provider passes
 `createPullRequest: false`, so the agent path opens no pull request at all. The one
 production caller of `ensureOpenPullRequest` is `community/proposal-apply-bot.ts` — the
-repo-lane merge-back, not agent mechanics. The agent's working branch is removed by
-`deleteWorkspace`, which `managed-backend.ts`'s `cleanup` calls when a previous dispatch is
-released (a resume, cancellation or abandonment), not at job completion.
-
-> [!NOTE]
-> `GitHubClient.ensureOpenPullRequest`'s doc comment describes the adapter closing that PR
-> when the job finishes. It does not: `closePullRequest` has no production caller. The
-> comment records an intent the shipped code never implemented — do not plan against it.
+repo-lane merge-back, not agent mechanics. That resumption PR is never closed programmatically
+(there is no `closePullRequest` method); it stays open for the life of the build. The agent's
+working branch is removed by `deleteWorkspace`, which `managed-backend.ts`'s `cleanup` calls
+when a previous dispatch is released (a resume, cancellation or abandonment), not at job
+completion.
 
 `BuilderKind` is `'platform' | 'self'`: the platform's own hosted builder, or the creator's
 own agent connected over MCP.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -246,11 +246,11 @@ channel**, calling `submit_sources`. It does not travel as a merged pull request
 `docs/steel-thread-plan.md`'s M4 history), and the managed Copilot provider passes
 `createPullRequest: false`, so the agent path opens no pull request at all. The one
 production caller of `ensureOpenPullRequest` is `community/proposal-apply-bot.ts` — the
-repo-lane merge-back, not agent mechanics. That resumption PR is never closed programmatically
-(there is no `closePullRequest` method); it stays open for the life of the build. The agent's
-working branch is removed by `deleteWorkspace`, which `managed-backend.ts`'s `cleanup` calls
-when a previous dispatch is released (a resume, cancellation or abandonment), not at job
-completion.
+repo-lane merge-back described just below, not agent mechanics; that PR follows the games
+repo's normal review-and-merge lifecycle, not any programmatic close (`GitHubClient` has no
+`closePullRequest` method). The agent's working branch is removed by `deleteWorkspace`, which
+`managed-backend.ts`'s `cleanup` calls when a previous dispatch is released (a resume,
+cancellation or abandonment), not at job completion.
 
 `BuilderKind` is `'platform' | 'self'`: the platform's own hosted builder, or the creator's
 own agent connected over MCP.

--- a/docs/auth-and-usage-plan.md
+++ b/docs/auth-and-usage-plan.md
@@ -109,8 +109,9 @@ the coarse outer layer (and is the only limiter on `/api/auth/*`).
   - `requireSession` Fastify guard applied per-route. Basic-Auth hook stays outermost.
 - `apps/api/src/platform/store.ts` (new) — thin Firestore wrapper with an **in-memory fake for tests**
   (same seam pattern as the `githubClient` stubs; unit tests never touch real Firestore).
-- `submissions.ts` — owner recorded on create; transactional quota check before
-  `createIssue`; preview requires session; counters incremented on spend.
+- `submissions.ts` — owner recorded on create; transactional quota check before job
+  creation (native-job allocation and direct agent dispatch, not a GitHub issue); preview
+  requires session; counters incremented on spend.
 
 ## Web changes
 


### PR DESCRIPTION
## Summary
- Removes `GitHubClient.createIssue` and `.closePullRequest` — both have zero production callers. Issue-first job creation was retired (see `docs/steel-thread-plan.md`'s M4 history); closing a resumption PR was never wired up anywhere.
- `closeIssue` and `updateIssueBody` are also zero-caller in production but are kept (out of this PR's narrow scope) — their doc comments are corrected to say so plainly instead of describing flows that don't happen.
- Fixes `ensureOpenPullRequest`'s doc comment to describe its actual sole caller (`proposal-apply-bot.ts`'s repo-lane merge-back PR, reviewed and merged normally via CODEOWNERS) instead of the retired agent-resumption intent it originally described.
- Syncs `docs/architecture.md` and `docs/auth-and-usage-plan.md`, which both referenced the removed methods.
- Updates the one test (`local-games-repo.test.ts`) that exercised the deleted `createIssue` path, and strips the now-nonexistent `createIssue`/`closePullRequest` stub properties from all 16 other `GitHubClient`-typed test doubles across the API test suite (unreachable by `type-check` since `apps/api/tsconfig.json` excludes `*.test.ts`, but real TS2353 errors caught by review).
- Small cleanups item from the architecture punch list.

## Test plan
- [x] `npm run type-check -w @gamedevpl/api` — clean
- [x] `npm run lint` (repo root) — 0 errors, same 131 pre-existing warnings
- [x] `npx vitest run` (apps/api) — 3610+ tests, all passing except one confirmed pre-existing flake (`catalog-search.test.ts`, unrelated — a network-timeout test that passes in isolation)
- [x] All 17 test files touched by the stub cleanup re-run individually — 643 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VaPzGSyNfZ7nvGcJgYNSdL)_