### PR TITLE
feat(cli): a checkout is a workshop — the local agent edits the game you are standing in

### DIFF
--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -7,6 +7,10 @@ decides the next version — see [`.claude/skills/cli-release/SKILL.md`](../../.
 
 ## Unreleased
 
+### Added
+
+- Started in a game checkout, `gamedevpl` opens that game instead of asking what to make
+
 ### Fixed
 
 - `gamedevpl` prints the version it actually is; every release so far reported 0.1.0 in the banner, footer and `help`

--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -10,6 +10,9 @@ decides the next version — see [`.claude/skills/cli-release/SKILL.md`](../../.
 ### Added
 
 - Started in a game checkout, `gamedevpl` opens that game instead of asking what to make
+- In a checkout, saying what to change runs `claude` / `codex` / `gemini` / `vibe` from your machine on the game,
+  verifies the tree and offers to deliver; `/delegate <task>` skips the chat, `/builder self|platform` picks who builds,
+  and `gamedevpl delegate "<task>" [--submit]` does the same non-interactively
 
 ### Fixed
 

--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -85,7 +85,7 @@ With builder `self`, a plain message goes to the Studio chat first — questions
 answers; a change request runs the local agent in `games/<slug>` with a brief, then the
 static ladder, then offers to deliver. The agent never sees the OAuth grant. Ctrl+C stops
 the agent, not the session. `/delegate <task>` skips the chat; `gamedevpl delegate "<task>"
-[--agent codex] [--submit]` is the non-interactive form (exit `1` when the agent or the
+[--agent codex] [--handoff] [--submit]` is the non-interactive form (exit `1` when the agent or the
 ladder fails).
 
 `gamedevpl connect <slug>` prints the MCP handoff (URL, kickoff, install snippet).

--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -35,7 +35,7 @@ node apps/cli/dist/gamedevpl.mjs help
 ## Verbs
 
 `login` `logout` `whoami` `games` `status` `share` `profile` `handle` `builder`
-`connect` `checkout` `pull` `diff` `submit` `quota` `notifications` `update` `help`
+`connect` `delegate` `checkout` `pull` `diff` `submit` `quota` `notifications` `update` `help`
 
 Exit codes: `0` gate green · `1` gate red · `2` refused · `3` auth · `4` input required.
 
@@ -73,6 +73,20 @@ gamedevpl status <token-or-slug>
 
 `submit` is preview-mode delivery. A green gate is not a publish. `--publish` runs the
 full local ladder and delivers `mode=publish`; an operator still publishes.
+
+## In a checkout
+
+`gamedevpl` started inside a checkout (any subdirectory) opens that game. It shows the
+sync state, which of `claude` / `codex` / `gemini` / `vibe` are on PATH, and who builds.
+If a local agent is found and the platform still builds, it asks once whether to hand the
+round to your machine (`/builder self`); `/builder platform` hands it back.
+
+With builder `self`, a plain message goes to the Studio chat first — questions get
+answers; a change request runs the local agent in `games/<slug>` with a brief, then the
+static ladder, then offers to deliver. The agent never sees the OAuth grant. Ctrl+C stops
+the agent, not the session. `/delegate <task>` skips the chat; `gamedevpl delegate "<task>"
+[--agent codex] [--submit]` is the non-interactive form (exit `1` when the agent or the
+ladder fails).
 
 `gamedevpl connect <slug>` prints the MCP handoff (URL, kickoff, install snippet).
 `--agent claude` (or `codex` / `gemini` / `vibe`) spawns that vendor CLI with a

--- a/apps/cli/src/argv.ts
+++ b/apps/cli/src/argv.ts
@@ -6,6 +6,7 @@ export const SLASH_VERBS = [
   'handle',
   'builder',
   'connect',
+  'delegate',
   'checkout',
   'quota',
   'notifications',

--- a/apps/cli/src/checkout.test.ts
+++ b/apps/cli/src/checkout.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, it } from 'vitest';
 import {
   checkoutGame,
   changedPaths,
+  findCheckout,
   inspectGame,
   localGameFiles,
   pullGame,
@@ -256,5 +257,32 @@ describe('checkout', () => {
   it('refuses a path that would leave the checkout', () => {
     const dest = mkdtempSync(join(tmpdir(), 'gdpl-esc2-'));
     expect(() => writeGameFiles(dest, 'ghost-roads', [{ path: '../outside.ts', content: 'nope' }])).toThrow(/outside/);
+  });
+});
+
+// Inside a checkout, that game opens; no guessing.
+describe('findCheckout', () => {
+  it('finds the slug in the directory itself', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'gamedev-find-'));
+    writeFileSync(join(dir, '.gamedev-slug'), 'airtime\n');
+    expect(findCheckout(dir)).toEqual({ slug: 'airtime', root: dir });
+  });
+
+  it('walks up from a subdirectory, so games/<slug>/ works', () => {
+    const root = mkdtempSync(join(tmpdir(), 'gamedev-find-'));
+    writeFileSync(join(root, '.gamedev-slug'), 'airtime');
+    const deep = join(root, 'games', 'airtime', 'game');
+    mkdirSync(deep, { recursive: true });
+    expect(findCheckout(deep)?.slug).toBe('airtime');
+  });
+
+  it('returns null outside a checkout', () => {
+    expect(findCheckout(mkdtempSync(join(tmpdir(), 'gamedev-none-')))).toBeNull();
+  });
+
+  it('ignores an empty marker rather than opening a nameless game', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'gamedev-empty-'));
+    writeFileSync(join(dir, '.gamedev-slug'), '   \n');
+    expect(findCheckout(dir)).toBeNull();
   });
 });

--- a/apps/cli/src/checkout.ts
+++ b/apps/cli/src/checkout.ts
@@ -1,5 +1,5 @@
 import { mkdirSync, readFileSync, writeFileSync, existsSync, readdirSync, rmSync, lstatSync } from 'node:fs';
-import { dirname, join } from 'node:path';
+import { dirname, join, resolve } from 'node:path';
 import { spawnSync } from 'node:child_process';
 import { cliUsage, gitRemoteUrl } from './bin-name.js';
 import type { ApiClient } from './api.js';
@@ -27,6 +27,19 @@ export type VersionRow = {
 export function readCheckoutSlug(cwd: string): string | null {
   const path = join(cwd, '.gamedev-slug');
   return existsSync(path) ? readFileSync(path, 'utf8').trim() || null : null;
+}
+
+// Walk up, so any subdirectory of a checkout finds it.
+export function findCheckout(cwd: string): { slug: string; root: string } | null {
+  let dir = resolve(cwd);
+  for (let depth = 0; depth < 40; depth += 1) {
+    const slug = readCheckoutSlug(dir);
+    if (slug) return { slug, root: dir };
+    const parent = dirname(dir);
+    if (parent === dir) return null;
+    dir = parent;
+  }
+  return null;
 }
 
 function defaultRun(cmd: string, args: string[], cwd: string): void {

--- a/apps/cli/src/delegate.ts
+++ b/apps/cli/src/delegate.ts
@@ -24,15 +24,54 @@ export function childEnv(parent: NodeJS.ProcessEnv, roundToken: string, mcp?: Ch
   return env;
 }
 
+type EventShape = {
+  text?: unknown;
+  message?: unknown;
+  type?: unknown;
+  result?: unknown;
+  item?: { type?: unknown; text?: unknown; command?: unknown };
+};
+
+const QUIET_EVENT_TYPES = /^(system|user|thread\.|turn\.|item\.started)/;
+
+function textOf(value: unknown): string | null {
+  return typeof value === 'string' && value.trim() ? value : null;
+}
+
+// Claude, codex and vibe each wrap text differently; show the words.
+function contentText(message: unknown): string | null {
+  const content = (message as { content?: unknown } | undefined)?.content;
+  if (!Array.isArray(content)) return null;
+  const parts = (content as Array<{ type?: string; text?: string; name?: string }>).flatMap((block) => {
+    if (block.type === 'text' && block.text) return [block.text];
+    if (block.type === 'tool_use' && block.name) return [`⚙ ${block.name}`];
+    return [];
+  });
+  return parts.length ? parts.join(' ') : null;
+}
+
 export function parseEventLine(line: string): string | null {
   const trimmed = line.trim();
   if (!trimmed) return null;
+  let parsed: EventShape;
   try {
-    const parsed = JSON.parse(trimmed) as { text?: string; message?: string; type?: string };
-    return parsed.text ?? parsed.message ?? parsed.type ?? trimmed;
+    parsed = JSON.parse(trimmed) as EventShape;
   } catch {
     return null;
   }
+  if (!parsed || typeof parsed !== 'object') return trimmed;
+  const direct =
+    textOf(parsed.text) ??
+    textOf(parsed.message) ??
+    contentText(parsed.message) ??
+    textOf(parsed.result) ??
+    textOf(parsed.item?.text);
+  if (direct) return direct;
+  const command = textOf(parsed.item?.command);
+  if (command) return `⚙ ${command}`;
+  const type = textOf(parsed.type);
+  if (!type) return trimmed;
+  return QUIET_EVENT_TYPES.test(type) ? null : type;
 }
 
 export function renderDelegateStream(adapter: string, lines: string[], verbose: boolean): string[] {

--- a/apps/cli/src/help.ts
+++ b/apps/cli/src/help.ts
@@ -8,8 +8,9 @@ const BLURB: Record<SlashVerb, string> = {
   share: 'play URL — share <slug>',
   profile: 'signed-in profile',
   handle: 'get or set handle',
-  builder: 'who is building — builder <slug>',
+  builder: 'who builds — builder <slug>, or self|platform here',
   connect: 'MCP handoff, or --agent',
+  delegate: 'local agent edits the checkout — delegate <task>',
   checkout: 'clone a game — checkout <slug>',
   quota: "today's submission budget",
   notifications: 'unread notifications',
@@ -27,7 +28,13 @@ export function formatHelp(slash = false): string {
   const prefix = slash ? '/' : '';
   const rows = SLASH_VERBS.map((verb) => `  ${(prefix + verb).padEnd(18)}${BLURB[verb]}`);
   const intro = slash
-    ? [`${CLI_BIN} ${CLI_VERSION}`, '', '  type to talk — a game starts when you ask · /quit to leave', '']
+    ? [
+        `${CLI_BIN} ${CLI_VERSION}`,
+        '',
+        '  type to talk — a game starts when you ask · /quit to leave',
+        '  in a checkout: say what to change; a local agent edits it, /submit delivers',
+        '',
+      ]
     : [
         `${CLI_BIN} ${CLI_VERSION} — Studio from a terminal`,
         '',

--- a/apps/cli/src/main.test.ts
+++ b/apps/cli/src/main.test.ts
@@ -1,7 +1,10 @@
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { pathToFileURL } from 'node:url';
 import { PassThrough } from 'node:stream';
 import { describe, expect, it, vi } from 'vitest';
-import { isLaunchedEntry, isGitRemoteHelper, runCli } from './main.js';
+import { isGitRemoteHelper, isLaunchedEntry, openCheckoutGame, runCli } from './main.js';
 import { EXIT_AUTH, EXIT_GREEN, EXIT_INPUT } from './exit-codes.js';
 
 function io() {
@@ -102,5 +105,48 @@ describe('runCli verbs', () => {
     expect(isGitRemoteHelper(['node', '/bin/gamedevpl', 'status', 'tok'])).toBe(false);
     expect(isGitRemoteHelper(['node', '/bin/gamedevpl', 'connect', 'gamedevpl://sky-dodge'])).toBe(false);
     expect(isGitRemoteHelper(['node', '/bin/git-remote-gamedevpl', 'origin', 'gamedevpl://sky-dodge'])).toBe(true);
+  });
+});
+
+describe('openCheckoutGame', () => {
+  function api(handler: (path: string) => unknown) {
+    return {
+      origin: 'https://example.test',
+      request: async <T>(_method: string, path: string): Promise<T> => handler(path) as T,
+      requestBytes: async () => Buffer.alloc(0),
+    };
+  }
+
+  it('opens the game whose checkout the shell is standing in', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'gamedev-open-'));
+    writeFileSync(join(dir, '.gamedev-slug'), 'airtime');
+    const opened = await openCheckoutGame(
+      api(() => ({ games: [{ slug: 'airtime', token: 'tok-airtime' }] })),
+      dir,
+    );
+    expect(opened).toEqual({ token: 'tok-airtime', slug: 'airtime' });
+  });
+
+  it('opens nothing outside a checkout', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'gamedev-open-none-'));
+    expect(
+      await openCheckoutGame(
+        api(() => ({ games: [] })),
+        dir,
+      ),
+    ).toBeNull();
+  });
+
+  // Someone else game, or no network, must not break the prompt.
+  it('falls back to a plain session when the game cannot be resolved', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'gamedev-open-fail-'));
+    writeFileSync(join(dir, '.gamedev-slug'), 'not-mine');
+    const opened = await openCheckoutGame(
+      api(() => {
+        throw new Error('offline');
+      }),
+      dir,
+    );
+    expect(opened).toBeNull();
   });
 });

--- a/apps/cli/src/main.test.ts
+++ b/apps/cli/src/main.test.ts
@@ -124,7 +124,7 @@ describe('openCheckoutGame', () => {
       api(() => ({ games: [{ slug: 'airtime', token: 'tok-airtime' }] })),
       dir,
     );
-    expect(opened).toEqual({ token: 'tok-airtime', slug: 'airtime' });
+    expect(opened).toEqual({ token: 'tok-airtime', slug: 'airtime', root: dir });
   });
 
   it('opens nothing outside a checkout', async () => {

--- a/apps/cli/src/main.ts
+++ b/apps/cli/src/main.ts
@@ -4,7 +4,7 @@ import { pathToFileURL } from 'node:url';
 import { stdin, stdout, stderr } from 'node:process';
 import { parseArgv, jsonMode, SLASH_VERBS } from './argv.js';
 import { GIT_REMOTE_HELPER, GIT_REMOTE_SCHEME, cliUsage } from './bin-name.js';
-import { createApi, requireTtyFlag } from './api.js';
+import { createApi, requireTtyFlag, type ApiClient } from './api.js';
 import {
   encryptedFileStore,
   FILE_FALLBACK_WARNING,
@@ -16,7 +16,8 @@ import { runLoopbackLogin } from './login.js';
 import { originFromEnv } from './oauth.js';
 import { CliError, EXIT_GREEN, EXIT_INPUT, EXIT_REFUSED } from './exit-codes.js';
 import { describeError, pipeNeedsFlag } from './errors.js';
-import { checkoutGame, diffGame, formatSyncLines, pullGame, readCheckoutSlug } from './checkout.js';
+import { studioToken } from './studio.js';
+import { checkoutGame, diffGame, findCheckout, formatSyncLines, pullGame, readCheckoutSlug } from './checkout.js';
 import { connectGame } from './connect.js';
 import { formatSubmitLines, submitGame } from './submit.js';
 import { runGitRemoteHelper } from './git-remote-main.js';
@@ -41,6 +42,17 @@ export function isGitRemoteHelper(argv: string[]): boolean {
   const first = argv[2];
   if (first && !first.startsWith('-') && (SLASH_VERBS as readonly string[]).includes(first)) return false;
   return true;
+}
+
+// A checkout here means working on that game, not a new one.
+export async function openCheckoutGame(api: ApiClient, cwd: string): Promise<{ token: string; slug: string } | null> {
+  const found = findCheckout(cwd);
+  if (!found) return null;
+  try {
+    return { token: await studioToken(api, found.slug), slug: found.slug };
+  } catch {
+    return null;
+  }
 }
 
 export async function runCli(
@@ -181,11 +193,14 @@ export async function runCli(
     if (verb === 'repl') {
       if (!tty || !io.stdout.isTTY) throw pipeNeedsFlag(`a verb such as ${cliUsage('whoami')}`);
       const { runInkRepl } = await import('./tui/host.js');
+      const opened: { token: string; slug?: string } | null =
+        typeof flags.token === 'string' ? { token: flags.token } : await openCheckoutGame(api, process.cwd());
       return runInkRepl({
         api,
         env,
         io,
-        token: typeof flags.token === 'string' ? flags.token : null,
+        token: opened?.token ?? null,
+        ...(opened?.slug ? { slug: opened.slug } : {}),
       });
     }
     io.stderr.write(`unknown verb ${verb} — ${cliUsage('help')}\n`);

--- a/apps/cli/src/main.ts
+++ b/apps/cli/src/main.ts
@@ -24,7 +24,8 @@ import { runGitRemoteHelper } from './git-remote-main.js';
 import { runStatusVerb } from './status-watch.js';
 import { dispatchReadVerb } from './verbs.js';
 import { formatHelp } from './help.js';
-import { detectLocalAdapters, workshopTurn } from './workshop.js';
+import { detectLocalAdapters, handoffBuilder, workshopTurn } from './workshop.js';
+import { getStatus } from './turn.js';
 
 function storeFromEnv(env: NodeJS.ProcessEnv, warn: (line: string) => void): TokenStore {
   const token = env.GAMEDEV_TOKEN?.trim();
@@ -72,14 +73,33 @@ async function runDelegateVerb(input: {
   if (!request) throw new CliError(cliUsage('delegate', '"<task>"'), EXIT_INPUT, '<task>');
   const opened = await openCheckoutGame(input.api, input.cwd);
   if (!opened) throw new CliError('not inside a game checkout', EXIT_INPUT, cliUsage('checkout', '<slug>'));
-  const deliver = input.flags.submit === true;
+  let builder = (await getStatus(input.api, opened.token)).builder ?? 'platform';
+  if (builder !== 'self' && input.flags.handoff === true) {
+    const outcome = await handoffBuilder(input.api, opened.token, 'self', builder);
+    if (outcome.pending) {
+      throw new CliError(
+        'handoff pending — the platform agent has not acknowledged yet',
+        EXIT_REFUSED,
+        'retry shortly',
+      );
+    }
+    builder = outcome.builder;
+  }
+  if (builder !== 'self') {
+    throw new CliError(
+      `builder is ${builder} — the platform owns this round`,
+      EXIT_REFUSED,
+      `${cliUsage('delegate', '--handoff')} takes it here`,
+    );
+  }
   const ws = {
     ...opened,
     env: input.env,
     adapters: detectLocalAdapters(input.env),
-    builder: 'self',
-    pick: async (choices: string[]) => (deliver ? choices[0]! : (choices[1] ?? '')),
+    builder,
+    pick: async () => '',
     abort: { current: null },
+    unattended: { deliver: input.flags.submit === true },
   };
   const ok = await workshopTurn({
     api: input.api,

--- a/apps/cli/src/main.ts
+++ b/apps/cli/src/main.ts
@@ -14,7 +14,7 @@ import {
 } from './keychain.js';
 import { runLoopbackLogin } from './login.js';
 import { originFromEnv } from './oauth.js';
-import { CliError, EXIT_GREEN, EXIT_INPUT, EXIT_REFUSED } from './exit-codes.js';
+import { CliError, EXIT_GREEN, EXIT_INPUT, EXIT_RED, EXIT_REFUSED } from './exit-codes.js';
 import { describeError, pipeNeedsFlag } from './errors.js';
 import { studioToken } from './studio.js';
 import { checkoutGame, diffGame, findCheckout, formatSyncLines, pullGame, readCheckoutSlug } from './checkout.js';
@@ -24,6 +24,7 @@ import { runGitRemoteHelper } from './git-remote-main.js';
 import { runStatusVerb } from './status-watch.js';
 import { dispatchReadVerb } from './verbs.js';
 import { formatHelp } from './help.js';
+import { detectLocalAdapters, workshopTurn } from './workshop.js';
 
 function storeFromEnv(env: NodeJS.ProcessEnv, warn: (line: string) => void): TokenStore {
   const token = env.GAMEDEV_TOKEN?.trim();
@@ -45,14 +46,49 @@ export function isGitRemoteHelper(argv: string[]): boolean {
 }
 
 // A checkout here means working on that game, not a new one.
-export async function openCheckoutGame(api: ApiClient, cwd: string): Promise<{ token: string; slug: string } | null> {
+export async function openCheckoutGame(
+  api: ApiClient,
+  cwd: string,
+): Promise<{ token: string; slug: string; root: string } | null> {
   const found = findCheckout(cwd);
   if (!found) return null;
   try {
-    return { token: await studioToken(api, found.slug), slug: found.slug };
+    return { token: await studioToken(api, found.slug), ...found };
   } catch {
     return null;
   }
+}
+
+// Non-interactive twin of the REPL turn: agent, ladder, optional delivery.
+async function runDelegateVerb(input: {
+  api: ApiClient;
+  args: string[];
+  flags: Record<string, string | boolean>;
+  env: NodeJS.ProcessEnv;
+  cwd: string;
+  write: (line: string) => void;
+}): Promise<number> {
+  const request = input.args.join(' ').trim();
+  if (!request) throw new CliError(cliUsage('delegate', '"<task>"'), EXIT_INPUT, '<task>');
+  const opened = await openCheckoutGame(input.api, input.cwd);
+  if (!opened) throw new CliError('not inside a game checkout', EXIT_INPUT, cliUsage('checkout', '<slug>'));
+  const deliver = input.flags.submit === true;
+  const ws = {
+    ...opened,
+    env: input.env,
+    adapters: detectLocalAdapters(input.env),
+    builder: 'self',
+    pick: async (choices: string[]) => (deliver ? choices[0]! : (choices[1] ?? '')),
+    abort: { current: null },
+  };
+  const ok = await workshopTurn({
+    api: input.api,
+    ws,
+    request,
+    agent: typeof input.flags.agent === 'string' ? input.flags.agent : undefined,
+    write: input.write,
+  });
+  return ok ? EXIT_GREEN : EXIT_RED;
 }
 
 export async function runCli(
@@ -188,19 +224,28 @@ export async function runCli(
       });
       return EXIT_GREEN;
     }
+    if (verb === 'delegate') {
+      return runDelegateVerb({
+        api,
+        args,
+        flags,
+        env,
+        cwd: process.cwd(),
+        write: (line) => io.stdout.write(`${line}\n`),
+      });
+    }
     const read = await dispatchReadVerb({ verb, args, flags, api, io });
     if (read !== null) return read;
     if (verb === 'repl') {
       if (!tty || !io.stdout.isTTY) throw pipeNeedsFlag(`a verb such as ${cliUsage('whoami')}`);
       const { runInkRepl } = await import('./tui/host.js');
-      const opened: { token: string; slug?: string } | null =
-        typeof flags.token === 'string' ? { token: flags.token } : await openCheckoutGame(api, process.cwd());
+      const opened = typeof flags.token === 'string' ? null : await openCheckoutGame(api, process.cwd());
       return runInkRepl({
         api,
         env,
         io,
-        token: opened?.token ?? null,
-        ...(opened?.slug ? { slug: opened.slug } : {}),
+        token: typeof flags.token === 'string' ? flags.token : (opened?.token ?? null),
+        ...(opened ? { checkout: { slug: opened.slug, root: opened.root } } : {}),
       });
     }
     io.stderr.write(`unknown verb ${verb} — ${cliUsage('help')}\n`);

--- a/apps/cli/src/repl.ts
+++ b/apps/cli/src/repl.ts
@@ -13,7 +13,7 @@ import { CLI_VERSION } from './update.js';
 import { formatError } from './errors.js';
 import { formatHelp } from './help.js';
 import { MASCOT_ASCII } from './tui/mascot.js';
-import { handoffBuilder, workshopTurn, type Workshop } from './workshop.js';
+import { handoffBuilder, handoffLine, refreshBuilder, workshopTurn, type Workshop } from './workshop.js';
 
 export type ReplLineResult = {
   next: 'continue' | 'quit';
@@ -65,7 +65,7 @@ export async function handleReplLine(input: {
     if (cmd === 'submit') {
       try {
         const parsed = parseArgv(['node', 'cli', 'submit', ...rest]);
-        const dest = parsed.args[0] ?? process.cwd();
+        const dest = parsed.args[0] ?? input.workshop?.root ?? process.cwd();
         const slug = (typeof parsed.flags.slug === 'string' ? parsed.flags.slug : null) ?? readCheckoutSlug(dest);
         if (!slug) {
           input.write(`run it as ${cliUsage('submit', '[dir]')}`);
@@ -87,7 +87,7 @@ export async function handleReplLine(input: {
     if (cmd === 'connect' || cmd === 'checkout' || cmd === 'pull' || cmd === 'diff') {
       try {
         const parsed = parseArgv(['node', 'cli', cmd, ...rest]);
-        const cwd = process.cwd();
+        const cwd = input.workshop?.root ?? process.cwd();
         const slug = parsed.args[0] || (cmd === 'checkout' ? undefined : readCheckoutSlug(cwd));
         if (!slug) {
           input.write(`run it as ${cliUsage(cmd)}`);
@@ -198,6 +198,7 @@ async function handleWorkshopVerb(input: {
     if (input.cmd === 'builder') {
       const wanted = input.rest[0];
       if (wanted !== 'self' && wanted !== 'platform') {
+        await refreshBuilder(input.api, ws);
         input.write(`builder ${ws.builder} — /builder self or /builder platform to switch`);
         return;
       }
@@ -205,12 +206,9 @@ async function handleWorkshopVerb(input: {
         input.write(`builder is already ${wanted}`);
         return;
       }
-      ws.builder = await handoffBuilder(input.api, ws.token, wanted);
-      input.write(
-        wanted === 'self'
-          ? `builder self — your local agent edits games/${ws.slug}`
-          : `builder platform — say what to change and the platform builds; /pull when it lands`,
-      );
+      const outcome = await handoffBuilder(input.api, ws.token, wanted, ws.builder);
+      ws.builder = outcome.builder;
+      input.write(handoffLine(outcome, ws.slug));
       return;
     }
     const parsed = parseArgv(['node', 'cli', 'delegate', ...input.rest]);

--- a/apps/cli/src/repl.ts
+++ b/apps/cli/src/repl.ts
@@ -13,6 +13,7 @@ import { CLI_VERSION } from './update.js';
 import { formatError } from './errors.js';
 import { formatHelp } from './help.js';
 import { MASCOT_ASCII } from './tui/mascot.js';
+import { handoffBuilder, workshopTurn, type Workshop } from './workshop.js';
 
 export type ReplLineResult = {
   next: 'continue' | 'quit';
@@ -26,6 +27,8 @@ export async function handleReplLine(input: {
   api: ApiClient;
   token: string | null;
   conversationId?: string;
+  // Set when the session opened from a game checkout.
+  workshop?: Workshop;
   write: (s: string) => void;
 }): Promise<ReplLineResult> {
   const trimmed = input.line.trim();
@@ -35,6 +38,14 @@ export async function handleReplLine(input: {
     const [cmd, ...rest] = trimmed.slice(1).split(/\s+/);
     if (cmd === 'help') {
       input.write(formatHelp(true));
+      return { next: 'continue' };
+    }
+    const ws = input.workshop;
+    if (
+      ws &&
+      (cmd === 'delegate' || (cmd === 'builder' && (!rest[0] || rest[0] === 'self' || rest[0] === 'platform')))
+    ) {
+      await handleWorkshopVerb({ cmd, rest, api: input.api, ws, write: input.write });
       return { next: 'continue' };
     }
     if (cmd === 'status') {
@@ -156,12 +167,67 @@ export async function handleReplLine(input: {
   }
   try {
     const result = await postTurn(input.api, input.token, trimmed);
-    if (result.kind === 'reply') input.write(`◆ ${result.text}`);
-    else input.write(`▸ build ${result.roundId}${result.ack ? ` — ${result.ack}` : ''}`);
+    if (result.kind === 'reply') {
+      input.write(`◆ ${result.text}`);
+      return { next: 'continue' };
+    }
+    input.write(`▸ build ${result.roundId}${result.ack ? ` — ${result.ack}` : ''}`);
+    const ws = input.workshop;
+    if (!ws) return { next: 'continue' };
+    if (ws.builder !== 'self') {
+      input.write(`the platform builds this round — /pull when it lands, or /builder self to build here`);
+      return { next: 'continue' };
+    }
+    await workshopTurn({ api: input.api, ws, request: trimmed, ack: result.ack, write: input.write });
     return { next: 'continue' };
   } catch (error) {
     input.write(formatError(error));
     return { next: 'continue' };
+  }
+}
+
+async function handleWorkshopVerb(input: {
+  cmd: string;
+  rest: string[];
+  api: ApiClient;
+  ws: Workshop;
+  write: (s: string) => void;
+}): Promise<void> {
+  const { ws } = input;
+  try {
+    if (input.cmd === 'builder') {
+      const wanted = input.rest[0];
+      if (wanted !== 'self' && wanted !== 'platform') {
+        input.write(`builder ${ws.builder} — /builder self or /builder platform to switch`);
+        return;
+      }
+      if (wanted === ws.builder) {
+        input.write(`builder is already ${wanted}`);
+        return;
+      }
+      ws.builder = await handoffBuilder(input.api, ws.token, wanted);
+      input.write(
+        wanted === 'self'
+          ? `builder self — your local agent edits games/${ws.slug}`
+          : `builder platform — say what to change and the platform builds; /pull when it lands`,
+      );
+      return;
+    }
+    const parsed = parseArgv(['node', 'cli', 'delegate', ...input.rest]);
+    const request = parsed.args.join(' ');
+    if (!request) {
+      input.write(`say what to do: /delegate make the jump feel floatier`);
+      return;
+    }
+    await workshopTurn({
+      api: input.api,
+      ws,
+      request,
+      agent: typeof parsed.flags.agent === 'string' ? parsed.flags.agent : undefined,
+      write: input.write,
+    });
+  } catch (error) {
+    input.write(formatError(error));
   }
 }
 

--- a/apps/cli/src/tui/host.ts
+++ b/apps/cli/src/tui/host.ts
@@ -8,6 +8,7 @@ import type { ApiClient } from '../api.js';
 import { ReplApp } from './app.js';
 import { createRoundWatch } from './round-watch.js';
 import { createTuiSession, formatSessionIdentity } from './session.js';
+import { openWorkshop, settleBuilder, type Workshop } from '../workshop.js';
 
 export async function runInkRepl(input: {
   api: ApiClient;
@@ -15,12 +16,17 @@ export async function runInkRepl(input: {
   io: { stdin: NodeJS.ReadStream; stdout: NodeJS.WriteStream };
   token: string | null;
   // Set when a checkout in the working directory opened this session.
-  slug?: string;
+  checkout?: { slug: string; root: string };
 }): Promise<number> {
   const isTty = Boolean(input.io.stdout.isTTY);
   const color = wantsColor(input.env, isTty);
   const host: { instance?: ReturnType<typeof render> } = {};
+  const abort: Workshop['abort'] = { current: null };
   const session = createTuiSession(replBanner(isTty, input.env), () => {
+    if (abort.current) {
+      abort.current.abort();
+      return;
+    }
     session.close();
     host.instance?.unmount();
     process.exit(EXIT_GREEN);
@@ -34,11 +40,16 @@ export async function runInkRepl(input: {
   let token = input.token;
   let conversationId: string | undefined;
   let who = '';
-  let slug = input.slug ?? '';
+  let slug = input.checkout?.slug ?? '';
   const paintIdentity = (): void => session.setIdentity(formatSessionIdentity(who, slug));
-  if (input.slug) {
+  let workshop: Workshop | undefined;
+  if (input.checkout && token) {
     paintIdentity();
-    session.writeLine(`◆ ${input.slug} — from the checkout here. Say what to change, or /help.`);
+    const write = (line: string): void => session.writeLine(line);
+    const opened = await openWorkshop({ api: input.api, token, ...input.checkout, env: input.env, write });
+    workshop = { ...input.checkout, token, env: input.env, ...opened, pick: session.prompt, abort };
+    workshop.builder = await settleBuilder({ api: input.api, ws: workshop, status: opened.status, write });
+    session.writeLine('say what to change, or /help');
   }
   const watch = createRoundWatch({
     getToken: () => token,
@@ -72,6 +83,7 @@ export async function runInkRepl(input: {
           api: input.api,
           token,
           conversationId,
+          workshop,
           write: (text) => session.writeLine(text),
         });
       } catch (error) {

--- a/apps/cli/src/tui/host.ts
+++ b/apps/cli/src/tui/host.ts
@@ -14,6 +14,8 @@ export async function runInkRepl(input: {
   env: NodeJS.ProcessEnv;
   io: { stdin: NodeJS.ReadStream; stdout: NodeJS.WriteStream };
   token: string | null;
+  // Set when a checkout in the working directory opened this session.
+  slug?: string;
 }): Promise<number> {
   const isTty = Boolean(input.io.stdout.isTTY);
   const color = wantsColor(input.env, isTty);
@@ -32,8 +34,12 @@ export async function runInkRepl(input: {
   let token = input.token;
   let conversationId: string | undefined;
   let who = '';
-  let slug = '';
+  let slug = input.slug ?? '';
   const paintIdentity = (): void => session.setIdentity(formatSessionIdentity(who, slug));
+  if (input.slug) {
+    paintIdentity();
+    session.writeLine(`◆ ${input.slug} — from the checkout here. Say what to change, or /help.`);
+  }
   const watch = createRoundWatch({
     getToken: () => token,
     api: input.api,

--- a/apps/cli/src/turn.ts
+++ b/apps/cli/src/turn.ts
@@ -17,6 +17,7 @@ export async function getTurns(
 export type RoundStatus = {
   status: string;
   slug?: string;
+  builder?: string;
   phase?: string;
   gateProgress?: { stage: string; index: number; total: number };
   previewGate?: { green: boolean };

--- a/apps/cli/src/workshop.test.ts
+++ b/apps/cli/src/workshop.test.ts
@@ -1,0 +1,378 @@
+import { mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { describe, expect, it } from 'vitest';
+import { createApi } from './api.js';
+import { loadAdapters } from './adapters.js';
+import { writeBase, writeGameFiles } from './checkout.js';
+import { parseEventLine } from './delegate.js';
+import { memoryStore } from './keychain.js';
+import { handleReplLine } from './repl.js';
+import {
+  describeAdapters,
+  detectLocalAdapters,
+  openWorkshop,
+  settleBuilder,
+  syncWarning,
+  workshopBrief,
+  workshopTurn,
+  type AdapterRun,
+  type Workshop,
+} from './workshop.js';
+
+const SLUG = 'airtime';
+const claude = loadAdapters().adapters.find((spec) => spec.name === 'claude')!;
+const codex = loadAdapters().adapters.find((spec) => spec.name === 'codex')!;
+
+function json(data: unknown, status = 200): Response {
+  return new Response(JSON.stringify(data), { status, headers: { 'content-type': 'application/json' } });
+}
+
+function checkout(files = [{ path: 'game.ts', content: 'A' }]): string {
+  const root = mkdtempSync(join(tmpdir(), 'gdpl-ws-'));
+  writeGameFiles(root, SLUG, files);
+  writeBase(root, 'v1', files);
+  writeFileSync(join(root, '.gamedev-slug'), SLUG);
+  return root;
+}
+
+function platform(seen: string[], extra?: (path: string, init?: RequestInit) => Response | null) {
+  return createApi({
+    origin: 'https://www.gamedev.pl',
+    store: memoryStore({ accessToken: 'gdpl_oat_creator', tokenType: 'Bearer', scope: 'creator' }),
+    fetch: async (url, init) => {
+      const path = String(url);
+      seen.push(`${init?.method ?? 'GET'} ${path}${init?.body ? ` ${String(init.body)}` : ''}`);
+      const handled = extra?.(path, init);
+      if (handled) return handled;
+      if (path.endsWith('/versions')) {
+        return json({ versions: [{ version: 'v1', createdAt: '2026-09-01', sourceFiles: ['game.ts'] }] });
+      }
+      if (path.includes('/tree')) return json({ version: 'v1', files: [{ path: 'game.ts', content: 'A' }] });
+      if (path.endsWith('/api/submissions/tok')) return json({ status: 'needs_changes', builder: 'self' });
+      if (path.endsWith('/sources')) return json({ files: [] });
+      if (path.endsWith('/sources/stage')) return json({ accepted: true });
+      if (path.endsWith('/sources/deliver')) return json({ accepted: true, version: 'v2', gateStarted: true });
+      if (path.endsWith('/turn')) return json({ kind: 'build', roundId: 7, ack: 'Floatier jump.' });
+      if (path.endsWith('/handoff')) return json({ accepted: true });
+      return json({}, 404);
+    },
+  });
+}
+
+function workshop(root: string, over: Partial<Workshop> = {}): Workshop {
+  return {
+    slug: SLUG,
+    root,
+    token: 'tok',
+    env: { PATH: '/usr/bin', HOME: root, GAMEDEV_TOKEN: 'gdpl_oat_creator' },
+    adapters: [claude],
+    builder: 'self',
+    pick: async (choices) => choices[0]!,
+    abort: { current: null },
+    run: () => ({ status: 0, stderr: '' }),
+    ...over,
+  };
+}
+
+describe('workshopTurn', () => {
+  it('runs the agent in games/<slug> with a brief, no creator token, then delivers', async () => {
+    const root = checkout();
+    const seen: string[] = [];
+    const lines: string[] = [];
+    const calls: Parameters<AdapterRun>[0][] = [];
+    const runAdapter: AdapterRun = async (input) => {
+      calls.push(input);
+      writeFileSync(join(input.cwd, 'game.ts'), 'B');
+      input.onLine?.('{"type":"assistant","message":{"content":[{"type":"text","text":"Made the jump floatier."}]}}');
+      return { code: 0 };
+    };
+    const ok = await workshopTurn({
+      api: platform(seen),
+      ws: workshop(root, { runAdapter }),
+      request: 'make the jump floatier',
+      ack: 'Floatier jump.',
+      write: (line) => lines.push(line),
+    });
+    expect(ok).toBe(true);
+    expect(calls).toHaveLength(1);
+    expect(calls[0]!.cwd).toBe(join(root, 'games', SLUG));
+    expect(calls[0]!.spec.name).toBe('claude');
+    expect(calls[0]!.prompt).toContain('make the jump floatier');
+    expect(calls[0]!.prompt).toContain('Floatier jump.');
+    expect(calls[0]!.prompt).toContain('gamedevpl submit');
+    expect(JSON.stringify(calls[0]!.env)).not.toMatch(/gdpl_oat_/);
+    expect(lines.join('\n')).toContain('claude ▸ Made the jump floatier.');
+    expect(lines.join('\n')).toContain('static ladder green');
+    expect(lines.join('\n')).toContain('delivery accepted airtime @ v2');
+    expect(seen.some((row) => row.includes('/sources/stage') && row.includes('"content":"B"'))).toBe(true);
+    expect(seen.some((row) => row.includes('/sources/deliver'))).toBe(true);
+  });
+
+  it('keeps the edit local when the creator declines delivery', async () => {
+    const root = checkout();
+    const seen: string[] = [];
+    const lines: string[] = [];
+    const runAdapter: AdapterRun = async (input) => {
+      writeFileSync(join(input.cwd, 'game.ts'), 'B');
+      return { code: 0 };
+    };
+    const ok = await workshopTurn({
+      api: platform(seen),
+      ws: workshop(root, { runAdapter, pick: async (choices) => choices[1]! }),
+      request: 'tweak',
+      write: (line) => lines.push(line),
+    });
+    expect(ok).toBe(true);
+    expect(lines.join('\n')).toContain('/submit when ready');
+    expect(seen.some((row) => row.includes('/sources/deliver'))).toBe(false);
+    expect(readFileSync(join(root, 'games', SLUG, 'game.ts'), 'utf8')).toBe('B');
+  });
+
+  it('does not offer delivery when the ladder is red', async () => {
+    const root = checkout();
+    const seen: string[] = [];
+    const lines: string[] = [];
+    let picks = 0;
+    const ok = await workshopTurn({
+      api: platform(seen),
+      ws: workshop(root, {
+        runAdapter: async () => ({ code: 0 }),
+        run: (_cmd, args) =>
+          args[1] === 'check:static' ? { status: 1, stderr: 'game.ts:3 unused import' } : { status: 0, stderr: '' },
+        pick: async (choices) => {
+          picks += 1;
+          return choices[0]!;
+        },
+      }),
+      request: 'tweak',
+      write: (line) => lines.push(line),
+    });
+    expect(ok).toBe(false);
+    expect(picks).toBe(0);
+    expect(lines.join('\n')).toContain('verify failed at check_static: game.ts:3 unused import');
+    expect(seen.some((row) => row.includes('/sources/deliver'))).toBe(false);
+  });
+
+  it('reports a stopped agent instead of verifying half-written files', async () => {
+    const root = checkout();
+    const lines: string[] = [];
+    const ws = workshop(root, {
+      runAdapter: async (input) =>
+        new Promise((resolve) => input.abort?.addEventListener('abort', () => resolve({ code: null }))),
+    });
+    const turn = workshopTurn({ api: platform([]), ws, request: 'tweak', write: (line) => lines.push(line) });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(ws.abort.current).not.toBeNull();
+    ws.abort.current!.abort();
+    expect(await turn).toBe(false);
+    expect(ws.abort.current).toBeNull();
+    expect(lines.join('\n')).toContain('claude stopped');
+    expect(lines.join('\n')).not.toContain('verifying');
+  });
+
+  it('asks which agent when several are installed, and honours --agent', async () => {
+    const root = checkout();
+    const names: string[] = [];
+    const questions: string[] = [];
+    const ws = workshop(root, {
+      adapters: [claude, codex],
+      env: { PATH: root, HOME: root },
+      runAdapter: async (input) => (names.push(input.spec.name), { code: 1 }),
+      pick: async (choices, question) => (questions.push(question), choices[1]!),
+    });
+    await workshopTurn({ api: platform([]), ws, request: 'tweak', write: () => undefined });
+    expect(questions).toEqual(['Which agent?']);
+    expect(names).toEqual(['codex']);
+    writeFileSync(join(root, 'claude'), '');
+    await workshopTurn({ api: platform([]), ws, request: 'tweak', agent: 'claude', write: () => undefined });
+    expect(names).toEqual(['codex', 'claude']);
+  });
+});
+
+describe('the REPL inside a checkout', () => {
+  it('lets the platform chat first, then builds locally when it says build', async () => {
+    const root = checkout();
+    const seen: string[] = [];
+    const lines: string[] = [];
+    const prompts: string[] = [];
+    const runAdapter: AdapterRun = async (input) => (prompts.push(input.prompt), { code: 0 });
+    const ws = workshop(root, { runAdapter, pick: async (choices) => choices[1]! });
+    const api = platform(seen, (path, init) =>
+      path.endsWith('/turn') && String(init?.body).includes('how big')
+        ? json({ kind: 'reply', text: 'About 40 files.' })
+        : null,
+    );
+    await handleReplLine({ line: 'how big is it?', api, token: 'tok', workshop: ws, write: (s) => lines.push(s) });
+    expect(prompts).toHaveLength(0);
+    expect(lines.join('\n')).toContain('About 40 files.');
+    await handleReplLine({
+      line: 'make the jump floatier',
+      api,
+      token: 'tok',
+      workshop: ws,
+      write: (s) => lines.push(s),
+    });
+    expect(prompts).toHaveLength(1);
+    expect(prompts[0]).toContain('make the jump floatier');
+    expect(lines.join('\n')).toContain('▸ build 7 — Floatier jump.');
+  });
+
+  it('leaves a platform-built round to the platform and says how to pull', async () => {
+    const root = checkout();
+    const lines: string[] = [];
+    let spawned = 0;
+    const ws = workshop(root, { builder: 'platform', runAdapter: async () => ((spawned += 1), { code: 0 }) });
+    await handleReplLine({
+      line: 'make it harder',
+      api: platform([]),
+      token: 'tok',
+      workshop: ws,
+      write: (s) => lines.push(s),
+    });
+    expect(spawned).toBe(0);
+    expect(lines.join('\n')).toContain('/pull when it lands');
+  });
+
+  it('/delegate skips the chat and runs the local agent directly', async () => {
+    const root = checkout();
+    const seen: string[] = [];
+    const lines: string[] = [];
+    const prompts: string[] = [];
+    const ws = workshop(root, {
+      runAdapter: async (input) => (prompts.push(input.prompt), { code: 0 }),
+      pick: async (choices) => choices[1]!,
+    });
+    await handleReplLine({
+      line: '/delegate add a pause menu',
+      api: platform(seen),
+      token: 'tok',
+      workshop: ws,
+      write: (s) => lines.push(s),
+    });
+    expect(seen.some((row) => row.includes('/turn'))).toBe(false);
+    expect(prompts).toHaveLength(1);
+    expect(prompts[0]).toContain('add a pause menu');
+    expect(lines.join('\n')).toContain('/submit when ready');
+  });
+
+  it('/builder platform hands the round back through the handoff route', async () => {
+    const root = checkout();
+    const seen: string[] = [];
+    const lines: string[] = [];
+    const ws = workshop(root);
+    await handleReplLine({
+      line: '/builder',
+      api: platform(seen),
+      token: 'tok',
+      workshop: ws,
+      write: (s) => lines.push(s),
+    });
+    expect(lines.join('\n')).toContain('builder self');
+    await handleReplLine({
+      line: '/builder platform',
+      api: platform(seen),
+      token: 'tok',
+      workshop: ws,
+      write: (s) => lines.push(s),
+    });
+    expect(ws.builder).toBe('platform');
+    expect(
+      seen.some((row) => row.includes('/api/submissions/tok/handoff') && row.includes('"builder":"platform"')),
+    ).toBe(true);
+    expect(lines.join('\n')).toContain('builder platform');
+  });
+});
+
+describe('opening a checkout', () => {
+  it('describes sync, local agents and the builder', async () => {
+    const root = checkout();
+    writeFileSync(join(root, 'games', SLUG, 'game.ts'), 'B');
+    const lines: string[] = [];
+    const opened = await openWorkshop({
+      api: platform([]),
+      token: 'tok',
+      slug: SLUG,
+      root,
+      env: { PATH: '/nowhere' },
+      which: (cmd) => (cmd === 'codex' ? '/usr/bin/codex' : null),
+      write: (line) => lines.push(line),
+    });
+    expect(opened.adapters.map((spec) => spec.name)).toEqual(['codex']);
+    expect(opened.builder).toBe('self');
+    expect(lines.join('\n')).toContain('base v1 · local only');
+    expect(lines.join('\n')).toContain('local-only: game.ts');
+    expect(lines.join('\n')).toContain('local agents: codex');
+    expect(lines.join('\n')).toContain('builder self · needs_changes');
+  });
+
+  it('warns when the platform is ahead of the checkout', () => {
+    expect(
+      syncWarning({ kind: 'platform_only', version: 'v2', local: [], platform: ['game.ts'], conflict: [] }),
+    ).toContain('/pull first');
+    expect(syncWarning({ kind: 'clean', version: 'v2', local: [], platform: [], conflict: [] })).toBeNull();
+    expect(describeAdapters([])).toContain('no local agent on PATH');
+    expect(detectLocalAdapters({ PATH: '/nowhere', HOME: '/nowhere' })).toEqual([]);
+  });
+
+  it('offers a local agent the round once, and hands off only when chosen', async () => {
+    const seen: string[] = [];
+    const lines: string[] = [];
+    const base = { token: 'tok', slug: SLUG, adapters: [claude], builder: 'platform' };
+    const kept = await settleBuilder({
+      api: platform(seen),
+      ws: { ...base, pick: async (choices) => choices[1]! },
+      status: 'needs_changes',
+      write: (line) => lines.push(line),
+    });
+    expect(kept).toBe('platform');
+    expect(seen.some((row) => row.includes('/handoff'))).toBe(false);
+    const taken = await settleBuilder({
+      api: platform(seen),
+      ws: { ...base, pick: async (choices) => choices[0]! },
+      status: 'needs_changes',
+      write: (line) => lines.push(line),
+    });
+    expect(taken).toBe('self');
+    expect(seen.some((row) => row.includes('/handoff') && row.includes('"builder":"self"'))).toBe(true);
+    const published = await settleBuilder({
+      api: platform(seen),
+      ws: { ...base, pick: async () => 'never asked' },
+      status: 'published',
+      write: () => undefined,
+    });
+    expect(published).toBe('platform');
+  });
+
+  it('writes a brief that names the game and forbids publishing', () => {
+    const brief = workshopBrief(SLUG, 'add a boss');
+    expect(brief).toContain('"airtime"');
+    expect(brief).toContain('add a boss');
+    expect(brief).not.toContain('Studio understood');
+    expect(brief).toMatch(/Do not run git/);
+  });
+});
+
+describe('parseEventLine', () => {
+  it('shows the words from claude, codex and plain text events', () => {
+    expect(
+      parseEventLine(
+        '{"type":"assistant","message":{"content":[{"type":"text","text":"hi"},{"type":"tool_use","name":"Edit"}]}}',
+      ),
+    ).toBe('hi ⚙ Edit');
+    expect(parseEventLine('{"type":"item.completed","item":{"type":"agent_message","text":"done"}}')).toBe('done');
+    expect(parseEventLine('{"type":"item.completed","item":{"type":"command_execution","command":"npm test"}}')).toBe(
+      '⚙ npm test',
+    );
+    expect(parseEventLine('{"type":"result","result":"all good"}')).toBe('all good');
+    expect(parseEventLine('{"text":"plain"}')).toBe('plain');
+  });
+
+  it('hides bookkeeping events and non-JSON noise', () => {
+    expect(parseEventLine('{"type":"system","subtype":"init"}')).toBeNull();
+    expect(parseEventLine('{"type":"thread.started","thread_id":"t"}')).toBeNull();
+    expect(parseEventLine('{"type":"user","message":{"content":[{"type":"tool_result"}]}}')).toBeNull();
+    expect(parseEventLine('not json')).toBeNull();
+    expect(parseEventLine('')).toBeNull();
+  });
+});

--- a/apps/cli/src/workshop.test.ts
+++ b/apps/cli/src/workshop.test.ts
@@ -218,6 +218,76 @@ describe('the REPL inside a checkout', () => {
     expect(lines.join('\n')).toContain('▸ build 7 — Floatier jump.');
   });
 
+  it('/delegate refuses while the platform owns the round', async () => {
+    const root = checkout();
+    const lines: string[] = [];
+    let spawned = 0;
+    const ws = workshop(root, { builder: 'platform', runAdapter: async () => ((spawned += 1), { code: 0 }) });
+    await handleReplLine({
+      line: '/delegate tweak',
+      api: platform([]),
+      token: 'tok',
+      workshop: ws,
+      write: (s) => lines.push(s),
+    });
+    expect(spawned).toBe(0);
+    expect(lines.join('\n')).toContain('/builder self');
+  });
+
+  it('does not spawn on a checkout the platform has moved past', async () => {
+    const root = checkout();
+    const lines: string[] = [];
+    let spawned = 0;
+    const api = platform([], (path) =>
+      path.includes('/tree') ? json({ version: 'v2', files: [{ path: 'game.ts', content: 'C' }] }) : null,
+    );
+    const ws = workshop(root, { runAdapter: async () => ((spawned += 1), { code: 0 }) });
+    await handleReplLine({ line: '/delegate tweak', api, token: 'tok', workshop: ws, write: (s) => lines.push(s) });
+    expect(spawned).toBe(0);
+    expect(lines.join('\n')).toContain('/pull first');
+  });
+
+  it('a pending handoff keeps the platform as builder', async () => {
+    const root = checkout();
+    const lines: string[] = [];
+    const api = platform([], (path) =>
+      path.endsWith('/handoff') ? json({ ok: true, pending: true, builder: 'platform', target: 'self' }, 202) : null,
+    );
+    const ws = workshop(root, { builder: 'platform' });
+    await handleReplLine({ line: '/builder self', api, token: 'tok', workshop: ws, write: (s) => lines.push(s) });
+    expect(ws.builder).toBe('platform');
+    expect(lines.join('\n')).toContain('handoff pending');
+  });
+
+  it('/builder alone re-reads who owns the round', async () => {
+    const root = checkout();
+    const lines: string[] = [];
+    const api = platform([], (path) =>
+      path.endsWith('/api/submissions/tok') ? json({ status: 'needs_changes', builder: 'platform' }) : null,
+    );
+    const ws = workshop(root);
+    await handleReplLine({ line: '/builder', api, token: 'tok', workshop: ws, write: (s) => lines.push(s) });
+    expect(ws.builder).toBe('platform');
+    expect(lines.join('\n')).toContain('builder platform');
+  });
+
+  it('unattended, several agents mean the first one whatever --submit says', async () => {
+    const root = checkout();
+    const names: string[] = [];
+    for (const deliver of [false, true]) {
+      const ws = workshop(root, {
+        adapters: [claude, codex],
+        unattended: { deliver },
+        pick: async () => {
+          throw new Error('no picks unattended');
+        },
+        runAdapter: async (input) => (names.push(input.spec.name), { code: 1 }),
+      });
+      await workshopTurn({ api: platform([]), ws, request: 'tweak', write: () => undefined });
+    }
+    expect(names).toEqual(['claude', 'claude']);
+  });
+
   it('leaves a platform-built round to the platform and says how to pull', async () => {
     const root = checkout();
     const lines: string[] = [];

--- a/apps/cli/src/workshop.ts
+++ b/apps/cli/src/workshop.ts
@@ -1,0 +1,264 @@
+import { join } from 'node:path';
+import type { ApiClient } from './api.js';
+import { detectAdapter, loadAdapters, whichOnPath, type AdapterSpec } from './adapters.js';
+import { cliUsage } from './bin-name.js';
+import { formatSyncLines, inspectGame, type SyncResult } from './checkout.js';
+import { childEnv, renderDelegateStream, spawnAdapter } from './delegate.js';
+import { formatError } from './errors.js';
+import { CliError, EXIT_INPUT, EXIT_REFUSED } from './exit-codes.js';
+import { formatSubmitLines, submitGame } from './submit.js';
+import { getStatus, isTerminalStatus } from './turn.js';
+import { runLadder } from './verify.js';
+
+export type PickChoice = (choices: string[], question: string) => Promise<string>;
+
+export type AdapterRun = (input: {
+  spec: AdapterSpec;
+  prompt: string;
+  cwd: string;
+  env: NodeJS.ProcessEnv;
+  abort?: AbortSignal;
+  onLine?: (line: string) => void;
+}) => Promise<{ code: number | null }>;
+
+type VerifyRun = NonNullable<Parameters<typeof runLadder>[0]['run']>;
+
+export type Workshop = {
+  slug: string;
+  root: string;
+  token: string;
+  env: NodeJS.ProcessEnv;
+  adapters: AdapterSpec[];
+  builder: string;
+  pick: PickChoice;
+  // Ctrl+C aborts the running child through this, not the REPL.
+  abort: { current: AbortController | null };
+  runAdapter?: AdapterRun;
+  run?: VerifyRun;
+};
+
+export const ADAPTER_TIMEOUT_MS = 30 * 60_000;
+
+export function detectLocalAdapters(
+  env: NodeJS.ProcessEnv,
+  which: (cmd: string) => string | null = (cmd) => whichOnPath(cmd, env),
+): AdapterSpec[] {
+  const file = loadAdapters(env);
+  return file.adapters.flatMap((row) => {
+    const spec = detectAdapter(row.name, which, file);
+    return spec ? [spec] : [];
+  });
+}
+
+async function defaultAdapterRun(input: Parameters<AdapterRun>[0]): Promise<{ code: number | null }> {
+  const child = spawnAdapter({ ...input, timeoutMs: ADAPTER_TIMEOUT_MS });
+  const feed = (chunk: Buffer): void => {
+    for (const line of String(chunk).split('\n')) if (line.trim()) input.onLine?.(line);
+  };
+  child.stdout?.on('data', feed);
+  child.stderr?.on('data', feed);
+  return { code: await new Promise<number | null>((resolve) => child.once('exit', (value) => resolve(value))) };
+}
+
+export function workshopBrief(slug: string, request: string, ack?: string): string {
+  return [
+    `You are editing the gamedev.pl game "${slug}". This directory is its source tree (games/${slug} in the checkout).`,
+    `Creator request: ${request}`,
+    ack ? `Studio understood it as: ${ack}` : '',
+    'Change only files in this directory. Do not run git, install packages, or publish — the creator delivers with `gamedevpl submit`.',
+    'When done, `npm run typecheck` and `npm run check:static` at the checkout root must pass.',
+  ]
+    .filter(Boolean)
+    .join('\n');
+}
+
+export function describeAdapters(adapters: AdapterSpec[], all = loadAdapters().adapters): string {
+  if (adapters.length) return `local agents: ${adapters.map((spec) => spec.name).join(', ')}`;
+  return `no local agent on PATH (${all.map((spec) => spec.name).join(', ')}) — the platform builds; /pull afterwards`;
+}
+
+export function syncWarning(sync: SyncResult): string | null {
+  if (sync.kind === 'platform_only') return `the platform is ahead (${sync.platform.join(', ')}) — /pull first`;
+  if (sync.kind === 'conflict') return `conflict on ${sync.conflict.join(', ')} — /diff before editing`;
+  if (sync.kind === 'legacy') return `no base version here — ${cliUsage('checkout', '<slug>')} again for a clean copy`;
+  return null;
+}
+
+export async function openWorkshop(input: {
+  api: ApiClient;
+  token: string;
+  slug: string;
+  root: string;
+  env: NodeJS.ProcessEnv;
+  which?: (cmd: string) => string | null;
+  write: (line: string) => void;
+}): Promise<{ adapters: AdapterSpec[]; builder: string; status: string }> {
+  const adapters = detectLocalAdapters(input.env, input.which);
+  input.write(`◆ ${input.slug} — the checkout at ${input.root}`);
+  try {
+    const { sync } = await inspectGame({ api: input.api, slug: input.slug, dest: input.root });
+    input.write(formatSyncLines(sync).join('\n'));
+    const warning = syncWarning(sync);
+    if (warning) input.write(`! ${warning}`);
+  } catch (error) {
+    input.write(formatError(error));
+  }
+  input.write(describeAdapters(adapters));
+  let builder = 'platform';
+  let status = '';
+  try {
+    const round = await getStatus(input.api, input.token);
+    builder = round.builder ?? 'platform';
+    status = round.status;
+    input.write(`builder ${builder} · ${status}`);
+  } catch (error) {
+    input.write(formatError(error));
+  }
+  return { adapters, builder, status };
+}
+
+export async function handoffBuilder(api: ApiClient, token: string, builder: 'self' | 'platform'): Promise<string> {
+  await api.request('POST', `/api/submissions/${encodeURIComponent(token)}/handoff`, {
+    builder,
+    stopActivePlatformAgent: builder === 'self',
+  });
+  return builder;
+}
+
+// Asked once per session, only where a local agent could take over.
+export async function settleBuilder(input: {
+  api: ApiClient;
+  ws: Pick<Workshop, 'token' | 'slug' | 'adapters' | 'builder' | 'pick'>;
+  status: string;
+  write: (line: string) => void;
+}): Promise<string> {
+  const { ws } = input;
+  if (!ws.adapters.length || ws.builder === 'self' || isTerminalStatus(input.status)) return ws.builder;
+  const local = `${ws.adapters[0]!.name} here, in this checkout`;
+  const choice = await ws.pick([local, 'the platform — I will /pull afterwards'], `Who builds ${ws.slug}?`);
+  if (choice !== local) return ws.builder;
+  try {
+    const builder = await handoffBuilder(input.api, ws.token, 'self');
+    input.write(`builder self — ${ws.adapters[0]!.name} edits games/${ws.slug}; /builder platform hands it back`);
+    return builder;
+  } catch (error) {
+    input.write(`${formatError(error)}\nthe platform keeps building — /builder self to retry`);
+    return ws.builder;
+  }
+}
+
+export function pickAdapter(ws: Pick<Workshop, 'adapters' | 'env'>, name?: string): AdapterSpec {
+  if (name) {
+    const spec =
+      ws.adapters.find((row) => row.name === name) ??
+      detectAdapter(name, (cmd) => whichOnPath(cmd, ws.env), loadAdapters(ws.env));
+    if (!spec) throw new CliError(`adapter ${name} is not on PATH`, EXIT_INPUT, `install ${name}, or omit --agent`);
+    return spec;
+  }
+  const spec = ws.adapters[0];
+  if (!spec) {
+    throw new CliError(
+      'no local agent on PATH — install claude, codex, gemini or vibe',
+      EXIT_REFUSED,
+      '/builder platform lets the platform build instead',
+    );
+  }
+  return spec;
+}
+
+export async function chooseAdapter(
+  ws: Pick<Workshop, 'adapters' | 'env' | 'pick'>,
+  name?: string,
+): Promise<AdapterSpec> {
+  if (name || ws.adapters.length < 2) return pickAdapter(ws, name);
+  const chosen = await ws.pick(
+    ws.adapters.map((spec) => spec.name),
+    'Which agent?',
+  );
+  return pickAdapter(ws, chosen || ws.adapters[0]!.name);
+}
+
+export async function runLocalBuild(input: {
+  ws: Workshop;
+  spec: AdapterSpec;
+  brief: string;
+  write: (line: string) => void;
+}): Promise<boolean> {
+  const { ws, spec } = input;
+  const cwd = spec.cwd === 'game-dir' ? join(ws.root, 'games', ws.slug) : ws.root;
+  const controller = new AbortController();
+  ws.abort.current = controller;
+  input.write(`▸ ${spec.name} is working in games/${ws.slug} — Ctrl+C stops it`);
+  let result: { code: number | null };
+  try {
+    result = await (ws.runAdapter ?? defaultAdapterRun)({
+      spec,
+      prompt: input.brief,
+      cwd,
+      env: childEnv(ws.env, ''),
+      abort: controller.signal,
+      onLine: (line) => {
+        for (const shown of renderDelegateStream(spec.name, [line], false)) input.write(shown);
+      },
+    });
+  } finally {
+    ws.abort.current = null;
+  }
+  if (controller.signal.aborted) {
+    input.write(`${spec.name} stopped — the tree keeps whatever it wrote; /diff to see`);
+    return false;
+  }
+  if ((result.code ?? 1) !== 0) {
+    input.write(`${spec.name} exited ${result.code ?? 'null'} — /diff to see what changed`);
+    return false;
+  }
+  input.write('verifying — typecheck, check:static');
+  const verify = runLadder({ cwd: ws.root, publish: false, run: ws.run });
+  if (!verify.ok) {
+    const detail = verify.detail.split('\n').find((line) => line.trim()) ?? '';
+    input.write(`verify failed at ${verify.stage}${detail ? `: ${detail}` : ''}\nfix by hand, or ask again`);
+    return false;
+  }
+  input.write('✓ static ladder green');
+  return true;
+}
+
+export async function offerSubmit(input: {
+  api: ApiClient;
+  ws: Workshop;
+  write: (line: string) => void;
+}): Promise<void> {
+  const { ws } = input;
+  const deliver = 'deliver a preview';
+  const choice = await ws.pick([deliver, 'not yet — keep editing'], `Deliver ${ws.slug}?`);
+  if (choice !== deliver) {
+    input.write('kept locally — /submit when ready');
+    return;
+  }
+  try {
+    const result = await submitGame({ api: input.api, slug: ws.slug, dest: ws.root, run: ws.run });
+    input.write(formatSubmitLines(result, ws.slug).join('\n'));
+  } catch (error) {
+    input.write(formatError(error));
+  }
+}
+
+// One creator request, end to end: agent, ladder, offer.
+export async function workshopTurn(input: {
+  api: ApiClient;
+  ws: Workshop;
+  request: string;
+  ack?: string;
+  agent?: string;
+  write: (line: string) => void;
+}): Promise<boolean> {
+  const spec = await chooseAdapter(input.ws, input.agent);
+  const ok = await runLocalBuild({
+    ws: input.ws,
+    spec,
+    brief: workshopBrief(input.ws.slug, input.request, input.ack),
+    write: input.write,
+  });
+  if (ok) await offerSubmit(input);
+  return ok;
+}

--- a/apps/cli/src/workshop.ts
+++ b/apps/cli/src/workshop.ts
@@ -35,7 +35,11 @@ export type Workshop = {
   abort: { current: AbortController | null };
   runAdapter?: AdapterRun;
   run?: VerifyRun;
+  // One-shot verb: no picks, first agent, deliver or not.
+  unattended?: { deliver: boolean };
 };
+
+export type HandoffOutcome = { builder: string; pending: boolean };
 
 export const ADAPTER_TIMEOUT_MS = 30 * 60_000;
 
@@ -117,12 +121,35 @@ export async function openWorkshop(input: {
   return { adapters, builder, status };
 }
 
-export async function handoffBuilder(api: ApiClient, token: string, builder: 'self' | 'platform'): Promise<string> {
-  await api.request('POST', `/api/submissions/${encodeURIComponent(token)}/handoff`, {
-    builder,
-    stopActivePlatformAgent: builder === 'self',
-  });
-  return builder;
+// 202: the old builder owns the round until its agent acks.
+export async function handoffBuilder(
+  api: ApiClient,
+  token: string,
+  builder: 'self' | 'platform',
+  current: string,
+): Promise<HandoffOutcome> {
+  const body = await api.request<{ pending?: boolean; builder?: string }>(
+    'POST',
+    `/api/submissions/${encodeURIComponent(token)}/handoff`,
+    { builder, stopActivePlatformAgent: builder === 'self' },
+  );
+  if (body?.pending) return { builder: body.builder ?? current, pending: true };
+  return { builder, pending: false };
+}
+
+export function handoffLine(outcome: HandoffOutcome, slug: string): string {
+  if (outcome.pending) {
+    return `handoff pending — builder stays ${outcome.builder} until its agent acknowledges; /builder re-checks`;
+  }
+  return outcome.builder === 'self'
+    ? `builder self — your local agent edits games/${slug}; /builder platform hands it back`
+    : `builder platform — say what to change and the platform builds; /pull when it lands`;
+}
+
+export async function refreshBuilder(api: ApiClient, ws: Pick<Workshop, 'token' | 'builder'>): Promise<string> {
+  const round = await getStatus(api, ws.token);
+  ws.builder = round.builder ?? ws.builder;
+  return ws.builder;
 }
 
 // Asked once per session, only where a local agent could take over.
@@ -138,9 +165,9 @@ export async function settleBuilder(input: {
   const choice = await ws.pick([local, 'the platform — I will /pull afterwards'], `Who builds ${ws.slug}?`);
   if (choice !== local) return ws.builder;
   try {
-    const builder = await handoffBuilder(input.api, ws.token, 'self');
-    input.write(`builder self — ${ws.adapters[0]!.name} edits games/${ws.slug}; /builder platform hands it back`);
-    return builder;
+    const outcome = await handoffBuilder(input.api, ws.token, 'self', ws.builder);
+    input.write(handoffLine(outcome, ws.slug));
+    return outcome.builder;
   } catch (error) {
     input.write(`${formatError(error)}\nthe platform keeps building — /builder self to retry`);
     return ws.builder;
@@ -167,10 +194,10 @@ export function pickAdapter(ws: Pick<Workshop, 'adapters' | 'env'>, name?: strin
 }
 
 export async function chooseAdapter(
-  ws: Pick<Workshop, 'adapters' | 'env' | 'pick'>,
+  ws: Pick<Workshop, 'adapters' | 'env' | 'pick' | 'unattended'>,
   name?: string,
 ): Promise<AdapterSpec> {
-  if (name || ws.adapters.length < 2) return pickAdapter(ws, name);
+  if (name || ws.adapters.length < 2 || ws.unattended) return pickAdapter(ws, name);
   const chosen = await ws.pick(
     ws.adapters.map((spec) => spec.name),
     'Which agent?',
@@ -230,7 +257,11 @@ export async function offerSubmit(input: {
 }): Promise<void> {
   const { ws } = input;
   const deliver = 'deliver a preview';
-  const choice = await ws.pick([deliver, 'not yet — keep editing'], `Deliver ${ws.slug}?`);
+  const choice = ws.unattended
+    ? ws.unattended.deliver
+      ? deliver
+      : ''
+    : await ws.pick([deliver, 'not yet — keep editing'], `Deliver ${ws.slug}?`);
   if (choice !== deliver) {
     input.write('kept locally — /submit when ready');
     return;
@@ -243,6 +274,31 @@ export async function offerSubmit(input: {
   }
 }
 
+// Only a self-owned, synchronized checkout may be edited locally.
+export async function readyToEdit(input: {
+  api: ApiClient;
+  ws: Workshop;
+  write: (line: string) => void;
+}): Promise<boolean> {
+  const { ws } = input;
+  if (ws.builder !== 'self') {
+    input.write(`builder is ${ws.builder} — /builder self takes the round here first`);
+    return false;
+  }
+  try {
+    const { sync } = await inspectGame({ api: input.api, slug: ws.slug, dest: ws.root });
+    const warning = syncWarning(sync);
+    if (warning) {
+      input.write(`! ${warning}`);
+      return false;
+    }
+    return true;
+  } catch (error) {
+    input.write(`cannot check the checkout against the platform — ${formatError(error)}`);
+    return false;
+  }
+}
+
 // One creator request, end to end: agent, ladder, offer.
 export async function workshopTurn(input: {
   api: ApiClient;
@@ -252,6 +308,7 @@ export async function workshopTurn(input: {
   agent?: string;
   write: (line: string) => void;
 }): Promise<boolean> {
+  if (!(await readyToEdit(input))) return false;
   const spec = await chooseAdapter(input.ws, input.agent);
   const ok = await runLocalBuild({
     ws: input.ws,


### PR DESCRIPTION
Until now `gamedevpl` run inside a checkout (`airtime/` with `.gamedev-slug`, `games/`, `shared/`) behaved as if no game existed, and even after opening the game the platform builder was the only thing that could change it — on the platform, racing the local copy. The delegation modules (`delegate.ts`, `choice.ts`, `verify.ts`, adapters) existed but nothing in the REPL reached them.

## What a creator gets

**Autodiscovery.** Started in a checkout (any subdirectory), the REPL opens that game instead of asking what to make, and prints the workshop state:

```
◆ airtime — the checkout at /Users/me/airtime
base v7 · local only
local-only: game.ts
local agents: claude, codex
builder platform · needs_changes
Who builds airtime?
▸ claude here, in this checkout
  the platform — I will /pull afterwards
```

If the platform is ahead / in conflict / the checkout has no base, it says so and points at `/pull` or `/diff` before anything edits the tree.

**Who builds is an explicit, one-time choice.** Handing the round to this machine goes through the existing handoff route (`builder: self`) — the platform then never dispatches its own builder on a game being edited locally. `/builder platform` hands it back; `/builder` alone shows the current one. `/builder <slug>` still reads any game.

**A plain message still talks to Studio first.** Questions get answers (`kind: reply`). When the chat agent decides to build (`kind: build`) and the builder is `self`, the local agent runs in `games/<slug>` with a short brief (the request, Studio's ack, "do not git/publish — the creator delivers with `gamedevpl submit`"), its events stream into the transcript, the static ladder runs (`typecheck`, `check:static`), and delivery is offered:

```
▸ build 7 — Floatier jump.
▸ claude is working in games/airtime — Ctrl+C stops it
claude ▸ Made the jump floatier. ⚙ Edit
verifying — typecheck, check:static
✓ static ladder green
Deliver airtime?
▸ deliver a preview
  not yet — keep editing
```

If the builder is still `platform`, the REPL says the platform builds this round and to `/pull` when it lands — no local spawn.

- `/delegate <task> [--agent codex]` skips the chat and runs the agent directly.
- `gamedevpl delegate "<task>" [--agent x] [--submit]` is the non-interactive twin: exit `1` when the agent or the ladder fails.
- **Ctrl+C stops the running agent, not the session** — the tree keeps what it wrote, `/diff` shows it.
- Several agents on PATH → a pick; one → used; none → the platform builds and the opening says so.

## Boundary

The child gets `childEnv(env, '')`: no OAuth grant, no PAT (the test asserts `gdpl_oat_` never reaches it). The brief tells the agent not to publish; delivery stays a creator action in the REPL.

## Also

- `parseEventLine` now renders claude (`message.content[]` text / tool_use) and codex (`item.text`, `item.command`) events as words; bookkeeping events (`system`, `user`, `thread.*`, `turn.*`) are hidden. Previously claude events printed as `[object Object]`.
- `RoundStatus.builder`, `delegate` in `SLASH_VERBS` + help, README section "In a checkout", changelog `Added` entries (next cut → 0.4.0).

## Verified

- 15 new tests in `workshop.test.ts` (agent runs in `games/<slug>` with the brief and a clean env, then stages + delivers; declined delivery keeps the edit local; red ladder never offers delivery; abort path; agent pick + `--agent`; REPL chat-then-build; platform round left alone; `/delegate`; `/builder platform` through the handoff route; opening lines; `settleBuilder` asks once and only hands off when chosen; event parsing) plus `findCheckout` / `openCheckoutGame` from the autodiscovery commit.
- `@gamedevpl/cli` 180 green · CLI and API type-check green · `npm run lint` green (comment-prose, module-size, changelog guard).

Not done here: the platform-built branch still relies on the creator running `/pull`; auto-pulling when a round lands is a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AJNcxBU2JJg3mPykeMqLGw

---
_Generated by [Claude Code](https://claude.ai/code/session_01AJNcxBU2JJg3mPykeMqLGw)_