### PR TITLE
Potential fix for code scanning alert no. 51: Client-side cross-site scripting

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -241,7 +241,14 @@ export function App() {
       setIsAuthModalOpen(true);
       return;
     }
-    window.location.replace(oauthReturn);
+    try {
+      const oauthUrl = new URL(oauthReturn, window.location.origin);
+      if (oauthUrl.origin !== window.location.origin) return;
+      if (oauthUrl.pathname !== '/oauth/authorize' && oauthUrl.pathname !== '/device') return;
+      window.location.replace(`${oauthUrl.pathname}${oauthUrl.search}`);
+    } catch {
+      return;
+    }
   }, [authLoading, user]);
 
   // Unpublished `/play/<slug>` uses UnpublishedPlayView's own theater (not `stageContent`),

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -42,7 +42,7 @@ import { ClosedBetaSplash } from './ClosedBetaSplash.js';
 import { BetaInvitePage } from './BetaInvitePage.js';
 import { AppLoadingScreen } from './AppLoadingScreen.js';
 import { ControllerView } from './surfaces/party/ControllerView.js';
-import { parseOAuthReturnParam } from './oauthReturn.js';
+import { navigateToOAuthReturn, parseOAuthReturnParam } from './oauthRedirect.js';
 
 // Deferred: an anonymous player playing a published game never has to pay for the
 // weight of the admin console, the studio (and everything it drags in — the code
@@ -241,14 +241,7 @@ export function App() {
       setIsAuthModalOpen(true);
       return;
     }
-    try {
-      const oauthUrl = new URL(oauthReturn, window.location.origin);
-      if (oauthUrl.origin !== window.location.origin) return;
-      if (oauthUrl.pathname !== '/oauth/authorize' && oauthUrl.pathname !== '/device') return;
-      window.location.replace(`${oauthUrl.pathname}${oauthUrl.search}`);
-    } catch {
-      return;
-    }
+    navigateToOAuthReturn(oauthReturn, window.location);
   }, [authLoading, user]);
 
   // Unpublished `/play/<slug>` uses UnpublishedPlayView's own theater (not `stageContent`),

--- a/apps/web/src/oauthRedirect.test.ts
+++ b/apps/web/src/oauthRedirect.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it, vi } from 'vitest';
+import { navigateToOAuthReturn } from './oauthRedirect.js';
+
+describe('navigateToOAuthReturn', () => {
+  it('navigates only to an approved same-origin OAuth route', () => {
+    const location = { origin: 'https://www.gamedev.pl', replace: vi.fn() };
+
+    navigateToOAuthReturn('/oauth/authorize?client_id=abc', location);
+    navigateToOAuthReturn('https://evil.test/oauth/authorize', location);
+    navigateToOAuthReturn('/admin', location);
+
+    expect(location.replace).toHaveBeenCalledOnce();
+    expect(location.replace).toHaveBeenCalledWith('/oauth/authorize?client_id=abc');
+  });
+});

--- a/apps/web/src/oauthRedirect.ts
+++ b/apps/web/src/oauthRedirect.ts
@@ -1,0 +1,12 @@
+export { parseOAuthReturnParam } from './oauthReturn.js';
+
+export function navigateToOAuthReturn(path: string, location: Pick<Location, 'origin' | 'replace'>): void {
+  try {
+    const oauthUrl = new URL(path, location.origin);
+    if (oauthUrl.origin !== location.origin) return;
+    if (oauthUrl.pathname !== '/oauth/authorize' && oauthUrl.pathname !== '/device') return;
+    location.replace(`${oauthUrl.pathname}${oauthUrl.search}`);
+  } catch {
+    return;
+  }
+}


### PR DESCRIPTION
Potential fix for [https://github.com/gamedevpl/www.gamedev.pl/security/code-scanning/51](https://github.com/gamedevpl/www.gamedev.pl/security/code-scanning/51)

Use **URL parsing + strict allowlisting of pathname** before redirecting.  
Best fix without changing behavior: in `apps/web/src/App.tsx`, parse the returned path with `new URL(oauthReturn, window.location.origin)`, ensure `url.origin === window.location.origin`, and allow only exact pathnames `/oauth/authorize` or `/device`. Then call `window.location.replace(url.pathname + url.search)` (optionally `+ url.hash` if needed; here not needed). This converts custom string checks at sink-time into canonicalized validation right before navigation and prevents protocol/encoding bypasses.

Changes needed:
- Edit the OAuth redirect `useEffect` in `apps/web/src/App.tsx` around lines 236–245.
- No new imports required.
- No dependency additions required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
