### PR TITLE
Log scorecard aggregates for unattended monitoring

### DIFF
--- a/apps/api/src/creation/scorecard-aggregate-log.test.ts
+++ b/apps/api/src/creation/scorecard-aggregate-log.test.ts
@@ -62,15 +62,18 @@ describe('scorecard aggregate log', () => {
   });
 
   it('carries no game-supplied strings either', async () => {
-    await seed(store, [
-      event({ type: 'game_error', slug: 'brick-storm', message: 'ReferenceError: <script>boom</script>' } as never),
-    ]);
+    await seed(store, [event({ type: 'error', slug: 'brick-storm', message: 'ReferenceError: boom' })]);
     const lines: ScorecardAggregateLog[] = [];
 
     await runScorecardSweep({ store, onAggregate: (line) => lines.push(line) });
 
+    // Assert the sample reached the scorecard, or the omission below proves nothing.
+    const card = await store.getScorecard('brick-storm');
+    expect(card?.untrusted.errorSamples).toContainEqual({ message: 'ReferenceError: boom', count: 1 });
+
     // `untrusted` contains these; a log would un-contain them.
     expect(JSON.stringify(lines)).not.toContain('boom');
+    expect(lines[0]?.errors).toBe(1);
   });
 
   it('stays silent for a game whose scorecard failed to persist', async () => {

--- a/apps/api/src/creation/scorecard-aggregate-log.test.ts
+++ b/apps/api/src/creation/scorecard-aggregate-log.test.ts
@@ -1,0 +1,93 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { InMemoryStore, type TelemetryEvent } from '../platform/store.js';
+import { runScorecardSweep } from './scorecard.js';
+import { SCORECARD_AGGREGATE_EVENT, type ScorecardAggregateLog } from './scorecard-aggregate-log.js';
+import { MIN_FEEDBACK_FOR_THEMES, type ThemeExtractor } from '../community/feedback-themes.js';
+
+const today = () => new Date().toISOString().slice(0, 10);
+
+function event(partial: Partial<TelemetryEvent> & { type: TelemetryEvent['type'] }): TelemetryEvent {
+  return {
+    slug: 'brick-storm',
+    sessionId: 's1',
+    at: new Date().toISOString(),
+    ...partial,
+  } as TelemetryEvent;
+}
+
+async function seed(store: InMemoryStore, events: TelemetryEvent[]) {
+  await store.appendTelemetryEvents(today(), events);
+}
+
+describe('scorecard aggregate log', () => {
+  let store: InMemoryStore;
+
+  beforeEach(async () => {
+    store = new InMemoryStore();
+    await store.upsertUser({ uid: 'g:alice' });
+    await seed(store, [event({ type: 'game_opened', slug: 'brick-storm' })]);
+  });
+
+  it('emits one line per scorecard written, carrying the numbers a reader acts on', async () => {
+    const lines: ScorecardAggregateLog[] = [];
+
+    await runScorecardSweep({ store, onAggregate: (line) => lines.push(line) });
+
+    expect(lines).toHaveLength(1);
+    expect(lines[0]).toMatchObject({
+      event: SCORECARD_AGGREGATE_EVENT,
+      slug: 'brick-storm',
+      sessions: 1,
+      feedbackCount: 0,
+    });
+  });
+
+  it('carries no player words — not the notes, and not the themes distilled from them', async () => {
+    const secret = 'the boss on level three killed my cat';
+    for (let index = 0; index < MIN_FEEDBACK_FOR_THEMES; index += 1) {
+      await store.addPlayerFeedback('brick-storm', 'g:alice', `${secret} ${index}`);
+    }
+    const themeExtractor: ThemeExtractor = { extract: async () => [{ theme: secret, count: 3 }] };
+    const lines: ScorecardAggregateLog[] = [];
+
+    await runScorecardSweep({ store, themeExtractor, onAggregate: (line) => lines.push(line) });
+
+    // Logs outlive rows; erase-player-signals.ts cannot reach them.
+    const serialized = JSON.stringify(lines);
+    expect(serialized).not.toContain(secret);
+    expect(serialized).not.toContain('boss');
+    expect(lines[0]?.feedbackCount).toBe(MIN_FEEDBACK_FOR_THEMES);
+    expect(lines[0]?.feedbackThemeCount).toBe(1);
+    expect((await store.getScorecard('brick-storm'))?.untrusted.feedbackThemes).toHaveLength(1);
+  });
+
+  it('carries no game-supplied strings either', async () => {
+    await seed(store, [
+      event({ type: 'game_error', slug: 'brick-storm', message: 'ReferenceError: <script>boom</script>' } as never),
+    ]);
+    const lines: ScorecardAggregateLog[] = [];
+
+    await runScorecardSweep({ store, onAggregate: (line) => lines.push(line) });
+
+    // `untrusted` contains these; a log would un-contain them.
+    expect(JSON.stringify(lines)).not.toContain('boom');
+  });
+
+  it('stays silent for a game whose scorecard failed to persist', async () => {
+    const lines: ScorecardAggregateLog[] = [];
+    const failing = Object.create(store) as InMemoryStore;
+    failing.putScorecard = async () => {
+      throw new Error('firestore rejected the write');
+    };
+
+    const result = await runScorecardSweep({
+      store: failing,
+      onAggregate: (line) => lines.push(line),
+      onError: () => {},
+    });
+
+    // A line for an absent scorecard contradicts the database.
+    expect(result.failed).toBe(1);
+    expect(lines).toEqual([]);
+  });
+});

--- a/apps/api/src/creation/scorecard-aggregate-log.ts
+++ b/apps/api/src/creation/scorecard-aggregate-log.ts
@@ -1,0 +1,53 @@
+import type { Scorecard } from '../platform/store.js';
+
+// Filter readers grep on; see docs/agent-gcp-access.md.
+export const SCORECARD_AGGREGATE_EVENT = 'scorecard_aggregate';
+
+// Omits themes and untrusted strings; docs/agent-gcp-access.md says why.
+export interface ScorecardAggregateLog {
+  event: typeof SCORECARD_AGGREGATE_EVENT;
+  slug: string;
+  computedAt: string;
+  windowDays: number;
+  windowTruncated: boolean;
+  sessions: number;
+  bounces: number;
+  closes: number;
+  medianPlaySeconds: number;
+  totalPlaySeconds: number;
+  errors: number;
+  stallRate: number;
+  medianFps: number | null;
+  finishRate: number | null;
+  winRate: number | null;
+  sessionsWithEnding: number;
+  votesUp: number;
+  votesDown: number;
+  feedbackCount: number;
+  feedbackThemeCount: number;
+}
+
+export function toAggregateLog(card: Scorecard): ScorecardAggregateLog {
+  return {
+    event: SCORECARD_AGGREGATE_EVENT,
+    slug: card.slug,
+    computedAt: card.computedAt,
+    windowDays: card.window.days.length,
+    windowTruncated: card.window.truncated,
+    sessions: card.sessions.count,
+    bounces: card.sessions.bounces,
+    closes: card.sessions.closes,
+    medianPlaySeconds: card.sessions.medianPlaySeconds,
+    totalPlaySeconds: card.sessions.totalPlaySeconds,
+    errors: card.health.errors,
+    stallRate: card.health.stallRate,
+    medianFps: card.health.medianFps,
+    finishRate: card.depth.finishRate,
+    winRate: card.depth.winRate,
+    sessionsWithEnding: card.depth.sessionsWithEnding,
+    votesUp: card.votes.up,
+    votesDown: card.votes.down,
+    feedbackCount: card.feedback.count,
+    feedbackThemeCount: card.untrusted.feedbackThemes?.length ?? 0,
+  };
+}

--- a/apps/api/src/creation/scorecard.ts
+++ b/apps/api/src/creation/scorecard.ts
@@ -15,6 +15,7 @@ import {
   type ThemeExtractor,
 } from '../platform/feedback-themes-contract.js';
 import type { Scorecard, Store, TelemetryEvent } from '../platform/store.js';
+import { toAggregateLog, type ScorecardAggregateLog } from './scorecard-aggregate-log.js';
 
 /**
  * The scorecard sweep (docs/improvement-loop-plan.md IL-2 "Distill").
@@ -74,6 +75,8 @@ export interface ScorecardSweepDeps {
   onError?: (slug: string, error: unknown) => void;
   /** Called when theme extraction failed for a game; the scorecard is still written without themes. */
   onThemeError?: (slug: string, error: unknown) => void;
+  // Called per scorecard written; the route owns the logger.
+  onAggregate?: (line: ScorecardAggregateLog) => void;
 }
 
 export interface ScorecardSweepResult {
@@ -208,11 +211,11 @@ export async function runScorecardSweep(deps: ScorecardSweepDeps): Promise<Score
         }
       }
 
-      await store.putScorecard(
-        health.slug,
-        buildScorecard(health, { votes, feedbackCount, feedbackThemes }, window, computedAt),
-      );
+      const card = buildScorecard(health, { votes, feedbackCount, feedbackThemes }, window, computedAt);
+      await store.putScorecard(health.slug, card);
       written += 1;
+      // After the write: a line for an absent scorecard lies.
+      deps.onAggregate?.(toAggregateLog(card));
     } catch (error) {
       // One unwritable game must not cost every later game its scorecard — the same
       // rule the notification sweep follows for one bad submission.
@@ -271,6 +274,8 @@ export async function registerScorecardRoutes(app: FastifyInstance, options: Sco
           // has been failing every night is invisible in the result, where a game with
           // nothing to summarize looks exactly the same.
           onThemeError: (slug, error) => request.log.warn({ err: error, slug }, 'feedback theme extraction failed'),
+          // Only path by which an unattended reader sees these.
+          onAggregate: (line) => request.log.info(line, 'scorecard aggregate'),
         });
         // Logged at error level when anything failed: a nightly job nobody watches is
         // exactly the kind that fails quietly for weeks, and `failed > 0` is the signal.

--- a/docs/agent-gcp-access.md
+++ b/docs/agent-gcp-access.md
@@ -106,6 +106,45 @@ node infra/gcp-read.mjs logs 'jsonPayload.event="mcp_unknown_session" OR jsonPay
 node infra/gcp-read.mjs logs 'resource.type="cloud_run_revision" AND httpRequest.requestUrl=~"/api/mcp" AND httpRequest.userAgent=~"openai|claude"' --since 6h --limit 50
 ```
 
+### Per-game aggregates — how an unattended run reads product health
+
+The nightly scorecard sweep writes one structured line per game it scores, so the numbers
+IL-3 reasons about are reachable with the `logging.viewer` this account already holds:
+
+```bash
+# Every game scored by last night's sweep
+node infra/gcp-read.mjs logs 'jsonPayload.event="scorecard_aggregate"' --since 36h --limit 500
+
+# One game over time — logs keep the history that scorecard/current does not
+node infra/gcp-read.mjs logs 'jsonPayload.event="scorecard_aggregate" AND jsonPayload.slug="brick-storm"' --since 30d --limit 60
+```
+
+**This is deliberately the whole access path, and no endpoint was built for it.** The
+alternative considered was an OIDC-gated `/api/internal/aggregates` on the pattern of the
+sweeps in `app.ts`. The log wins on three counts: it opens no new public URL, it needs no
+new credential or env var, it does not widen this account's role beyond infrastructure
+reads — and it yields a time series for free, where `games/{slug}/scorecard/current` keeps
+only the newest state.
+
+What the line carries is fixed by `toAggregateLog` in
+[`apps/api/src/creation/scorecard.ts`](../apps/api/src/creation/scorecard.ts): session and
+vote counts, health and depth rates, `feedbackCount`, and `feedbackThemeCount`.
+
+What it will not carry, and why it is a test rather than a convention:
+
+- **`feedbackThemes`** — distilled from players' own words, and `MIN_FEEDBACK_FOR_THEMES`
+  is 3, so a theme counted once across three notes is one person's sentence in an
+  aggregate's clothing. Small _n_ is the reason, not the privacy notice: a log is a copy
+  that outlives the row and that `erase-player-signals.ts` cannot reach. Read themes on
+  the operator page, where the rows behind them are still deletable.
+- **`errorSamples` and `progressLabels`** — game-supplied strings, quarantined under
+  `untrusted` on the scorecard exactly so they reach as few places as possible.
+
+Counts are safe by contrast: they describe a game rather than a person, and account
+deletion already flows into them without help from here — `clearVote` corrects the parent
+counters, and the next sweep recomputes `feedback.count` from the rows that remain. A
+logged line is a snapshot of what was true that night, which stays true afterwards.
+
 `raw` is the escape hatch: any runbook `gcloud` step has a REST equivalent, and the credential
 — not the wrapper — is what stops a mutation. Start with `whoami`; if a command 403s, that
 output tells you immediately whether it is a permission boundary or a real fault.

--- a/eslint-rules/module-boundary-map.mjs
+++ b/eslint-rules/module-boundary-map.mjs
@@ -257,6 +257,7 @@ const FILE_BUCKET = {
   'seed-paths': 'creation',
   'session-crash': 'creation',
   scorecard: 'creation',
+  'scorecard-aggregate-log': 'creation',
   'knowledge-search': 'creation',
   // Collapses jobs to distinct games for the Studio shelf -- pure Store-record
   // grouping, no catalog dependency, only ever read by creator-studio.ts.

--- a/eslint-rules/module-size-baseline.json
+++ b/eslint-rules/module-size-baseline.json
@@ -227,7 +227,7 @@
     "apps/api/src/creation/remix.test.ts": 1371,
     "apps/api/src/creation/remix.ts": 1377,
     "apps/api/src/creation/scorecard.test.ts": 343,
-    "apps/api/src/creation/scorecard.ts": 287,
+    "apps/api/src/creation/scorecard.ts": 291,
     "apps/api/src/creation/seed-availability.test.ts": 98,
     "apps/api/src/creation/seed-availability.ts": 100,
     "apps/api/src/creation/seed-bundle.test.ts": 77,


### PR DESCRIPTION
## Summary
Adds structured logging of scorecard aggregates to enable unattended monitoring of game health metrics via GCP Cloud Logging, without requiring new endpoints or credentials.

## Key Changes
- **New module `scorecard-aggregate-log.ts`**: Defines `ScorecardAggregateLog` interface and `toAggregateLog()` function that converts a `Scorecard` to a loggable aggregate, deliberately omitting player feedback text and game-supplied strings (themes and error messages) that are quarantined in the scorecard's `untrusted` field
- **Updated `scorecard.ts`**: 
  - Added `onAggregate` callback to `ScorecardSweepDeps` interface
  - Invokes `onAggregate` after each scorecard is successfully written to the database
  - Registered the callback in `registerScorecardRoutes` to log aggregates at info level
- **Comprehensive test suite** (`scorecard-aggregate-log.test.ts`): Verifies that:
  - One log line is emitted per scorecard written
  - Player feedback text and extracted themes are not included in logs
  - Game-supplied error strings are excluded
  - No log is written if scorecard persistence fails
- **Documentation** (`docs/agent-gcp-access.md`): Added section explaining the access pattern, rationale for using logs over a new endpoint, and what data is intentionally excluded and why

## Implementation Details
- The aggregate log captures session counts, play time metrics, health/depth rates, vote counts, and feedback counts—all numeric aggregates safe for long-term retention
- Logs are written only after successful database persistence to avoid contradicting the actual state
- The design avoids opening new public URLs, requiring new credentials, or widening IAM roles—leveraging existing `logging.viewer` access
- Logs provide a time series that the current scorecard endpoint cannot, enabling historical trend analysis

https://claude.ai/code/session_01NX7zNLa9nsGewawum7vWrA