### PR TITLE
Bump managed Gemini default to 3.8

### DIFF
--- a/apps/api/src/agent-surface/agent-backend-env.test.ts
+++ b/apps/api/src/agent-surface/agent-backend-env.test.ts
@@ -206,7 +206,7 @@ describe('createAgentBackendRegistryFromEnv', () => {
 
     expect(registry.platformByVendor.get('gemini')?.name).toBe('managed:gemini');
     expect(info).toHaveBeenCalledWith(
-      expect.objectContaining({ vendor: 'gemini', model: 'gemini-3.7-flash' }),
+      expect.objectContaining({ vendor: 'gemini', model: 'gemini-3.8-flash' }),
       'managed agent dispatch enabled',
     );
   });
@@ -226,7 +226,7 @@ describe('createAgentBackendRegistryFromEnv', () => {
     createAgentBackendRegistryFromEnv({ info, warn: vi.fn() });
 
     expect(info).toHaveBeenCalledWith(
-      expect.objectContaining({ vendor: 'gemini', model: 'gemini-3.7-flash' }),
+      expect.objectContaining({ vendor: 'gemini', model: 'gemini-3.8-flash' }),
       'managed agent dispatch enabled',
     );
   });

--- a/apps/api/src/agent-surface/managed-provider-gemini.ts
+++ b/apps/api/src/agent-surface/managed-provider-gemini.ts
@@ -11,7 +11,7 @@ import {
 
 export const GEMINI_VENDOR = 'gemini';
 export const GEMINI_DEFAULT_AGENT = 'antigravity-preview-05-2026';
-export const GEMINI_DEFAULT_MODEL = 'gemini-3.7-flash';
+export const GEMINI_DEFAULT_MODEL = 'gemini-3.8-flash';
 
 const DEFAULT_BASE_URL = 'https://generativelanguage.googleapis.com/v1beta';
 const DEFAULT_TIMEOUT_MS = 30_000;


### PR DESCRIPTION
Managed agent dispatch should default Gemini rounds to the newer 3.8 Flash model when no override is supplied.

This keeps the code path that builds the Gemini managed provider and the registry expectations in sync, so the backend actually runs on 3.8 by default instead of the older 3.7 default.

**Changes**
- Update the Gemini managed-provider default model constant to `gemini-3.8-flash`.
- Update the backend-env tests that assert the emitted default model.

**Notes**
- I kept the change scoped to the managed-agent backend default path and its directly coupled tests.
- No docs were updated because the repo search only showed the managed-agent probe docs referencing the older default, and that probe is separate from the live backend default path.