### PR TITLE
Upgrade Gemini Flash defaults to 3.8

### DIFF
--- a/apps/api/scripts/managed-probe.ts
+++ b/apps/api/scripts/managed-probe.ts
@@ -120,7 +120,7 @@ const model =
     : vendor === 'copilot'
       ? 'claude-sonnet-4.6'
       : vendor === 'gemini'
-        ? 'gemini-3.7-flash'
+        ? 'gemini-3.8-flash'
         : undefined);
 if (!apiKey || !model) {
   console.error(`--vendor ${vendor} needs an API key and model`);

--- a/apps/api/src/agent-surface/agent-backend-env.test.ts
+++ b/apps/api/src/agent-surface/agent-backend-env.test.ts
@@ -206,7 +206,7 @@ describe('createAgentBackendRegistryFromEnv', () => {
 
     expect(registry.platformByVendor.get('gemini')?.name).toBe('managed:gemini');
     expect(info).toHaveBeenCalledWith(
-      expect.objectContaining({ vendor: 'gemini', model: 'gemini-3.7-flash' }),
+      expect.objectContaining({ vendor: 'gemini', model: 'gemini-3.8-flash' }),
       'managed agent dispatch enabled',
     );
   });
@@ -226,7 +226,7 @@ describe('createAgentBackendRegistryFromEnv', () => {
     createAgentBackendRegistryFromEnv({ info, warn: vi.fn() });
 
     expect(info).toHaveBeenCalledWith(
-      expect.objectContaining({ vendor: 'gemini', model: 'gemini-3.7-flash' }),
+      expect.objectContaining({ vendor: 'gemini', model: 'gemini-3.8-flash' }),
       'managed agent dispatch enabled',
     );
   });

--- a/apps/api/src/agent-surface/managed-provider-gemini.ts
+++ b/apps/api/src/agent-surface/managed-provider-gemini.ts
@@ -11,7 +11,7 @@ import {
 
 export const GEMINI_VENDOR = 'gemini';
 export const GEMINI_DEFAULT_AGENT = 'antigravity-preview-05-2026';
-export const GEMINI_DEFAULT_MODEL = 'gemini-3.7-flash';
+export const GEMINI_DEFAULT_MODEL = 'gemini-3.8-flash';
 
 const DEFAULT_BASE_URL = 'https://generativelanguage.googleapis.com/v1beta';
 const DEFAULT_TIMEOUT_MS = 30_000;

--- a/apps/api/src/community/feedback-themes.ts
+++ b/apps/api/src/community/feedback-themes.ts
@@ -175,7 +175,7 @@ export class VertexThemeExtractor implements ThemeExtractor {
         region: this.options.region,
         defaultRegion: 'global',
         model: this.options.model,
-        defaultModel: 'gemini-3.7-flash',
+        defaultModel: 'gemini-3.8-flash',
         // Thinking level goes via `.thinking()` below — see moderation.ts's VertexChecker.
         generationConfig: {
           responseMimeType: 'application/json',

--- a/apps/api/src/creation/chat-agent.test.ts
+++ b/apps/api/src/creation/chat-agent.test.ts
@@ -286,7 +286,7 @@ describe('VertexStudioChatAgent', () => {
     expect(totalChars).toBeLessThan(MAX_PROMPT_CHARS);
   });
 
-  it('keeps thinking at the cheap floor on every call — gemini-3.7-flash rejects both a raw thinkingBudget:0 and thinking:false (which genaicode maps to the also-rejected MINIMAL level)', async () => {
+  it('keeps thinking at the cheap floor on every call — gemini-3.8-flash rejects both a raw thinkingBudget:0 and thinking:false (which genaicode maps to the also-rejected MINIMAL level)', async () => {
     let seen: GenerationRequest | undefined;
     const agent = new VertexStudioChatAgent({
       client: stubClient(textResult('ok'), (req) => (seen = req)),

--- a/apps/api/src/creation/chat-agent.ts
+++ b/apps/api/src/creation/chat-agent.ts
@@ -8,7 +8,7 @@ import type { JobStall } from './job-state.js';
 
 // decide() throws on any failure; callers must fail open.
 
-export const DEFAULT_CHAT_MODEL = 'gemini-3.7-flash';
+export const DEFAULT_CHAT_MODEL = 'gemini-3.8-flash';
 // Live Vertex ran slower than the API key it was tuned on.
 export const DEFAULT_CHAT_TIMEOUT_MS = 8000;
 // Enough for genre/premise, not a spec dump.

--- a/apps/api/src/creation/code-lane.ts
+++ b/apps/api/src/creation/code-lane.ts
@@ -40,7 +40,7 @@ import { formatRemixTurns } from './remix-turns.js';
  * compile. No agent, no tools, no credentials in a runtime.
  */
 
-export const DEFAULT_CODE_MODEL = 'gemini-3.7-flash';
+export const DEFAULT_CODE_MODEL = 'gemini-3.8-flash';
 export const DEFAULT_PICK_TIMEOUT_MS = 8000;
 export const DEFAULT_EDIT_TIMEOUT_MS = 20000;
 /** Rounds of "here is the compiler error, try again" before giving up. */

--- a/apps/api/src/creation/editor-assist.ts
+++ b/apps/api/src/creation/editor-assist.ts
@@ -35,7 +35,7 @@ import { formatRemixTurns } from './remix-turns.js';
 
 export { ASSIST_LANES, type AssistLane };
 
-export const DEFAULT_ASSIST_MODEL = 'gemini-3.7-flash';
+export const DEFAULT_ASSIST_MODEL = 'gemini-3.8-flash';
 export const DEFAULT_ASSIST_TIMEOUT_MS = 8000;
 /** Utterances are one-liners; a wall of text is a prompt-injection vehicle, not a tweak. */
 export const MAX_UTTERANCE_LENGTH = 240;

--- a/apps/api/src/creation/game-seed.test.ts
+++ b/apps/api/src/creation/game-seed.test.ts
@@ -2,9 +2,7 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import {
   buildGeneratePrompt,
   collectSeedFiles,
-  isAllowedSeedPath,
   isUsableSeed,
-  normalizeSeedPath,
   parseSeedResponse,
   renderKnowledgeContext,
   ModelGameSeeder,
@@ -96,55 +94,6 @@ describe('parseSeedResponse', () => {
 
   it('finds no files in prose', () => {
     expect(parseSeedResponse('I cannot help with that request.').files).toEqual([]);
-  });
-});
-
-describe('seed path containment', () => {
-  it('strips the games/<slug>/ prefix a model actually emits', () => {
-    expect(normalizeSeedPath('games/my-game/SPEC.md', 'my-game')).toBe('SPEC.md');
-    expect(normalizeSeedPath('./game/model.ts', 'my-game')).toBe('game/model.ts');
-  });
-
-  it('refuses everything outside the one game directory', () => {
-    for (const allowed of [
-      'SPEC.md',
-      'GAME.json',
-      'game.ts',
-      'index.html',
-      'style.css',
-      'ACCEPTANCE.json',
-      'EDITOR.json',
-      'EDITOR.ts',
-      'EDITOR.content.json',
-      'game/model.ts',
-      'game/ai/steering.ts',
-    ]) {
-      expect(isAllowedSeedPath(allowed), allowed).toBe(true);
-    }
-
-    for (const refused of [
-      // Another game, the engine, the tooling, and CI — the four things a seed must
-      // never be able to reach, however the model labels them.
-      'games/other-game/game.ts',
-      'shared/modules/gfx.ts',
-      'tools/validate.ts',
-      '.github/workflows/validate.yml',
-      '../evil.ts',
-      'game/../../evil.ts',
-      '/etc/passwd',
-      // Right directory, wrong kind of file: media and goldens are the gate's to write.
-      'TRACE.json',
-      'CAPTURE.json',
-      'media/opening.png',
-      'game/notes.md',
-    ]) {
-      expect(isAllowedSeedPath(normalizeSeedPath(refused, 'my-game')), refused).toBe(false);
-    }
-  });
-
-  it('does not let another game be reached by prefixing it with this slug', () => {
-    // `games/my-game/` is stripped once; what remains still has to be inside the game.
-    expect(isAllowedSeedPath(normalizeSeedPath('games/my-game/../other/game.ts', 'my-game'))).toBe(false);
   });
 });
 

--- a/apps/api/src/creation/game-seed.test.ts
+++ b/apps/api/src/creation/game-seed.test.ts
@@ -112,7 +112,10 @@ describe('seed path containment', () => {
       'game.ts',
       'index.html',
       'style.css',
-      'ACCEPTANCE.json', 'EDITOR.json', 'EDITOR.ts', 'EDITOR.content.json',
+      'ACCEPTANCE.json',
+      'EDITOR.json',
+      'EDITOR.ts',
+      'EDITOR.content.json',
       'game/model.ts',
       'game/ai/steering.ts',
     ]) {
@@ -198,7 +201,8 @@ describe('isUsableSeed', () => {
     // The failure mode this exists for: a seed branch that claims a scaffold exists
     // while containing nothing the agent could continue.
     expect(isUsableSeed([file('SPEC.md')])).toBe(false);
-    expect(isUsableSeed([file('EDITOR.ts'), file('SPEC.md'), file('game.ts'), file('game/model.ts')])).toBe(false); expect(isUsableSeed([file('SPEC.md'), file('game.ts')])).toBe(false);
+    expect(isUsableSeed([file('EDITOR.ts'), file('SPEC.md'), file('game.ts'), file('game/model.ts')])).toBe(false);
+    expect(isUsableSeed([file('SPEC.md'), file('game.ts')])).toBe(false);
     expect(isUsableSeed([])).toBe(false);
   });
 });
@@ -337,7 +341,7 @@ function stubClient(responses: { text: string; inputTokens?: number; outputToken
     const response = responses[Math.min(call++, responses.length - 1)];
     return makeChain(() => ({
       parts: [{ type: 'text' as const, text: response.text }],
-      model: 'gemini-3.7-flash',
+      model: 'gemini-3.8-flash',
       usage: { inputTokens: response.inputTokens ?? 100, outputTokens: response.outputTokens ?? 50 },
     }));
   };
@@ -352,7 +356,7 @@ function stubClientWithPrompts(responses: { text: string }[]) {
     const response = responses[Math.min(call++, responses.length - 1)];
     return makeChain(() => ({
       parts: [{ type: 'text' as const, text: response.text }],
-      model: 'gemini-3.7-flash',
+      model: 'gemini-3.8-flash',
       usage: { inputTokens: 100, outputTokens: 50 },
     }));
   }) as unknown as ConstructorParameters<typeof ModelGameSeeder>[0]['client'];
@@ -411,13 +415,13 @@ interface GameKitGameContext {
 describe('ModelGameSeeder', () => {
   const request = { slug: 'my-game', title: 'My Game', spec: 'A game about tanks' };
 
-  it('asks for the low thinking floor, not a raw budget gemini-3.7-flash rejects', async () => {
+  it('asks for the low thinking floor, not a raw budget gemini-3.8-flash rejects', async () => {
     const thinkingArgs: unknown[] = [];
     const client = (() =>
       makeChain(
         () => ({
           parts: [{ type: 'text' as const, text: '{"picks":["apex-sprint"]}' }],
-          model: 'gemini-3.7-flash',
+          model: 'gemini-3.8-flash',
           usage: { inputTokens: 100, outputTokens: 10 },
         }),
         { onThinking: (arg) => thinkingArgs.push(arg) },
@@ -450,7 +454,7 @@ describe('ModelGameSeeder', () => {
     expect(draft!.usage).toEqual({
       inputTokens: 30_400,
       outputTokens: 8_010,
-      model: 'gemini-3.7-flash',
+      model: 'gemini-3.8-flash',
       provider: 'vertex',
     });
   });
@@ -478,7 +482,7 @@ describe('ModelGameSeeder', () => {
           if (thisCall !== 0) throw new Error('the generate call must stream, not run()');
           return {
             parts: [{ type: 'text' as const, text: '{"picks":["apex-sprint"]}' }],
-            model: 'gemini-3.7-flash',
+            model: 'gemini-3.8-flash',
             usage: { inputTokens: 100, outputTokens: 10 },
           };
         },
@@ -489,7 +493,7 @@ describe('ModelGameSeeder', () => {
             type: 'done' as const,
             result: {
               parts: [{ type: 'text' as const, text: GOOD_DRAFT }],
-              model: 'gemini-3.7-flash',
+              model: 'gemini-3.8-flash',
               usage: { inputTokens: 30_000, outputTokens: 8_000 },
             },
           };
@@ -754,7 +758,12 @@ describe('ModelGameSeeder', () => {
     expect(draft!.compiles).toBe(true);
     expect(draft!.repaired).toBe(true);
     expect(draft!.files.find((file) => file.path === 'game/model.ts')!.content).toBe('export const SPEED = 4;\n');
-    expect(draft!.files.map((file) => file.path).sort()).toEqual(['EDITOR.json', 'SPEC.md', 'game.ts', 'game/model.ts']);
+    expect(draft!.files.map((file) => file.path).sort()).toEqual([
+      'EDITOR.json',
+      'SPEC.md',
+      'game.ts',
+      'game/model.ts',
+    ]);
     // The repair round is billed like the rounds before it.
     expect(draft!.usage.inputTokens).toBe(400 + 30_000 + 9_000);
     expect(draft!.usage.outputTokens).toBe(10 + 8_000 + 700);

--- a/apps/api/src/creation/game-seed.ts
+++ b/apps/api/src/creation/game-seed.ts
@@ -35,7 +35,17 @@ import type { QueryKnowledgeFn } from './knowledge-search.js';
  * objective ("collect at least one star"), and a seed that leaves it there fails the
  * gate's accept stage structurally, for every game, no matter how good the draft is.
  */
-const TOP_LEVEL_ALLOWED = new Set(['SPEC.md', 'GAME.json', 'game.ts', 'index.html', 'style.css', 'ACCEPTANCE.json', 'EDITOR.json', 'EDITOR.ts', 'EDITOR.content.json']);
+const TOP_LEVEL_ALLOWED = new Set([
+  'SPEC.md',
+  'GAME.json',
+  'game.ts',
+  'index.html',
+  'style.css',
+  'ACCEPTANCE.json',
+  'EDITOR.json',
+  'EDITOR.ts',
+  'EDITOR.content.json',
+]);
 
 /** The fence label carrying the hand-off note rather than a file. */
 const NOTES_FENCE = 'NOTES';
@@ -268,7 +278,8 @@ export function collectSeedFiles(parsed: ParsedSeedResponse, slug: string): Seed
  */
 export function isUsableSeed(files: SeedFile[]): boolean {
   const paths = new Set(files.map((file) => file.path));
-  const hasModule = files.some((file) => file.path.startsWith('game/') && file.path.endsWith('.ts')); const hasEditor = paths.has('EDITOR.json');
+  const hasModule = files.some((file) => file.path.startsWith('game/') && file.path.endsWith('.ts'));
+  const hasEditor = paths.has('EDITOR.json');
   return paths.has('game.ts') && paths.has('SPEC.md') && hasModule && hasEditor;
 }
 
@@ -537,7 +548,7 @@ export class ModelGameSeeder implements GameSeeder {
     spec: string,
     providerId: string,
   ): Promise<{ picks: string[]; usage: SeedUsage }> {
-    // Raw thinkingBudget:0 also 400s on gemini-3.7-flash; 'low' is the floor.
+    // Raw thinkingBudget:0 also 400s on gemini-3.8-flash; 'low' is the floor.
     // Reasoning-locked models reject temperature overrides; schema constraints suffice.
     const result = await this.client(providerId)(buildPickPrompt(context, spec, this.references))
       .responseFormat(this.pickResponseFormat())

--- a/apps/api/src/creation/game-seed.ts
+++ b/apps/api/src/creation/game-seed.ts
@@ -16,7 +16,6 @@
 // same exposure refine.ts has carried in production, same containment — output lands
 // in a workspace whose only exits are our gate and human review, and the path guard
 // below refuses anything outside one game directory.
-import path from 'node:path';
 import { z } from 'zod';
 import type { GenAIClient, GenerationResult } from 'genaicode';
 import { createSeedClient, type SeedProviderConfig } from './seed-provider.js';
@@ -27,25 +26,9 @@ import { typeCheckGame } from './type-check.js';
 import type { TypeCheckResult } from './type-check.js';
 import { TYPECHECK_PREFLIGHT_BUDGET_MS } from './typecheck-preflight.js';
 import type { QueryKnowledgeFn } from './knowledge-search.js';
+import { isAllowedSeedPath, normalizeSeedPath } from './seed-paths.js';
 
-/**
- * Files a seed is allowed to write, relative to `games/<slug>/`.
- *
- * ACCEPTANCE.json is included deliberately: the games repo template ships a placeholder
- * objective ("collect at least one star"), and a seed that leaves it there fails the
- * gate's accept stage structurally, for every game, no matter how good the draft is.
- */
-const TOP_LEVEL_ALLOWED = new Set([
-  'SPEC.md',
-  'GAME.json',
-  'game.ts',
-  'index.html',
-  'style.css',
-  'ACCEPTANCE.json',
-  'EDITOR.json',
-  'EDITOR.ts',
-  'EDITOR.content.json',
-]);
+export { isAllowedSeedPath, normalizeSeedPath } from './seed-paths.js';
 
 /** The fence label carrying the hand-off note rather than a file. */
 const NOTES_FENCE = 'NOTES';
@@ -160,33 +143,6 @@ export interface GameSeeder {
 }
 
 const PickSchema = z.object({ picks: z.array(z.string()).optional() });
-
-/**
- * Strips what a model prepends in practice, so the guard judges the path a file would
- * actually land on rather than the string it was labelled with.
- */
-export function normalizeSeedPath(relative: string, slug: string): string {
-  let normalized = relative.trim().replaceAll('\\', '/').replace(/^\.\//, '');
-  const prefix = `games/${slug}/`;
-  if (normalized.startsWith(prefix)) normalized = normalized.slice(prefix.length);
-  return path.posix.normalize(normalized);
-}
-
-/**
- * Whether a normalized path is inside the one game directory this seed may write.
- *
- * The whole containment story for generated content: a draft is model output derived
- * from untrusted creator text, so nothing decides where its bytes go except this
- * function. Traversal, absolute paths, other games, `shared/`, `tools/` and every
- * non-source file are refused rather than sanitized.
- */
-export function isAllowedSeedPath(normalized: string): boolean {
-  if (!normalized || normalized.startsWith('..') || normalized.startsWith('/') || path.posix.isAbsolute(normalized)) {
-    return false;
-  }
-  if (TOP_LEVEL_ALLOWED.has(normalized)) return true;
-  return normalized.startsWith('game/') && normalized.endsWith('.ts');
-}
 
 export interface ParsedSeedResponse {
   files: { path: string; content: string }[];

--- a/apps/api/src/creation/refine.ts
+++ b/apps/api/src/creation/refine.ts
@@ -160,7 +160,7 @@ export class VertexSpecRefiner implements SpecRefiner {
         region: this.options.region,
         defaultRegion: 'global',
         model: this.options.model,
-        defaultModel: 'gemini-3.7-flash',
+        defaultModel: 'gemini-3.8-flash',
         generationConfig: {
           responseMimeType: 'application/json',
         } as VertexGenerationConfig,
@@ -176,7 +176,7 @@ export class VertexSpecRefiner implements SpecRefiner {
         region: this.options.region,
         defaultRegion: 'global',
         model: this.options.model,
-        defaultModel: 'gemini-3.7-flash',
+        defaultModel: 'gemini-3.8-flash',
       });
     return this.groundingClient;
   }

--- a/apps/api/src/creation/seed-paths.test.ts
+++ b/apps/api/src/creation/seed-paths.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+import { isAllowedSeedPath, normalizeSeedPath } from './seed-paths.js';
+
+describe('seed path containment', () => {
+  it('strips the games/<slug>/ prefix a model actually emits', () => {
+    expect(normalizeSeedPath('games/my-game/SPEC.md', 'my-game')).toBe('SPEC.md');
+    expect(normalizeSeedPath('./game/model.ts', 'my-game')).toBe('game/model.ts');
+  });
+
+  it('refuses everything outside the one game directory', () => {
+    for (const allowed of [
+      'SPEC.md',
+      'GAME.json',
+      'game.ts',
+      'index.html',
+      'style.css',
+      'ACCEPTANCE.json',
+      'EDITOR.json',
+      'EDITOR.ts',
+      'EDITOR.content.json',
+      'game/model.ts',
+      'game/ai/steering.ts',
+    ]) {
+      expect(isAllowedSeedPath(allowed), allowed).toBe(true);
+    }
+
+    for (const refused of [
+      'games/other-game/game.ts',
+      'shared/modules/gfx.ts',
+      'tools/validate.ts',
+      '.github/workflows/validate.yml',
+      '../evil.ts',
+      'game/../../evil.ts',
+      '/etc/passwd',
+      'TRACE.json',
+      'CAPTURE.json',
+      'media/opening.png',
+      'game/notes.md',
+    ]) {
+      expect(isAllowedSeedPath(normalizeSeedPath(refused, 'my-game')), refused).toBe(false);
+    }
+  });
+  it('does not let another game be reached by prefixing it with this slug', () => {
+    expect(isAllowedSeedPath(normalizeSeedPath('games/my-game/../other/game.ts', 'my-game'))).toBe(false);
+  });
+});

--- a/apps/api/src/creation/seed-paths.ts
+++ b/apps/api/src/creation/seed-paths.ts
@@ -1,0 +1,28 @@
+import path from 'node:path';
+
+const TOP_LEVEL_ALLOWED = new Set([
+  'SPEC.md',
+  'GAME.json',
+  'game.ts',
+  'index.html',
+  'style.css',
+  'ACCEPTANCE.json',
+  'EDITOR.json',
+  'EDITOR.ts',
+  'EDITOR.content.json',
+]);
+
+export function normalizeSeedPath(relative: string, slug: string): string {
+  let normalized = relative.trim().replaceAll('\\', '/').replace(/^\.\//, '');
+  const prefix = `games/${slug}/`;
+  if (normalized.startsWith(prefix)) normalized = normalized.slice(prefix.length);
+  return path.posix.normalize(normalized);
+}
+
+export function isAllowedSeedPath(normalized: string): boolean {
+  if (!normalized || normalized.startsWith('..') || normalized.startsWith('/') || path.posix.isAbsolute(normalized)) {
+    return false;
+  }
+  if (TOP_LEVEL_ALLOWED.has(normalized)) return true;
+  return normalized.startsWith('game/') && normalized.endsWith('.ts');
+}

--- a/apps/api/src/creation/seed-stream.test.ts
+++ b/apps/api/src/creation/seed-stream.test.ts
@@ -8,7 +8,7 @@ async function* chunks(pieces: string[]): AsyncGenerator<StreamEvent> {
     type: 'done',
     result: {
       parts: [{ type: 'text', text: pieces.join('') }],
-      model: 'gemini-3.7-flash',
+      model: 'gemini-3.8-flash',
       usage: { inputTokens: 100, outputTokens: 50 },
     },
   };

--- a/apps/api/src/creation/tab-complete.ts
+++ b/apps/api/src/creation/tab-complete.ts
@@ -2,7 +2,7 @@ import { resultText, type GenAIClient, type GenerationResult } from 'genaicode';
 import { createVertexClient, type VertexGenerationConfig } from '../platform/genai.js';
 
 // TA-01: prompt-based FIM — Vertex Gemini has no suffix field.
-export const DEFAULT_TAB_COMPLETE_MODEL = 'gemini-3.7-flash';
+export const DEFAULT_TAB_COMPLETE_MODEL = 'gemini-3.8-flash';
 export const DEFAULT_TAB_COMPLETE_TIMEOUT_MS = 4000;
 // continue.dev's shape: ~700 tokens prefix, ~300 suffix, ~4 chars/token.
 export const MAX_PREFIX_CHARS = 3000;

--- a/apps/api/src/platform/moderation.ts
+++ b/apps/api/src/platform/moderation.ts
@@ -118,7 +118,7 @@ export interface VertexCheckerOptions {
   projectId?: string;
   region?: string;
   model?: string;
-  // Gemini 3 thinking level ('low' | 'medium' | 'high'). gemini-3.7-flash dropped
+  // Gemini 3 thinking level ('low' | 'medium' | 'high'). gemini-3.8-flash dropped
   // 'minimal' (400 THINKING_LEVEL_MINIMAL unsupported) — 'low' is now the floor.
   thinkingLevel?: string;
   timeoutMs?: number;
@@ -162,7 +162,7 @@ export class VertexChecker implements ContentChecker {
         region: this.options.region,
         defaultRegion: 'global',
         model: this.options.model,
-        defaultModel: 'gemini-3.7-flash',
+        defaultModel: 'gemini-3.8-flash',
         // Thinking level goes on the request via `.thinking()` below, not here: genaicode's
         // Google provider computes its own thinkingConfig from `request.thinking` whenever a
         // request calls `.json()`, and that computed value — MINIMAL when `.thinking()` was

--- a/apps/api/src/store/records/dispatch.ts
+++ b/apps/api/src/store/records/dispatch.ts
@@ -46,7 +46,7 @@ export interface JobCostEntry {
   at: string;
   /**
    * Who charged for it: an agent backend (`copilot`), a service (`cloud-build`), or —
-   * for a `seed` entry — the model id that billed the tokens (`gemini-3.7-flash`).
+   * for a `seed` entry — the model id that billed the tokens (`gemini-3.8-flash`).
    * A model id here is a well-formed entry, not corrupt data.
    */
   by: string;

--- a/apps/api/src/submissions.test.ts
+++ b/apps/api/src/submissions.test.ts
@@ -4141,7 +4141,7 @@ describe('the Studio mini chat agent (feedback route)', () => {
       kind: 'reply' as const,
       text: 'Still building.',
       tokens: { input: 500, output: 40 },
-      model: 'gemini-3.7-flash',
+      model: 'gemini-3.8-flash',
     }));
     const { app, authHeaders, store } = await createApp({
       githubClient: createGithubClientStub({ jobId: 90 }).githubClient,
@@ -4167,7 +4167,7 @@ describe('the Studio mini chat agent (feedback route)', () => {
 
     const record = await store.getSubmission(job.jobId);
     const entry = record?.costs?.find((cost) => cost.kind === 'chat');
-    expect(entry).toMatchObject({ by: 'gemini-3.7-flash', tokens: { input: 500, output: 40 } });
+    expect(entry).toMatchObject({ by: 'gemini-3.8-flash', tokens: { input: 500, output: 40 } });
     await app.close();
   });
 
@@ -6686,7 +6686,7 @@ describe('seeded dispatch', () => {
           slug,
           files: [{ path: 'game.ts', content: 'export {};\n' }],
           references: ['apex-sprint'],
-          usage: { inputTokens: 30_000, outputTokens: 9_000, model: 'gemini-3.7-flash' },
+          usage: { inputTokens: 30_000, outputTokens: 9_000, model: 'gemini-3.8-flash' },
           elapsedMs: 41_000,
           compiles: false,
           repaired: false,
@@ -6737,7 +6737,7 @@ describe('seeded dispatch', () => {
     // premium request with no numbers behind it.
     const seedCost = record?.costs?.find((entry) => entry.kind === 'seed');
     expect(seedCost?.tokens).toEqual({ input: 30_000, output: 9_000 });
-    expect(seedCost?.by).toBe('gemini-3.7-flash');
+    expect(seedCost?.by).toBe('gemini-3.8-flash');
 
     await app.close();
   });
@@ -6824,7 +6824,7 @@ describe('seeded dispatch', () => {
           slug: request.slug,
           files: [{ path: 'game.ts', content: 'export {};\n' }],
           references: ['apex-sprint'],
-          usage: { inputTokens: 100, outputTokens: 50, model: 'gemini-3.7-flash', provider: 'vertex' },
+          usage: { inputTokens: 100, outputTokens: 50, model: 'gemini-3.8-flash', provider: 'vertex' },
           elapsedMs: 1_000,
           compiles: true,
           repaired: false,

--- a/docs/managed-agent-backend.md
+++ b/docs/managed-agent-backend.md
@@ -386,7 +386,7 @@ npm run managed:probe -w @gamedevpl/api -- --vendor gemini --wait \
   --wait-seconds 120 --budget-tokens 50000
 ```
 
-`--vendor gemini` defaults to `gemini-3.7-flash`; `GEMINI_API_KEY` or
+`--vendor gemini` defaults to `gemini-3.8-flash`; `GEMINI_API_KEY` or
 `MANAGED_AGENT_API_KEY` supplies the credential and `--model` overrides the model label.
 
 OpenAI also uses a native token ceiling, forwarded as `max_output_tokens` — a partial


### PR DESCRIPTION
## Why
The repo still referenced `gemini-3.7-flash` in runtime defaults, managed-agent wiring, tests, and docs. This upgrade aligns the site stack with `gemini-3.8-flash` so model defaults and expectations match across code paths.

## What changed
- Switched Gemini default model constants and `defaultModel` fallbacks from `gemini-3.7-flash` to `gemini-3.8-flash` in managed-provider and API creation/moderation surfaces.
- Updated related tests and assertions that pin model IDs in usage/cost and environment expectations.
- Updated managed backend docs and inline comments that referenced `gemini-3.7-flash` behavior/examples.

## Notes
This is a targeted model-name upgrade only; no behavioral logic changes were introduced beyond changing the default model identifier.