### PR TITLE
Build the Hosting upload with the image's VITE values, so asset hashes match

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -906,6 +906,15 @@ jobs:
         # on every deploy.
         #
         # Needs roles/firebasehosting.admin on the deploy service account.
+        # The hashes must match the image's. Vite content-hashes each chunk, and the main
+        # bundle inlines these three values, so a build without them produces a different
+        # index-*.js name than the one the image's index.html references — measured on the
+        # first deploy: the CSS (which embeds nothing) was served by Hosting, the JS fell
+        # through to the rewrite. Same env as "Build and push image", kept in lockstep.
+        env:
+          VITE_GOOGLE_OAUTH_CLIENT_ID: ${{ vars.GOOGLE_OAUTH_CLIENT_ID }}
+          VITE_APPLE_SERVICES_ID: ${{ vars.APPLE_SERVICES_ID }}
+          VITE_MP_RELAY_URL: ${{ vars.MP_RELAY_URL }}
         run: |
           # npm ci alone leaves the workspace packages unbuilt, and apps/web will not
           # typecheck against their stale dists.
@@ -913,7 +922,7 @@ jobs:
           npm run build --workspace apps/web
           rm -rf infra/firebase/public/assets
           cp -r apps/web/dist/assets infra/firebase/public/assets
-          npx firebase-tools deploy \
+          npx firebase-tools@15.29.0 deploy \
             --only hosting \
             --project "$PROJECT_ID" \
             --config infra/firebase/firebase.json \


### PR DESCRIPTION
## What

One-step fix to the deploy workflow: the "Upload web assets to Firebase Hosting" step now builds `apps/web` with the same three `VITE_*` values the image build receives, so the hashed asset names it uploads are the ones the image's `index.html` actually references. `firebase-tools` is pinned to `15.29.0`, the version the first deploy resolved.

## What the first deploy showed

#1170 shipped the upload step and it worked end to end — 357 files, Workload Identity auth to Hosting, promotion. Then measuring what Hosting actually serves, for the two assets the live `index.html` references:

| Asset | Served by |
|---|---|
| `index-*.css` | Hosting itself (`vary` without `cookie`) |
| `index-*.js` | **fell through to the Cloud Run rewrite** (`vary` with `cookie`) |

## Why

Vite content-hashes each chunk. The main JS bundle inlines `VITE_GOOGLE_OAUTH_CLIENT_ID`, `VITE_APPLE_SERVICES_ID` and `VITE_MP_RELAY_URL`; the CSS embeds none of them. The "Build and push image" step passes those as build args from repo variables. The upload step built without them — so it produced an `index-*.js` under a different name than the one the image's `index.html` asks for, while the CSS hash matched.

Reproduced locally: two builds differing only in the client id give the **same** CSS hash and a **different** JS hash.

## Why nothing looked broken

The fallback did exactly what it was designed to do. Anything Hosting lacks falls through the `**` rewrite to the origin, which always carries a complete copy — so the JS was served from Cloud Run, uncached, never a 404. Safe, and invisible without measuring. That is the failure this fix makes rare.

## Notes for review

- The `env` block is a copy of the one on "Build and push image", with a comment saying the two must stay in lockstep. Drift between them reproduces exactly this symptom.
- Pinning `firebase-tools` closes a separate small hole: `npx firebase-tools` unpinned fetched whatever was latest on each deploy, so a CLI release could change the step under us on a random day.
- Verification after this deploys: fetch `gamedevpl.web.app/`, take the current `index-*.js` name, fetch it twice through Hosting — expect `vary` without `cookie` and `x-cache: HIT` on the second. That is the gate for the DNS cutover.

## Test plan

- `npm run lint` — exit 0, full seal chain including the Hosting config gate and the env-manifest check that parses this workflow.
- YAML parses.
- Local reproduction of the hash behaviour described above.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EptooEgKrMQT6zxdp5DABq

---
_Generated by [Claude Code](https://claude.ai/code/session_01EptooEgKrMQT6zxdp5DABq)_