### PR TITLE
Report the callers Cloud Run cannot attribute

### DIFF
--- a/apps/api/src/platform/client-address-metrics.test.ts
+++ b/apps/api/src/platform/client-address-metrics.test.ts
@@ -1,0 +1,72 @@
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import Fastify from 'fastify';
+import { registerClientAddress } from './client-address.js';
+import { registerRateLimit } from './rate-limit.js';
+import { isUnattributable, UNATTRIBUTABLE_CLIENT_LOG_MSG } from './client-address-metrics.js';
+
+describe('isUnattributable', () => {
+  it('names the addresses that are never a caller', () => {
+    expect(isUnattributable('0.0.0.0')).toBe(true);
+    expect(isUnattributable('::')).toBe(true);
+    expect(isUnattributable('')).toBe(true);
+    expect(isUnattributable('203.0.113.7')).toBe(false);
+  });
+});
+
+async function appReporting(records: object[]) {
+  const app = Fastify({
+    trustProxy: 1,
+    logger: { level: 'warn' },
+  });
+  app.log.warn = ((context: object, message: string) => {
+    if (message === UNATTRIBUTABLE_CLIENT_LOG_MSG) records.push(context);
+  }) as typeof app.log.warn;
+  registerClientAddress(app);
+  await registerRateLimit(app);
+  app.addHook('onRequest', async (request) => {
+    request.log.warn = app.log.warn;
+  });
+  app.get('/capped', { config: { rateLimit: { max: 1, timeWindow: '1 minute' } } }, async () => ({ ok: true }));
+  return app;
+}
+
+describe('reporting an unattributable caller', () => {
+  it('records the refusal, which is the question worth answering', async () => {
+    const records: { unattributableClient: { rateLimited: boolean; route: string; statusCode: number } }[] = [];
+    const app = await appReporting(records as object[]);
+
+    await app.inject({ method: 'GET', url: '/capped', headers: { 'x-forwarded-for': '0.0.0.0' } });
+    await app.inject({ method: 'GET', url: '/capped', headers: { 'x-forwarded-for': '0.0.0.0' } });
+    await app.close();
+
+    expect(records).toHaveLength(2);
+    expect(records[0]?.unattributableClient.rateLimited).toBe(false);
+    // The second shares the first one's bucket, which is the harm.
+    expect(records[1]?.unattributableClient.rateLimited).toBe(true);
+    expect(records[1]?.unattributableClient.statusCode).toBe(429);
+    expect(records[1]?.unattributableClient.route).toBe('/capped');
+  });
+
+  it('stays quiet for a caller it can attribute', async () => {
+    const records: object[] = [];
+    const app = await appReporting(records);
+
+    await app.inject({ method: 'GET', url: '/capped', headers: { 'x-forwarded-for': '203.0.113.7' } });
+    await app.close();
+
+    expect(records).toHaveLength(0);
+  });
+});
+
+describe('the alert that reads these logs', () => {
+  const here = dirname(fileURLToPath(import.meta.url));
+  const script = readFileSync(resolve(here, '../../../../infra/setup-monitoring.sh'), 'utf8');
+
+  it('filters on the message this module emits', () => {
+    expect(UNATTRIBUTABLE_CLIENT_LOG_MSG).toBe('unattributable client address');
+    expect(script).toContain(UNATTRIBUTABLE_CLIENT_LOG_MSG);
+  });
+});

--- a/apps/api/src/platform/client-address-metrics.test.ts
+++ b/apps/api/src/platform/client-address-metrics.test.ts
@@ -16,7 +16,8 @@ describe('isUnattributable', () => {
   it('names the addresses that are never a caller', () => {
     expect(isUnattributable('0.0.0.0')).toBe(true);
     expect(isUnattributable('::')).toBe(true);
-    expect(isUnattributable('')).toBe(true);
+    // An upgrade with no socket, a different and already-handled case.
+    expect(isUnattributable('')).toBe(false);
     expect(isUnattributable('203.0.113.7')).toBe(false);
   });
 });

--- a/apps/api/src/platform/client-address-metrics.test.ts
+++ b/apps/api/src/platform/client-address-metrics.test.ts
@@ -1,11 +1,16 @@
 import { readFileSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it } from 'vitest';
 import Fastify from 'fastify';
 import { registerClientAddress } from './client-address.js';
 import { registerRateLimit } from './rate-limit.js';
-import { isUnattributable, UNATTRIBUTABLE_CLIENT_LOG_MSG } from './client-address-metrics.js';
+import {
+  IP_BUCKET_REFUSAL_LOG_MSG,
+  isUnattributable,
+  UNATTRIBUTABLE_CLIENT_LOG_MSG,
+} from './client-address-metrics.js';
+import { isRateLimited, onIpRefusal } from './ip-rate-limit.js';
 
 describe('isUnattributable', () => {
   it('names the addresses that are never a caller', () => {
@@ -16,48 +21,78 @@ describe('isUnattributable', () => {
   });
 });
 
-async function appReporting(records: object[]) {
-  const app = Fastify({
-    trustProxy: 1,
-    logger: { level: 'warn' },
-  });
-  app.log.warn = ((context: object, message: string) => {
-    if (message === UNATTRIBUTABLE_CLIENT_LOG_MSG) records.push(context);
+async function appReporting(records: { msg: string; context: object }[]) {
+  const app = Fastify({ trustProxy: 1, logger: { level: 'warn' } });
+  const capture = ((context: object, msg: string) => {
+    if (msg === UNATTRIBUTABLE_CLIENT_LOG_MSG || msg === IP_BUCKET_REFUSAL_LOG_MSG) records.push({ msg, context });
   }) as typeof app.log.warn;
+  app.log.warn = capture;
   registerClientAddress(app);
   await registerRateLimit(app);
   app.addHook('onRequest', async (request) => {
-    request.log.warn = app.log.warn;
+    request.log.warn = capture;
   });
   app.get('/capped', { config: { rateLimit: { max: 1, timeWindow: '1 minute' } } }, async () => ({ ok: true }));
+  // A per-account quota, which is not the shared bucket.
+  app.get('/quota', async (_request, reply) => reply.status(429).send({ error: 'daily quota exceeded' }));
   return app;
 }
 
+function messages(records: { msg: string }[]) {
+  return records.map((r) => r.msg);
+}
+
 describe('reporting an unattributable caller', () => {
-  it('records the refusal, which is the question worth answering', async () => {
-    const records: { unattributableClient: { rateLimited: boolean; route: string; statusCode: number } }[] = [];
-    const app = await appReporting(records as object[]);
+  afterEach(() => onIpRefusal(null));
+
+  it('separates sharing the bucket from being refused by it', async () => {
+    const records: { msg: string; context: object }[] = [];
+    const app = await appReporting(records);
 
     await app.inject({ method: 'GET', url: '/capped', headers: { 'x-forwarded-for': '0.0.0.0' } });
+    expect(messages(records)).toEqual([UNATTRIBUTABLE_CLIENT_LOG_MSG]);
+
+    records.length = 0;
     await app.inject({ method: 'GET', url: '/capped', headers: { 'x-forwarded-for': '0.0.0.0' } });
+    expect(messages(records)).toContain(IP_BUCKET_REFUSAL_LOG_MSG);
+
+    await app.close();
+  });
+
+  it('never counts a per-account 429 as the bucket refusing anyone', async () => {
+    const records: { msg: string; context: object }[] = [];
+    const app = await appReporting(records);
+
+    await app.inject({ method: 'GET', url: '/quota', headers: { 'x-forwarded-for': '0.0.0.0' } });
     await app.close();
 
-    expect(records).toHaveLength(2);
-    expect(records[0]?.unattributableClient.rateLimited).toBe(false);
-    // The second shares the first one's bucket, which is the harm.
-    expect(records[1]?.unattributableClient.rateLimited).toBe(true);
-    expect(records[1]?.unattributableClient.statusCode).toBe(429);
-    expect(records[1]?.unattributableClient.route).toBe('/capped');
+    // The volume signal still sees it; the refusal signal must not.
+    expect(messages(records)).toEqual([UNATTRIBUTABLE_CLIENT_LOG_MSG]);
   });
 
   it('stays quiet for a caller it can attribute', async () => {
-    const records: object[] = [];
+    const records: { msg: string; context: object }[] = [];
     const app = await appReporting(records);
 
     await app.inject({ method: 'GET', url: '/capped', headers: { 'x-forwarded-for': '203.0.113.7' } });
     await app.close();
 
     expect(records).toHaveLength(0);
+  });
+});
+
+describe('the in-handler sliding window', () => {
+  afterEach(() => onIpRefusal(null));
+
+  it('reports its own refusals, which no response hook could attribute', () => {
+    const refused: string[] = [];
+    onIpRefusal((ip) => refused.push(ip));
+    const buckets = new Map<string, number[]>();
+
+    expect(isRateLimited(buckets, '0.0.0.0', 1000, 1, 60_000)).toBe(false);
+    expect(isRateLimited(buckets, '0.0.0.0', 1000, 1, 60_000)).toBe(true);
+
+    expect(refused).toEqual(['0.0.0.0']);
   });
 });
 
@@ -68,5 +103,7 @@ describe('the alert that reads these logs', () => {
   it('filters on the message this module emits', () => {
     expect(UNATTRIBUTABLE_CLIENT_LOG_MSG).toBe('unattributable client address');
     expect(script).toContain(UNATTRIBUTABLE_CLIENT_LOG_MSG);
+    expect(IP_BUCKET_REFUSAL_LOG_MSG).toBe('unattributable client refused by ip limiter');
+    expect(script).toContain(IP_BUCKET_REFUSAL_LOG_MSG);
   });
 });

--- a/apps/api/src/platform/client-address-metrics.ts
+++ b/apps/api/src/platform/client-address-metrics.ts
@@ -6,8 +6,9 @@ export const UNATTRIBUTABLE_CLIENT_LOG_MSG = 'unattributable client address';
 export const IP_BUCKET_REFUSAL_LOG_MSG = 'unattributable client refused by ip limiter';
 
 // The unspecified address in either family, never a real caller.
-const UNATTRIBUTABLE = new Set(['0.0.0.0', '::', '::0', '']);
+const UNATTRIBUTABLE = new Set(['0.0.0.0', '::', '::0']);
 
+// Empty means no socket, which is a different case entirely.
 export function isUnattributable(clientIp: string): boolean {
   return UNATTRIBUTABLE.has(clientIp.trim());
 }

--- a/apps/api/src/platform/client-address-metrics.ts
+++ b/apps/api/src/platform/client-address-metrics.ts
@@ -1,0 +1,29 @@
+// unattributable_client telemetry. Message string is a contract with setup-monitoring.sh.
+
+export const UNATTRIBUTABLE_CLIENT_LOG_MSG = 'unattributable client address';
+
+// The unspecified address in either family, never a real caller.
+const UNATTRIBUTABLE = new Set(['0.0.0.0', '::', '::0', '']);
+
+export function isUnattributable(clientIp: string): boolean {
+  return UNATTRIBUTABLE.has(clientIp.trim());
+}
+
+export interface UnattributableClientTelemetry {
+  // The route pattern, never the raw URL, to keep ids out.
+  route: string;
+  method: string;
+  statusCode: number;
+  // 429 here is the whole question: did a limiter actually refuse someone.
+  rateLimited: boolean;
+  authenticated: boolean;
+  forwardedFor: string | null;
+}
+
+interface Logger {
+  warn: (context: object, message: string) => void;
+}
+
+export function logUnattributableClient(log: Logger, telemetry: UnattributableClientTelemetry): void {
+  log.warn({ unattributableClient: telemetry }, UNATTRIBUTABLE_CLIENT_LOG_MSG);
+}

--- a/apps/api/src/platform/client-address-metrics.ts
+++ b/apps/api/src/platform/client-address-metrics.ts
@@ -2,6 +2,9 @@
 
 export const UNATTRIBUTABLE_CLIENT_LOG_MSG = 'unattributable client address';
 
+// Separate message: only an IP-keyed limiter can prove the bucket refused.
+export const IP_BUCKET_REFUSAL_LOG_MSG = 'unattributable client refused by ip limiter';
+
 // The unspecified address in either family, never a real caller.
 const UNATTRIBUTABLE = new Set(['0.0.0.0', '::', '::0', '']);
 
@@ -13,9 +16,8 @@ export interface UnattributableClientTelemetry {
   // The route pattern, never the raw URL, to keep ids out.
   route: string;
   method: string;
+  // Context only: a 429 here may be an account quota.
   statusCode: number;
-  // 429 here is the whole question: did a limiter actually refuse someone.
-  rateLimited: boolean;
   authenticated: boolean;
   forwardedFor: string | null;
 }
@@ -26,4 +28,8 @@ interface Logger {
 
 export function logUnattributableClient(log: Logger, telemetry: UnattributableClientTelemetry): void {
   log.warn({ unattributableClient: telemetry }, UNATTRIBUTABLE_CLIENT_LOG_MSG);
+}
+
+export function logIpBucketRefusal(log: Logger, telemetry: { clientIp: string }): void {
+  log.warn({ ipBucketRefusal: telemetry }, IP_BUCKET_REFUSAL_LOG_MSG);
 }

--- a/apps/api/src/platform/client-address.ts
+++ b/apps/api/src/platform/client-address.ts
@@ -1,5 +1,6 @@
 import type { FastifyInstance, FastifyRequest } from 'fastify';
-import { isUnattributable, logUnattributableClient } from './client-address-metrics.js';
+import { isUnattributable, logIpBucketRefusal, logUnattributableClient } from './client-address-metrics.js';
+import { onIpRefusal } from './ip-rate-limit.js';
 
 // Forgeable unless nothing can reach the service around the edge.
 const EDGE_CLIENT_IP_HEADER = 'fastly-client-ip';
@@ -42,7 +43,11 @@ export function registerClientAddress(app: FastifyInstance): void {
     request.clientIp = resolveClientIp(request);
   });
 
-  // These callers share one bucket, so record whether that refused anyone.
+  // The plugin stamps this header only on its own refusals.
+  const refusedByPlugin = (reply: { statusCode: number; getHeader: (name: string) => unknown }) =>
+    reply.statusCode === 429 && reply.getHeader('x-ratelimit-limit') !== undefined;
+
+  // How much traffic shares the one bucket, and on which routes.
   app.addHook('onResponse', async (request, reply) => {
     if (!isUnattributable(request.clientIp)) return;
     const forwardedFor = request.headers['x-forwarded-for'];
@@ -50,9 +55,14 @@ export function registerClientAddress(app: FastifyInstance): void {
       route: request.routeOptions?.url ?? 'unrouted',
       method: request.method,
       statusCode: reply.statusCode,
-      rateLimited: reply.statusCode === 429,
       authenticated: Boolean(request.user),
       forwardedFor: typeof forwardedFor === 'string' ? forwardedFor : null,
     });
+    if (refusedByPlugin(reply)) logIpBucketRefusal(request.log, { clientIp: request.clientIp });
+  });
+
+  // Whether it refused anyone, reported only where that is provable.
+  onIpRefusal((ip) => {
+    if (isUnattributable(ip)) logIpBucketRefusal(app.log, { clientIp: ip });
   });
 }

--- a/apps/api/src/platform/client-address.ts
+++ b/apps/api/src/platform/client-address.ts
@@ -1,4 +1,5 @@
 import type { FastifyInstance, FastifyRequest } from 'fastify';
+import { isUnattributable, logUnattributableClient } from './client-address-metrics.js';
 
 // Forgeable unless nothing can reach the service around the edge.
 const EDGE_CLIENT_IP_HEADER = 'fastly-client-ip';
@@ -39,5 +40,19 @@ export function registerClientAddress(app: FastifyInstance): void {
   app.decorateRequest('clientIp', '');
   app.addHook('onRequest', async (request) => {
     request.clientIp = resolveClientIp(request);
+  });
+
+  // These callers share one bucket, so record whether that refused anyone.
+  app.addHook('onResponse', async (request, reply) => {
+    if (!isUnattributable(request.clientIp)) return;
+    const forwardedFor = request.headers['x-forwarded-for'];
+    logUnattributableClient(request.log, {
+      route: request.routeOptions?.url ?? 'unrouted',
+      method: request.method,
+      statusCode: reply.statusCode,
+      rateLimited: reply.statusCode === 429,
+      authenticated: Boolean(request.user),
+      forwardedFor: typeof forwardedFor === 'string' ? forwardedFor : null,
+    });
   });
 }

--- a/apps/api/src/platform/ip-rate-limit.ts
+++ b/apps/api/src/platform/ip-rate-limit.ts
@@ -1,3 +1,12 @@
+type RefusalObserver = (ip: string) => void;
+
+let observeRefusal: RefusalObserver | null = null;
+
+// Only this helper knows it refused, and on which key.
+export function onIpRefusal(observer: RefusalObserver | null): void {
+  observeRefusal = observer;
+}
+
 // Sliding-window rate limiter keyed by client IP.
 export function isRateLimited(
   buckets: Map<string, number[]>,
@@ -9,6 +18,7 @@ export function isRateLimited(
   const requests = (buckets.get(ip) ?? []).filter((timestamp) => currentTime - timestamp < windowMs);
   if (requests.length >= maxRequests) {
     buckets.set(ip, requests);
+    observeRefusal?.(ip);
     return true;
   }
 

--- a/infra/setup-monitoring.sh
+++ b/infra/setup-monitoring.sh
@@ -341,6 +341,18 @@ ensure_log_metric unattributable_client_requests \
   'Requests whose caller Cloud Run reported as the unspecified address (shared rate-limit bucket).' \
   "resource.type=\"cloud_run_revision\" AND resource.labels.service_name=\"${PRIMARY_SERVICE}\" AND jsonPayload.msg=\"unattributable client address\""
 
+# The one that decides the fix. Volume above only says how many share the bucket; this says
+# whether the bucket has refused anyone, which is a different question and the answer nobody
+# has. Its own message rather than a status filter on the metric above, because a 429 there
+# can be a per-account quota (creation/improve-routes.ts) that has nothing to do with the
+# shared address — counting those would answer this question wrongly and confidently.
+#
+# Emitted only where the refusal is provable: the IP-keyed sliding window in
+# platform/ip-rate-limit.ts, and the rate-limit plugin's own onExceeded.
+ensure_log_metric unattributable_client_refusals \
+  'An IP-keyed limiter refused a caller with no attributable address.' \
+  "resource.type=\"cloud_run_revision\" AND resource.labels.service_name=\"${PRIMARY_SERVICE}\" AND jsonPayload.msg=\"unattributable client refused by ip limiter\""
+
 # The in-process tsc preflight (typecheck-preflight.ts) abandons a check that ran past its
 # soft wall and accepts the delivery unvalidated rather than blocking the agent — the same
 # fail-open shape as everywhere else in this pipeline. One skip is a heavy round (a big

--- a/infra/setup-monitoring.sh
+++ b/infra/setup-monitoring.sh
@@ -325,6 +325,22 @@ ensure_log_metric knowledge_query_calls \
   'knowledge_query calls, any mode. Backs alert A26.' \
   "resource.type=\"cloud_run_revision\" AND resource.labels.service_name=\"${PRIMARY_SERVICE}\" AND jsonPayload.msg=\"knowledge_query answered\""
 
+# Callers Cloud Run could not attribute: X-Forwarded-For arrives holding 0.0.0.0, the
+# unspecified address, so every one of them lands in a single shared per-IP bucket. Measured
+# at ~3% of requests and present since 2026-08-04, long before any CDN work. Harmless while
+# traffic is low and a trap under a wave, which is when a shared bucket refuses hardest.
+#
+# The counter that matters is the rateLimited field, not the volume: it says whether the
+# shared bucket has actually refused anyone yet, which is what decides the fix. Failing open
+# would be wrong here — the auth brute-force limiter reads the same address, and anyone able
+# to reach us by this path would get unlimited attempts.
+#
+# The message string is the contract with apps/api/src/platform/client-address-metrics.ts,
+# asserted from both sides by client-address-metrics.test.ts.
+ensure_log_metric unattributable_client_requests \
+  'Requests whose caller Cloud Run reported as the unspecified address (shared rate-limit bucket).' \
+  "resource.type=\"cloud_run_revision\" AND resource.labels.service_name=\"${PRIMARY_SERVICE}\" AND jsonPayload.msg=\"unattributable client address\""
+
 # The in-process tsc preflight (typecheck-preflight.ts) abandons a check that ran past its
 # soft wall and accepts the delivery unvalidated rather than blocking the agent — the same
 # fail-open shape as everywhere else in this pipeline. One skip is a heavy round (a big


### PR DESCRIPTION
## What

Roughly **3% of requests** arrive with `X-Forwarded-For` holding `0.0.0.0` — the unspecified address, written by Google's frontend itself. Every one of those callers lands in a single shared per-IP rate-limit bucket.

This reports them, and reports separately whether that bucket has refused anyone. **It deliberately does not change any limiter's behaviour.**

## The evidence

Measured live against production:

```
"x-forwarded-for":  "0.0.0.0"
"forwarded":        "for=\"0.0.0.0\";proto=https"
"forwardedForHops": 1
```

Two things follow, and the second is easy to get wrong:

- The header is **present**, with **exactly one entry** — precisely what `trustProxy: 1` expects. So `trustProxy` is resolving faithfully and nothing about its hop count is misconfigured. This is not a case of a missing header falling back to `socket.remoteAddress`; there is nothing to fall back from. The value is authoritative-looking and useless.
- Cloud Run logs put the first occurrence at **2026-08-04**, so this predates the CDN work rather than following from it.

## Why this measures instead of fixing

Both obvious fixes are wrong on the evidence currently available:

- **Keep the shared bucket** (status quo) and these callers refuse each other. Harmless at today's volume; a trap under a traffic wave, which is exactly when a shared bucket refuses hardest — and surviving traffic waves is the point of the surrounding work.
- **Fail open** and it gets worse, not better. The auth brute-force limiter reads the same address, so anyone able to reach us by this path would get unlimited login attempts. That is a regression on today, not a fix. (The fail-open precedent in `mp.ts` is sound for a feature-availability cap and does not transfer to a security limiter.)

Choosing between them needs one fact nobody has: **has the shared bucket actually refused anyone yet.** So that is what this reports.

## Two signals, because one could not be honest

The first draft of this inferred the refusal from a 429 in the response hook. Review showed that answers the question **wrongly and confidently**: `creation/improve-routes.ts` returns 429 for a per-account daily quota, and several editor routes do the same for account and session limits. None of those say anything about callers sharing an address.

The cause was a mismatch of vantage points. The response hook knows the route and the status but not *which* limiter refused. The limiter knows it refused and on which key but not the route. Inferring from the status joined those two blind spots.

So each signal now reports only what its own vantage point can prove:

- **`unattributable client address`** — from the response hook: how much traffic shares the bucket, and on which routes. `statusCode` is kept as context, **not** as evidence.
- **`unattributable client refused by ip limiter`** — from the IP-keyed sliding window itself, plus the rate-limit plugin's refusals, which are provable from the `x-ratelimit-*` headers it stamps and nothing else does.

Each gets its own metric, so refusals are counted by construction rather than by a status predicate that could not have separated the two cases.

## Notes for review

- An empty `clientIp` (an upgrade request with no socket) is **excluded** on purpose. It is a known, already-handled condition — `mp.ts` declines to cap what it cannot classify — and folding it in would have inflated the population this is trying to size.
- The plugin's refusal is detected in the hook rather than through `onExceeded`, so `rate-limit.ts` stays at its ceiling: telemetry about unattributable callers does not belong in the file that registers the plugin. **No baseline moves in this PR.**
- Message strings are asserted from **both sides**, matching the convention the other log-backed metrics use. The reasoning in `setup-monitoring.sh` is worth keeping: a filter that matches nothing yields a metric that is always zero, which reads exactly like "no problem".
- **This is a bridge.** Measured through a CDN, the same client presents a real address, so fronting the service resolves the condition for this traffic. The policy question belongs to that window; this exists so the decision is made on data rather than a guess.

## Test plan

- `client-address-metrics.test.ts`: the unspecified address is recognised in both families and an empty one is not; sharing the bucket and being refused by it are reported separately; **a per-account 429 is never counted as the bucket refusing anyone**; an attributable caller produces nothing; the sliding window reports its own refusals; both monitoring filters match the emitted messages.
- Verified the header-based plugin detection is load-bearing by reverting it — the refusal assertion fails without it.
- `npm run lint` — exit 0, full seal chain.
- `npm test` — 5638 tests, exit 0.
- `tsc --noEmit` — clean.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EptooEgKrMQT6zxdp5DABq