### PR TITLE
ci: build the app and world images on the GitHub runner, not in Cloud Build

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -60,15 +60,27 @@ jobs:
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@e427ad8a34f8676edf47cf7d7925499adf3eb74f # v2
 
-      - name: Build image via Cloud Build
+      - name: Build and push image
+        # Built on this runner, not in Cloud Build. CI already builds this exact Dockerfile
+        # here for its image-boot check, so every master push was paying Cloud Build to do
+        # it a second time — 627 builds and ~1,900 default-pool minutes in August 2026, for
+        # work GitHub's runner does inside its free allowance. infra/cloudbuild.yaml stays
+        # as the hand-run path behind infra/deploy-api.sh.
+        env:
+          VITE_GOOGLE_OAUTH_CLIENT_ID: ${{ vars.GOOGLE_OAUTH_CLIENT_ID }}
+          VITE_APPLE_SERVICES_ID: ${{ vars.APPLE_SERVICES_ID }}
+          VITE_MP_RELAY_URL: ${{ vars.MP_RELAY_URL }}
         run: |
           SHORT_SHA=$(echo "${DEPLOY_SHA}" | cut -c1-7)
           IMAGE="${REGION}-docker.pkg.dev/${PROJECT_ID}/${REPO}/app:${SHORT_SHA}"
           echo "IMAGE=${IMAGE}" >> $GITHUB_ENV
-          gcloud builds submit . \
-            --config infra/cloudbuild.yaml \
-            --substitutions "_IMAGE=${IMAGE},_GOOGLE_OAUTH_CLIENT_ID=${{ vars.GOOGLE_OAUTH_CLIENT_ID }},_APPLE_SERVICES_ID=${{ vars.APPLE_SERVICES_ID }},_MP_RELAY_URL=${{ vars.MP_RELAY_URL }}" \
-            --project "$PROJECT_ID"
+          gcloud auth configure-docker "${REGION}-docker.pkg.dev" --quiet
+          docker build -f apps/api/Dockerfile \
+            --build-arg "VITE_GOOGLE_OAUTH_CLIENT_ID=${VITE_GOOGLE_OAUTH_CLIENT_ID}" \
+            --build-arg "VITE_APPLE_SERVICES_ID=${VITE_APPLE_SERVICES_ID}" \
+            --build-arg "VITE_MP_RELAY_URL=${VITE_MP_RELAY_URL}" \
+            -t "${IMAGE}" .
+          docker push "${IMAGE}"
 
       - name: Deploy candidate revision to Cloud Run
         # Repo variables arrive as step env rather than being interpolated into the script.
@@ -846,8 +858,10 @@ jobs:
 
           if [ "$NEEDS_BUILD" = true ]; then
             echo "Building ${TARGET_IMAGE}"
-            gcloud builds submit . --config infra/cloudbuild-world.yaml \
-              --substitutions "_IMAGE=${TARGET_IMAGE}" --project "$PROJECT_ID"
+            # Same runner-side build as the app image, for the same reason.
+            gcloud auth configure-docker "${REGION}-docker.pkg.dev" --quiet
+            docker build -f apps/world/Dockerfile -t "${TARGET_IMAGE}" .
+            docker push "${TARGET_IMAGE}"
             # --image alone, never --set-env-vars: this step must not be able to
             # reconfigure the zone host by omission. Its env and secrets are
             # deploy-world.sh's business.

--- a/infra/cloudbuild-world.yaml
+++ b/infra/cloudbuild-world.yaml
@@ -1,3 +1,4 @@
+# Hand-run path only: the deploy workflow builds this image on the GitHub runner.
 # Builds the gamedev-world zone host image from the repo root using apps/world/Dockerfile
 # and pushes it to Artifact Registry. Invoked by infra/deploy-world.sh.
 #

--- a/infra/cloudbuild.yaml
+++ b/infra/cloudbuild.yaml
@@ -1,3 +1,4 @@
+# Hand-run path only: the deploy workflow builds this image on the GitHub runner.
 # Builds the gamedev.pl app image (static web + API) from the repo root using
 # apps/api/Dockerfile and pushes it to Artifact Registry. Invoked by
 # infra/deploy-api.sh via `gcloud builds submit --config infra/cloudbuild.yaml`.


### PR DESCRIPTION
## Why

Every master push built `apps/api/Dockerfile` **twice**: once on the CI runner for the image-boot check (`ci.yml` → *Production image*), then again in Cloud Build from the deploy workflow. The August invoice prices the second build: **627 untagged default-pool builds, ~1,900 minutes, ≈ 8 USD net** — for work GitHub's runner already does inside its free allowance.

## What changed

- `deploy.yml` builds and pushes the app image itself: `gcloud auth configure-docker` on the WIF credentials it already deploys with (the deployer SA holds `artifactregistry.writer`), `docker build` with the same three `VITE_*` build args the Cloud Build substitutions carried, `docker push`. The build args ride as step env, not inline `${{ }}` — the reason is documented on the very next step.
- The conditional world-image build (`gamedev-world`) gets the same treatment.
- `infra/cloudbuild.yaml` and `infra/cloudbuild-world.yaml` stay, each marked as the hand-run path behind `infra/deploy-api.sh`. `npm run env-manifest` still passes — both deploy paths thread the same env; only the build tool differs.

## Deliberately not touched: gate builds

The other ~1,900 Cloud Build minutes in August are gates, and I looked hard at cutting them before deciding not to. Duration distribution for August, by mode:

| mode | n | p50 | p95 | max |
|---|---|---|---|---|
| preview | 300 | 1.6 min | 2.6 | 4.2 |
| health | 107 | 1.8 | 2.7 | 17.3 |
| full (publish) | 194 | 2.7 | **30.3** | 30.5 |

The long tail is two games — `transport-tycoon-remake` and `global-thermonuclear-strategy` — whose full gates legitimately run **15–25 minutes and pass** (the agency gate playing them). The ten 30-minute `TIMEOUT` rows on the same two games are the wall-clock hang the games repo fixed on 2026-08-29. So a shorter gate timeout would break real games, not save money, and preview/health gates are already cheap and bounded (health sweep starts at most 3 per night). Left alone on purpose.

## Verification

- YAML parses; `npm run env-manifest` green.
- The first deploy after merge is the real test: the *Build and push image* step should finish in ~3 min on the runner and Cloud Build's history should stop gaining untagged builds. I will watch that deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
