### PR TITLE
fix(security): patch fast-uri and fastify vulnerabilities

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -48,7 +48,7 @@
     "@google-cloud/firestore": "^8.7.0",
     "diff": "^9.0.0",
     "esbuild": "0.25.12",
-    "fastify": "^5.10.0",
+    "fastify": "^5.12.3",
     "fastify-rate-limit": "npm:@fastify/rate-limit@^11.1.0",
     "genaicode": "^2.3.0",
     "google-auth-library": "^10.9.0",

--- a/apps/api/src/platform/app.ts
+++ b/apps/api/src/platform/app.ts
@@ -231,7 +231,7 @@ export async function buildApp(options: BuildAppOptions = {}): Promise<FastifyIn
   // nothing in the logs. MAX_REMIX_ID_LENGTH is the bound the minter respects.
   const app = Fastify({
     logger: options.logger ?? false,
-    trustProxy: 1,
+    trustProxy: (_address, hop) => hop === 0,
     routerOptions: { maxParamLength: MAX_REMIX_ID_LENGTH },
   });
 

--- a/apps/api/src/platform/client-address-metrics.test.ts
+++ b/apps/api/src/platform/client-address-metrics.test.ts
@@ -23,7 +23,7 @@ describe('isUnattributable', () => {
 });
 
 async function appReporting(records: { msg: string; context: object }[]) {
-  const app = Fastify({ trustProxy: 1, logger: { level: 'warn' } });
+  const app = Fastify({ trustProxy: (_address, hop) => hop === 0, logger: { level: 'warn' } });
   const capture = ((context: object, msg: string) => {
     if (msg === UNATTRIBUTABLE_CLIENT_LOG_MSG || msg === IP_BUCKET_REFUSAL_LOG_MSG) records.push({ msg, context });
   }) as typeof app.log.warn;

--- a/apps/api/src/platform/rate-limit.test.ts
+++ b/apps/api/src/platform/rate-limit.test.ts
@@ -8,7 +8,7 @@ afterEach(() => {
 });
 
 async function appWithCappedRoute() {
-  const app = Fastify({ trustProxy: 1 });
+  const app = Fastify({ trustProxy: (_address, hop) => hop === 0 });
   registerClientAddress(app);
   await registerRateLimit(app);
   app.get('/capped', { config: { rateLimit: { max: 2, timeWindow: '1 minute' } } }, async () => ({ ok: true }));

--- a/apps/world/package.json
+++ b/apps/world/package.json
@@ -16,7 +16,7 @@
     "@gamedevpl/zone-core": "*",
     "@google-cloud/firestore": "^8.7.0",
     "esbuild": "0.25.12",
-    "fastify": "^5.10.0",
+    "fastify": "^5.12.3",
     "zod": "^3.23.8"
   },
   "devDependencies": {

--- a/apps/world/src/app.ts
+++ b/apps/world/src/app.ts
@@ -73,7 +73,7 @@ export async function buildWorldApp(options: WorldAppOptions): Promise<WorldApp>
   // Cloud Run appends the real client IP to X-Forwarded-For rather than replacing it, so
   // trusting exactly one hop resolves to the entry Cloud Run itself wrote. `true` would
   // take the leftmost and let any caller pick their own rate-limit bucket.
-  const app = Fastify({ logger: options.logger ?? false, trustProxy: 1 });
+  const app = Fastify({ logger: options.logger ?? false, trustProxy: (_address, hop) => hop === 0 });
   const host = new ZoneHost({
     ...options,
     secret,

--- a/package-lock.json
+++ b/package-lock.json
@@ -45,7 +45,7 @@
         "@google-cloud/firestore": "^8.7.0",
         "diff": "^9.0.0",
         "esbuild": "0.25.12",
-        "fastify": "^5.10.0",
+        "fastify": "^5.12.3",
         "fastify-rate-limit": "npm:@fastify/rate-limit@^11.1.0",
         "genaicode": "^2.3.0",
         "google-auth-library": "^10.9.0",
@@ -173,7 +173,7 @@
         "@gamedevpl/zone-core": "*",
         "@google-cloud/firestore": "^8.7.0",
         "esbuild": "0.25.12",
-        "fastify": "^5.10.0",
+        "fastify": "^5.12.3",
         "zod": "^3.23.8"
       },
       "devDependencies": {
@@ -4477,9 +4477,9 @@
       }
     },
     "node_modules/fast-uri": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
-      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.7.tgz",
+      "integrity": "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==",
       "funding": [
         {
           "type": "github",
@@ -4493,9 +4493,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/fastify": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/fastify/-/fastify-5.10.0.tgz",
-      "integrity": "sha512-A9L0ziuWGQHgEEVgF3davQ9vbD93IuX+lo2IsxapQmu5b/Y/ynn9m9K5JHt9dvyJXOFc5iN0Zk5GHEOqnzhWjg==",
+      "version": "5.12.3",
+      "resolved": "https://registry.npmjs.org/fastify/-/fastify-5.12.3.tgz",
+      "integrity": "sha512-reZ8wce5VNCcufIt9AVtzZa3L4u1j8esikn7OEgHWLVpRpL5R7Y2+Xzj70OUkv5zDfzUAxXZT6cu4Rt0zr3EKA==",
       "funding": [
         {
           "type": "github",
@@ -4518,7 +4518,7 @@
         "find-my-way": "^9.6.0",
         "light-my-request": "^6.0.0",
         "pino": "^9.14.0 || ^10.1.0",
-        "process-warning": "^5.0.0",
+        "process-warning": "^5.1.0",
         "rfdc": "^1.3.1",
         "secure-json-parse": "^4.0.0",
         "semver": "^7.6.0",
@@ -5756,9 +5756,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {
@@ -6178,9 +6178,9 @@
       }
     },
     "node_modules/process-warning": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-5.0.0.tgz",
-      "integrity": "sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-5.1.0.tgz",
+      "integrity": "sha512-jQSaVHsPgtyw60e1rQ/A+/ArPEj/S8pS/vFnyGa/gYFXrKk/6RuDkoqVDQ5NI5MmS01698ltlAk0NoDBNLujRw==",
       "funding": [
         {
           "type": "github",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "vitest": "^3.2.7"
   },
   "overrides": {
-    "fast-uri": "^3.1.2",
+    "fast-uri": "^3.1.7",
     "esbuild": "^0.25.0",
     "minimatch@^9.0.0": "^10.2.5"
   },


### PR DESCRIPTION
### Summary
Resolves Dependabot security alerts for `fast-uri` and `fastify`:

#### Dependabot Alerts Resolved
- [fast-uri vulnerable to host confusion via percent-encoded scheme normalization](https://github.com/gamedevpl/www.gamedev.pl/security/dependabot/1218) (#1218 High) - [GHSA-jqff-g426-hqxp](https://github.com/advisories/GHSA-jqff-g426-hqxp) / CVE-2026-76172
- [fast-uri vulnerable to host confusion via skipped IDN canonicalization on scheme-relative references](https://github.com/gamedevpl/www.gamedev.pl/security/dependabot/1214) (#1214 High) - [GHSA-5jgf-p345-68v8](https://github.com/advisories/GHSA-5jgf-p345-68v8) / CVE-2026-75931
- [fast-uri vulnerable to server-side request forgery via malformed IPv6 normalization](https://github.com/gamedevpl/www.gamedev.pl/security/dependabot/1217) (#1217 High) - [GHSA-f65p-4m7j-42xc](https://github.com/advisories/GHSA-f65p-4m7j-42xc) / CVE-2026-75975
- [fast-uri vulnerable to server-side request forgery via repeated hostname percent-decoding](https://github.com/gamedevpl/www.gamedev.pl/security/dependabot/1216) (#1216 High) - [GHSA-fph4-wmhf-6fwf](https://github.com/advisories/GHSA-fph4-wmhf-6fwf) / CVE-2026-75899
- [fastify vulnerable to X-Forwarded-* spoofing under trustProxy hop-count](https://github.com/gamedevpl/www.gamedev.pl/security/dependabot/1213) (#1213 Moderate) - [GHSA-3m5p-2c4r-xxw2](https://github.com/advisories/GHSA-3m5p-2c4r-xxw2)
- [fastify vulnerable to schema validation bypass via root primitive coercion mismatch](https://github.com/gamedevpl/www.gamedev.pl/security/dependabot/1215) (#1215 Moderate) - [GHSA-w2qp-rph6-63g4](https://github.com/advisories/GHSA-w2qp-rph6-63g4) / CVE-2026-18504

Additionally bumps `nanoid` to 3.3.18 ([GHSA-2v37-7h3g-55p8](https://github.com/advisories/GHSA-2v37-7h3g-55p8)), resulting in 0 remaining vulnerabilities in `npm audit`.

### Changes
1. **`package.json`**: Update override `"fast-uri": "^3.1.2"` -> `"fast-uri": "^3.1.7"`.
2. **`apps/api/package.json` & `apps/world/package.json`**: Update dependency `"fastify": "^5.10.0"` -> `"fastify": "^5.12.3"`.
3. **`apps/api/src/platform/app.ts` & `apps/world/src/app.ts`**: Fastify 5.12+ disabled numeric `trustProxy: <number>` at runtime and in types due to hop-count spoofing risks. Migrated `trustProxy: 1` to `trustProxy: (_address, hop) => hop === 0` to satisfy the new type and maintain Cloud Run 1-hop client resolution semantics. Updated corresponding unit test instances.
4. **`package-lock.json`**: Updated lockfile to reflect hoisted `fastify@5.12.3`, `fast-uri@3.1.7`, and `nanoid@3.3.18`.

### Verification
- `npm audit`: `found 0 vulnerabilities`
- `npm run type-check`: clean across all workspaces
- `npm run lint`: clean (0 errors)
- `npm run test`: clean across monorepo
- `npm run build`: clean