### PR TITLE
ci(cli): publish the release with gh, not a third-party action

### DIFF
--- a/.github/workflows/cli-release.yml
+++ b/.github/workflows/cli-release.yml
@@ -42,9 +42,12 @@ jobs:
         with:
           subject-path: apps/cli/dist/release/*
       - name: Publish GitHub Release
-        uses: softprops/action-gh-release@v2
-        with:
-          tag_name: cli-v${{ env.VERSION }}
-          name: gamedevpl CLI v${{ env.VERSION }}
-          generate_release_notes: true
-          files: apps/cli/dist/release/*
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          gh release create "cli-v$VERSION" \
+            --title "gamedevpl CLI v$VERSION" \
+            --target "$GITHUB_SHA" \
+            --generate-notes \
+            apps/cli/dist/release/*


### PR DESCRIPTION
## The install one-liner is broken in production

`curl -fsSL https://www.gamedev.pl/install.sh | bash` fails with **404**. The installer is live and correct — it fetches `gamedevpl` and `SHA256SUMS` from Releases under the `cli-v0.1.0` tag — but **the repository has no releases at all**, so there is nothing to fetch. This has been the state since Wave F merged; anyone who used the one-liner from `/cli` hit it.

## Root cause: the release workflow has never run a single job

`cli-release.yml` exists and looks right, but it has fired twice and **both runs ended in `startup_failure` with zero jobs**:

| Run | Trigger | Result |
| --- | --- | --- |
| #1 | push of tag `cli-v0.1.0` (06:39 today) | `startup_failure`, 0 jobs |
| #2 | manual `workflow_dispatch`, version `0.1.0` | `startup_failure`, 0 jobs |

Zero jobs means the run was rejected before anything started — a workflow-level problem, not a step failing. The YAML parses cleanly, which leaves the **action allowlist** as the leading candidate: `softprops/action-gh-release@v2` is the only action in any workflow in this repo that GitHub does not own. I cannot read the org's Actions policy from here, so I am stating that as the hypothesis the evidence points to rather than as fact — but the fix is correct regardless and matches the convention every other workflow here already follows.

## The change

Replaces the third-party action with `gh release create`, which is preinstalled on the runner and authenticated by the job's own `GITHUB_TOKEN`. The workflow now uses only GitHub-owned actions (`actions/checkout`, `actions/setup-node`, `actions/attest-build-provenance`). `--target "$GITHUB_SHA"` pins the release to the commit that was actually built.

## Verified locally

I built the artifact with the same script CI runs (`apps/cli/scripts/compile-release.sh`) against current `master`:

```
bundled dist/gamedevpl.mjs — shebang Node script, Ink+yoga inlined
cli-v0.1.0 artifact — 1.5 MB
e6cbe341…88aaa  gamedevpl
```

It runs: `--help` lists the verb set, and it correctly detects a non-TTY. So the bundle is sound and the only thing between it and a working install is publishing.

## One thing to decide before the next dispatch

The existing `cli-v0.1.0` tag points at `a23efbe`, which predates gamedevpl/www.gamedev.pl#1158 — so a release cut against that tag would ship the CLI **without** the PAT credential-boundary fix. Either delete the stale tag so the workflow recreates it at current `master`, or bump to `0.1.1` (the installer's default `VERSION` would need the same bump). I did not touch the tag, since that is a call for the repo owner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AJNcxBU2JJg3mPykeMqLGw

---
_Generated by [Claude Code](https://claude.ai/code/session_01AJNcxBU2JJg3mPykeMqLGw)_