### PR TITLE
ci(cli): drop --generate-notes, it overflows on a first release

### DIFF
--- a/.github/workflows/cli-release.yml
+++ b/.github/workflows/cli-release.yml
@@ -49,5 +49,5 @@ jobs:
           gh release create "cli-v$VERSION" \
             --title "gamedevpl CLI v$VERSION" \
             --target "$GITHUB_SHA" \
-            --generate-notes \
+            --notes "Install: \`curl -fsSL https://www.gamedev.pl/install.sh | bash\`" \
             apps/cli/dist/release/*


### PR DESCRIPTION
Follow-up to gamedevpl/www.gamedev.pl#1161. That fix worked: the workflow now starts, builds the bundle, and uploads a provenance attestation to Rekor. It fails one step later.

```
HTTP 422: Validation Failed
body is too long (maximum is 125000 characters)
```

`--generate-notes` had no previous tag to diff against — this is the repository's first release — so it generated notes spanning the entire commit history, well past GitHub's 125k limit on a release body.

Replaced with a one-line note carrying the install command. Once a `cli-v*` release exists, a later version could go back to `--generate-notes` and get a sane diff, but there is no reason to reach for it.

This is the last known thing between `curl -fsSL https://www.gamedev.pl/install.sh | bash` and a working install.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AJNcxBU2JJg3mPykeMqLGw

---
_Generated by [Claude Code](https://claude.ai/code/session_01AJNcxBU2JJg3mPykeMqLGw)_