### PR TITLE
fix(cli): keep PATs out of a delegated sub-agent's environment

### DIFF
--- a/apps/cli/src/delegate.test.ts
+++ b/apps/cli/src/delegate.test.ts
@@ -26,9 +26,7 @@ describe('delegation credential boundary', () => {
     expect(env.PATH).toBe('/usr/bin');
   });
 
-  // A PAT is class-A too: it reaches the whole creator lifecycle, so it is a
-  // bigger prize than the round key we deliberately hand over. CI creators hold
-  // one under names we do not control, so the value pattern has to catch it.
+  // A PAT is class-A, so the child never sees one.
   it('strips creator PAT material under any variable name', () => {
     const env = childEnv(
       {

--- a/apps/cli/src/delegate.test.ts
+++ b/apps/cli/src/delegate.test.ts
@@ -25,6 +25,26 @@ describe('delegation credential boundary', () => {
     expect(env.GAMEDEV_ROUND_TOKEN).toBe('round-scoped-only');
     expect(env.PATH).toBe('/usr/bin');
   });
+
+  // A PAT is class-A too: it reaches the whole creator lifecycle, so it is a
+  // bigger prize than the round key we deliberately hand over. CI creators hold
+  // one under names we do not control, so the value pattern has to catch it.
+  it('strips creator PAT material under any variable name', () => {
+    const env = childEnv(
+      {
+        PATH: '/usr/bin',
+        CI_TOKEN: 'gdpl_pat_0123456789abcdef_secret',
+        GDPL_PAT_BACKUP: 'whatever',
+        HOME: '/tmp',
+      },
+      'round-scoped-only',
+    );
+    expect(JSON.stringify(env)).not.toMatch(/gdpl_pat_/);
+    expect(env.CI_TOKEN).toBeUndefined();
+    expect(env.GDPL_PAT_BACKUP).toBeUndefined();
+    expect(env.GAMEDEV_ROUND_TOKEN).toBe('round-scoped-only');
+    expect(env.PATH).toBe('/usr/bin');
+  });
 });
 
 describe('delegation event rendering', () => {

--- a/apps/cli/src/delegate.ts
+++ b/apps/cli/src/delegate.ts
@@ -2,14 +2,16 @@ import { spawn, type ChildProcess } from 'node:child_process';
 import { formatAdapterEvent, sanitizeEventPayload } from './ansi.js';
 import type { AdapterSpec } from './adapters.js';
 
-export const CREATOR_TOKEN_PATTERN = /gdpl_oat_/;
+// Every account-scoped credential shape, not just OAuth. A PAT reaches the whole
+// creator lifecycle, so it must never ride into a sub-agent either.
+export const CREATOR_TOKEN_PATTERN = /gdpl_(oat|pat)_/;
 
 export function childEnv(parent: NodeJS.ProcessEnv, roundToken: string): NodeJS.ProcessEnv {
   const env: NodeJS.ProcessEnv = {};
   for (const [key, value] of Object.entries(parent)) {
     if (value === undefined) continue;
     if (CREATOR_TOKEN_PATTERN.test(value)) continue;
-    if (/GAMEDEV_TOKEN|GDPL_OAT|OAUTH_ACCESS/i.test(key)) continue;
+    if (/GAMEDEV_TOKEN|GDPL_OAT|GDPL_PAT|OAUTH_ACCESS/i.test(key)) continue;
     env[key] = value;
   }
   env.GAMEDEV_ROUND_TOKEN = roundToken;

--- a/apps/cli/src/delegate.ts
+++ b/apps/cli/src/delegate.ts
@@ -2,8 +2,7 @@ import { spawn, type ChildProcess } from 'node:child_process';
 import { formatAdapterEvent, sanitizeEventPayload } from './ansi.js';
 import type { AdapterSpec } from './adapters.js';
 
-// Every account-scoped credential shape, not just OAuth. A PAT reaches the whole
-// creator lifecycle, so it must never ride into a sub-agent either.
+// A PAT reaches the whole account, not just one round.
 export const CREATOR_TOKEN_PATTERN = /gdpl_(oat|pat)_/;
 
 export function childEnv(parent: NodeJS.ProcessEnv, roundToken: string): NodeJS.ProcessEnv {


### PR DESCRIPTION
## The gap

`childEnv` in `apps/cli/src/delegate.ts` filtered environment *values* against `/gdpl_oat_/`, so it caught OAuth access tokens but not personal access tokens. The key denylist covered `GAMEDEV_TOKEN`, so a PAT living under any other name — `CI_TOKEN`, or whatever convention a creator uses — was passed straight to the spawned vendor agent.

## Why it matters more than the case it was written for

A PAT is **account-scoped**: it authenticates the whole creator lifecycle (profile, submissions, notifications, quota), so it is a strictly bigger prize than the round-scoped token we hand over deliberately. And it is not hypothetical — "PAT for CI" is the documented credential story, and self-service PAT minting shipped in Wave E (#1081), so creators hold them on exactly the machines where delegation runs.

The root cause is upstream of the code: the plan's invariant said *"sub-agents never receive the creator's OAuth token"*, which is narrower than the threat, and the implementation matched the invariant faithfully. The ops-side wording is corrected in a companion change.

## The fix

- `CREATOR_TOKEN_PATTERN` now matches `/gdpl_(oat|pat)_/`.
- The key denylist gains `GDPL_PAT`.
- A new test puts a PAT under an unlisted variable name and asserts it never reaches the child.

## Verification

- New test **fails against the old filter** with the PAT visible in the child env (`expected '{"PATH":"/usr/bin","CI_TOKEN":"gdpl_p…' not to match /gdpl_pat_/`), passes with the fix.
- `npm test -w @gamedevpl/cli` — 23 files, 86 tests, all pass.
- `npm run type-check` and eslint on the changed files — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AJNcxBU2JJg3mPykeMqLGw

---
_Generated by [Claude Code](https://claude.ai/code/session_01AJNcxBU2JJg3mPykeMqLGw)_