### PR TITLE
Mirror the Dockerfile's full VITE set in the Hosting upload build

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -910,8 +910,12 @@ jobs:
         # bundle inlines these three values, so a build without them produces a different
         # index-*.js name than the one the image's index.html references — measured on the
         # first deploy: the CSS (which embeds nothing) was served by Hosting, the JS fell
-        # through to the rewrite. Same env as "Build and push image", kept in lockstep.
+        # through to the rewrite. The set must equal the Dockerfile's VITE_* ARGs, not just
+        # the ones the image build passes: the Dockerfile defines VITE_API_BASE_URL as an
+        # empty string, and Vite compiles a defined-empty variable differently from an
+        # absent one — measured, the JS hash differs on that alone while the CSS matches.
         env:
+          VITE_API_BASE_URL: ''
           VITE_GOOGLE_OAUTH_CLIENT_ID: ${{ vars.GOOGLE_OAUTH_CLIENT_ID }}
           VITE_APPLE_SERVICES_ID: ${{ vars.APPLE_SERVICES_ID }}
           VITE_MP_RELAY_URL: ${{ vars.MP_RELAY_URL }}


### PR DESCRIPTION
## What

One line of substance: the "Upload web assets to Firebase Hosting" step now defines `VITE_API_BASE_URL: ''`, mirroring the Dockerfile's fourth `VITE_*` ARG. The comment above the block now names the Dockerfile's ARG list — not the image step's pass-through list — as the source of truth.

## Why #1175 was not enough

#1175 aligned the three `VITE_*` values the image build passes explicitly. The next deploy's log shows, in one run, that the JS hash still differed:

| Build | `index-*.js` | `index-*.css` |
|---|---|---|
| image ("Build and push image") | `index-4PCEr719.js` — what the live `index.html` references | `index-Cgp6SJbn.css` |
| runner (upload step) | `index-C0dLRDTi.js` | `index-Cgp6SJbn.css` |

The Dockerfile declares **four** `VITE_*` ARGs. `VITE_API_BASE_URL` has an empty default, so inside the image build it is a *defined empty string*; the runner never defined it at all. Vite compiles a defined-empty variable differently from an absent one, and the main bundle reads it in several API modules — so the two bundles diverge on that alone, while the CSS (which embeds nothing) matches.

Reproduced locally with the three other values held constant: unset vs `''` gives a different JS hash and the same CSS hash.

## Notes for review

- The source of truth for this env block is the Dockerfile's `ARG VITE_*` list. Anyone adding a fifth ARG there needs to add it here; the comment says so.
- Nothing else changes. The pinned `firebase-tools` version from #1175 stays.
- Verification after deploy: fetch `gamedevpl.web.app/`, take the current `index-*.js` name, fetch it twice through Hosting — expect `vary` **without** `cookie` and `x-cache: HIT` on the second. That is the DNS cutover gate.

## Test plan

- `npm run lint` — exit 0, full seal chain including the env-manifest check that parses this workflow.
- YAML parses.
- Local reproduction described above.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EptooEgKrMQT6zxdp5DABq

---
_Generated by [Claude Code](https://claude.ai/code/session_01EptooEgKrMQT6zxdp5DABq)_