### PR TITLE
Keep the Ink REPL in sync with Studio round status

### DIFF
--- a/apps/cli/src/live.test.ts
+++ b/apps/cli/src/live.test.ts
@@ -3,6 +3,7 @@ import { createLiveScreen, renderLive } from './live.js';
 import {
   formatStatusLines,
   formatStatusEvent,
+  formatRoundLive,
   runStatusVerb,
   shouldAnnounceStatus,
   statusWatchDelayMs,
@@ -119,6 +120,16 @@ describe('status watch', () => {
         'building|smoke:2/4',
       ),
     ).toBe(false);
+  });
+
+  it('does not repeat a sanitized failure reason on the live strip', () => {
+    const esc = String.fromCharCode(27);
+    expect(
+      formatRoundLive(
+        { status: 'needs_changes', failure: { reason: `${esc}[31mgate_red${esc}[0m` } },
+        'https://www.gamedev.pl',
+      ),
+    ).toEqual(['needs_changes (gate_red)']);
   });
 
   it('returns EXIT_RED when the publish gate is red', async () => {

--- a/apps/cli/src/live.test.ts
+++ b/apps/cli/src/live.test.ts
@@ -98,10 +98,27 @@ describe('status watch', () => {
       shouldAnnounceStatus({ status: 'needs_changes', previewGate: { green: true } }, '', 'needs_changes|||1'),
     ).toBe(true);
     expect(shouldAnnounceStatus({ status: 'building' }, '', 'building')).toBe(false);
-    expect(shouldAnnounceStatus({ status: 'building', stall: 'quiet' }, 'building', 'building|quiet')).toBe(true);
+    expect(shouldAnnounceStatus({ status: 'building', stall: 'quiet' }, 'building', 'building|quiet')).toBe(false);
     expect(formatStatusEvent({ status: 'needs_changes', previewGate: { green: true } })).toBe(
       'round finished — Studio is waiting (preview green)',
     );
+  });
+
+  it('keeps gate_red as an open round and skips gate-progress announcements', () => {
+    expect(shouldAnnounceStatus({ status: 'needs_changes', failure: { reason: 'gate_red' } }, '', 'k')).toBe(false);
+    expect(formatStatusEvent({ status: 'needs_changes', failure: { reason: 'gate_red' } })).toBe(
+      'needs_changes (gate_red)',
+    );
+    expect(formatStatusEvent({ status: 'needs_changes', previewGate: { green: false } })).toBe(
+      'needs_changes (preview red)',
+    );
+    expect(
+      shouldAnnounceStatus(
+        { status: 'building', gateProgress: { stage: 'smoke', index: 2, total: 4 } },
+        'building',
+        'building|smoke:2/4',
+      ),
+    ).toBe(false);
   });
 
   it('returns EXIT_RED when the publish gate is red', async () => {

--- a/apps/cli/src/live.test.ts
+++ b/apps/cli/src/live.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from 'vitest';
 import { createLiveScreen, renderLive } from './live.js';
-import { formatStatusLines, runStatusVerb, statusWatchDelayMs } from './status-watch.js';
+import {
+  formatStatusLines,
+  formatStatusEvent,
+  runStatusVerb,
+  shouldAnnounceStatus,
+  statusWatchDelayMs,
+} from './status-watch.js';
 import { createApi } from './api.js';
 import { memoryStore } from './keychain.js';
 import { EXIT_GREEN, EXIT_RED } from './exit-codes.js';
@@ -85,6 +91,17 @@ describe('status watch', () => {
     expect(calls).toBe(2);
     expect(chunks.join('')).toContain('\x1b[');
     expect(chunks.join('')).toContain('published');
+  });
+
+  it('announces a finished Studio round even on the first poll', () => {
+    expect(
+      shouldAnnounceStatus({ status: 'needs_changes', previewGate: { green: true } }, '', 'needs_changes|||1'),
+    ).toBe(true);
+    expect(shouldAnnounceStatus({ status: 'building' }, '', 'building')).toBe(false);
+    expect(shouldAnnounceStatus({ status: 'building', stall: 'quiet' }, 'building', 'building|quiet')).toBe(true);
+    expect(formatStatusEvent({ status: 'needs_changes', previewGate: { green: true } })).toBe(
+      'round finished — Studio is waiting (preview green)',
+    );
   });
 
   it('returns EXIT_RED when the publish gate is red', async () => {

--- a/apps/cli/src/repl.test.ts
+++ b/apps/cli/src/repl.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, it } from 'vitest';
-import { handleReplLine } from './repl.js';
+import { handleReplLine, replBanner } from './repl.js';
 import { createApi } from './api.js';
 import { memoryStore } from './keychain.js';
+import { MASCOT_ASCII } from './tui/mascot.js';
 
 describe('repl turn loop', () => {
   it('prints a reply and does not invent a second request', async () => {
@@ -55,6 +56,7 @@ describe('repl turn loop', () => {
     expect(seen.some((row) => row.includes('/refine'))).toBe(true);
     expect(seen.some((row) => row.startsWith('POST ') && row.endsWith('/api/submissions'))).toBe(true);
     expect(result.token).toBe('new-tok');
+    expect(result.slug).toBe('robot-garden');
     expect(lines.join('\n')).toContain('robot-garden');
   });
 
@@ -97,6 +99,7 @@ describe('repl turn loop', () => {
     });
     expect(opened.token).toBe('new-tok');
     expect(opened.draft).toBeNull();
+    expect(opened.slug).toBe('robot-garden');
   });
 
   it('treats a blank line as a no-op', async () => {
@@ -122,13 +125,37 @@ describe('repl turn loop', () => {
       fetch: async () => new Response('{}', { status: 404 }),
     });
     const result = await handleReplLine({
-      line: '/status tok',
+      line: '/connect sky',
       api,
       token: 'tok',
       write: (s) => lines.push(s),
     });
     expect(result.next).toBe('continue');
-    expect(lines.join('\n')).toBe('run it as gamedevpl status');
+    expect(lines.join('\n')).toBe('run it as gamedevpl connect');
+  });
+
+  it('prints the open session status from /status', async () => {
+    const lines: string[] = [];
+    const api = createApi({
+      origin: 'https://www.gamedev.pl',
+      store: memoryStore({ accessToken: 'gdpl_oat_t', tokenType: 'Bearer', scope: 'creator' }),
+      fetch: async (url) => {
+        if (String(url).endsWith('/api/submissions/tok')) {
+          return new Response(JSON.stringify({ status: 'needs_changes', previewGate: { green: true } }), {
+            status: 200,
+          });
+        }
+        return new Response('{}', { status: 404 });
+      },
+    });
+    const result = await handleReplLine({
+      line: '/status',
+      api,
+      token: 'tok',
+      write: (s) => lines.push(s),
+    });
+    expect(result.next).toBe('continue');
+    expect(lines.join('\n')).toContain('needs_changes');
   });
 
   it('parses slash-verb flags the same way as argv', async () => {
@@ -151,5 +178,12 @@ describe('repl turn loop', () => {
     });
     expect(result.next).toBe('continue');
     expect(JSON.parse(lines.join('\n'))).toEqual({ submissions: [{ slug: 'sky-dodge' }] });
+  });
+});
+
+describe('repl banner', () => {
+  it('draws the mascot on a TTY and stays one line in a pipe', () => {
+    expect(replBanner(true, {})).toContain(MASCOT_ASCII);
+    expect(replBanner(false, {})).not.toContain('╭');
   });
 });

--- a/apps/cli/src/repl.ts
+++ b/apps/cli/src/repl.ts
@@ -1,14 +1,18 @@
 import { CLI_BIN, cliUsage } from './bin-name.js';
 import { glyphs, wantsColor } from './renderer.js';
 import { completeSlash, parseArgv, SLASH_VERBS, type SlashVerb } from './argv.js';
-import { postTurn } from './turn.js';
+import { getStatus, postTurn } from './turn.js';
+import { formatStatusLines } from './status-watch.js';
 import type { ApiClient } from './api.js';
 import { dispatchReadVerb } from './verbs.js';
 import { answerDraft, beginIntake, formatQuestion, submitIdea, type IntakeDraft } from './create.js';
+import { CLI_VERSION } from './update.js';
+import { MASCOT_ASCII } from './tui/mascot.js';
 
 export type ReplLineResult = {
   next: 'continue' | 'quit';
   token?: string | null;
+  slug?: string;
   draft?: IntakeDraft | null;
 };
 
@@ -19,7 +23,7 @@ async function openFromSpec(
 ): Promise<ReplLineResult> {
   const created = await submitIdea(api, spec.title, spec.concept);
   write(`▸ opened ${created.slug ?? created.token}`);
-  return { next: 'continue', token: created.token, draft: null };
+  return { next: 'continue', token: created.token, draft: null, slug: created.slug };
 }
 
 export async function handleReplLine(input: {
@@ -36,6 +40,20 @@ export async function handleReplLine(input: {
     const [cmd, ...rest] = trimmed.slice(1).split(/\s+/);
     if (cmd === 'help') {
       input.write(SLASH_VERBS.map((verb) => `/${verb}`).join('\n'));
+      return { next: 'continue' };
+    }
+    if (cmd === 'status') {
+      const tok = rest[0] || input.token;
+      if (!tok) {
+        input.write(`run it as ${cliUsage('status')}`);
+        return { next: 'continue' };
+      }
+      try {
+        const status = await getStatus(input.api, tok);
+        input.write(formatStatusLines(status, input.api.origin).join('\n'));
+      } catch (error) {
+        input.write(error instanceof Error ? error.message : String(error));
+      }
       return { next: 'continue' };
     }
     if (cmd && (SLASH_VERBS as readonly string[]).includes(cmd)) {
@@ -89,5 +107,6 @@ export async function handleReplLine(input: {
 
 export function replBanner(isTty: boolean, env: NodeJS.ProcessEnv): string {
   const g = glyphs(wantsColor(env, isTty));
-  return `${g.agent} ${CLI_BIN} — ${g.prompt} to talk, /help for verbs`;
+  const hint = `${g.agent} ${CLI_BIN} ${CLI_VERSION} — ${g.prompt} to talk, /help for verbs`;
+  return isTty ? `${MASCOT_ASCII}\n${hint}` : hint;
 }

--- a/apps/cli/src/status-watch.ts
+++ b/apps/cli/src/status-watch.ts
@@ -24,6 +24,57 @@ export function formatStatusLines(status: RoundStatus, origin: string): string[]
   return lines;
 }
 
+export function statusFingerprint(status: RoundStatus): string {
+  const gate = status.gateProgress;
+  const preview = status.previewGate;
+  return [
+    status.status,
+    status.phase ?? '',
+    status.stall ?? '',
+    gate ? `${gate.stage}:${gate.index}/${gate.total}` : '',
+    status.preview?.slug ?? '',
+    status.slug ?? '',
+    status.failure?.reason ?? '',
+    preview == null ? '' : preview.green ? '1' : '0',
+  ].join('|');
+}
+
+export function formatStatusEvent(status: RoundStatus): string {
+  if (status.status === 'needs_changes' && status.previewGate?.green) {
+    return 'round finished — Studio is waiting (preview green)';
+  }
+  if (status.status === 'needs_changes' && status.previewGate?.green === false) {
+    return 'round finished — preview gate red';
+  }
+  if (status.status === 'needs_changes') {
+    const why = status.failure?.reason ? ` (${sanitizeEventPayload(status.failure.reason)})` : '';
+    return `round finished — needs_changes${why}`;
+  }
+  if (status.status === 'published') return 'published';
+  if (status.status === 'abandoned') return 'abandoned';
+  const stall = status.stall ? ` (${status.stall})` : '';
+  if (status.gateProgress) {
+    const { stage, index, total } = status.gateProgress;
+    return `${status.status}${stall} · ${stage} ${index}/${total}`;
+  }
+  return `${status.status}${stall}`;
+}
+
+export function shouldAnnounceStatus(status: RoundStatus, previousKey: string, key: string): boolean {
+  if (key === previousKey) return false;
+  if (status.status === 'needs_changes' || isTerminalStatus(status.status)) return true;
+  return previousKey !== '';
+}
+
+export function formatRoundLive(status: RoundStatus, origin: string): string[] {
+  const lines = [formatStatusEvent(status)];
+  if (status.preview?.slug) lines.push(previewUrl(origin, status.preview.slug));
+  if (status.failure?.reason && !lines[0]?.includes(status.failure.reason)) {
+    lines.push(sanitizeEventPayload(status.failure.reason));
+  }
+  return lines.slice(0, 4);
+}
+
 export async function runStatusVerb(input: {
   api: ApiClient;
   token: string;

--- a/apps/cli/src/status-watch.ts
+++ b/apps/cli/src/status-watch.ts
@@ -39,12 +39,26 @@ export function statusFingerprint(status: RoundStatus): string {
   ].join('|');
 }
 
+const REPAIRABLE_REASONS = new Set(['gate_red', 'kit_outdated', 'gate_crashed', 'session_crashed']);
+
+export function isRepairableNeedsChanges(status: RoundStatus): boolean {
+  if (status.status !== 'needs_changes') return false;
+  if (status.failure?.reason && REPAIRABLE_REASONS.has(status.failure.reason)) return true;
+  return status.previewGate?.green === false;
+}
+
+export function isRoundBoundary(status: RoundStatus): boolean {
+  if (isTerminalStatus(status.status)) return true;
+  return status.status === 'needs_changes' && !isRepairableNeedsChanges(status);
+}
+
 export function formatStatusEvent(status: RoundStatus): string {
+  if (isRepairableNeedsChanges(status)) {
+    const why = status.failure?.reason ?? 'preview red';
+    return `needs_changes (${sanitizeEventPayload(why)})`;
+  }
   if (status.status === 'needs_changes' && status.previewGate?.green) {
     return 'round finished — Studio is waiting (preview green)';
-  }
-  if (status.status === 'needs_changes' && status.previewGate?.green === false) {
-    return 'round finished — preview gate red';
   }
   if (status.status === 'needs_changes') {
     const why = status.failure?.reason ? ` (${sanitizeEventPayload(status.failure.reason)})` : '';
@@ -62,8 +76,7 @@ export function formatStatusEvent(status: RoundStatus): string {
 
 export function shouldAnnounceStatus(status: RoundStatus, previousKey: string, key: string): boolean {
   if (key === previousKey) return false;
-  if (status.status === 'needs_changes' || isTerminalStatus(status.status)) return true;
-  return previousKey !== '';
+  return isRoundBoundary(status);
 }
 
 export function formatRoundLive(status: RoundStatus, origin: string): string[] {

--- a/apps/cli/src/status-watch.ts
+++ b/apps/cli/src/status-watch.ts
@@ -43,7 +43,8 @@ const REPAIRABLE_REASONS = new Set(['gate_red', 'kit_outdated', 'gate_crashed', 
 
 export function isRepairableNeedsChanges(status: RoundStatus): boolean {
   if (status.status !== 'needs_changes') return false;
-  if (status.failure?.reason && REPAIRABLE_REASONS.has(status.failure.reason)) return true;
+  const reason = status.failure?.reason ? sanitizeEventPayload(status.failure.reason) : '';
+  if (reason && REPAIRABLE_REASONS.has(reason)) return true;
   return status.previewGate?.green === false;
 }
 
@@ -82,9 +83,8 @@ export function shouldAnnounceStatus(status: RoundStatus, previousKey: string, k
 export function formatRoundLive(status: RoundStatus, origin: string): string[] {
   const lines = [formatStatusEvent(status)];
   if (status.preview?.slug) lines.push(previewUrl(origin, status.preview.slug));
-  if (status.failure?.reason && !lines[0]?.includes(status.failure.reason)) {
-    lines.push(sanitizeEventPayload(status.failure.reason));
-  }
+  const reason = status.failure?.reason ? sanitizeEventPayload(status.failure.reason) : '';
+  if (reason && !lines[0]?.includes(reason)) lines.push(reason);
   return lines.slice(0, 4);
 }
 

--- a/apps/cli/src/tui/app.tsx
+++ b/apps/cli/src/tui/app.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import { Box, Text, useInput, useStdout } from 'ink';
 import { CLI_BIN } from '../bin-name.js';
 import { glyphs } from '../renderer.js';
+import { CLI_VERSION } from '../update.js';
 import type { TuiSession, TuiState } from './session.js';
 
 export function ReplApp({ session, color }: { session: TuiSession; color: boolean }) {
@@ -52,8 +53,9 @@ export function ReplApp({ session, color }: { session: TuiSession; color: boolea
   const border = color ? 'round' : 'single';
   const accent = color ? 'cyan' : undefined;
   const prompt = glyphs(color).prompt;
-  const body = Math.max(4, rows - 7);
+  const body = Math.max(4, rows - 8);
   const shown = state.lines.slice(-body);
+  const footer = `${state.identity || CLI_BIN} · ${CLI_VERSION}`;
   return (
     <Box flexDirection="column" height={rows}>
       <Box flexDirection="column" flexGrow={1}>
@@ -67,14 +69,16 @@ export function ReplApp({ session, color }: { session: TuiSession; color: boolea
         ))}
       </Box>
       <Box flexDirection="column" borderStyle={border} borderColor={accent} paddingX={1}>
-        <Text dimColor>{CLI_BIN}</Text>
         {state.mode === 'pick' ? (
-          state.choices.map((choice, index) => (
-            <Text key={`pick:${index}:${choice}`} color={index === state.pickIndex ? accent : undefined}>
-              {index === state.pickIndex ? '▸ ' : '  '}
-              {choice}
-            </Text>
-          ))
+          <>
+            {state.question ? <Text>{state.question}</Text> : null}
+            {state.choices.map((choice, index) => (
+              <Text key={`pick:${index}:${choice}`} color={index === state.pickIndex ? accent : undefined}>
+                {index === state.pickIndex ? '▸ ' : '  '}
+                {choice}
+              </Text>
+            ))}
+          </>
         ) : state.mode === 'busy' ? (
           <Text dimColor>▸ …</Text>
         ) : (
@@ -83,6 +87,7 @@ export function ReplApp({ session, color }: { session: TuiSession; color: boolea
           </Text>
         )}
       </Box>
+      <Text dimColor>{footer}</Text>
     </Box>
   );
 }

--- a/apps/cli/src/tui/host.ts
+++ b/apps/cli/src/tui/host.ts
@@ -6,7 +6,8 @@ import { wantsColor } from '../renderer.js';
 import type { ApiClient } from '../api.js';
 import type { IntakeDraft } from '../create.js';
 import { ReplApp } from './app.js';
-import { createTuiSession } from './session.js';
+import { createRoundWatch } from './round-watch.js';
+import { createTuiSession, formatSessionIdentity } from './session.js';
 
 export async function runInkRepl(input: {
   api: ApiClient;
@@ -29,11 +30,31 @@ export async function runInkRepl(input: {
     patchConsole: false,
   });
   let token = input.token;
+  let who = '';
+  let slug = '';
+  const paintIdentity = (): void => session.setIdentity(formatSessionIdentity(who, slug));
+  void input.api
+    .request<{ handle?: string; uid?: string }>('GET', '/api/me/profile')
+    .then((profile) => {
+      who = profile.handle ?? profile.uid ?? '';
+      paintIdentity();
+    })
+    .catch(() => undefined);
+  const watch = createRoundWatch({
+    getToken: () => token,
+    api: input.api,
+    setLive: (live) => session.setLive(live),
+    announce: (text) => session.writeLine(text),
+    onSlug: (next) => {
+      slug = next;
+      paintIdentity();
+    },
+  });
   let draft: IntakeDraft | null = null;
   try {
     for (;;) {
       const asking = draft?.questions[draft.index];
-      const line = await session.prompt(asking?.choices);
+      const line = await session.prompt(asking?.choices, asking?.prompt);
       const result = await handleReplLine({
         line,
         api: input.api,
@@ -41,11 +62,19 @@ export async function runInkRepl(input: {
         draft,
         write: (text) => session.writeLine(text),
       });
-      if (result.token !== undefined) token = result.token;
+      if (result.token !== undefined) {
+        token = result.token;
+        watch.poke();
+      }
+      if (result.slug) {
+        slug = result.slug;
+        paintIdentity();
+      }
       if (result.draft !== undefined) draft = result.draft;
       if (result.next === 'quit') break;
     }
   } finally {
+    watch.stop();
     session.close();
     host.instance?.unmount();
   }

--- a/apps/cli/src/tui/mascot.ts
+++ b/apps/cli/src/tui/mascot.ts
@@ -1,0 +1,9 @@
+// Pixel blob as a few terminal lines — not the SVG.
+export const MASCOT_ASCII = [
+  '      ╭───●───╮  ╭───●───╮',
+  '     ╭╯                ╰╮',
+  '    ╱    ●        ●      ╲',
+  '    ╲        ▄▄▄▄        ╱',
+  '     ╰──╮          ╭──╯',
+  '        ╰──────────╯',
+].join('\n');

--- a/apps/cli/src/tui/round-watch.test.ts
+++ b/apps/cli/src/tui/round-watch.test.ts
@@ -63,4 +63,46 @@ describe('round watch', () => {
     expect(polls).toBe(1);
     expect(announced).toEqual(['published']);
   });
+
+  it('paints auth failures on the live strip and ignores 404', async () => {
+    const live: string[][] = [];
+    const holder: { current?: ReturnType<typeof createRoundWatch> } = {};
+    const api = createApi({
+      origin: 'https://www.gamedev.pl',
+      store: memoryStore({ accessToken: 'gdpl_oat_t', tokenType: 'Bearer', scope: 'creator' }),
+      fetch: async () => {
+        holder.current?.stop();
+        return new Response('{}', { status: 401 });
+      },
+    });
+    holder.current = createRoundWatch({
+      getToken: () => 'tok',
+      api,
+      setLive: (lines) => live.push(lines),
+      announce: () => undefined,
+      sleep: async () => undefined,
+    });
+    await holder.current.run;
+    expect(live[0]?.[0]).toMatch(/credential expired/);
+
+    const ignored: string[][] = [];
+    const miss: { current?: ReturnType<typeof createRoundWatch> } = {};
+    const missingApi = createApi({
+      origin: 'https://www.gamedev.pl',
+      store: memoryStore({ accessToken: 'gdpl_oat_t', tokenType: 'Bearer', scope: 'creator' }),
+      fetch: async () => {
+        miss.current?.stop();
+        return new Response('{}', { status: 404 });
+      },
+    });
+    miss.current = createRoundWatch({
+      getToken: () => 'tok',
+      api: missingApi,
+      setLive: (lines) => ignored.push(lines),
+      announce: () => undefined,
+      sleep: async () => undefined,
+    });
+    await miss.current.run;
+    expect(ignored).toEqual([]);
+  });
 });

--- a/apps/cli/src/tui/round-watch.test.ts
+++ b/apps/cli/src/tui/round-watch.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+import { createApi } from '../api.js';
+import { memoryStore } from '../keychain.js';
+import { createRoundWatch } from './round-watch.js';
+
+describe('round watch', () => {
+  it('paints live building then announces when Studio is waiting', async () => {
+    const live: string[][] = [];
+    const announced: string[] = [];
+    let polls = 0;
+    const holder: { current?: ReturnType<typeof createRoundWatch> } = {};
+    const api = createApi({
+      origin: 'https://www.gamedev.pl',
+      store: memoryStore({ accessToken: 'gdpl_oat_t', tokenType: 'Bearer', scope: 'creator' }),
+      fetch: async () => {
+        polls += 1;
+        const body =
+          polls === 1
+            ? { status: 'building', slug: 'diminishing-sparks' }
+            : { status: 'needs_changes', slug: 'diminishing-sparks', previewGate: { green: true } };
+        if (polls >= 2) holder.current?.stop();
+        return new Response(JSON.stringify(body), { status: 200 });
+      },
+    });
+    const slugs: string[] = [];
+    holder.current = createRoundWatch({
+      getToken: () => 'tok',
+      api,
+      setLive: (lines) => live.push(lines),
+      announce: (text) => announced.push(text),
+      onSlug: (slug) => slugs.push(slug),
+      sleep: async () => undefined,
+    });
+    await holder.current.run;
+    expect(polls).toBe(2);
+    expect(live[0]?.[0]).toBe('building');
+    expect(announced).toEqual(['round finished — Studio is waiting (preview green)']);
+    expect(live.at(-1)?.[0]).toContain('round finished');
+    expect(slugs).toEqual(['diminishing-sparks', 'diminishing-sparks']);
+  });
+});

--- a/apps/cli/src/tui/round-watch.test.ts
+++ b/apps/cli/src/tui/round-watch.test.ts
@@ -38,4 +38,29 @@ describe('round watch', () => {
     expect(live.at(-1)?.[0]).toContain('round finished');
     expect(slugs).toEqual(['diminishing-sparks', 'diminishing-sparks']);
   });
+
+  it('stops polling once the round is published', async () => {
+    let polls = 0;
+    const announced: string[] = [];
+    const api = createApi({
+      origin: 'https://www.gamedev.pl',
+      store: memoryStore({ accessToken: 'gdpl_oat_t', tokenType: 'Bearer', scope: 'creator' }),
+      fetch: async () => {
+        polls += 1;
+        return new Response(JSON.stringify({ status: 'published' }), { status: 200 });
+      },
+    });
+    const watch = createRoundWatch({
+      getToken: () => 'tok',
+      api,
+      setLive: () => undefined,
+      announce: (text) => announced.push(text),
+      sleep: async () => {
+        throw new Error('should not sleep after published');
+      },
+    });
+    await watch.run;
+    expect(polls).toBe(1);
+    expect(announced).toEqual(['published']);
+  });
 });

--- a/apps/cli/src/tui/round-watch.ts
+++ b/apps/cli/src/tui/round-watch.ts
@@ -1,4 +1,4 @@
-import { getStatus, type RoundStatus } from '../turn.js';
+import { getStatus, isTerminalStatus, type RoundStatus } from '../turn.js';
 import {
   formatRoundLive,
   formatStatusEvent,
@@ -44,6 +44,10 @@ export function createRoundWatch(input: {
           const key = statusFingerprint(status);
           if (shouldAnnounceStatus(status, lastKey, key)) input.announce(formatStatusEvent(status));
           lastKey = key;
+          if (isTerminalStatus(status.status)) {
+            stopped = true;
+            break;
+          }
         } catch {
           // 404 until a game is open
         }

--- a/apps/cli/src/tui/round-watch.ts
+++ b/apps/cli/src/tui/round-watch.ts
@@ -1,4 +1,6 @@
 import { getStatus, isTerminalStatus, type RoundStatus } from '../turn.js';
+import { CliError } from '../exit-codes.js';
+import { describeError } from '../errors.js';
 import {
   formatRoundLive,
   formatStatusEvent,
@@ -48,8 +50,10 @@ export function createRoundWatch(input: {
             stopped = true;
             break;
           }
-        } catch {
-          // 404 until a game is open
+        } catch (error) {
+          if (!(error instanceof CliError && error.message === 'not found')) {
+            input.setLive([describeError(error).message]);
+          }
         }
       }
       if (stopped) break;

--- a/apps/cli/src/tui/round-watch.ts
+++ b/apps/cli/src/tui/round-watch.ts
@@ -1,0 +1,71 @@
+import { getStatus, type RoundStatus } from '../turn.js';
+import {
+  formatRoundLive,
+  formatStatusEvent,
+  shouldAnnounceStatus,
+  statusFingerprint,
+  statusWatchDelayMs,
+} from '../status-watch.js';
+import type { ApiClient } from '../api.js';
+
+export type RoundWatch = {
+  poke: () => void;
+  stop: () => void;
+  run: Promise<void>;
+};
+
+export function createRoundWatch(input: {
+  getToken: () => string | null;
+  api: ApiClient;
+  setLive: (lines: string[]) => void;
+  announce: (text: string) => void;
+  onSlug?: (slug: string) => void;
+  sleep?: (ms: number) => Promise<void>;
+}): RoundWatch {
+  let stopped = false;
+  let wake: (() => void) | null = null;
+  const sleep = input.sleep ?? ((ms: number) => new Promise((resolve) => setTimeout(resolve, ms)));
+
+  function poke(): void {
+    wake?.();
+  }
+
+  const run = (async () => {
+    let lastKey = '';
+    let lastStatus: RoundStatus | undefined;
+    while (!stopped) {
+      const token = input.getToken();
+      if (token) {
+        try {
+          const status = await getStatus(input.api, token);
+          lastStatus = status;
+          if (status.slug) input.onSlug?.(status.slug);
+          input.setLive(formatRoundLive(status, input.api.origin));
+          const key = statusFingerprint(status);
+          if (shouldAnnounceStatus(status, lastKey, key)) input.announce(formatStatusEvent(status));
+          lastKey = key;
+        } catch {
+          // 404 until a game is open
+        }
+      }
+      if (stopped) break;
+      const delay = lastStatus ? statusWatchDelayMs(lastStatus) : 3000;
+      await Promise.race([
+        sleep(delay),
+        new Promise<void>((resolve) => {
+          wake = resolve;
+        }),
+      ]);
+      wake = null;
+    }
+  })();
+
+  return {
+    poke,
+    stop() {
+      stopped = true;
+      poke();
+    },
+    run,
+  };
+}

--- a/apps/cli/src/tui/session.test.ts
+++ b/apps/cli/src/tui/session.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { createTuiSession } from './session.js';
+import { createTuiSession, formatSessionIdentity } from './session.js';
 
 describe('tui session', () => {
   it('resolves a prompt from submit and a pick from the highlighted choice', async () => {
@@ -13,6 +13,26 @@ describe('tui session', () => {
     session.movePick(1);
     session.submit();
     expect(await picked).toBe('chaotic');
+  });
+
+  it('keeps live status across submit and stores the picker question', async () => {
+    const session = createTuiSession('banner');
+    session.setLive(['building']);
+    session.setIdentity('gt · maze');
+    const picked = session.prompt(['calm', 'chaotic'], 'What tone?');
+    expect(session.get().question).toBe('What tone?');
+    session.submit();
+    expect(await picked).toBe('calm');
+    expect(session.get().live).toEqual(['building']);
+    expect(session.get().identity).toBe('gt · maze');
+    expect(session.get().question).toBe('');
+  });
+
+  it('splits a multiline banner into transcript rows', () => {
+    const session = createTuiSession('one\ntwo');
+    expect(session.get().lines).toEqual(['one', 'two']);
+    expect(formatSessionIdentity('gt', 'maze')).toBe('gt · maze');
+    expect(formatSessionIdentity('', 'maze')).toBe('maze');
   });
 
   it('exits busy work from cancel when no prompt is pending', async () => {

--- a/apps/cli/src/tui/session.ts
+++ b/apps/cli/src/tui/session.ts
@@ -3,6 +3,8 @@ export type TuiMode = 'prompt' | 'pick' | 'busy';
 export type TuiState = {
   lines: string[];
   live: string[];
+  identity: string;
+  question: string;
   mode: TuiMode;
   draft: string;
   choices: string[];
@@ -14,19 +16,26 @@ export type TuiSession = {
   subscribe: (fn: (state: TuiState) => void) => () => void;
   writeLine: (text: string) => void;
   setLive: (live: string[]) => void;
+  setIdentity: (identity: string) => void;
   setDraft: (draft: string) => void;
   deleteLast: () => void;
   movePick: (delta: number) => void;
-  prompt: (choices?: string[]) => Promise<string>;
+  prompt: (choices?: string[], question?: string) => Promise<string>;
   submit: () => void;
   cancel: () => void;
   close: () => void;
 };
 
+export function formatSessionIdentity(who: string, slug: string): string {
+  return [who, slug].filter(Boolean).join(' · ');
+}
+
 export function createTuiSession(banner: string, onBusyCancel?: () => void): TuiSession {
   let state: TuiState = {
-    lines: banner ? [banner] : [],
+    lines: banner ? banner.split('\n') : [],
     live: [],
+    identity: '',
+    question: '',
     mode: 'busy',
     draft: '',
     choices: [],
@@ -51,11 +60,15 @@ export function createTuiSession(banner: string, onBusyCancel?: () => void): Tui
       };
     },
     writeLine(text) {
-      state = { ...state, lines: [...state.lines, text] };
+      state = { ...state, lines: [...state.lines, ...text.split('\n')] };
       emit();
     },
     setLive(live) {
       state = { ...state, live: live.slice(0, 4) };
+      emit();
+    },
+    setIdentity(identity) {
+      state = { ...state, identity };
       emit();
     },
     setDraft(draft) {
@@ -79,7 +92,7 @@ export function createTuiSession(banner: string, onBusyCancel?: () => void): Tui
       state = { ...state, pickIndex: (state.pickIndex + delta + n) % n };
       emit();
     },
-    prompt(choices) {
+    prompt(choices, question) {
       if (pending) {
         const stale = pending;
         pending = null;
@@ -91,6 +104,7 @@ export function createTuiSession(banner: string, onBusyCancel?: () => void): Tui
           ...state,
           mode: choices?.length ? 'pick' : 'prompt',
           choices: choices ?? [],
+          question: question ?? '',
           pickIndex: 0,
           draft: '',
         };
@@ -103,7 +117,7 @@ export function createTuiSession(banner: string, onBusyCancel?: () => void): Tui
       const resolve = pending;
       pending = null;
       const spoken = line.trim() ? [...state.lines, `› ${line}`] : state.lines;
-      state = { ...state, lines: spoken, mode: 'busy', draft: '', live: [], choices: [] };
+      state = { ...state, lines: spoken, mode: 'busy', draft: '', choices: [], question: '', pickIndex: 0 };
       emit();
       resolve(line);
     },
@@ -119,7 +133,7 @@ export function createTuiSession(banner: string, onBusyCancel?: () => void): Tui
       }
       const resolve = pending;
       pending = null;
-      state = { ...state, mode: 'busy', draft: '', live: [], choices: [] };
+      state = { ...state, mode: 'busy', draft: '', choices: [], question: '', pickIndex: 0 };
       emit();
       resolve('/quit');
     },

--- a/apps/cli/src/turn.ts
+++ b/apps/cli/src/turn.ts
@@ -16,6 +16,7 @@ export async function getTurns(
 
 export type RoundStatus = {
   status: string;
+  slug?: string;
   phase?: string;
   gateProgress?: { stage: string; index: number; total: number };
   previewGate?: { green: boolean };

--- a/apps/cli/src/verbs.test.ts
+++ b/apps/cli/src/verbs.test.ts
@@ -64,4 +64,15 @@ describe('dispatchReadVerb', () => {
     expect(await dispatchReadVerb({ verb: 'share', args: ['sky-dodge'], flags: {}, api, io })).toBe(EXIT_GREEN);
     expect(io.read()).toContain('/play/sky-dodge');
   });
+
+  it('prints quota as a sentence, not raw JSON', async () => {
+    const io = out();
+    const api = createApi({
+      origin: 'https://www.gamedev.pl',
+      store: memoryStore({ accessToken: 'gdpl_pat_x', tokenType: 'Bearer', scope: 'creator' }),
+      fetch: async () => new Response(JSON.stringify({ submissions: { used: 1, limit: 5 } }), { status: 200 }),
+    });
+    expect(await dispatchReadVerb({ verb: 'quota', args: [], flags: {}, api, io })).toBe(EXIT_GREEN);
+    expect(io.read().trim()).toBe('1 of 5 submissions today');
+  });
 });

--- a/apps/cli/src/verbs.ts
+++ b/apps/cli/src/verbs.ts
@@ -11,6 +11,13 @@ function emit(io: Io, asJson: boolean, data: unknown, line: string): void {
   io.stdout.write(asJson ? `${JSON.stringify(data)}\n` : `${line}\n`);
 }
 
+export function formatQuotaLine(data: Record<string, unknown>): string {
+  const submissions = data.submissions as { used?: number; limit?: number | null } | undefined;
+  if (!submissions || typeof submissions.used !== 'number') return JSON.stringify(data);
+  if (submissions.limit == null) return `${submissions.used} submissions today (no daily ceiling)`;
+  return `${submissions.used} of ${submissions.limit} submissions today`;
+}
+
 export async function dispatchReadVerb(input: {
   verb: string;
   args: string[];
@@ -37,7 +44,7 @@ export async function dispatchReadVerb(input: {
   }
   if (verb === 'quota') {
     const data = await api.request<Record<string, unknown>>('GET', '/api/me/quota');
-    emit(io, asJson, data, JSON.stringify(data));
+    emit(io, asJson, data, formatQuotaLine(data));
     return EXIT_GREEN;
   }
   if (verb === 'notifications') {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
The Ink REPL treated `▸ opened <slug>` as the last word on the round. After that it only waited for the next typed line, so Studio could already be on `needs_changes` / preview green while the terminal still showed the open line.

This watches `GET /api/submissions/:token` on the Studio cadence (3s while building, 10s otherwise), paints the current status in the live strip, and writes a transcript line only on a round boundary: preview-green `needs_changes`, `published`, or `abandoned`. `gate_red` / `kit_outdated` stay an open repair round (same as `transitionClosesRound`). Gate progress only repaints the live strip. The watcher stops on `published` / `abandoned`. `/status` in the REPL uses the open session token. `/quota` prints a sentence instead of raw JSON.

TUI chrome takes the useful bits from other interactive CLIs without copying an alternate-screen takeover: ASCII mascot on first paint, `›` composer with no extra `gamedevpl` label, picker question inside the box, session footer (`who · slug · version`). Live status is not cleared on submit.

```bash
npm test -w @gamedevpl/cli
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c227c8cb-c1d6-41f1-9f0a-5787614f7ba7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c227c8cb-c1d6-41f1-9f0a-5787614f7ba7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

