### PR TITLE
fix(web): remove obsolete editable badge from catalog and game details

### DIFF
--- a/apps/web/src/GameDetailPage.tsx
+++ b/apps/web/src/GameDetailPage.tsx
@@ -82,11 +82,6 @@ export function GameDetailPage({ game, state, onPlay, onPlayTogether, onRemix, o
         <div className="game-page-kicker">
           {authorPath ? <a href={authorPath}>{authorLabel}</a> : <span>{authorLabel}</span>}
           {game.genre ? <span className="game-page-genre">{game.genre}</span> : null}
-          {game.editor === 'content' ? (
-            <span className="game-page-genre game-page-editor-badge">
-              <PixelIcon name="pencil" size={11} /> {t('catalog.editorBadge')}
-            </span>
-          ) : null}
         </div>
         <h1>{game.title}</h1>
 

--- a/apps/web/src/GamePage.tsx
+++ b/apps/web/src/GamePage.tsx
@@ -234,11 +234,6 @@ export function GamePage({
           <span aria-hidden="true"> / </span>
           <span className="game-page-breadcrumb-slug">{slug}</span>
           {entry.genre ? <span className="game-page-genre">{entry.genre}</span> : null}
-          {entry.editor === 'content' ? (
-            <span className="game-page-genre game-page-editor-badge">
-              <PixelIcon name="pencil" size={11} /> {t('catalog.editorBadge')}
-            </span>
-          ) : null}
         </nav>
         <h1>{entry.title}</h1>
         {page.description ? <p className="game-page-description">{page.description}</p> : null}
@@ -262,7 +257,12 @@ export function GamePage({
             </a>
           ) : null}
           {entry.editor === 'content' ? (
-            <button type="button" className="secondary-btn game-page-remix" onClick={openRemixEntry} ref={remixButtonRef}>
+            <button
+              type="button"
+              className="secondary-btn game-page-remix"
+              onClick={openRemixEntry}
+              ref={remixButtonRef}
+            >
               <PixelIcon name="wrench" size={13} /> {t('gamePage.remix')}
             </button>
           ) : null}

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -268,8 +268,6 @@
     "cameraBadge": "Camera play",
     "cameraTooltip": "This game can show your camera behind the play surface — nothing is recorded or sent",
     "savesBadge": "Saves progress",
-    "editorBadge": "Editable",
-    "editorTooltip": "This game has a built-in content editor",
     "sortLabel": "Sort games",
     "toolbarLabel": "Catalog filters and sort",
     "yoursBadge": "Yours",

--- a/apps/web/src/i18n/locales/pl.json
+++ b/apps/web/src/i18n/locales/pl.json
@@ -268,8 +268,6 @@
     "cameraBadge": "Gra z kamerą",
     "cameraTooltip": "Ta gra może pokazać kamerę pod powierzchnią gry — nic nie jest nagrywane ani wysyłane",
     "savesBadge": "Zapisuje postępy",
-    "editorBadge": "Edytowalna",
-    "editorTooltip": "Ta gra ma wbudowany edytor zawartości",
     "sortLabel": "Sortuj gry",
     "toolbarLabel": "Filtry i sortowanie katalogu",
     "yoursBadge": "Twoje",

--- a/apps/web/src/surfaces/catalog/ArcadeCatalog.test.tsx
+++ b/apps/web/src/surfaces/catalog/ArcadeCatalog.test.tsx
@@ -521,7 +521,6 @@ describe('ArcadeCatalog shared-world badge', () => {
               slug: 'shared-one',
               title: 'Shared One',
               world: 'shared' as const,
-              editor: 'content' as const,
             },
             { ...entries[1]!, slug: 'solo-one', title: 'Solo One', world: null },
           ],
@@ -540,8 +539,6 @@ describe('ArcadeCatalog shared-world badge', () => {
     const badged = cards.find((card) => card.querySelector('.card-world-badge'));
     expect(badged?.textContent).toContain('Shared One');
     expect(badged?.textContent).not.toContain('Solo One');
-    expect(badged?.querySelector('[title="This game has a built-in content editor"]')).not.toBeNull();
-    expect(cards[1]?.querySelector('[title="This game has a built-in content editor"]')).toBeNull();
 
     await act(async () => {
       root.unmount();

--- a/apps/web/src/surfaces/catalog/ArcadeCatalog.tsx
+++ b/apps/web/src/surfaces/catalog/ArcadeCatalog.tsx
@@ -427,11 +427,6 @@ function CatalogCard({
                   <PixelIcon name="star" size={12} /> {t('catalog.worldBadge')}
                 </span>
               )}
-              {entry.editor === 'content' && (
-                <span className="card-party-badge" title={t('catalog.editorTooltip')}>
-                  <PixelIcon name="pencil" size={12} /> {t('catalog.editorBadge')}
-                </span>
-              )}
               {/* Advisory, like saves: says the game answers tilt where the device offers
                 it, while the keyboard stays the whole game everywhere else. Reuses the
                 party pill style — it is the same "how you can drive this" family. */}

--- a/apps/web/src/surfaces/catalog/CatalogRail.test.tsx
+++ b/apps/web/src/surfaces/catalog/CatalogRail.test.tsx
@@ -67,9 +67,9 @@ function render(entries: CatalogEntry[]) {
 }
 
 describe('RailCard hover video preview', () => {
-  it('shows the editor capability badge on editable rail cards', () => {
+  it('does not show an editor capability badge on editable rail cards', () => {
     render([withVideo]);
-    expect(container.querySelector('[title="This game has a built-in content editor"]')).not.toBeNull();
+    expect(container.querySelector('[title="This game has a built-in content editor"]')).toBeNull();
   });
 
   it('arms the trailer after a mouse hover dwell and drops it on leave', async () => {

--- a/apps/web/src/surfaces/catalog/CatalogRail.tsx
+++ b/apps/web/src/surfaces/catalog/CatalogRail.tsx
@@ -162,18 +162,11 @@ function RailCard({
           </div>
         )}
         <span className="rail-card-genre">{entry.genre}</span>
-        {(entry.multiplayer || entry.editor === 'content') && (
+        {entry.multiplayer && (
           <div className="rail-card-capabilities">
-            {entry.multiplayer && (
-              <span className="rail-card-party-badge">
-                <PixelIcon name="phone" size={11} /> {t('party.playersBadge', { max: entry.multiplayer.maxPlayers })}
-              </span>
-            )}
-            {entry.editor === 'content' && (
-              <span className="rail-card-party-badge" title={t('catalog.editorTooltip')}>
-                <PixelIcon name="pencil" size={11} /> {t('catalog.editorBadge')}
-              </span>
-            )}
+            <span className="rail-card-party-badge">
+              <PixelIcon name="phone" size={11} /> {t('party.playersBadge', { max: entry.multiplayer.maxPlayers })}
+            </span>
           </div>
         )}
         {hasVideo && (


### PR DESCRIPTION
## Summary
- Removes the "Edytowalna" / "Editable" badge and its tooltip (`t('catalog.editorBadge')`, `t('catalog.editorTooltip')`) across catalog surfaces:
  - `CatalogRail.tsx`: removes editor capability badge from game cards while retaining multiplayer badges.
  - `ArcadeCatalog.tsx`: removes editor capability badge from game cards in the catalog view.
  - `GameDetailPage.tsx` and `GamePage.tsx`: removes redundant editable badge in the kicker/breadcrumb next to the genre (the explicit action button to edit content remains intact).
  - `en.json` and `pl.json`: removes unused `editorBadge` and `editorTooltip` translation keys.
- Updates unit tests in `CatalogRail.test.tsx` and `ArcadeCatalog.test.tsx` to verify the badge is no longer rendered and keeps file line ceilings intact.

## Test plan
- [x] `npm run type-check` — passed
- [x] `npm run lint` — passed (0 errors, within module size & comment prose baselines)
- [x] `npm run test` — passed (457 test files, 5513 tests)
- [x] `npm run build` — passed