### PR TITLE
Fail the CLI bundle clearly when ink is missing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,7 @@ jobs:
       - run: npm run type-check
       - run: npm run test
       - run: npm run build
+      - run: npm run bundle -w @gamedevpl/cli && node apps/cli/dist/gamedevpl.mjs help
 
   # Cross-repo lockstep with gamedevpl/www.gamedev.pl-games (issue #247). The unit
   # tests above already pin this repo's half + a GameKit-shaped fixture; this job

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ what each destructive one actually consumes, and why the rest are hidden.
 opens a REPL: describe a game, then iterate. `gamedevpl checkout <slug>` is the own-editor
 path. Installers (`/install.sh`) 404 while `CLI_SURFACE` is off. With the flag on, the
 route serves the script even if no `cli-v*` GitHub release exists yet — that download is
-what fails then. Until a release ships, `npm run bundle -w @gamedevpl/cli`. Details:
+what fails then. Until a release ships, `npm install` then `npm run bundle -w @gamedevpl/cli`. Details:
 [`apps/cli/README.md`](./apps/cli/README.md).
 
 > **Creating games is in closed beta.** The tools load for anyone; the calls need an

--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -19,8 +19,15 @@ curl -fsSL https://www.gamedev.pl/install.sh | bash
 The installer is 404 until the `CLI_SURFACE` deploy flag is on. Checksums come from GitHub
 Releases tagged `cli-v*` (one `gamedevpl` asset). `gamedevpl update` uses the same channel.
 
-Until a release exists: `npm run bundle -w @gamedevpl/cli` and run `apps/cli/dist/gamedevpl.mjs`.
-The bundled script inlines Ink (React for terminals). `gamedevpl` with no verb is that TUI.
+Until a release exists, from the repo root after a pull:
+
+```bash
+npm install
+npm run bundle -w @gamedevpl/cli
+node apps/cli/dist/gamedevpl.mjs help
+```
+
+`ink` is a workspace dependency. Skipping `npm install` makes esbuild fail with `Could not resolve "ink"`. The bundled script inlines Ink. `gamedevpl` with no verb is that TUI.
 
 ## Verbs
 

--- a/apps/cli/scripts/build-binary.mjs
+++ b/apps/cli/scripts/build-binary.mjs
@@ -1,4 +1,5 @@
 import { build } from 'esbuild';
+import { createRequire } from 'node:module';
 import { chmodSync, mkdirSync, readdirSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -6,6 +7,12 @@ import { fileURLToPath } from 'node:url';
 const root = join(dirname(fileURLToPath(import.meta.url)), '..');
 const outDir = join(root, 'dist');
 mkdirSync(outDir, { recursive: true });
+
+try {
+  createRequire(join(root, 'package.json')).resolve('ink');
+} catch {
+  throw new Error('ink is missing — run npm install from the repo root, then retry the bundle');
+}
 
 await build({
   entryPoints: [join(root, 'src/main.ts')],
@@ -19,7 +26,7 @@ await build({
     'react-devtools-core': join(root, 'scripts/empty-devtools.mjs'),
   },
   banner: {
-    js: '#!/usr/bin/env node\nimport { createRequire } from "node:module";\nconst require = createRequire(import.meta.url);',
+    js: 'import { createRequire } from "node:module";\nconst require = createRequire(import.meta.url);',
   },
 });
 

--- a/apps/cli/src/bundle.test.ts
+++ b/apps/cli/src/bundle.test.ts
@@ -1,0 +1,22 @@
+import { execFileSync } from 'node:child_process';
+import { createRequire } from 'node:module';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const root = join(dirname(fileURLToPath(import.meta.url)), '..');
+
+describe('cli bundle', () => {
+  it('resolves ink from the CLI package', () => {
+    const require = createRequire(join(root, 'package.json'));
+    expect(require.resolve('ink')).toMatch(/ink/);
+  });
+
+  it('runs help through node on the shebang bundle', () => {
+    execFileSync(process.execPath, [join(root, 'scripts/build-binary.mjs')], { cwd: root });
+    const out = execFileSync(process.execPath, [join(root, 'dist/gamedevpl.mjs'), 'help'], {
+      encoding: 'utf8',
+    });
+    expect(out).toMatch(/gamedevpl/);
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
`npm run bundle -w @gamedevpl/cli` after pulling the CLI stack failed with esbuild `Could not resolve "ink"`. Ink is a workspace dependency; a pull without `npm install` leaves it out of `node_modules`. Tests never imported Ink, and CI never ran the bundle, so this path was unguarded.

- Fail the bundle script with an `npm install` hint instead of the esbuild wall
- Keep a single shebang so `node apps/cli/dist/gamedevpl.mjs help` works (banner + `main.ts` were stacking two)
- Cover that path in CLI tests and in CI

Does not enable `CLI_SURFACE`. Local workaround until this lands: `npm install` from the repo root, then bundle again.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c227c8cb-c1d6-41f1-9f0a-5787614f7ba7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c227c8cb-c1d6-41f1-9f0a-5787614f7ba7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

