### PR TITLE
feat(cli): choose installed coding agents for game builds

### DIFF
--- a/apps/api/src/creation/cli-chat-routes.test.ts
+++ b/apps/api/src/creation/cli-chat-routes.test.ts
@@ -91,6 +91,35 @@ describe('POST /api/cli/chat', () => {
     vi.restoreAllMocks();
   });
 
+  it('prepares a game without creating or dispatching until the builder is chosen', async () => {
+    const {
+      app,
+      store,
+      authHeaders: headers,
+    } = await createApp({
+      intakeAgent: new StubIntakeAgent({
+        kind: 'create',
+        title: 'Robot Garden',
+        concept: 'A garden full of robots that water plants.',
+      }),
+    });
+    const prepared = await chat(app, headers, { text: 'build my robot garden', prepareOnly: true });
+    expect(prepared.statusCode).toBe(200);
+    expect(prepared.json()).toMatchObject({ kind: 'proposal', title: 'Robot Garden' });
+    expect(await store.listSubmissionsByOwner('g:test-user')).toEqual([]);
+    const proposal = prepared.json();
+    const created = await app.inject({
+      method: 'POST',
+      url: '/api/submissions',
+      headers,
+      payload: { title: proposal.title, concept: proposal.concept, builder: 'self' },
+    });
+    expect(created.statusCode).toBe(200);
+    const [job] = await store.listSubmissionsByOwner('g:test-user');
+    expect(job.builder).toBe('self');
+    await app.close();
+  });
+
   it('404s when CLI_SURFACE is off', async () => {
     restore?.();
     restore = undefined;

--- a/apps/api/src/creation/cli-chat-routes.ts
+++ b/apps/api/src/creation/cli-chat-routes.ts
@@ -19,6 +19,7 @@ import { failClosedReply, IntakeChatAgent, type IntakeAgent } from './intake-age
 const ChatBodySchema = z.object({
   text: z.string().trim().min(1, 'text is required').max(MAX_REVISION_CHARS, 'text is too long'),
   conversationId: z.string().uuid().optional(),
+  prepareOnly: z.boolean().optional(),
 });
 
 export interface CliChatRoutesOptions {
@@ -138,6 +139,17 @@ export function registerCliChatRoutes(app: FastifyInstance, options: CliChatRout
         request.log.info({ cliChat: { outcome: 'reply' } }, 'cli intake chat');
         await saveTurns(store, uid, conversationId, history, text, decision.text, now);
         return reply.send({ kind: 'reply', text: decision.text, conversationId });
+      }
+
+      if (parsed.data.prepareOnly) {
+        await saveTurns(store, uid, conversationId, history, text, decision.ack ?? decision.title, now);
+        return reply.send({
+          kind: 'proposal',
+          title: decision.title,
+          concept: decision.concept,
+          ack: decision.ack,
+          conversationId,
+        });
       }
 
       const created = await createGame({

--- a/apps/api/src/creation/creator-feedback-handler.ts
+++ b/apps/api/src/creation/creator-feedback-handler.ts
@@ -58,11 +58,18 @@ function parseBody(mode: CreatorMessageMode, body: unknown) {
   if (mode === 'turn') {
     const parsed = TurnRequestSchema.safeParse(body);
     if (!parsed.success) return { error: parsed.error.issues[0]?.message ?? 'invalid request' };
-    return { data: { feedback: parsed.data.text, builder: parsed.data.builder, context: parsed.data.context } };
+    return {
+      data: {
+        feedback: parsed.data.text,
+        builder: parsed.data.builder,
+        context: parsed.data.context,
+        prepareOnly: parsed.data.prepareOnly,
+      },
+    };
   }
   const parsed = FeedbackRequestSchema.safeParse(body);
   if (!parsed.success) return { error: parsed.error.issues[0]?.message ?? 'invalid request' };
-  return { data: parsed.data };
+  return { data: { ...parsed.data, prepareOnly: false } };
 }
 
 function sendFeedbackOk(reply: FastifyReply, shotId: string | undefined, extra: Record<string, unknown> = {}) {
@@ -134,13 +141,7 @@ export async function handleCreatorFeedback(
 
   const feedbackUid = request.user?.uid;
   if (store && feedbackUid) {
-    const headroom = await peekQuota(
-      store,
-      feedbackUid,
-      dateStr,
-      dailyFeedbackQuota,
-      'feedback',
-    );
+    const headroom = await peekQuota(store, feedbackUid, dateStr, dailyFeedbackQuota, 'feedback');
     if (!headroom.allowed) {
       if (headroom.tier === 'blocked') {
         return reply.status(403).send({ error: 'account is blocked' });
@@ -255,6 +256,10 @@ export async function handleCreatorFeedback(
       }
     }
     if (chatOutcome?.kind === 'build') studioAckText = chatOutcome.ackText;
+  }
+
+  if (mode === 'turn' && parsed.data.prepareOnly) {
+    return reply.send({ kind: 'proposal', ...(studioAckText ? { ack: studioAckText } : {}) });
   }
 
   if (store) {

--- a/apps/api/src/creation/creator-studio.ts
+++ b/apps/api/src/creation/creator-studio.ts
@@ -25,6 +25,7 @@ export type CreatorScorecardsResponse = StudioScorecardsResponse;
 export type CreatorStudioGamesResponse = StudioGamesResponse;
 export type CreatorBuildsResponse = StudioBuildsResponse;
 import { composeWorkspaceArchive, WorkspaceCompositionError } from '../platform/workspace-archive.js';
+import { buildSpecStub } from './creator-code.js';
 import type { GamesStore, VersionManifest } from '../delivery/games-store.js';
 import type { Store, TelemetryEvent } from '../platform/store.js';
 import { normalizeLocale } from '../platform/translate.js';
@@ -408,27 +409,21 @@ export async function registerCreatorStudioRoutes(
         return reply.status(404).send({ error: 'no such game' });
       }
 
-      // Same preference order as the agent's own `get_sources`, and it has to be read off
-      // the *newest* round rather than the first owned record that happens to carry a
-      // version. An improvement round starts empty on a slug whose older job still points
-      // at the version it delivered before publication; scanning all records would hand
-      // back that older delivery, and a creator who edited it and delivered would overwrite
-      // newer published work with something derived from a superseded base. When the newest
-      // round has nothing of its own, the live publication is what they last played.
+      // Prefer the newest round, then the live publication.
       const tip = [...owned].sort((a, b) => b.createdAt.localeCompare(a.createdAt))[0];
       let version = tip.previewVersion ?? tip.deliveredVersion ?? null;
       if (!version) {
         const publication = await store.getPublication(slug);
         if (isPublished(publication)) version = publication.currentVersion;
       }
-      if (!version) {
+      if (!version && (request.query as { allowUndelivered?: string }).allowUndelivered !== 'true') {
         return reply.status(409).send({
           error: 'nothing_delivered',
           message: 'this game has no delivered version yet — let the first build finish, then check it out',
         });
       }
 
-      const manifest = await options.gamesStore.getManifest(slug, version);
+      const manifest = version ? await options.gamesStore.getManifest(slug, version) : { sourceFiles: [] };
       if (!manifest) {
         request.log.error({ slug, version }, 'workspace checkout: manifest missing for a version a job points at');
         return reply.status(502).send({ error: 'the delivered version could not be read back' });
@@ -437,9 +432,10 @@ export async function registerCreatorStudioRoutes(
       const sources = await Promise.all(
         manifest.sourceFiles.map(async (path) => ({
           path,
-          content: await options.gamesStore!.getSourceFile(slug, version, path),
+          content: await options.gamesStore!.getSourceFile(slug, version!, path),
         })),
       );
+      if (!version) sources.push({ path: 'SPEC.md', content: buildSpecStub(tip) });
       const missing = sources.filter((file) => file.content === null).map((file) => file.path);
       if (missing.length > 0) {
         request.log.error(

--- a/apps/api/src/creation/creator-turn.test.ts
+++ b/apps/api/src/creation/creator-turn.test.ts
@@ -150,6 +150,29 @@ describe('POST /api/submissions/:token/turn (CL-10, CL-11)', () => {
     await app.close();
   });
 
+  it('prepares a change without queueing it or starting another build', async () => {
+    const {
+      app,
+      store,
+      briefs,
+      authHeaders: headers,
+    } = await createApp({ chatAgent: { decide: async () => ({ kind: 'build', text: 'On it.' }) } });
+    const { token, jobId } = await openDraft(app, store, headers);
+    const before = briefs.length;
+    const messages = await store.listCreatorMessages(jobId);
+    const res = await app.inject({
+      method: 'POST',
+      url: `/api/submissions/${token}/turn`,
+      headers,
+      payload: { text: 'make the robots blue', prepareOnly: true },
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toEqual({ kind: 'proposal', ack: 'On it.' });
+    expect(briefs).toHaveLength(before);
+    expect(await store.listCreatorMessages(jobId)).toEqual(messages);
+    await app.close();
+  });
+
   it('accepts a one-character status question that feedback would reject', async () => {
     const decide = vi.fn(async () => ({ kind: 'reply' as const, text: '?' }));
     const { app, store, authHeaders: headers } = await createApp({ chatAgent: { decide } });

--- a/apps/api/src/creation/feedback-request.ts
+++ b/apps/api/src/creation/feedback-request.ts
@@ -45,6 +45,7 @@ export const FeedbackRequestSchema = z.object({
 });
 
 export const TurnRequestSchema = z.object({
+  prepareOnly: z.boolean().optional(),
   text: z
     .string({ required_error: 'text is required', invalid_type_error: 'text is required' })
     .trim()

--- a/apps/api/src/creator-studio-workspace.test.ts
+++ b/apps/api/src/creator-studio-workspace.test.ts
@@ -1,11 +1,12 @@
 import { gunzipSync, gzipSync } from 'node:zlib';
+import { writeTarGz } from './platform/tar.js';
 import { beforeEach, describe, expect, it } from 'vitest';
-import { buildApp } from './platform/app.js';
 import { mintSessionToken, SESSION_COOKIE_NAME } from './platform/auth.js';
 import type { GamesStore, VersionManifest } from './delivery/games-store.js';
-import type { GcsObjectStore } from './delivery/gcs-sign.js';
 import { InMemoryStore } from './platform/store.js';
-import { readTarEntries, writeTarGz, type TarEntry } from './platform/tar.js';
+import { objectsWithScaffold, createApp as createWorkspaceApp, entriesOf } from './creator-workspace-fixtures.js';
+const createApp = (store: InMemoryStore, objects: Map<string, Buffer>, gamesStore = stubGamesStore()) =>
+  createWorkspaceApp(store, objects, gamesStore);
 
 const sessionSecret = 'dev-session-secret-change-me';
 const ENGINE = 'deadbeef0123456789abcdef0123456789abcdef';
@@ -31,63 +32,6 @@ function stubGamesStore(sources = SOURCES): GamesStore {
       slug === SLUG && version === VERSION ? ({ sourceFiles: Object.keys(sources) } as VersionManifest) : null,
     getSourceFile: async (_slug: string, _version: string, path: string) => sources[path] ?? null,
   } as unknown as GamesStore;
-}
-
-function scaffoldTarball(): Buffer {
-  return gzipSync(
-    // Wrapped in a directory on purpose: the packer may or may not wrap, and the
-    // composer is supposed to tolerate both.
-    Buffer.from(
-      gunzipSync(
-        writeTarGz([
-          { path: 'workspace/README.md', content: '# your working copy\n' },
-          { path: 'workspace/setup.mjs', content: 'fetch the kit\n' },
-          { path: 'workspace/.gitignore', content: 'node_modules\n' },
-        ]),
-      ),
-    ),
-  );
-}
-
-function objectsWithScaffold(): Map<string, Buffer> {
-  return new Map<string, Buffer>([
-    [
-      'kits/current.json',
-      Buffer.from(JSON.stringify({ current: ENGINE, previous: null, updatedAt: '2026-08-01T00:00:00.000Z' })),
-    ],
-    ['kits/' + ENGINE + '.json', Buffer.from(JSON.stringify({ sha256: SHA, packedAt: '2026-08-01T00:00:00.000Z' }))],
-    ['kits/' + ENGINE + '.tgz', Buffer.from('fake-kit')],
-    ['workspaces/' + ENGINE + '.tgz', scaffoldTarball()],
-  ]);
-}
-
-function mockObjectStore(objects: Map<string, Buffer>): GcsObjectStore {
-  return {
-    readObject: async (name) => objects.get(name) ?? null,
-    objectExists: async (name) => objects.has(name),
-    signReadUrl: async (name) => `https://signed.example/${name}?sig=1`,
-  };
-}
-
-async function createApp(store: InMemoryStore, objects: Map<string, Buffer>, gamesStore = stubGamesStore()) {
-  return await buildApp({
-    store,
-    sessionSecret,
-    submissionRoutes: {
-      submissionTokenSecret: 'test-submission-secret',
-      agentChannel: { objectStore: mockObjectStore(objects), gamesStore },
-    },
-  });
-}
-
-async function entriesOf(archive: Buffer): Promise<TarEntry[]> {
-  const buffer = gunzipSync(archive);
-  async function* once(): AsyncGenerator<Uint8Array> {
-    yield buffer;
-  }
-  const entries: TarEntry[] = [];
-  for await (const item of readTarEntries(once())) entries.push(item);
-  return entries;
 }
 
 describe('GET /api/me/studio/games/:slug/workspace', () => {
@@ -190,6 +134,26 @@ describe('GET /api/me/studio/games/:slug/workspace', () => {
 
     expect(res.statusCode).toBe(409);
     expect(res.json().error).toBe('nothing_delivered');
+  });
+
+  it('can bootstrap an undelivered game with its brief and pinned kit', async () => {
+    const empty = new InMemoryStore();
+    await empty.upsertUser({ uid: 'g:creator' });
+    await empty.createSubmission(ISSUE, 'g:creator', 'Comet Courier');
+    await empty.setSubmissionSlug(ISSUE, SLUG);
+    const app = await createApp(empty, objectsWithScaffold());
+    const res = await app.inject({
+      method: 'GET',
+      url: `/api/me/studio/games/${SLUG}/workspace?allowUndelivered=true`,
+      headers: authHeaders('g:creator'),
+    });
+    expect(res.statusCode).toBe(200);
+    const entries = await entriesOf(res.rawPayload);
+    expect(Buffer.from(entries.find((row) => row.path === `games/${SLUG}/SPEC.md`)!.bytes).toString()).toContain(
+      'Comet Courier',
+    );
+    expect(Buffer.from(entries.find((row) => row.path === 'gamedev.lock')!.bytes).toString()).toContain(ENGINE);
+    await app.close();
   });
 
   it('checks out the live publication when the newest round has delivered nothing yet', async () => {

--- a/apps/api/src/creator-workspace-fixtures.ts
+++ b/apps/api/src/creator-workspace-fixtures.ts
@@ -1,0 +1,65 @@
+import { gunzipSync, gzipSync } from 'node:zlib';
+import { buildApp } from './platform/app.js';
+import type { GamesStore } from './delivery/games-store.js';
+import type { GcsObjectStore } from './delivery/gcs-sign.js';
+import { InMemoryStore } from './platform/store.js';
+import { readTarEntries, writeTarGz, type TarEntry } from './platform/tar.js';
+const sessionSecret = 'dev-session-secret-change-me';
+const ENGINE = 'deadbeef0123456789abcdef0123456789abcdef';
+const SHA = 'a'.repeat(64);
+
+function scaffoldTarball(): Buffer {
+  return gzipSync(
+    // The composer accepts archives with a wrapping directory.
+    Buffer.from(
+      gunzipSync(
+        writeTarGz([
+          { path: 'workspace/README.md', content: '# your working copy\n' },
+          { path: 'workspace/setup.mjs', content: 'fetch the kit\n' },
+          { path: 'workspace/.gitignore', content: 'node_modules\n' },
+        ]),
+      ),
+    ),
+  );
+}
+
+export function objectsWithScaffold(): Map<string, Buffer> {
+  return new Map<string, Buffer>([
+    [
+      'kits/current.json',
+      Buffer.from(JSON.stringify({ current: ENGINE, previous: null, updatedAt: '2026-08-01T00:00:00.000Z' })),
+    ],
+    ['kits/' + ENGINE + '.json', Buffer.from(JSON.stringify({ sha256: SHA, packedAt: '2026-08-01T00:00:00.000Z' }))],
+    ['kits/' + ENGINE + '.tgz', Buffer.from('fake-kit')],
+    ['workspaces/' + ENGINE + '.tgz', scaffoldTarball()],
+  ]);
+}
+
+function mockObjectStore(objects: Map<string, Buffer>): GcsObjectStore {
+  return {
+    readObject: async (name) => objects.get(name) ?? null,
+    objectExists: async (name) => objects.has(name),
+    signReadUrl: async (name) => `https://signed.example/${name}?sig=1`,
+  };
+}
+
+export async function createApp(store: InMemoryStore, objects: Map<string, Buffer>, gamesStore: GamesStore) {
+  return await buildApp({
+    store,
+    sessionSecret,
+    submissionRoutes: {
+      submissionTokenSecret: 'test-submission-secret',
+      agentChannel: { objectStore: mockObjectStore(objects), gamesStore },
+    },
+  });
+}
+
+export async function entriesOf(archive: Buffer): Promise<TarEntry[]> {
+  const buffer = gunzipSync(archive);
+  async function* once(): AsyncGenerator<Uint8Array> {
+    yield buffer;
+  }
+  const entries: TarEntry[] = [];
+  for await (const item of readTarEntries(once())) entries.push(item);
+  return entries;
+}

--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -9,6 +9,7 @@ decides the next version — see [`.claude/skills/cli-release/SKILL.md`](../../.
 
 ### Added
 
+- `gamedevpl agents` lists installed tools and local-file/MCP support; the REPL offers every available checkout agent and an agent picker for `/connect`
 - Started in a game checkout, `gamedevpl` opens that game instead of asking what to make
 - In a checkout, saying what to change runs `claude` / `codex` / `gemini` / `vibe` from your machine on the game,
   verifies the tree and offers to deliver; `/delegate <task>` skips the chat, `/builder self|platform` picks who builds,
@@ -16,6 +17,7 @@ decides the next version — see [`.claude/skills/cli-release/SKILL.md`](../../.
 
 ### Fixed
 
+- MCP agents run without a checkout in a scratch directory that remains available afterwards
 - `gamedevpl` prints the version it actually is; every release so far reported 0.1.0 in the banner, footer and `help`
 
 ## 0.3.0 — 2026-09-05

--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -9,6 +9,8 @@ decides the next version — see [`.claude/skills/cli-release/SKILL.md`](../../.
 
 ### Added
 
+- Choose an installed agent before creating a game or dispatching a revision; all seven bundled agents support local builds, with automatic checkout preparation when needed (#1181)
+- Copilot gains temporary MCP setup; launches validate required flags and report anonymous delegation funnel events (#1181)
 - `gamedevpl agents` lists installed tools and local-file/MCP support; the REPL offers every available checkout agent and an agent picker for `/connect` (#1181)
 - Started in a game checkout, `gamedevpl` opens that game instead of asking what to make
 - In a checkout, saying what to change runs `claude` / `codex` / `gemini` / `vibe` from your machine on the game,
@@ -17,6 +19,7 @@ decides the next version — see [`.claude/skills/cli-release/SKILL.md`](../../.
 
 ### Fixed
 
+- Cancelling connection stops before handoff; pending handoffs preserve the selected agent and task for `/retry` (#1181)
 - MCP agents run without a checkout in a scratch directory that remains available afterwards (#1181)
 - `gamedevpl` prints the version it actually is; every release so far reported 0.1.0 in the banner, footer and `help`
 

--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -9,7 +9,7 @@ decides the next version — see [`.claude/skills/cli-release/SKILL.md`](../../.
 
 ### Added
 
-- `gamedevpl agents` lists installed tools and local-file/MCP support; the REPL offers every available checkout agent and an agent picker for `/connect`
+- `gamedevpl agents` lists installed tools and local-file/MCP support; the REPL offers every available checkout agent and an agent picker for `/connect` (#1181)
 - Started in a game checkout, `gamedevpl` opens that game instead of asking what to make
 - In a checkout, saying what to change runs `claude` / `codex` / `gemini` / `vibe` from your machine on the game,
   verifies the tree and offers to deliver; `/delegate <task>` skips the chat, `/builder self|platform` picks who builds,
@@ -17,7 +17,7 @@ decides the next version — see [`.claude/skills/cli-release/SKILL.md`](../../.
 
 ### Fixed
 
-- MCP agents run without a checkout in a scratch directory that remains available afterwards
+- MCP agents run without a checkout in a scratch directory that remains available afterwards (#1181)
 - `gamedevpl` prints the version it actually is; every release so far reported 0.1.0 in the banner, footer and `help`
 
 ## 0.3.0 — 2026-09-05

--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -48,24 +48,36 @@ Never pass the creator OAuth token to a sub-agent.
 
 `gamedevpl agents` (or `/agents` in the REPL) checks executable files on `PATH` and
 lists the configured local-file and MCP modes. `--json` works without sign-in or a
-TTY. Detection does not launch agents, check provider login, or validate versions.
-Runs use the selected tool's own credentials and billing.
+TTY. Discovery does not start a build. Launch checks the installed tool's help for
+required flags and refuses incompatible versions before a handoff. Provider login
+stays with the selected tool; its authentication errors are shown in the terminal.
+Runs use that tool's own credentials and billing.
 
-The bundled local adapters are `claude`, `codex`, `gemini`, and `vibe`; automatic MCP
-configuration is available for `claude` and `codex`. `agy`, `cursor`, `cursor-agent`,
-and `copilot` are also detected, but detection alone does not enable execution.
+The bundled local adapters are `claude`, `codex`, `gemini`, `vibe`, `agy`, `cursor`,
+and `copilot`. Automatic MCP configuration is available for `claude`, `codex`, and
+`copilot`; the others use local files. Cursor runs `cursor-agent`, or `agent` only
+after its help identifies it as Cursor. The `cursor` editor launcher is listed
+separately and is never treated as a headless agent.
 Custom local adapters can be configured in `~/.config/gamedevpl/adapters.json` (or
 `GAMEDEV_ADAPTERS`); they remain unsupported and do not gain automatic MCP wiring.
 
 Inside a checkout, the builder picker lists every detected adapter and carries the
 selection into the first task. Subsequent tasks ask which agent when several exist.
-Outside a checkout, the REPL points to `/agents`; `/connect <slug>` offers installed
-MCP adapters or manual setup. Explicit `--agent` skips the picker. Cancelling a picker
+The conversation prepares a new game or revision before dispatch, then offers an
+agent or the platform builder. Without a checkout, agents use MCP when supported;
+otherwise the CLI downloads a checkout, installs its pinned kit and toolchain, and
+runs the local editing/verification/delivery flow. New games bootstrap from the brief
+and pinned Creator Kit without requiring a previous delivery. Pending handoffs retain
+the task and selected agent; `/retry` resumes them after ownership changes. `/connect <slug>` also offers
+installed MCP adapters or manual setup. Explicit `--agent` skips the picker. Cancelling a picker
 does not launch an agent or request a handoff. One-shot commands never prompt.
 
-Discovery and these picks currently emit no adoption telemetry; the shared
-`delegate_offered`/`delegate_used` vocabulary exists, but measuring this flow remains
-an instrumentation gap. No inventory, executable paths, or prompts are uploaded.
+Anonymous `delegate_offered` / `delegate_used` events measure the choice and launch;
+`verify_failed` and `delivered` cover the local result. They use the existing visit
+endpoint and a process-local random visit ID, with closed adapter/stage dimensions.
+No credentials, inventory, executable paths, game identifiers, or prompts are sent.
+The existing CLI funnel rollup measures offered-to-used conversion by adapter.
+Telemetry failures never block the task.
 
 ## Working copy
 
@@ -100,7 +112,7 @@ full local ladder and delivers `mode=publish`; an operator still publishes.
 ## In a checkout
 
 `gamedevpl` started inside a checkout (any subdirectory) opens that game. It shows the
-sync state, which of `claude` / `codex` / `gemini` / `vibe` are on PATH, and who builds.
+sync state, available local adapters, and who builds.
 If a local agent is found and the platform still builds, it asks once whether to hand the
 round to your machine (`/builder self`); `/builder platform` hands it back.
 
@@ -112,7 +124,7 @@ the agent, not the session. `/delegate <task>` skips the chat; `gamedevpl delega
 ladder fails).
 
 `gamedevpl connect <slug>` prints the MCP handoff (URL, kickoff, install snippet).
-`--agent claude` (or `codex`) launches the agent with temporary MCP configuration,
+`--agent claude` (or `codex` / `copilot`) launches the agent with temporary MCP configuration,
 never the creator OAuth grant or a PAT. The round must use builder `self`; explicit
 `--handoff` requests a switch and refuses execution while the switch is pending.
 In a matching checkout the agent works on that game's directory; review local changes
@@ -127,3 +139,8 @@ Versions come from [`CHANGELOG.md`](./CHANGELOG.md): add a line under `## Unrele
 the category that fits, and the `release(cli)` PR that opens on master is the cutoff —
 merging it publishes `cli-vX.Y.Z`. Rules, commands and traps:
 [`.claude/skills/cli-release/SKILL.md`](../../.claude/skills/cli-release/SKILL.md).
+
+Adapter invocation references: [Cursor headless](https://docs.cursor.com/en/cli/headless),
+[Gemini headless](https://geminicli.com/docs/cli/headless/), and
+[Copilot CLI](https://docs.github.com/en/copilot/reference/copilot-cli-reference/cli-command-reference).
+Installed Claude, Codex, agy, Vibe, and Copilot flags were checked against `--help`.

--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -34,7 +34,7 @@ node apps/cli/dist/gamedevpl.mjs help
 
 ## Verbs
 
-`login` `logout` `whoami` `games` `status` `share` `profile` `handle` `builder`
+`login` `logout` `whoami` `agents` `games` `status` `share` `profile` `handle` `builder`
 `connect` `delegate` `checkout` `pull` `diff` `submit` `quota` `notifications` `update` `help`
 
 Exit codes: `0` gate green · `1` gate red · `2` refused · `3` auth · `4` input required.
@@ -43,6 +43,29 @@ Exit codes: `0` gate green · `1` gate red · `2` refused · `3` auth · `4` inp
 stays on this machine. No paste. CI still uses `GAMEDEV_TOKEN` from secrets.
 Never pass the creator OAuth token to a sub-agent.
 `git push` / `git pull` against a checkout use `git-remote-gamedevpl` (same script).
+
+## Local agents
+
+`gamedevpl agents` (or `/agents` in the REPL) checks executable files on `PATH` and
+lists the configured local-file and MCP modes. `--json` works without sign-in or a
+TTY. Detection does not launch agents, check provider login, or validate versions.
+Runs use the selected tool's own credentials and billing.
+
+The bundled local adapters are `claude`, `codex`, `gemini`, and `vibe`; automatic MCP
+configuration is available for `claude` and `codex`. `agy`, `cursor`, `cursor-agent`,
+and `copilot` are also detected, but detection alone does not enable execution.
+Custom local adapters can be configured in `~/.config/gamedevpl/adapters.json` (or
+`GAMEDEV_ADAPTERS`); they remain unsupported and do not gain automatic MCP wiring.
+
+Inside a checkout, the builder picker lists every detected adapter and carries the
+selection into the first task. Subsequent tasks ask which agent when several exist.
+Outside a checkout, the REPL points to `/agents`; `/connect <slug>` offers installed
+MCP adapters or manual setup. Explicit `--agent` skips the picker. Cancelling a picker
+does not launch an agent or request a handoff. One-shot commands never prompt.
+
+Discovery and these picks currently emit no adoption telemetry; the shared
+`delegate_offered`/`delegate_used` vocabulary exists, but measuring this flow remains
+an instrumentation gap. No inventory, executable paths, or prompts are uploaded.
 
 ## Working copy
 
@@ -89,9 +112,14 @@ the agent, not the session. `/delegate <task>` skips the chat; `gamedevpl delega
 ladder fails).
 
 `gamedevpl connect <slug>` prints the MCP handoff (URL, kickoff, install snippet).
-`--agent claude` (or `codex` / `gemini` / `vibe`) spawns that vendor CLI with a
-round-scoped token only — never the OAuth grant or a PAT. After the adapter exits,
-`gamedevpl submit` is still the delivery command.
+`--agent claude` (or `codex`) launches the agent with temporary MCP configuration,
+never the creator OAuth grant or a PAT. The round must use builder `self`; explicit
+`--handoff` requests a switch and refuses execution while the switch is pending.
+In a matching checkout the agent works on that game's directory; review local changes
+before `gamedevpl submit`. Otherwise it uses a scratch directory and the MCP workflow;
+the CLI prints the directory and keeps any scratch files after exit. Check the delivery
+in Studio. Existing user MCP configuration is not overwritten.
+MCP progress appears while the agent runs; Ctrl+C in the REPL stops its process group.
 
 ## Releases
 

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -19,7 +19,8 @@
   },
   "dependencies": {
     "ink": "^5.2.1",
-    "react": "^18.3.1"
+    "react": "^18.3.1",
+    "@gamedevpl/contract": "*"
   },
   "devDependencies": {
     "@types/node": "^20.14.15",

--- a/apps/cli/src/adapters.json
+++ b/apps/cli/src/adapters.json
@@ -5,39 +5,113 @@
       "name": "claude",
       "command": "claude",
       "versionFlag": "--version",
-      "headless": ["-p", "--output-format", "stream-json"],
-      "events": { "flag": "--output-format=stream-json", "dialect": "ndjson" },
-      "budget": { "turns": "--max-turns" },
+      "headless": ["-p", "--verbose", "--permission-mode", "acceptEdits", "--output-format", "stream-json"],
+      "events": {
+        "flag": "--output-format=stream-json",
+        "dialect": "ndjson"
+      },
+      "budget": {
+        "turns": "--max-turns"
+      },
       "cwd": "game-dir",
-      "exit": { "success": [0], "failure": [1] }
+      "exit": {
+        "success": [0],
+        "failure": [1]
+      }
     },
     {
       "name": "codex",
       "command": "codex",
       "versionFlag": "--version",
-      "headless": ["exec", "--json"],
-      "events": { "flag": "--json", "dialect": "jsonl" },
+      "headless": ["exec", "--json", "--sandbox", "workspace-write", "--skip-git-repo-check"],
+      "events": {
+        "flag": "--json",
+        "dialect": "jsonl"
+      },
       "cwd": "game-dir",
-      "exit": { "success": [0], "failure": [1] }
+      "exit": {
+        "success": [0],
+        "failure": [1]
+      }
     },
     {
       "name": "gemini",
       "command": "gemini",
       "versionFlag": "--version",
-      "headless": ["-p"],
-      "events": { "flag": "", "dialect": "ndjson" },
+      "headless": ["--output-format", "stream-json", "--approval-mode", "auto_edit", "-p"],
+      "events": {
+        "flag": "",
+        "dialect": "ndjson"
+      },
       "cwd": "game-dir",
-      "exit": { "success": [0], "failure": [1] }
+      "exit": {
+        "success": [0],
+        "failure": [1]
+      }
     },
     {
       "name": "vibe",
       "command": "vibe",
       "versionFlag": "--version",
-      "headless": ["--prompt"],
-      "events": { "flag": "--output", "dialect": "ndjson" },
-      "budget": { "turns": "--max-turns", "price": "--max-price" },
+      "headless": ["--output", "streaming", "--agent", "accept-edits", "--trust", "--prompt"],
+      "events": {
+        "flag": "--output",
+        "dialect": "ndjson"
+      },
+      "budget": {
+        "turns": "--max-turns",
+        "price": "--max-price"
+      },
       "cwd": "game-dir",
-      "exit": { "success": [0], "failure": [1] }
+      "exit": {
+        "success": [0],
+        "failure": [1]
+      }
+    },
+    {
+      "name": "agy",
+      "command": "agy",
+      "versionFlag": "--help",
+      "headless": ["--mode", "accept-edits", "--sandbox", "--output-format", "stream-json", "--print"],
+      "events": {
+        "flag": "--output-format",
+        "dialect": "ndjson"
+      },
+      "cwd": "game-dir",
+      "exit": {
+        "success": [0],
+        "failure": [1]
+      }
+    },
+    {
+      "name": "cursor",
+      "command": "cursor-agent",
+      "versionFlag": "--version",
+      "headless": ["--print", "--force", "--output-format", "stream-json"],
+      "events": {
+        "flag": "--output-format",
+        "dialect": "ndjson"
+      },
+      "cwd": "game-dir",
+      "exit": {
+        "success": [0],
+        "failure": [1]
+      }
+    },
+    {
+      "name": "copilot",
+      "command": "copilot",
+      "versionFlag": "--version",
+      "headless": ["--output-format", "json", "--allow-tool=write", "--no-ask-user", "--prompt"],
+      "events": {
+        "flag": "--output-format",
+        "dialect": "ndjson"
+      },
+      "cwd": "game-dir",
+      "exit": {
+        "success": [0],
+        "failure": [1]
+      }
     }
   ]
 }

--- a/apps/cli/src/adapters.test.ts
+++ b/apps/cli/src/adapters.test.ts
@@ -1,10 +1,21 @@
 import { describe, expect, it } from 'vitest';
-import { loadAdapters, detectAdapter } from './adapters.js';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { loadAdapters, detectAdapter, preflightAdapter } from './adapters.js';
 
 describe('adapter registry', () => {
-  it('ships the blessed four as data', () => {
+  it('ships local adapters for all supported agents', () => {
     const file = loadAdapters({ HOME: '/tmp/does-not-exist-gamedev' });
-    expect(file.adapters.map((row) => row.name).sort()).toEqual(['claude', 'codex', 'gemini', 'vibe']);
+    expect(file.adapters.map((row) => row.name).sort()).toEqual([
+      'agy',
+      'claude',
+      'codex',
+      'copilot',
+      'cursor',
+      'gemini',
+      'vibe',
+    ]);
   });
 
   it('detects only adapters present on PATH', () => {
@@ -12,4 +23,23 @@ describe('adapter registry', () => {
     expect(detectAdapter('claude', () => '/usr/bin/claude', file)?.command).toBe('claude');
     expect(detectAdapter('claude', () => null, file)).toBeNull();
   });
+});
+
+it('validates flags even when a CLI exits before its output pipe flushes', () => {
+  const root = mkdtempSync(join(tmpdir(), 'gdpl-help-'));
+  const command = join(root, 'fixture');
+  const base = loadAdapters({ HOME: root }).adapters[0]!;
+  try {
+    writeFileSync(
+      command,
+      `#!${process.execPath}\nprocess.stdout.write('x'.repeat(20000) + ' --required'); process.exit(0);`,
+      { mode: 0o700 },
+    );
+    expect(() => preflightAdapter({ ...base, command, headless: ['--required'] }, process.env)).not.toThrow();
+    expect(() => preflightAdapter({ ...base, command, headless: ['--missing'] }, process.env)).toThrow(
+      'does not support --missing',
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
 });

--- a/apps/cli/src/adapters.ts
+++ b/apps/cli/src/adapters.ts
@@ -1,7 +1,19 @@
-import { accessSync, constants, existsSync, readFileSync, statSync } from 'node:fs';
-import { homedir } from 'node:os';
+import {
+  accessSync,
+  closeSync,
+  constants,
+  existsSync,
+  mkdtempSync,
+  openSync,
+  readFileSync,
+  rmSync,
+  statSync,
+} from 'node:fs';
+import { homedir, tmpdir } from 'node:os';
 import { dirname, join, delimiter } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { spawnSync } from 'node:child_process';
+import { CliError, EXIT_REFUSED } from './exit-codes.js';
 import bundled from './adapters.json' with { type: 'json' };
 
 export interface AdapterSpec {
@@ -53,7 +65,46 @@ export function detectAdapter(
 ): AdapterSpec | null {
   const spec = file.adapters.find((row) => row.name === name);
   if (!spec) return null;
-  return which(spec.command) ? spec : null;
+  if (which(spec.command)) return spec;
+  if (name === 'cursor') {
+    const alias = which('agent');
+    if (alias) {
+      const help = probeHelp(alias, ['--help'], process.env);
+      if (help && /cursor/i.test(help)) return { ...spec, command: alias };
+    }
+  }
+  return null;
+}
+
+export function preflightAdapter(spec: AdapterSpec, env: NodeJS.ProcessEnv): void {
+  const args = spec.name === 'codex' ? ['exec', '--help'] : ['--help'];
+  const help = probeHelp(spec.command, args, env);
+  if (help === null) {
+    throw new CliError(`cannot run ${spec.name} --help`, EXIT_REFUSED, `check ${spec.command} in your terminal`);
+  }
+  const flags = spec.headless.filter((arg) => arg.startsWith('-')).map((arg) => arg.split('=')[0]!);
+  const missing = flags.filter((flag) => !help.includes(flag));
+  if (missing.length)
+    throw new CliError(
+      `${spec.name} does not support ${missing.join(', ')}`,
+      EXIT_REFUSED,
+      `update ${spec.name} or choose another agent`,
+    );
+}
+
+function probeHelp(command: string, args: string[], env: NodeJS.ProcessEnv): string | null {
+  const dir = mkdtempSync(join(tmpdir(), 'gamedev-agent-help-'));
+  const path = join(dir, 'help.txt');
+  const fd = openSync(path, 'w', 0o600);
+  try {
+    // Some CLIs exit before pipe buffers flush; files preserve their help.
+    const result = spawnSync(command, args, { env, timeout: 10_000, stdio: ['ignore', fd, fd] });
+    if (result.error || result.status !== 0 || statSync(path).size > 1024 * 1024) return null;
+    return readFileSync(path, 'utf8');
+  } finally {
+    closeSync(fd);
+    rmSync(dir, { recursive: true, force: true });
+  }
 }
 
 export function whichOnPath(cmd: string, env: NodeJS.ProcessEnv = process.env): string | null {

--- a/apps/cli/src/adapters.ts
+++ b/apps/cli/src/adapters.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync } from 'node:fs';
+import { accessSync, constants, existsSync, readFileSync, statSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { dirname, join, delimiter } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -60,7 +60,12 @@ export function whichOnPath(cmd: string, env: NodeJS.ProcessEnv = process.env): 
   for (const dir of (env.PATH ?? '').split(delimiter)) {
     if (!dir) continue;
     const candidate = join(dir, cmd);
-    if (existsSync(candidate)) return candidate;
+    try {
+      accessSync(candidate, constants.X_OK);
+      if (statSync(candidate).isFile()) return candidate;
+    } catch {
+      continue;
+    }
   }
   return null;
 }

--- a/apps/cli/src/agents.test.ts
+++ b/apps/cli/src/agents.test.ts
@@ -1,0 +1,211 @@
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { delimiter, join } from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { PassThrough } from 'node:stream';
+import { discoverAgents, formatAgents } from './agents.js';
+import { loadAdapters, whichOnPath } from './adapters.js';
+import { runCli } from './main.js';
+import { handleReplLine } from './repl.js';
+import type { ApiClient } from './api.js';
+import { connectGame } from './connect.js';
+
+const dirs: string[] = [];
+function directory(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'gdpl-agents-'));
+  dirs.push(dir);
+  return dir;
+}
+
+afterEach(() => {
+  for (const dir of dirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+  vi.unstubAllGlobals();
+});
+
+describe('agent discovery', () => {
+  it('ignores non-executable files and directories, following PATH order', () => {
+    const first = directory();
+    const second = directory();
+    writeFileSync(join(first, 'claude'), '');
+    chmodSync(join(first, 'claude'), 0o600);
+    mkdirSync(join(first, 'codex'));
+    writeFileSync(join(second, 'claude'), '#!/bin/sh\nexit 99\n', { mode: 0o700 });
+    const env = { PATH: [first, second].join(delimiter) };
+    expect(whichOnPath('claude', env)).toBe(join(second, 'claude'));
+    expect(whichOnPath('codex', env)).toBeNull();
+  });
+
+  it('separates detected programs from executable integrations', () => {
+    const agents = discoverAgents({ HOME: directory() }, (cmd) => `/bin/${cmd}`);
+    expect(agents.find((row) => row.name === 'claude')).toMatchObject({ installed: true, local: true, mcp: true });
+    expect(agents.find((row) => row.name === 'vibe')).toMatchObject({ installed: true, local: true, mcp: false });
+    for (const name of ['agy', 'cursor', 'cursor-agent', 'copilot']) {
+      expect(agents.find((row) => row.name === name)).toMatchObject({ installed: true, local: false, mcp: false });
+    }
+    expect(formatAgents(agents)).toContain('login and version compatibility are not checked');
+  });
+
+  it('admits custom local adapters without inventing MCP wiring', () => {
+    const file = loadAdapters({ HOME: directory() });
+    file.adapters = [{ ...file.adapters[0]!, name: 'agy', command: 'agy' }];
+    const rows = discoverAgents({}, () => '/bin/agy', file).filter((row) => row.name === 'agy');
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({ local: true, mcp: false });
+  });
+
+  it('lists agents as JSON without login, a TTY, network or execution', async () => {
+    const dir = directory();
+    writeFileSync(join(dir, 'claude'), '#!/bin/sh\nexit 99\n', { mode: 0o700 });
+    const fetch = vi.fn(() => {
+      throw new Error('no network');
+    });
+    vi.stubGlobal('fetch', fetch);
+    const stdout = new PassThrough();
+    let output = '';
+    stdout.on('data', (chunk: Buffer) => {
+      output += String(chunk);
+    });
+    const code = await runCli(
+      ['node', 'gamedevpl', 'agents', '--json'],
+      { HOME: dir, PATH: dir },
+      {
+        stdin: new PassThrough() as unknown as NodeJS.ReadStream,
+        stdout: stdout as unknown as NodeJS.WriteStream,
+        stderr: new PassThrough() as unknown as NodeJS.WriteStream,
+      },
+    );
+    expect(code).toBe(0);
+    expect(JSON.parse(output).agents.filter((row: { installed: boolean }) => row.installed)).toEqual([
+      { name: 'claude', command: 'claude', installed: true, local: true, mcp: true },
+    ]);
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it('cancels an MCP agent choice before any API call or handoff', async () => {
+    const dir = directory();
+    for (const cmd of ['claude', 'codex', 'vibe', 'cursor']) {
+      writeFileSync(join(dir, cmd), '#!/bin/sh\nexit 99\n', { mode: 0o700 });
+    }
+    const request = vi.fn(async () => {
+      throw new Error('should not call API');
+    });
+    const pick = vi.fn(async (_choices: string[], _question: string) => '/quit');
+    await handleReplLine({
+      line: '/connect sky-dodge --handoff',
+      api: { request } as unknown as ApiClient,
+      token: null,
+      env: { HOME: dir, PATH: dir },
+      pick,
+      write: () => undefined,
+    });
+    expect(pick.mock.calls[0]?.[0]).toEqual(['claude', 'codex', 'show manual MCP setup']);
+    expect(request).not.toHaveBeenCalled();
+  });
+
+  it('runs a real child without a checkout, preserving scratch files and removing MCP credentials', async () => {
+    const dir = directory();
+    writeFileSync(
+      join(dir, 'claude'),
+      `#!${process.execPath}
+const fs = require('node:fs');
+const args = process.argv.slice(2);
+const config = args[args.indexOf('--mcp-config') + 1];
+if (!fs.readFileSync(config, 'utf8').includes('gdpl_cak_test')) process.exit(2);
+fs.writeFileSync('scratch.txt', 'kept');
+console.log(JSON.stringify({ text: JSON.stringify({ cwd: process.cwd(), config }) }));
+`,
+      { mode: 0o700 },
+    );
+    const api = {
+      request: async (_method: string, path: string) =>
+        path.includes('/api/me/studio')
+          ? { games: [{ slug: 'sky-dodge', token: 'tok' }] }
+          : {
+              mcpUrl: 'https://example.test/mcp',
+              authorizationHeader: 'Bearer gdpl_cak_test',
+              kickoffPrompt: 'Build it',
+            },
+    } as unknown as ApiClient;
+    const lines: string[] = [];
+    await connectGame({
+      api,
+      slug: 'sky-dodge',
+      dest: dir,
+      agent: 'claude',
+      env: { PATH: dir, HOME: dir },
+      write: (line) => lines.push(line),
+    });
+    const report = JSON.parse(lines.find((line) => line.startsWith('claude ▸ {'))!.split(' ▸ ')[1]!) as {
+      cwd: string;
+      config: string;
+    };
+    dirs.push(report.cwd);
+    expect(report.cwd).not.toBe(dir);
+    expect(readFileSync(join(report.cwd, 'scratch.txt'), 'utf8')).toBe('kept');
+    expect(existsSync(report.config)).toBe(false);
+    expect(lines.at(-1)).toContain('check the round in Studio');
+  });
+
+  it('waits for a pending handoff before fetching MCP credentials or spawning', async () => {
+    const paths: string[] = [];
+    const api = {
+      request: async (_method: string, path: string) => {
+        paths.push(path);
+        return path.includes('/api/me/studio') ? { games: [{ slug: 'sky-dodge', token: 'tok' }] } : { pending: true };
+      },
+    } as unknown as ApiClient;
+    const runAdapter = vi.fn(async () => ({ code: 0, lines: [] }));
+    await expect(
+      connectGame({
+        api,
+        slug: 'sky-dodge',
+        dest: directory(),
+        agent: 'claude',
+        handoff: true,
+        which: () => '/bin/claude',
+        runAdapter,
+        write: () => undefined,
+      }),
+    ).rejects.toThrow('handoff pending');
+    expect(paths.some((path) => path.endsWith('/connect'))).toBe(false);
+    expect(runAdapter).not.toHaveBeenCalled();
+  });
+
+  it('streams MCP progress before exit and stops the child when cancelled', async () => {
+    const dir = directory();
+    writeFileSync(
+      join(dir, 'claude'),
+      `#!${process.execPath}
+console.log(JSON.stringify({ text: 'working' }));
+setInterval(() => {}, 1000);
+`,
+      { mode: 0o700 },
+    );
+    const api = {
+      request: async (_method: string, path: string) =>
+        path.includes('/api/me/studio')
+          ? { games: [{ slug: 'sky-dodge', token: 'tok' }] }
+          : {
+              mcpUrl: 'https://example.test/mcp',
+              authorizationHeader: 'Bearer gdpl_cak_test',
+              kickoffPrompt: 'Build it',
+            },
+    } as unknown as ApiClient;
+    const controller = new AbortController();
+    await expect(
+      connectGame({
+        api,
+        slug: 'sky-dodge',
+        dest: dir,
+        agent: 'claude',
+        env: { PATH: dir, HOME: dir },
+        abort: controller.signal,
+        write: (line) => {
+          if (line.startsWith('MCP workspace: ')) dirs.push(line.slice('MCP workspace: '.length).split(' — ')[0]!);
+          if (line.includes('claude ▸ working')) controller.abort();
+        },
+      }),
+    ).rejects.toThrow('claude stopped');
+    expect(controller.signal.aborted).toBe(true);
+  });
+});

--- a/apps/cli/src/agents.test.ts
+++ b/apps/cli/src/agents.test.ts
@@ -39,10 +39,10 @@ describe('agent discovery', () => {
     const agents = discoverAgents({ HOME: directory() }, (cmd) => `/bin/${cmd}`);
     expect(agents.find((row) => row.name === 'claude')).toMatchObject({ installed: true, local: true, mcp: true });
     expect(agents.find((row) => row.name === 'vibe')).toMatchObject({ installed: true, local: true, mcp: false });
-    for (const name of ['agy', 'cursor', 'cursor-agent', 'copilot']) {
-      expect(agents.find((row) => row.name === name)).toMatchObject({ installed: true, local: false, mcp: false });
+    for (const name of ['agy', 'cursor']) {
+      expect(agents.find((row) => row.name === name)).toMatchObject({ installed: true, local: true, mcp: false });
     }
-    expect(formatAgents(agents)).toContain('login and version compatibility are not checked');
+    expect(formatAgents(agents)).toContain('launch verifies required CLI flags');
   });
 
   it('admits custom local adapters without inventing MCP wiring', () => {
@@ -107,6 +107,7 @@ describe('agent discovery', () => {
     writeFileSync(
       join(dir, 'claude'),
       `#!${process.execPath}
+if (process.argv.includes('--help')) { console.log('-p --verbose --permission-mode --output-format'); process.exit(0); }
 const fs = require('node:fs');
 const args = process.argv.slice(2);
 const config = args[args.indexOf('--mcp-config') + 1];
@@ -176,6 +177,8 @@ console.log(JSON.stringify({ text: JSON.stringify({ cwd: process.cwd(), config }
     writeFileSync(
       join(dir, 'claude'),
       `#!${process.execPath}
+if (process.argv.includes('--help')) { console.log('-p --verbose --permission-mode --output-format'); process.exit(0); }
+process.on('SIGTERM', () => {});
 console.log(JSON.stringify({ text: 'working' }));
 setInterval(() => {}, 1000);
 `,

--- a/apps/cli/src/agents.ts
+++ b/apps/cli/src/agents.ts
@@ -1,4 +1,4 @@
-import { loadAdapters, whichOnPath, type AdapterFile } from './adapters.js';
+import { detectAdapter, loadAdapters, whichOnPath, type AdapterFile } from './adapters.js';
 
 export type AgentAvailability = {
   name: string;
@@ -8,15 +8,10 @@ export type AgentAvailability = {
   mcp: boolean;
 };
 
-const DISCOVERY_ONLY = [
-  { name: 'agy', command: 'agy' },
-  { name: 'cursor', command: 'cursor' },
-  { name: 'cursor-agent', command: 'cursor-agent' },
-  { name: 'copilot', command: 'copilot' },
-];
+const DISCOVERY_ONLY = [{ name: 'cursor-editor', command: 'cursor' }];
 
 export function adapterMcpSupported(name: string): boolean {
-  return name === 'claude' || name === 'codex';
+  return name === 'claude' || name === 'codex' || name === 'copilot';
 }
 
 export function discoverAgents(
@@ -29,7 +24,9 @@ export function discoverAgents(
   return known.map(({ name, command }) => ({
     name,
     command,
-    installed: which(command) !== null,
+    installed: registered.some((spec) => spec.name === name)
+      ? detectAdapter(name, which, file) !== null
+      : which(command) !== null,
     local: registered.some((spec) => spec.name === name),
     mcp: registered.some((spec) => spec.name === name) && adapterMcpSupported(name),
   }));
@@ -43,7 +40,7 @@ export function formatAgents(agents: AgentAvailability[]): string {
   return [
     ...lines,
     '',
-    'Detection checks executable files only; provider login and version compatibility are not checked.',
+    'Discovery checks executable files; launch verifies required CLI flags. Provider login is managed by the agent.',
     'Local files: gamedevpl delegate "<task>" --agent <name> inside a checkout.',
     'MCP: gamedevpl connect <slug> --agent <name>. The round must use builder self.',
     'Agent runs use that tool’s own credentials and billing.',

--- a/apps/cli/src/agents.ts
+++ b/apps/cli/src/agents.ts
@@ -1,0 +1,56 @@
+import { loadAdapters, whichOnPath, type AdapterFile } from './adapters.js';
+
+export type AgentAvailability = {
+  name: string;
+  command: string;
+  installed: boolean;
+  local: boolean;
+  mcp: boolean;
+};
+
+const DISCOVERY_ONLY = [
+  { name: 'agy', command: 'agy' },
+  { name: 'cursor', command: 'cursor' },
+  { name: 'cursor-agent', command: 'cursor-agent' },
+  { name: 'copilot', command: 'copilot' },
+];
+
+export function adapterMcpSupported(name: string): boolean {
+  return name === 'claude' || name === 'codex';
+}
+
+export function discoverAgents(
+  env: NodeJS.ProcessEnv = process.env,
+  which: (command: string) => string | null = (command) => whichOnPath(command, env),
+  file: AdapterFile = loadAdapters(env),
+): AgentAvailability[] {
+  const registered = file.adapters.map(({ name, command }) => ({ name, command }));
+  const known = [...registered, ...DISCOVERY_ONLY.filter((row) => !registered.some((spec) => spec.name === row.name))];
+  return known.map(({ name, command }) => ({
+    name,
+    command,
+    installed: which(command) !== null,
+    local: registered.some((spec) => spec.name === name),
+    mcp: registered.some((spec) => spec.name === name) && adapterMcpSupported(name),
+  }));
+}
+
+export function formatAgents(agents: AgentAvailability[]): string {
+  const lines = agents.map((agent) => {
+    const modes = [agent.local ? 'local files' : '', agent.mcp ? 'MCP' : ''].filter(Boolean).join(' + ');
+    return `${agent.name}: ${agent.installed ? 'found' : 'not on PATH'} — ${modes || 'no execution adapter configured'}`;
+  });
+  return [
+    ...lines,
+    '',
+    'Detection checks executable files only; provider login and version compatibility are not checked.',
+    'Local files: gamedevpl delegate "<task>" --agent <name> inside a checkout.',
+    'MCP: gamedevpl connect <slug> --agent <name>. The round must use builder self.',
+    'Agent runs use that tool’s own credentials and billing.',
+  ].join('\n');
+}
+
+export function agentHint(agents: AgentAvailability[]): string | null {
+  const names = agents.filter((row) => row.installed && (row.local || row.mcp)).map((row) => row.name);
+  return names.length ? `local agents: ${names.join(', ')} — /agents shows local-file and MCP options` : null;
+}

--- a/apps/cli/src/argv.ts
+++ b/apps/cli/src/argv.ts
@@ -1,4 +1,5 @@
 export const SLASH_VERBS = [
+  'agents',
   'games',
   'status',
   'share',

--- a/apps/cli/src/chat.ts
+++ b/apps/cli/src/chat.ts
@@ -2,11 +2,18 @@ import type { ApiClient } from './api.js';
 
 export type CliChatResult =
   | { kind: 'reply'; text: string; conversationId: string }
+  | { kind: 'proposal'; title: string; concept: string; ack?: string; conversationId: string }
   | { kind: 'create'; token: string; slug: string; ack?: string; conversationId: string };
 
-export async function postCliChat(api: ApiClient, text: string, conversationId?: string): Promise<CliChatResult> {
+export async function postCliChat(
+  api: ApiClient,
+  text: string,
+  conversationId?: string,
+  prepareOnly = false,
+): Promise<CliChatResult> {
   return api.request<CliChatResult>('POST', '/api/cli/chat', {
     text,
     ...(conversationId ? { conversationId } : {}),
+    ...(prepareOnly ? { prepareOnly: true } : {}),
   });
 }

--- a/apps/cli/src/checkout.test.ts
+++ b/apps/cli/src/checkout.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from 'node:os';
 import { describe, expect, it } from 'vitest';
 import {
   checkoutGame,
+  fetchLatestTree,
   changedPaths,
   findCheckout,
   inspectGame,
@@ -285,4 +286,13 @@ describe('findCheckout', () => {
     writeFileSync(join(dir, '.gamedev-slug'), '   \n');
     expect(findCheckout(dir)).toBeNull();
   });
+});
+
+it('uses an empty synchronization base for a game without deliveries', async () => {
+  const api = createApi({
+    origin: 'https://example.test',
+    store: memoryStore({ accessToken: 't', tokenType: 'Bearer', scope: 'creator' }),
+    fetch: async () => Response.json({ versions: [] }),
+  });
+  await expect(fetchLatestTree(api, 'fresh')).resolves.toEqual({ version: 'undelivered', files: [] });
 });

--- a/apps/cli/src/checkout.ts
+++ b/apps/cli/src/checkout.ts
@@ -82,7 +82,7 @@ export function changedPaths(local: TreeFile[], remote: TreeFile[]): string[] {
 export async function fetchLatestTree(api: ApiClient, slug: string): Promise<{ version: string; files: TreeFile[] }> {
   const listed = await api.request<{ versions: VersionRow[] }>('GET', `/api/me/studio/games/${slug}/versions`);
   const latest = listed.versions[0];
-  if (!latest) throw new CliError('this game has no delivered version yet', EXIT_REFUSED);
+  if (!latest) return { version: 'undelivered', files: [] };
   const tree = await api.request<{ version: string; files: TreeFile[] }>(
     'GET',
     `/api/me/studio/games/${slug}/versions/${latest.version}/tree`,
@@ -110,12 +110,15 @@ export async function checkoutGame(input: {
   dest: string;
   fetchBuffer?: (url: string) => Promise<Buffer>;
   run?: (cmd: string, args: string[], cwd: string) => void;
+  allowUndelivered?: boolean;
 }): Promise<{ dest: string; remote: string }> {
   const run = input.run ?? defaultRun;
   mkdirSync(input.dest, { recursive: true });
   const archive = input.fetchBuffer
     ? await input.fetchBuffer(`${input.api.origin}/api/me/studio/games/${input.slug}/workspace`)
-    : await input.api.requestBytes(`/api/me/studio/games/${input.slug}/workspace`);
+    : await input.api.requestBytes(
+        `/api/me/studio/games/${input.slug}/workspace${input.allowUndelivered ? '?allowUndelivered=true' : ''}`,
+      );
   const tgz = join(input.dest, '.gamedev-workspace.tgz');
   writeFileSync(tgz, archive);
   try {
@@ -128,7 +131,7 @@ export async function checkoutGame(input: {
   }
   try {
     const tree = await fetchLatestTree(input.api, input.slug);
-    writeGameFiles(input.dest, input.slug, tree.files);
+    if (tree.version !== 'undelivered') writeGameFiles(input.dest, input.slug, tree.files);
     writeBase(input.dest, tree.version, tree.files);
   } catch {
     const local = localGameFiles(input.dest, input.slug);

--- a/apps/cli/src/connect.test.ts
+++ b/apps/cli/src/connect.test.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { existsSync, statSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { describe, expect, it } from 'vitest';
@@ -13,6 +13,61 @@ function json(data: unknown, status = 200): Response {
 }
 
 describe('connectGame', () => {
+  it('cancels a deferred studio lookup before handoff or credentials', async () => {
+    const controller = new AbortController();
+    const seen: string[] = [];
+    const api = createApi({
+      origin: 'https://example.test',
+      store: memoryStore({ accessToken: 't', tokenType: 'Bearer', scope: 'creator' }),
+      fetch: async (url) => {
+        seen.push(String(url));
+        controller.abort();
+        return json({ games: [{ slug: 'sky-dodge', token: 'tok' }] });
+      },
+    });
+    await expect(
+      connectGame({
+        api,
+        slug: 'sky-dodge',
+        dest: '/tmp',
+        handoff: true,
+        abort: controller.signal,
+        write: () => undefined,
+      }),
+    ).rejects.toThrow('cancelled');
+    expect(seen).toHaveLength(1);
+    expect(seen[0]).toContain('/api/me/studio');
+  });
+
+  it('cancels after handoff without fetching credentials or launching', async () => {
+    const controller = new AbortController();
+    const seen: string[] = [];
+    const api = createApi({
+      origin: 'https://example.test',
+      store: memoryStore({ accessToken: 't', tokenType: 'Bearer', scope: 'creator' }),
+      fetch: async (url) => {
+        seen.push(String(url));
+        if (String(url).endsWith('/handoff')) {
+          controller.abort();
+          return json({ ok: true });
+        }
+        return json({ games: [{ slug: 'sky-dodge', token: 'tok' }] });
+      },
+    });
+    await expect(
+      connectGame({
+        api,
+        slug: 'sky-dodge',
+        dest: '/tmp',
+        handoff: true,
+        abort: controller.signal,
+        write: () => undefined,
+      }),
+    ).rejects.toThrow('cancelled');
+    expect(seen).toHaveLength(2);
+    expect(seen.some((url) => url.endsWith('/connect'))).toBe(false);
+  });
+
   it('prints a working MCP handoff from the connect route', async () => {
     const lines: string[] = [];
     const seen: string[] = [];
@@ -334,4 +389,44 @@ describe('connectGame', () => {
     ).rejects.toMatchObject({ message: expect.stringMatching(/not on PATH/) });
     expect(seen.some((row) => row.endsWith('/handoff'))).toBe(false);
   });
+});
+
+it('uses a private temporary Copilot MCP config and removes it on failure', async () => {
+  let configPath = '';
+  const api = createApi({
+    origin: 'https://example.test',
+    store: memoryStore({ accessToken: 'creator', tokenType: 'Bearer', scope: 'creator' }),
+    fetch: async (url) =>
+      String(url).includes('/api/me/studio')
+        ? json({ games: [{ slug: 'robots', token: 'tok' }] })
+        : json({
+            mcpUrl: 'https://example.test/api/mcp',
+            kickoffPrompt: 'Build it',
+            authorizationHeader: 'Authorization: Bearer gdpl_cak_secret',
+          }),
+  });
+  await expect(
+    connectGame({
+      api,
+      slug: 'robots',
+      dest: '/tmp',
+      agent: 'copilot',
+      which: () => '/bin/copilot',
+      write: () => undefined,
+      runAdapter: async ({ spec }) => {
+        configPath = spec.headless[spec.headless.indexOf('--additional-mcp-config') + 1]!.slice(1);
+        expect(statSync(configPath).mode & 0o777).toBe(0o600);
+        expect(JSON.parse(readFileSync(configPath, 'utf8')).mcpServers.gamedevpl).toMatchObject({
+          type: 'http',
+          url: 'https://example.test/api/mcp',
+          headers: { Authorization: 'Bearer gdpl_cak_secret' },
+          tools: ['*'],
+        });
+        expect(spec.headless).toContain('--allow-tool=gamedevpl');
+        throw new Error('agent failed');
+      },
+    }),
+  ).rejects.toThrow('agent failed');
+  expect(configPath).not.toBe('');
+  expect(existsSync(configPath)).toBe(false);
 });

--- a/apps/cli/src/connect.test.ts
+++ b/apps/cli/src/connect.test.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { describe, expect, it } from 'vitest';
@@ -75,6 +75,8 @@ describe('connectGame', () => {
 
   it('spawns an adapter with MCP auth, not the submission-status token', async () => {
     const dest = mkdtempSync(join(tmpdir(), 'gdpl-connect-'));
+    writeFileSync(join(dest, '.gamedev-slug'), 'sky-dodge');
+    mkdirSync(join(dest, 'games', 'sky-dodge'), { recursive: true });
     const seenEnv: NodeJS.ProcessEnv[] = [];
     const seenSpecs: string[][] = [];
     const api = createApi({
@@ -155,9 +157,12 @@ describe('connectGame', () => {
       dest,
       agent: 'codex',
       which: (cmd) => (cmd === 'codex' ? '/usr/bin/codex' : null),
-      runAdapter: async ({ spec }) => {
+      runAdapter: async ({ spec, cwd }) => {
         headless = spec.headless;
         expect(spec.name).toBe('codex');
+        expect(existsSync(cwd)).toBe(true);
+        expect(cwd).not.toBe(dest);
+        expect(spec.headless).toContain('--skip-git-repo-check');
         return { code: 0, lines: [] };
       },
       write: () => undefined,

--- a/apps/cli/src/connect.ts
+++ b/apps/cli/src/connect.ts
@@ -1,13 +1,16 @@
-import { rmSync, writeFileSync } from 'node:fs';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { randomUUID } from 'node:crypto';
+import { createInterface } from 'node:readline';
 import type { ApiClient } from './api.js';
 import { detectAdapter, loadAdapters, whichOnPath, type AdapterSpec } from './adapters.js';
 import { cliUsage } from './bin-name.js';
 import { CREATOR_TOKEN_PATTERN, childEnv, renderDelegateStream, spawnAdapter } from './delegate.js';
 import { CliError, EXIT_AUTH, EXIT_INPUT, EXIT_RED, EXIT_REFUSED } from './exit-codes.js';
 import { studioToken } from './studio.js';
+import { adapterMcpSupported } from './agents.js';
+import { findCheckout } from './checkout.js';
 
 export type ConnectPayload = {
   mcpUrl?: string;
@@ -23,24 +26,23 @@ export type AdapterRun = (input: {
   prompt: string;
   cwd: string;
   env: NodeJS.ProcessEnv;
+  abort?: AbortSignal;
+  onLine?: (line: string) => void;
 }) => Promise<{ code: number | null; lines: string[] }>;
 
-async function defaultAdapterRun(input: {
-  spec: AdapterSpec;
-  prompt: string;
-  cwd: string;
-  env: NodeJS.ProcessEnv;
-}): Promise<{ code: number | null; lines: string[] }> {
+async function defaultAdapterRun(input: Parameters<AdapterRun>[0]): Promise<{ code: number | null; lines: string[] }> {
   const child = spawnAdapter({ ...input, timeoutMs: 10 * 60_000 });
   const lines: string[] = [];
-  child.stdout?.on('data', (chunk: Buffer) => {
-    lines.push(...String(chunk).split('\n'));
-  });
-  child.stderr?.on('data', (chunk: Buffer) => {
-    lines.push(...String(chunk).split('\n'));
-  });
-  const code = await new Promise<number | null>((resolve) => {
-    child.once('exit', (value) => resolve(value));
+  for (const stream of [child.stdout, child.stderr]) {
+    if (stream)
+      createInterface({ input: stream }).on('line', (line: string) => {
+        if (input.onLine) input.onLine(line);
+        else lines.push(line);
+      });
+  }
+  const code = await new Promise<number | null>((resolve, reject) => {
+    child.once('error', reject);
+    child.once('close', (value) => resolve(value));
   });
   return { code, lines };
 }
@@ -112,10 +114,6 @@ function tomlString(value: string): string {
   return `"${value.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
 }
 
-function adapterMcpSupported(name: string): boolean {
-  return name === 'claude' || name === 'codex';
-}
-
 function wireAdapterMcp(
   spec: AdapterSpec,
   payload: { mcpUrl: string; authorizationHeader: string },
@@ -157,6 +155,7 @@ export async function connectGame(input: {
   handoff?: boolean;
   which?: (cmd: string) => string | null;
   runAdapter?: AdapterRun;
+  abort?: AbortSignal;
   write: (line: string) => void;
 }): Promise<{ spawned: boolean; mcp: boolean }> {
   const env = input.env ?? process.env;
@@ -179,10 +178,21 @@ export async function connectGame(input: {
     );
   }
   if (input.handoff) {
-    await input.api.request('POST', `/api/submissions/${encodeURIComponent(token)}/handoff`, {
-      builder: 'self',
-      stopActivePlatformAgent: true,
-    });
+    const outcome = await input.api.request<{ pending?: boolean }>(
+      'POST',
+      `/api/submissions/${encodeURIComponent(token)}/handoff`,
+      {
+        builder: 'self',
+        stopActivePlatformAgent: true,
+      },
+    );
+    if (outcome.pending) {
+      throw new CliError(
+        'handoff pending — the platform agent still owns this round',
+        EXIT_REFUSED,
+        'retry after the handoff completes',
+      );
+    }
   }
 
   let payload: ConnectPayload;
@@ -219,22 +229,48 @@ export async function connectGame(input: {
     );
   }
   requireMcpAuth(payload);
+  if (input.abort?.aborted) throw new CliError('agent launch cancelled', EXIT_REFUSED, 'retry when ready');
 
   const wired = wireAdapterMcp(spec, payload);
   try {
-    const cwd = spec.cwd === 'game-dir' ? join(input.dest, 'games', input.slug) : input.dest;
+    const checkout = findCheckout(input.dest);
+    const local = checkout?.slug === input.slug;
+    const cwd = local
+      ? spec.cwd === 'game-dir'
+        ? join(checkout.root, 'games', input.slug)
+        : checkout.root
+      : mkdtempSync(join(tmpdir(), 'gamedev-mcp-work-'));
+    if (!local) {
+      input.write(`MCP workspace: ${cwd} — scratch files are kept here after the agent exits`);
+      if (spec.name === 'codex') wired.spec.headless.push('--skip-git-repo-check');
+    }
     const result = await (input.runAdapter ?? defaultAdapterRun)({
       spec: wired.spec,
       prompt:
         payload.kickoffPrompt ?? `Edit ${input.slug} in this checkout. The creator will deliver with gamedevpl submit.`,
       cwd,
       env: childEnv(env, '', { url: payload.mcpUrl, authorization: payload.authorizationHeader }),
+      abort: input.abort,
+      onLine: (line) => {
+        for (const shown of renderDelegateStream(spec.name, [line], false)) input.write(shown);
+      },
     });
     for (const line of renderDelegateStream(spec.name, result.lines, false)) input.write(line);
+    if (input.abort?.aborted) {
+      throw new CliError(
+        `${spec.name} stopped — files remain at ${cwd}`,
+        EXIT_REFUSED,
+        'review the files before retrying',
+      );
+    }
     if ((result.code ?? 1) !== 0) {
       throw new CliError(`${spec.name} exited ${result.code ?? 'null'}`, EXIT_RED, cliUsage('submit'));
     }
-    input.write(`adapter finished — review the tree, then ${cliUsage('submit')}`);
+    input.write(
+      local
+        ? `adapter finished — review the tree, then ${cliUsage('submit')}`
+        : `adapter finished — check the round in Studio; scratch files remain at ${cwd}`,
+    );
     return { spawned: true, mcp: true };
   } finally {
     for (const path of wired.cleanup) rmSync(path, { force: true });

--- a/apps/cli/src/connect.ts
+++ b/apps/cli/src/connect.ts
@@ -4,13 +4,14 @@ import { tmpdir } from 'node:os';
 import { randomUUID } from 'node:crypto';
 import { createInterface } from 'node:readline';
 import type { ApiClient } from './api.js';
-import { detectAdapter, loadAdapters, whichOnPath, type AdapterSpec } from './adapters.js';
+import { detectAdapter, loadAdapters, preflightAdapter, whichOnPath, type AdapterSpec } from './adapters.js';
 import { cliUsage } from './bin-name.js';
 import { CREATOR_TOKEN_PATTERN, childEnv, renderDelegateStream, spawnAdapter } from './delegate.js';
 import { CliError, EXIT_AUTH, EXIT_INPUT, EXIT_RED, EXIT_REFUSED } from './exit-codes.js';
 import { studioToken } from './studio.js';
 import { adapterMcpSupported } from './agents.js';
 import { findCheckout } from './checkout.js';
+import type { CliTelemetry } from './telemetry.js';
 
 export type ConnectPayload = {
   mcpUrl?: string;
@@ -120,8 +121,11 @@ function wireAdapterMcp(
 ): { spec: AdapterSpec; cleanup: string[] } {
   if (spec.name === 'claude') {
     const mcpPath = join(tmpdir(), `gamedev-mcp-${randomUUID()}.json`);
-    writeFileSync(mcpPath, mcpConfigBody(payload));
-    return { spec: { ...spec, headless: [...spec.headless, '--mcp-config', mcpPath] }, cleanup: [mcpPath] };
+    writeFileSync(mcpPath, mcpConfigBody(payload), { mode: 0o600 });
+    return {
+      spec: { ...spec, headless: ['--mcp-config', mcpPath, '--allowedTools', 'mcp__gamedevpl__*', ...spec.headless] },
+      cleanup: [mcpPath],
+    };
   }
   if (spec.name === 'codex') {
     const auth = authorizationValue(payload.authorizationHeader);
@@ -139,8 +143,21 @@ function wireAdapterMcp(
       cleanup: [],
     };
   }
+  if (spec.name === 'copilot') {
+    const mcpPath = join(tmpdir(), `gamedev-mcp-${randomUUID()}.json`);
+    const config = JSON.parse(mcpConfigBody(payload)) as { mcpServers: { gamedevpl: Record<string, unknown> } };
+    config.mcpServers.gamedevpl.tools = ['*'];
+    writeFileSync(mcpPath, JSON.stringify(config), { mode: 0o600 });
+    return {
+      spec: {
+        ...spec,
+        headless: ['--additional-mcp-config', `@${mcpPath}`, '--allow-tool=gamedevpl', ...spec.headless],
+      },
+      cleanup: [mcpPath],
+    };
+  }
   throw new CliError(
-    `adapter ${spec.name} has no MCP wiring — use claude or codex, or omit --agent`,
+    `adapter ${spec.name} has no MCP wiring — use a local checkout or claude, codex, copilot`,
     EXIT_INPUT,
     cliUsage('connect'),
   );
@@ -157,9 +174,15 @@ export async function connectGame(input: {
   runAdapter?: AdapterRun;
   abort?: AbortSignal;
   write: (line: string) => void;
+  telemetry?: CliTelemetry;
 }): Promise<{ spawned: boolean; mcp: boolean }> {
+  const checkCancelled = (): void => {
+    if (input.abort?.aborted) throw new CliError('agent launch cancelled', EXIT_REFUSED, 'retry when ready');
+  };
+  checkCancelled();
   const env = input.env ?? process.env;
   const token = await studioToken(input.api, input.slug);
+  checkCancelled();
   const spec = input.agent
     ? detectAdapter(input.agent, input.which ?? ((cmd) => whichOnPath(cmd, env)), loadAdapters(env))
     : null;
@@ -172,12 +195,15 @@ export async function connectGame(input: {
   }
   if (spec && !adapterMcpSupported(spec.name)) {
     throw new CliError(
-      `adapter ${spec.name} has no MCP wiring — use claude or codex, or omit --agent`,
+      `adapter ${spec.name} has no MCP wiring — use a checkout or claude, codex, copilot`,
       EXIT_INPUT,
       cliUsage('connect'),
     );
   }
+  if (spec && !input.runAdapter) preflightAdapter(spec, env);
+  checkCancelled();
   if (input.handoff) {
+    checkCancelled();
     const outcome = await input.api.request<{ pending?: boolean }>(
       'POST',
       `/api/submissions/${encodeURIComponent(token)}/handoff`,
@@ -186,6 +212,7 @@ export async function connectGame(input: {
         stopActivePlatformAgent: true,
       },
     );
+    checkCancelled();
     if (outcome.pending) {
       throw new CliError(
         'handoff pending — the platform agent still owns this round',
@@ -206,6 +233,7 @@ export async function connectGame(input: {
       `${cliUsage('connect', input.slug)} --handoff`,
     );
   }
+  checkCancelled();
 
   if (payload?.mcpUrl) {
     for (const line of formatHandoff(payload, input.slug)) input.write(line);
@@ -242,8 +270,8 @@ export async function connectGame(input: {
       : mkdtempSync(join(tmpdir(), 'gamedev-mcp-work-'));
     if (!local) {
       input.write(`MCP workspace: ${cwd} — scratch files are kept here after the agent exits`);
-      if (spec.name === 'codex') wired.spec.headless.push('--skip-git-repo-check');
     }
+    input.telemetry?.record('delegate_used', spec.name);
     const result = await (input.runAdapter ?? defaultAdapterRun)({
       spec: wired.spec,
       prompt:

--- a/apps/cli/src/delegate.ts
+++ b/apps/cli/src/delegate.ts
@@ -107,7 +107,13 @@ export function spawnAdapter(input: {
     }
   };
   const timer = setTimeout(kill, input.timeoutMs);
-  child.once('exit', () => clearTimeout(timer));
+  const cleanup = () => {
+    clearTimeout(timer);
+    input.abort?.removeEventListener('abort', kill);
+  };
+  child.once('close', cleanup);
+  child.once('error', cleanup);
   input.abort?.addEventListener('abort', kill, { once: true });
+  if (input.abort?.aborted) kill();
   return child;
 }

--- a/apps/cli/src/delegate.ts
+++ b/apps/cli/src/delegate.ts
@@ -25,6 +25,10 @@ export function childEnv(parent: NodeJS.ProcessEnv, roundToken: string, mcp?: Ch
 }
 
 type EventShape = {
+  content?: unknown;
+  response?: unknown;
+  data?: { content?: unknown };
+  error?: { message?: unknown };
   text?: unknown;
   message?: unknown;
   type?: unknown;
@@ -57,7 +61,7 @@ export function parseEventLine(line: string): string | null {
   try {
     parsed = JSON.parse(trimmed) as EventShape;
   } catch {
-    return null;
+    return trimmed;
   }
   if (!parsed || typeof parsed !== 'object') return trimmed;
   const direct =
@@ -65,7 +69,11 @@ export function parseEventLine(line: string): string | null {
     textOf(parsed.message) ??
     contentText(parsed.message) ??
     textOf(parsed.result) ??
-    textOf(parsed.item?.text);
+    textOf(parsed.item?.text) ??
+    textOf(parsed.content) ??
+    textOf(parsed.response) ??
+    textOf(parsed.data?.content) ??
+    textOf(parsed.error?.message);
   if (direct) return direct;
   const command = textOf(parsed.item?.command);
   if (command) return `⚙ ${command}`;
@@ -92,23 +100,39 @@ export function spawnAdapter(input: {
   timeoutMs: number;
   abort?: AbortSignal;
 }): ChildProcess {
-  const args = [...input.spec.headless, input.prompt];
-  const child = spawn(input.spec.command, args, {
+  return spawnCommand({ ...input, command: input.spec.command, args: [...input.spec.headless, input.prompt] });
+}
+
+export function spawnCommand(input: {
+  command: string;
+  args: string[];
+  cwd: string;
+  env: NodeJS.ProcessEnv;
+  timeoutMs: number;
+  abort?: AbortSignal;
+}): ChildProcess {
+  const child = spawn(input.command, input.args, {
     cwd: input.cwd,
     env: input.env,
     stdio: ['ignore', 'pipe', 'pipe'],
     detached: true,
   });
-  const kill = () => {
+  let escalation: ReturnType<typeof setTimeout> | undefined;
+  const signalGroup = (signal: NodeJS.Signals) => {
     try {
-      if (child.pid) process.kill(-child.pid, 'SIGTERM');
+      if (child.pid) process.kill(-child.pid, signal);
     } catch {
-      child.kill('SIGTERM');
+      child.kill(signal);
     }
+  };
+  const kill = () => {
+    signalGroup('SIGTERM');
+    escalation ??= setTimeout(() => signalGroup('SIGKILL'), 2_000);
   };
   const timer = setTimeout(kill, input.timeoutMs);
   const cleanup = () => {
     clearTimeout(timer);
+    clearTimeout(escalation);
     input.abort?.removeEventListener('abort', kill);
   };
   child.once('close', cleanup);

--- a/apps/cli/src/execution.test.ts
+++ b/apps/cli/src/execution.test.ts
@@ -1,0 +1,137 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { handleReplLine } from './repl.js';
+import { chooseExecution, type PendingExecution } from './execution.js';
+import { connectGame } from './connect.js';
+import type { ApiClient } from './api.js';
+
+vi.mock('./connect.js', () => ({ connectGame: vi.fn(async () => ({ spawned: true, mcp: true })) }));
+const roots: string[] = [];
+afterEach(() => {
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+  vi.clearAllMocks();
+});
+
+function environment(command = 'claude'): NodeJS.ProcessEnv {
+  const root = mkdtempSync(join(tmpdir(), 'gdpl-execution-'));
+  roots.push(root);
+  writeFileSync(
+    join(root, command),
+    `#!${process.execPath}
+if (!process.argv.includes('--help')) process.exit(99);
+console.log('-p --print --verbose --permission-mode --output-format --mode --sandbox');
+`,
+    { mode: 0o700 },
+  );
+  return { PATH: root, HOME: root };
+}
+
+describe('conversational builder selection', () => {
+  it('chooses self before creating a new game and starts MCP afterwards', async () => {
+    const order: string[] = [];
+    const bodies: unknown[] = [];
+    const api = {
+      origin: 'https://example.test',
+      request: async (_method: string, path: string, body: unknown) => {
+        order.push(path);
+        bodies.push(body);
+        return path === '/api/cli/chat'
+          ? { kind: 'proposal', title: 'Robots', concept: 'A garden of robots', conversationId: 'c' }
+          : { token: 'tok', slug: 'robots' };
+      },
+    } as unknown as ApiClient;
+    const result = await handleReplLine({
+      api,
+      token: null,
+      line: 'build robots',
+      env: environment(),
+      pick: async (choices) => {
+        order.push('pick');
+        return choices[0]!;
+      },
+      write: () => undefined,
+    });
+    expect(order).toEqual(['/api/cli/chat', 'pick', '/api/submissions']);
+    expect(bodies[0]).toMatchObject({ prepareOnly: true });
+    expect(bodies[1]).toMatchObject({ builder: 'self' });
+    expect(connectGame).toHaveBeenCalledWith(expect.objectContaining({ slug: 'robots', agent: 'claude' }));
+    expect(result).toMatchObject({ token: 'tok', slug: 'robots' });
+  });
+
+  it('does not create a game after the selection is cancelled', async () => {
+    const request = vi.fn(async () => ({
+      kind: 'proposal',
+      title: 'Robots',
+      concept: 'A garden of robots',
+      conversationId: 'c',
+    }));
+    await handleReplLine({
+      api: { request } as unknown as ApiClient,
+      token: null,
+      line: 'build robots',
+      env: environment(),
+      pick: async () => '/quit',
+      write: () => undefined,
+    });
+    expect(request).toHaveBeenCalledTimes(1);
+    expect(connectGame).not.toHaveBeenCalled();
+  });
+
+  it('does not deliver a revision or hand off when its selection is cancelled', async () => {
+    const request = vi.fn(async (_method: string, _path: string, _body?: unknown) => ({
+      kind: 'proposal',
+      ack: 'On it',
+    }));
+    await handleReplLine({
+      api: { request } as unknown as ApiClient,
+      token: 'tok',
+      line: 'make robots blue',
+      env: environment(),
+      pick: async () => '/quit',
+      write: () => undefined,
+    });
+    expect(request).toHaveBeenCalledTimes(1);
+    expect(request.mock.calls[0]?.[2]).toMatchObject({ prepareOnly: true });
+    expect(connectGame).not.toHaveBeenCalled();
+  });
+
+  it('offers a checkout for a tool without session-scoped MCP configuration', async () => {
+    const picked = await chooseExecution({
+      env: environment('agy'),
+      pick: async (choices) => {
+        expect(choices[0]).toContain('download a checkout');
+        return choices[0]!;
+      },
+    });
+    expect(picked).toMatchObject({ builder: 'self', spec: { name: 'agy' }, mode: 'local' });
+  });
+});
+
+it('retains a pending MCP task without a checkout and retries without another picker', async () => {
+  const pendingExecution: PendingExecution = {};
+  let builder = 'platform';
+  const posted: unknown[] = [];
+  const api = {
+    origin: 'https://example.test',
+    request: async (method: string, path: string, body?: unknown) => {
+      if (path.endsWith('/handoff')) return { pending: true, builder: 'platform' };
+      if (method === 'GET') return { slug: 'robots', builder, status: 'building' };
+      if ((body as { prepareOnly?: boolean })?.prepareOnly) return { kind: 'proposal' };
+      posted.push(body);
+      return { kind: 'build', roundId: 2 };
+    },
+  } as unknown as ApiClient;
+  const pick = vi.fn(async (choices: string[]) => choices[0]!);
+  const input = { api, token: 'tok', env: environment(), pick, pendingExecution, write: () => undefined };
+  await handleReplLine({ ...input, line: 'make robots blue' });
+  expect(posted).toHaveLength(0);
+  expect(pendingExecution.current?.request).toBe('make robots blue');
+  builder = 'self';
+  await handleReplLine({ ...input, line: '/retry' });
+  expect(pick).toHaveBeenCalledTimes(1);
+  expect(posted).toEqual([{ text: 'make robots blue' }]);
+  expect(connectGame).toHaveBeenCalledWith(expect.objectContaining({ agent: 'claude' }));
+  expect(pendingExecution.current).toBeUndefined();
+});

--- a/apps/cli/src/execution.ts
+++ b/apps/cli/src/execution.ts
@@ -1,0 +1,103 @@
+import { mkdtempSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import type { ApiClient } from './api.js';
+import { adapterMcpSupported } from './agents.js';
+import { preflightAdapter, type AdapterSpec } from './adapters.js';
+import { checkoutGame } from './checkout.js';
+import { connectGame } from './connect.js';
+import { CliError, EXIT_REFUSED } from './exit-codes.js';
+import { detectLocalAdapters, workshopTurn, type Workshop, type PickChoice } from './workshop.js';
+import type { CliTelemetry } from './telemetry.js';
+
+export type ExecutionChoice = { builder: 'platform' } | { builder: 'self'; spec: AdapterSpec; mode: 'local' | 'mcp' };
+
+export type PendingExecution = { current?: { choice: ExecutionChoice; request: string } };
+
+export async function chooseExecution(input: {
+  env: NodeJS.ProcessEnv;
+  pick: PickChoice;
+  workshop?: Workshop;
+  telemetry?: CliTelemetry;
+}): Promise<ExecutionChoice | null> {
+  const adapters = input.workshop?.adapters ?? detectLocalAdapters(input.env);
+  if (!adapters.length) return { builder: 'platform' };
+  if (input.workshop?.selectedAgent) {
+    const spec = adapters.find((row) => row.name === input.workshop!.selectedAgent);
+    if (spec) return { builder: 'self', spec, mode: 'local' };
+  }
+  const local = adapters.map((spec) => {
+    const mode = input.workshop ? 'local' : adapterMcpSupported(spec.name) ? 'mcp' : 'local';
+    const where = mode === 'mcp' ? 'MCP' : input.workshop ? 'this checkout' : 'download a checkout';
+    return {
+      choice: { builder: 'self' as const, spec, mode: mode as 'local' | 'mcp' },
+      label: `${spec.name} — ${where}; its own credentials and billing`,
+    };
+  });
+  for (const spec of adapters) input.telemetry?.record('delegate_offered', spec.name);
+  const platform = 'gamedev.pl builder — uses platform quota';
+  const chosen = await input.pick([...local.map((row) => row.label), platform], 'Who should build this task?');
+  if (chosen === platform) return { builder: 'platform' };
+  const choice = local.find((row) => row.label === chosen)?.choice;
+  if (!choice) return null;
+  if (!input.workshop?.runAdapter) preflightAdapter(choice.spec, input.env);
+  return choice;
+}
+
+export async function executeChoice(input: {
+  api: ApiClient;
+  choice: ExecutionChoice;
+  slug: string;
+  token: string;
+  request: string;
+  env: NodeJS.ProcessEnv;
+  pick: PickChoice;
+  write: (line: string) => void;
+  workshop?: Workshop;
+  abort: Workshop['abort'];
+  telemetry?: CliTelemetry;
+  onWorkshop?: (ws: Workshop) => void;
+}): Promise<Workshop | undefined> {
+  if (input.choice.builder === 'platform') return input.workshop;
+  const { spec, mode } = input.choice;
+  if (mode === 'mcp') {
+    const controller = new AbortController();
+    input.abort.current = controller;
+    try {
+      await connectGame({
+        api: input.api,
+        slug: input.slug,
+        dest: process.cwd(),
+        env: input.env,
+        agent: spec.name,
+        abort: controller.signal,
+        write: input.write,
+        telemetry: input.telemetry,
+      });
+    } finally {
+      input.abort.current = null;
+    }
+    return;
+  }
+  let ws = input.workshop;
+  if (!ws) {
+    const root = mkdtempSync(join(tmpdir(), 'gamedev-checkout-'));
+    input.write(`downloading ${input.slug} to ${root} — this checkout is kept after exit`);
+    await checkoutGame({ api: input.api, slug: input.slug, dest: root, allowUndelivered: true });
+    ws = {
+      slug: input.slug,
+      root,
+      token: input.token,
+      builder: 'self',
+      adapters: detectLocalAdapters(input.env),
+      env: input.env,
+      pick: input.pick,
+      abort: input.abort,
+      telemetry: input.telemetry,
+    };
+  }
+  input.onWorkshop?.(ws);
+  if (ws.builder !== 'self') throw new CliError('handoff still pending', EXIT_REFUSED, '/builder to refresh');
+  await workshopTurn({ api: input.api, ws, request: input.request, agent: spec.name, write: input.write });
+  return ws;
+}

--- a/apps/cli/src/help.ts
+++ b/apps/cli/src/help.ts
@@ -3,6 +3,7 @@ import { CLI_VERSION } from './update.js';
 import { SLASH_VERBS, type SlashVerb } from './argv.js';
 
 const BLURB: Record<SlashVerb, string> = {
+  agents: 'detect local agents and show supported modes',
   games: 'list your games',
   status: 'round status — status <token>',
   share: 'play URL — share <slug>',

--- a/apps/cli/src/help.ts
+++ b/apps/cli/src/help.ts
@@ -34,6 +34,7 @@ export function formatHelp(slash = false): string {
         '',
         '  type to talk — a game starts when you ask · /quit to leave',
         '  in a checkout: say what to change; a local agent edits it, /submit delivers',
+        '  /retry resumes a task waiting for builder handoff',
         '',
       ]
     : [

--- a/apps/cli/src/main.ts
+++ b/apps/cli/src/main.ts
@@ -24,7 +24,9 @@ import { runGitRemoteHelper } from './git-remote-main.js';
 import { runStatusVerb } from './status-watch.js';
 import { dispatchReadVerb } from './verbs.js';
 import { formatHelp } from './help.js';
-import { detectLocalAdapters, handoffBuilder, workshopTurn } from './workshop.js';
+import { detectLocalAdapters, handoffBuilder, pickAdapter, workshopTurn } from './workshop.js';
+import { preflightAdapter } from './adapters.js';
+import { createCliTelemetry, type CliTelemetry } from './telemetry.js';
 import { getStatus } from './turn.js';
 
 function storeFromEnv(env: NodeJS.ProcessEnv, warn: (line: string) => void): TokenStore {
@@ -62,6 +64,7 @@ export async function openCheckoutGame(
 
 // Non-interactive twin of the REPL turn: agent, ladder, optional delivery.
 async function runDelegateVerb(input: {
+  telemetry?: CliTelemetry;
   api: ApiClient;
   args: string[];
   flags: Record<string, string | boolean>;
@@ -71,6 +74,10 @@ async function runDelegateVerb(input: {
 }): Promise<number> {
   const request = input.args.join(' ').trim();
   if (!request) throw new CliError(cliUsage('delegate', '"<task>"'), EXIT_INPUT, '<task>');
+  const adapters = detectLocalAdapters(input.env);
+  const agent = typeof input.flags.agent === 'string' ? input.flags.agent : undefined;
+  const spec = pickAdapter({ adapters, env: input.env }, agent);
+  preflightAdapter(spec, input.env);
   const opened = await openCheckoutGame(input.api, input.cwd);
   if (!opened) throw new CliError('not inside a game checkout', EXIT_INPUT, cliUsage('checkout', '<slug>'));
   let builder = (await getStatus(input.api, opened.token)).builder ?? 'platform';
@@ -95,7 +102,8 @@ async function runDelegateVerb(input: {
   const ws = {
     ...opened,
     env: input.env,
-    adapters: detectLocalAdapters(input.env),
+    adapters,
+    telemetry: input.telemetry,
     builder,
     pick: async () => '',
     abort: { current: null },
@@ -129,6 +137,7 @@ export async function runCli(
   const store = storeFromEnv(env, (line) => io.stderr.write(line));
   const api = createApi({ origin, store, env });
   const tty = Boolean(io.stdin.isTTY);
+  const telemetry = verb === 'connect' || verb === 'delegate' ? createCliTelemetry(origin) : undefined;
 
   try {
     if (verb === 'help' || flags.help || flags.h) {
@@ -241,6 +250,7 @@ export async function runCli(
         agent: typeof flags.agent === 'string' ? flags.agent : undefined,
         handoff: flags.handoff === true,
         write: (line) => io.stdout.write(`${line}\n`),
+        telemetry,
       });
       return EXIT_GREEN;
     }
@@ -252,6 +262,7 @@ export async function runCli(
         env,
         cwd: process.cwd(),
         write: (line) => io.stdout.write(`${line}\n`),
+        telemetry,
       });
     }
     const read = await dispatchReadVerb({ verb, args, flags, api, io, env });
@@ -274,6 +285,8 @@ export async function runCli(
     const shown = describeError(error);
     io.stderr.write(`${shown.message}${shown.next ? `\nnext: ${shown.next}` : ''}\n`);
     return shown.code;
+  } finally {
+    await telemetry?.flush();
   }
 }
 

--- a/apps/cli/src/main.ts
+++ b/apps/cli/src/main.ts
@@ -254,7 +254,7 @@ export async function runCli(
         write: (line) => io.stdout.write(`${line}\n`),
       });
     }
-    const read = await dispatchReadVerb({ verb, args, flags, api, io });
+    const read = await dispatchReadVerb({ verb, args, flags, api, io, env });
     if (read !== null) return read;
     if (verb === 'repl') {
       if (!tty || !io.stdout.isTTY) throw pipeNeedsFlag(`a verb such as ${cliUsage('whoami')}`);

--- a/apps/cli/src/prepare-workspace.test.ts
+++ b/apps/cli/src/prepare-workspace.test.ts
@@ -1,0 +1,40 @@
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { prepareWorkspace } from './prepare-workspace.js';
+
+const roots: string[] = [];
+afterEach(() => {
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+function fixture(setup = "import {writeFileSync} from 'node:fs'; writeFileSync('kit-ready', 'yes');") {
+  const cwd = mkdtempSync(join(tmpdir(), 'gdpl-prepare-'));
+  roots.push(cwd);
+  writeFileSync(join(cwd, 'setup.mjs'), setup);
+  writeFileSync(join(cwd, 'gamedev.lock'), '{}');
+  writeFileSync(join(cwd, 'package.json'), '{}');
+  mkdirSync(join(cwd, 'bin'));
+  writeFileSync(
+    join(cwd, 'bin/npm'),
+    `#!${process.execPath}\nrequire('node:fs').writeFileSync('installed', process.argv.slice(2).join(' '));`,
+    { mode: 0o700 },
+  );
+  return { cwd, env: { PATH: join(cwd, 'bin') }, write: () => undefined };
+}
+describe('checkout preparation', () => {
+  it('prepares the kit before installing the toolchain', async () => {
+    const input = fixture();
+    await prepareWorkspace(input);
+    expect(existsSync(join(input.cwd, 'kit-ready'))).toBe(true);
+    expect(existsSync(join(input.cwd, 'installed'))).toBe(true);
+  });
+  it('does not run installation after setup fails or cancellation', async () => {
+    const input = fixture('process.exit(1)');
+    await expect(prepareWorkspace(input)).rejects.toThrow('setup did not complete');
+    expect(existsSync(join(input.cwd, 'installed'))).toBe(false);
+    const controller = new AbortController();
+    controller.abort();
+    await expect(prepareWorkspace({ ...input, abort: controller.signal })).rejects.toThrow('cancelled');
+  });
+});

--- a/apps/cli/src/prepare-workspace.ts
+++ b/apps/cli/src/prepare-workspace.ts
@@ -1,0 +1,36 @@
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { createInterface } from 'node:readline';
+import { childEnv, spawnCommand } from './delegate.js';
+import { sanitizeEventPayload } from './ansi.js';
+import { CliError, EXIT_REFUSED } from './exit-codes.js';
+
+export async function prepareWorkspace(input: {
+  cwd: string;
+  env: NodeJS.ProcessEnv;
+  abort?: AbortSignal;
+  write: (line: string) => void;
+}): Promise<void> {
+  const run = async (command: string, args: string[]): Promise<void> => {
+    if (input.abort?.aborted) throw new CliError('setup cancelled', EXIT_REFUSED);
+    const child = spawnCommand({ ...input, command, args, env: childEnv(input.env, ''), timeoutMs: 5 * 60_000 });
+    for (const stream of [child.stdout, child.stderr]) {
+      if (stream)
+        createInterface({ input: stream }).on('line', (line: string) => input.write(sanitizeEventPayload(line)));
+    }
+    const code = await new Promise<number | null>((resolve, reject) => {
+      child.once('error', reject);
+      child.once('close', resolve);
+    });
+    if (input.abort?.aborted || code !== 0)
+      throw new CliError('checkout setup did not complete', EXIT_REFUSED, `check the output in ${input.cwd}`);
+  };
+  if (existsSync(join(input.cwd, 'setup.mjs')) && existsSync(join(input.cwd, 'gamedev.lock'))) {
+    input.write('preparing the pinned Creator Kit');
+    await run(process.execPath, ['setup.mjs']);
+  }
+  if (existsSync(join(input.cwd, 'package.json')) && !existsSync(join(input.cwd, 'node_modules'))) {
+    input.write('installing the checkout toolchain');
+    await run('npm', ['ci']);
+  }
+}

--- a/apps/cli/src/repl.ts
+++ b/apps/cli/src/repl.ts
@@ -13,6 +13,8 @@ import { CLI_VERSION } from './update.js';
 import { formatError } from './errors.js';
 import { formatHelp } from './help.js';
 import { MASCOT_ASCII } from './tui/mascot.js';
+import { discoverAgents } from './agents.js';
+import type { PickChoice } from './workshop.js';
 import { handoffBuilder, handoffLine, refreshBuilder, workshopTurn, type Workshop } from './workshop.js';
 
 export type ReplLineResult = {
@@ -29,6 +31,9 @@ export async function handleReplLine(input: {
   conversationId?: string;
   // Set when the session opened from a game checkout.
   workshop?: Workshop;
+  env?: NodeJS.ProcessEnv;
+  pick?: PickChoice;
+  abort?: Workshop['abort'];
   write: (s: string) => void;
 }): Promise<ReplLineResult> {
   const trimmed = input.line.trim();
@@ -105,14 +110,35 @@ export async function handleReplLine(input: {
           const dest = parsed.args[1] ?? cwd;
           input.write(formatSyncLines(await diffGame({ api: input.api, slug, dest })).join('\n'));
         } else {
-          await connectGame({
-            api: input.api,
-            slug,
-            dest: cwd,
-            agent: typeof parsed.flags.agent === 'string' ? parsed.flags.agent : undefined,
-            handoff: parsed.flags.handoff === true,
-            write: input.write,
-          });
+          let agent = typeof parsed.flags.agent === 'string' ? parsed.flags.agent : undefined;
+          if (!agent && input.pick) {
+            const agents = discoverAgents(input.env).filter((row) => row.installed && row.mcp);
+            if (agents.length) {
+              const manual = 'show manual MCP setup';
+              const choice = await input.pick(
+                [...agents.map((row) => row.name), manual],
+                `Connect ${slug} — local agents use their own credentials and billing`,
+              );
+              if (choice !== manual && !agents.some((row) => row.name === choice)) return { next: 'continue' };
+              if (choice !== manual) agent = choice;
+            }
+          }
+          const controller = new AbortController();
+          if (input.abort) input.abort.current = controller;
+          try {
+            await connectGame({
+              api: input.api,
+              slug,
+              dest: cwd,
+              agent,
+              env: input.env,
+              handoff: parsed.flags.handoff === true,
+              write: input.write,
+              abort: controller.signal,
+            });
+          } finally {
+            if (input.abort) input.abort.current = null;
+          }
         }
       } catch (error) {
         input.write(formatError(error));
@@ -130,6 +156,7 @@ export async function handleReplLine(input: {
           flags: parsed.flags,
           api: input.api,
           io: { stdout },
+          env: input.env,
         });
         if (code !== null) {
           input.write(chunks.join('').trimEnd() || `/${cmd}`);

--- a/apps/cli/src/repl.ts
+++ b/apps/cli/src/repl.ts
@@ -1,7 +1,7 @@
 import { CLI_BIN, cliUsage } from './bin-name.js';
 import { glyphs, wantsColor } from './renderer.js';
 import { completeSlash, parseArgv, SLASH_VERBS, type SlashVerb } from './argv.js';
-import { getStatus, postTurn } from './turn.js';
+import { getStatus, postTurn, prepareTurn } from './turn.js';
 import { formatStatusLines } from './status-watch.js';
 import type { ApiClient } from './api.js';
 import { checkoutGame, diffGame, formatSyncLines, pullGame, readCheckoutSlug } from './checkout.js';
@@ -16,12 +16,15 @@ import { MASCOT_ASCII } from './tui/mascot.js';
 import { discoverAgents } from './agents.js';
 import type { PickChoice } from './workshop.js';
 import { handoffBuilder, handoffLine, refreshBuilder, workshopTurn, type Workshop } from './workshop.js';
+import { chooseExecution, executeChoice, type PendingExecution } from './execution.js';
+import type { CliTelemetry } from './telemetry.js';
 
 export type ReplLineResult = {
   next: 'continue' | 'quit';
   token?: string | null;
   slug?: string;
   conversationId?: string;
+  workshop?: Workshop;
 };
 
 export async function handleReplLine(input: {
@@ -34,9 +37,17 @@ export async function handleReplLine(input: {
   env?: NodeJS.ProcessEnv;
   pick?: PickChoice;
   abort?: Workshop['abort'];
+  telemetry?: CliTelemetry;
+  pendingExecution?: PendingExecution;
+  onWorkshop?: (ws: Workshop) => void;
   write: (s: string) => void;
 }): Promise<ReplLineResult> {
-  const trimmed = input.line.trim();
+  const retry = input.line.trim() === '/retry' ? input.pendingExecution?.current : undefined;
+  if (input.line.trim() === '/retry' && !retry) {
+    input.write('no pending task to retry');
+    return { next: 'continue' };
+  }
+  const trimmed = retry?.request ?? input.line.trim();
   if (!trimmed) return { next: 'continue' };
   if (trimmed === '/quit' || trimmed === '/exit') return { next: 'quit' };
   if (trimmed.startsWith('/')) {
@@ -50,6 +61,7 @@ export async function handleReplLine(input: {
       ws &&
       (cmd === 'delegate' || (cmd === 'builder' && (!rest[0] || rest[0] === 'self' || rest[0] === 'platform')))
     ) {
+      if (cmd === 'builder' && rest[0] === 'platform' && input.pendingExecution) delete input.pendingExecution.current;
       await handleWorkshopVerb({ cmd, rest, api: input.api, ws, write: input.write });
       return { next: 'continue' };
     }
@@ -114,6 +126,7 @@ export async function handleReplLine(input: {
           if (!agent && input.pick) {
             const agents = discoverAgents(input.env).filter((row) => row.installed && row.mcp);
             if (agents.length) {
+              for (const agent of agents) input.telemetry?.record('delegate_offered', agent.name);
               const manual = 'show manual MCP setup';
               const choice = await input.pick(
                 [...agents.map((row) => row.name), manual],
@@ -135,6 +148,7 @@ export async function handleReplLine(input: {
               handoff: parsed.flags.handoff === true,
               write: input.write,
               abort: controller.signal,
+              telemetry: input.telemetry,
             });
           } finally {
             if (input.abort) input.abort.current = null;
@@ -175,7 +189,43 @@ export async function handleReplLine(input: {
   }
   if (!input.token) {
     try {
-      const result = await postCliChat(input.api, trimmed, input.conversationId);
+      const result = await postCliChat(input.api, trimmed, input.conversationId, Boolean(input.pick));
+      if (result.kind === 'proposal') {
+        if (!input.pick) return { next: 'continue', conversationId: result.conversationId };
+        const env = input.env ?? process.env;
+        const choice = await chooseExecution({ env, pick: input.pick, telemetry: input.telemetry });
+        if (!choice) return { next: 'continue', conversationId: result.conversationId };
+        input.telemetry?.record('build_requested');
+        const created = await input.api.request<{ token: string; slug: string }>('POST', '/api/submissions', {
+          title: result.title,
+          concept: result.concept,
+          builder: choice.builder,
+        });
+        input.write(`▸ opened ${created.slug}`);
+        const opened: ReplLineResult = {
+          next: 'continue',
+          token: created.token,
+          slug: created.slug,
+          conversationId: result.conversationId,
+        };
+        try {
+          opened.workshop = await executeChoice({
+            api: input.api,
+            choice,
+            ...created,
+            request: result.concept,
+            env,
+            pick: input.pick,
+            write: input.write,
+            abort: input.abort ?? { current: null },
+            telemetry: input.telemetry,
+            onWorkshop: input.onWorkshop,
+          });
+        } catch (error) {
+          input.write(formatError(error));
+        }
+        return opened;
+      }
       if (result.kind === 'create') {
         input.write(`▸ opened ${result.slug}${result.ack ? ` — ${result.ack}` : ''}`);
         return {
@@ -193,6 +243,71 @@ export async function handleReplLine(input: {
     }
   }
   try {
+    if (input.pick) {
+      const prepared = retry ? { kind: 'proposal' as const } : await prepareTurn(input.api, input.token, trimmed);
+      if (prepared.kind === 'reply') {
+        input.write(`◆ ${prepared.text}`);
+        return { next: 'continue' };
+      }
+      if (prepared.kind === 'proposal') {
+        const env = input.env ?? process.env;
+        const choice =
+          retry?.choice ??
+          (await chooseExecution({
+            env,
+            pick: input.pick,
+            workshop: input.workshop,
+            telemetry: input.telemetry,
+          }));
+        if (!choice) return { next: 'continue' };
+        const status = await getStatus(input.api, input.token);
+        const slug = input.workshop?.slug ?? status.slug;
+        if (!slug) {
+          input.write('game slug is unavailable — /status to check the round');
+          return { next: 'continue' };
+        }
+        if (choice.builder !== (status.builder ?? 'platform')) {
+          const outcome = await handoffBuilder(input.api, input.token, choice.builder, status.builder ?? 'platform');
+          if (input.workshop) {
+            input.workshop.builder = outcome.builder;
+            if (choice.builder === 'self') input.workshop.selectedAgent = choice.spec.name;
+            else delete input.workshop.selectedAgent;
+          }
+          if (outcome.pending) {
+            if (input.pendingExecution) input.pendingExecution.current = { choice, request: trimmed };
+            input.write(`${handoffLine(outcome, slug)} — /retry resumes this task with the selected agent`);
+            return { next: 'continue' };
+          }
+        } else if (input.workshop) input.workshop.builder = choice.builder;
+        if (input.pendingExecution) delete input.pendingExecution.current;
+        input.telemetry?.record('build_requested');
+        const result = await postTurn(input.api, input.token, trimmed);
+        if (result.kind === 'reply') {
+          input.write(`◆ ${result.text}`);
+          return { next: 'continue' };
+        }
+        input.write(`▸ build ${result.roundId}${result.ack ? ` — ${result.ack}` : ''}`);
+        const workshop = await executeChoice({
+          api: input.api,
+          choice,
+          slug,
+          token: input.token,
+          request: trimmed,
+          env,
+          pick: input.pick,
+          write: input.write,
+          workshop: input.workshop,
+          abort: input.abort ?? { current: null },
+          telemetry: input.telemetry,
+          onWorkshop: input.onWorkshop,
+        });
+        return { next: 'continue', workshop };
+      }
+      input.write(
+        'CLI server does not support builder selection before dispatch — update the server before delegating',
+      );
+      return { next: 'continue' };
+    }
     const result = await postTurn(input.api, input.token, trimmed);
     if (result.kind === 'reply') {
       input.write(`◆ ${result.text}`);
@@ -234,6 +349,7 @@ async function handleWorkshopVerb(input: {
         return;
       }
       const outcome = await handoffBuilder(input.api, ws.token, wanted, ws.builder);
+      if (wanted === 'platform') delete ws.selectedAgent;
       ws.builder = outcome.builder;
       input.write(handoffLine(outcome, ws.slug));
       return;

--- a/apps/cli/src/telemetry.test.ts
+++ b/apps/cli/src/telemetry.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createCliTelemetry } from './telemetry.js';
+
+describe('CLI delegation telemetry', () => {
+  it('sends anonymous bounded dimensions using an ephemeral session identifier', async () => {
+    const send = vi.fn<typeof fetch>(async () => new Response('{}'));
+    const telemetry = createCliTelemetry('https://example.test', send);
+    telemetry.record('delegate_offered', 'copilot');
+    telemetry.record('delegate_used', '/home/private/custom-agent');
+    await telemetry.flush();
+    const events = send.mock.calls.map((call) => JSON.parse(String((call[1] as RequestInit).body)));
+    expect(events[0].visitId).toBe(events[1].visitId);
+    expect(events[1].events[0].adapter).toBe('custom');
+    expect(JSON.stringify(events)).not.toContain('/home/private');
+    expect(send.mock.calls[0]?.[1]).toMatchObject({ headers: { 'content-type': 'application/json' } });
+    const next = createCliTelemetry('https://example.test', send);
+    next.record('delegate_used', 'claude');
+    await next.flush();
+    expect(JSON.parse(String(send.mock.calls[2]?.[1]?.body)).visitId).not.toBe(events[0].visitId);
+  });
+
+  it('ignores telemetry failures', async () => {
+    const telemetry = createCliTelemetry('https://example.test', async () => {
+      throw new Error('offline');
+    });
+    telemetry.record('delegate_used', 'agy');
+    await expect(telemetry.flush()).resolves.toBeUndefined();
+  });
+});

--- a/apps/cli/src/telemetry.ts
+++ b/apps/cli/src/telemetry.ts
@@ -1,0 +1,45 @@
+import { randomUUID } from 'node:crypto';
+import { CLI_ADAPTERS, type CliStep, type CliVerifyStage } from '@gamedevpl/contract';
+
+export type CliTelemetry = {
+  record: (step: CliStep, adapter?: string, stage?: CliVerifyStage) => void;
+  flush: () => Promise<void>;
+};
+
+export function createCliTelemetry(origin: string, send: typeof fetch = fetch): CliTelemetry {
+  const visitId = randomUUID();
+  const started = Date.now();
+  const pending = new Set<Promise<void>>();
+  let count = 0;
+  return {
+    record(step, adapter, stage) {
+      if (++count > 200) return;
+      const msSinceStart = Math.min(86_400_000, Math.max(0, Date.now() - started));
+      const event = {
+        type: 'cli_step',
+        step,
+        msSinceStart,
+        ...(adapter ? { adapter: (CLI_ADAPTERS as readonly string[]).includes(adapter) ? adapter : 'custom' } : {}),
+        ...(stage ? { stage } : {}),
+      };
+      const task = Promise.resolve()
+        .then(() =>
+          send(`${origin}/api/telemetry/visit`, {
+            method: 'POST',
+            headers: { 'content-type': 'application/json' },
+            body: JSON.stringify({ visitId, flushMsSinceStart: msSinceStart, events: [event] }),
+            signal: AbortSignal.timeout(2000),
+          }),
+        )
+        .then(
+          () => undefined,
+          () => undefined,
+        );
+      pending.add(task);
+      void task.finally(() => pending.delete(task));
+    },
+    async flush() {
+      await Promise.all(pending);
+    },
+  };
+}

--- a/apps/cli/src/tui/host.ts
+++ b/apps/cli/src/tui/host.ts
@@ -9,6 +9,7 @@ import { ReplApp } from './app.js';
 import { createRoundWatch } from './round-watch.js';
 import { createTuiSession, formatSessionIdentity } from './session.js';
 import { openWorkshop, settleBuilder, type Workshop } from '../workshop.js';
+import { agentHint, discoverAgents } from '../agents.js';
 
 export async function runInkRepl(input: {
   api: ApiClient;
@@ -43,6 +44,10 @@ export async function runInkRepl(input: {
   let slug = input.checkout?.slug ?? '';
   const paintIdentity = (): void => session.setIdentity(formatSessionIdentity(who, slug));
   let workshop: Workshop | undefined;
+  if (!input.checkout) {
+    const hint = agentHint(discoverAgents(input.env));
+    if (hint) session.writeLine(hint);
+  }
   if (input.checkout && token) {
     paintIdentity();
     const write = (line: string): void => session.writeLine(line);
@@ -84,6 +89,9 @@ export async function runInkRepl(input: {
           token,
           conversationId,
           workshop,
+          env: input.env,
+          pick: session.prompt,
+          abort,
           write: (text) => session.writeLine(text),
         });
       } catch (error) {

--- a/apps/cli/src/tui/host.ts
+++ b/apps/cli/src/tui/host.ts
@@ -1,3 +1,4 @@
+import type { PendingExecution } from '../execution.js';
 import { render } from 'ink';
 import { createElement } from 'react';
 import { EXIT_GREEN } from '../exit-codes.js';
@@ -10,6 +11,7 @@ import { createRoundWatch } from './round-watch.js';
 import { createTuiSession, formatSessionIdentity } from './session.js';
 import { openWorkshop, settleBuilder, type Workshop } from '../workshop.js';
 import { agentHint, discoverAgents } from '../agents.js';
+import { createCliTelemetry } from '../telemetry.js';
 
 export async function runInkRepl(input: {
   api: ApiClient;
@@ -23,6 +25,7 @@ export async function runInkRepl(input: {
   const color = wantsColor(input.env, isTty);
   const host: { instance?: ReturnType<typeof render> } = {};
   const abort: Workshop['abort'] = { current: null };
+  const telemetry = createCliTelemetry(input.api.origin);
   const session = createTuiSession(replBanner(isTty, input.env), () => {
     if (abort.current) {
       abort.current.abort();
@@ -44,6 +47,7 @@ export async function runInkRepl(input: {
   let slug = input.checkout?.slug ?? '';
   const paintIdentity = (): void => session.setIdentity(formatSessionIdentity(who, slug));
   let workshop: Workshop | undefined;
+  const pendingExecution: PendingExecution = {};
   if (!input.checkout) {
     const hint = agentHint(discoverAgents(input.env));
     if (hint) session.writeLine(hint);
@@ -52,7 +56,7 @@ export async function runInkRepl(input: {
     paintIdentity();
     const write = (line: string): void => session.writeLine(line);
     const opened = await openWorkshop({ api: input.api, token, ...input.checkout, env: input.env, write });
-    workshop = { ...input.checkout, token, env: input.env, ...opened, pick: session.prompt, abort };
+    workshop = { ...input.checkout, token, env: input.env, ...opened, pick: session.prompt, abort, telemetry };
     workshop.builder = await settleBuilder({ api: input.api, ws: workshop, status: opened.status, write });
     session.writeLine('say what to change, or /help');
   }
@@ -92,6 +96,11 @@ export async function runInkRepl(input: {
           env: input.env,
           pick: session.prompt,
           abort,
+          telemetry,
+          pendingExecution,
+          onWorkshop: (opened) => {
+            workshop = opened;
+          },
           write: (text) => session.writeLine(text),
         });
       } catch (error) {
@@ -102,6 +111,7 @@ export async function runInkRepl(input: {
         token = result.token;
         watch.poke();
       }
+      if (result.workshop) workshop = result.workshop;
       if (result.slug) {
         slug = result.slug;
         paintIdentity();
@@ -113,6 +123,7 @@ export async function runInkRepl(input: {
     watch.stop();
     session.close();
     host.instance?.unmount();
+    await telemetry.flush();
   }
   return EXIT_GREEN;
 }

--- a/apps/cli/src/turn.ts
+++ b/apps/cli/src/turn.ts
@@ -2,6 +2,11 @@ import { CliError, EXIT_REFUSED } from './exit-codes.js';
 import type { ApiClient } from './api.js';
 
 export type TurnResult = { kind: 'reply'; text: string } | { kind: 'build'; ack?: string; roundId: number };
+export type PreparedTurnResult = TurnResult | { kind: 'proposal'; ack?: string };
+
+export async function prepareTurn(api: ApiClient, token: string, text: string): Promise<PreparedTurnResult> {
+  return api.request('POST', `/api/submissions/${encodeURIComponent(token)}/turn`, { text, prepareOnly: true });
+}
 
 export async function postTurn(api: ApiClient, token: string, text: string): Promise<TurnResult> {
   return api.request<TurnResult>('POST', `/api/submissions/${encodeURIComponent(token)}/turn`, { text });

--- a/apps/cli/src/verbs.ts
+++ b/apps/cli/src/verbs.ts
@@ -3,6 +3,7 @@ import { cliUsage } from './bin-name.js';
 import { jsonMode } from './argv.js';
 import { CliError, EXIT_GREEN, EXIT_INPUT } from './exit-codes.js';
 import { defaultInstallDest, updateCli } from './update.js';
+import { discoverAgents, formatAgents } from './agents.js';
 
 type Flags = Record<string, string | boolean>;
 type Io = { stdout: NodeJS.WriteStream };
@@ -24,9 +25,16 @@ export async function dispatchReadVerb(input: {
   flags: Flags;
   api: ApiClient;
   io: Io;
+  env?: NodeJS.ProcessEnv;
 }): Promise<number | null> {
   const asJson = jsonMode(input.flags);
   const { verb, args, api, io, flags } = input;
+
+  if (verb === 'agents') {
+    const agents = discoverAgents(input.env);
+    emit(io, asJson, { agents }, formatAgents(agents));
+    return EXIT_GREEN;
+  }
 
   if (verb === 'games') {
     const data = await api.request<{ submissions?: Array<{ slug?: string | null; title?: string }> }>(

--- a/apps/cli/src/workshop.test.ts
+++ b/apps/cli/src/workshop.test.ts
@@ -16,6 +16,7 @@ import {
   syncWarning,
   workshopBrief,
   workshopTurn,
+  chooseAdapter,
   type AdapterRun,
   type Workshop,
 } from './workshop.js';
@@ -355,6 +356,23 @@ describe('the REPL inside a checkout', () => {
 });
 
 describe('opening a checkout', () => {
+  it('offers every agent and carries the choice into only the first task', async () => {
+    const ws = workshop(checkout(), {
+      adapters: [claude, codex],
+      builder: 'platform',
+      pick: async (choices) => choices[1]!,
+    });
+    expect(await settleBuilder({ api: platform([]), ws, status: 'needs_changes', write: () => undefined })).toBe(
+      'self',
+    );
+    expect(ws.selectedAgent).toBe('codex');
+    ws.pick = async (choices) => choices[0]!;
+    expect((await chooseAdapter(ws)).name).toBe('codex');
+    expect((await chooseAdapter(ws)).name).toBe('claude');
+    ws.pick = async () => '/quit';
+    await expect(chooseAdapter(ws)).rejects.toThrow('selection cancelled');
+  });
+
   it('describes sync, local agents and the builder', async () => {
     const root = checkout();
     writeFileSync(join(root, 'games', SLUG, 'game.ts'), 'B');

--- a/apps/cli/src/workshop.test.ts
+++ b/apps/cli/src/workshop.test.ts
@@ -17,6 +17,7 @@ import {
   workshopBrief,
   workshopTurn,
   chooseAdapter,
+  refreshBuilder,
   type AdapterRun,
   type Workshop,
 } from './workshop.js';
@@ -72,6 +73,7 @@ function workshop(root: string, over: Partial<Workshop> = {}): Workshop {
     pick: async (choices) => choices[0]!,
     abort: { current: null },
     run: () => ({ status: 0, stderr: '' }),
+    runAdapter: async () => ({ code: 0 }),
     ...over,
   };
 }
@@ -356,6 +358,25 @@ describe('the REPL inside a checkout', () => {
 });
 
 describe('opening a checkout', () => {
+  it('retains the chosen agent while a handoff awaits acknowledgement', async () => {
+    const ws = workshop(checkout(), {
+      builder: 'platform',
+      adapters: [claude, codex],
+      pick: async (choices) => choices[1]!,
+    });
+    const api = platform([], (path) =>
+      path.endsWith('/handoff') ? json({ pending: true, builder: 'platform' }, 202) : null,
+    );
+    ws.builder = await settleBuilder({ api, ws, status: 'building', write: () => undefined });
+    expect(ws.builder).toBe('platform');
+    expect(ws.selectedAgent).toBe('codex');
+    await refreshBuilder(api, ws);
+    expect(ws.builder).toBe('self');
+    ws.pick = async () => {
+      throw new Error('must honor the existing choice');
+    };
+    expect((await chooseAdapter(ws)).name).toBe('codex');
+  });
   it('offers every agent and carries the choice into only the first task', async () => {
     const ws = workshop(checkout(), {
       adapters: [claude, codex],
@@ -460,7 +481,7 @@ describe('parseEventLine', () => {
     expect(parseEventLine('{"type":"system","subtype":"init"}')).toBeNull();
     expect(parseEventLine('{"type":"thread.started","thread_id":"t"}')).toBeNull();
     expect(parseEventLine('{"type":"user","message":{"content":[{"type":"tool_result"}]}}')).toBeNull();
-    expect(parseEventLine('not json')).toBeNull();
+    expect(parseEventLine('not json')).toBe('not json');
     expect(parseEventLine('')).toBeNull();
   });
 });

--- a/apps/cli/src/workshop.ts
+++ b/apps/cli/src/workshop.ts
@@ -29,6 +29,7 @@ export type Workshop = {
   token: string;
   env: NodeJS.ProcessEnv;
   adapters: AdapterSpec[];
+  selectedAgent?: string;
   builder: string;
   pick: PickChoice;
   // Ctrl+C aborts the running child through this, not the REPL.
@@ -61,7 +62,12 @@ async function defaultAdapterRun(input: Parameters<AdapterRun>[0]): Promise<{ co
   };
   child.stdout?.on('data', feed);
   child.stderr?.on('data', feed);
-  return { code: await new Promise<number | null>((resolve) => child.once('exit', (value) => resolve(value))) };
+  return {
+    code: await new Promise<number | null>((resolve, reject) => {
+      child.once('error', reject);
+      child.once('close', resolve);
+    }),
+  };
 }
 
 export function workshopBrief(slug: string, request: string, ack?: string): string {
@@ -155,17 +161,22 @@ export async function refreshBuilder(api: ApiClient, ws: Pick<Workshop, 'token' 
 // Asked once per session, only where a local agent could take over.
 export async function settleBuilder(input: {
   api: ApiClient;
-  ws: Pick<Workshop, 'token' | 'slug' | 'adapters' | 'builder' | 'pick'>;
+  ws: Pick<Workshop, 'token' | 'slug' | 'adapters' | 'builder' | 'pick' | 'selectedAgent'>;
   status: string;
   write: (line: string) => void;
 }): Promise<string> {
   const { ws } = input;
   if (!ws.adapters.length || ws.builder === 'self' || isTerminalStatus(input.status)) return ws.builder;
-  const local = `${ws.adapters[0]!.name} here, in this checkout`;
-  const choice = await ws.pick([local, 'the platform — I will /pull afterwards'], `Who builds ${ws.slug}?`);
-  if (choice !== local) return ws.builder;
+  const local = ws.adapters.map((spec) => `${spec.name} here — its own credentials and billing`);
+  const choice = await ws.pick(
+    [...local, 'the platform — uses your gamedev.pl quota; /pull afterwards'],
+    `Who builds ${ws.slug}?`,
+  );
+  const selected = ws.adapters[local.indexOf(choice)];
+  if (!selected) return ws.builder;
   try {
     const outcome = await handoffBuilder(input.api, ws.token, 'self', ws.builder);
+    if (!outcome.pending && outcome.builder === 'self') ws.selectedAgent = selected.name;
     input.write(handoffLine(outcome, ws.slug));
     return outcome.builder;
   } catch (error) {
@@ -194,15 +205,21 @@ export function pickAdapter(ws: Pick<Workshop, 'adapters' | 'env'>, name?: strin
 }
 
 export async function chooseAdapter(
-  ws: Pick<Workshop, 'adapters' | 'env' | 'pick' | 'unattended'>,
+  ws: Pick<Workshop, 'adapters' | 'env' | 'pick' | 'unattended' | 'selectedAgent'>,
   name?: string,
 ): Promise<AdapterSpec> {
+  const selected = ws.selectedAgent;
+  delete ws.selectedAgent;
+  if (!name && selected) return pickAdapter(ws, selected);
   if (name || ws.adapters.length < 2 || ws.unattended) return pickAdapter(ws, name);
   const chosen = await ws.pick(
     ws.adapters.map((spec) => spec.name),
     'Which agent?',
   );
-  return pickAdapter(ws, chosen || ws.adapters[0]!.name);
+  if (!ws.adapters.some((spec) => spec.name === chosen)) {
+    throw new CliError('agent selection cancelled', EXIT_REFUSED, '/delegate when ready');
+  }
+  return pickAdapter(ws, chosen);
 }
 
 export async function runLocalBuild(input: {

--- a/apps/cli/src/workshop.ts
+++ b/apps/cli/src/workshop.ts
@@ -1,6 +1,7 @@
 import { join } from 'node:path';
+import { createInterface } from 'node:readline';
 import type { ApiClient } from './api.js';
-import { detectAdapter, loadAdapters, whichOnPath, type AdapterSpec } from './adapters.js';
+import { detectAdapter, loadAdapters, preflightAdapter, whichOnPath, type AdapterSpec } from './adapters.js';
 import { cliUsage } from './bin-name.js';
 import { formatSyncLines, inspectGame, type SyncResult } from './checkout.js';
 import { childEnv, renderDelegateStream, spawnAdapter } from './delegate.js';
@@ -9,6 +10,8 @@ import { CliError, EXIT_INPUT, EXIT_REFUSED } from './exit-codes.js';
 import { formatSubmitLines, submitGame } from './submit.js';
 import { getStatus, isTerminalStatus } from './turn.js';
 import { runLadder } from './verify.js';
+import type { CliTelemetry } from './telemetry.js';
+import { prepareWorkspace } from './prepare-workspace.js';
 
 export type PickChoice = (choices: string[], question: string) => Promise<string>;
 
@@ -30,6 +33,7 @@ export type Workshop = {
   env: NodeJS.ProcessEnv;
   adapters: AdapterSpec[];
   selectedAgent?: string;
+  telemetry?: CliTelemetry;
   builder: string;
   pick: PickChoice;
   // Ctrl+C aborts the running child through this, not the REPL.
@@ -57,11 +61,9 @@ export function detectLocalAdapters(
 
 async function defaultAdapterRun(input: Parameters<AdapterRun>[0]): Promise<{ code: number | null }> {
   const child = spawnAdapter({ ...input, timeoutMs: ADAPTER_TIMEOUT_MS });
-  const feed = (chunk: Buffer): void => {
-    for (const line of String(chunk).split('\n')) if (line.trim()) input.onLine?.(line);
-  };
-  child.stdout?.on('data', feed);
-  child.stderr?.on('data', feed);
+  for (const stream of [child.stdout, child.stderr]) {
+    if (stream) createInterface({ input: stream }).on('line', (line: string) => input.onLine?.(line));
+  }
   return {
     code: await new Promise<number | null>((resolve, reject) => {
       child.once('error', reject);
@@ -161,13 +163,15 @@ export async function refreshBuilder(api: ApiClient, ws: Pick<Workshop, 'token' 
 // Asked once per session, only where a local agent could take over.
 export async function settleBuilder(input: {
   api: ApiClient;
-  ws: Pick<Workshop, 'token' | 'slug' | 'adapters' | 'builder' | 'pick' | 'selectedAgent'>;
+  ws: Pick<Workshop, 'token' | 'slug' | 'adapters' | 'builder' | 'pick' | 'selectedAgent' | 'telemetry'> &
+    Partial<Pick<Workshop, 'env' | 'runAdapter'>>;
   status: string;
   write: (line: string) => void;
 }): Promise<string> {
   const { ws } = input;
   if (!ws.adapters.length || ws.builder === 'self' || isTerminalStatus(input.status)) return ws.builder;
   const local = ws.adapters.map((spec) => `${spec.name} here — its own credentials and billing`);
+  for (const spec of ws.adapters) ws.telemetry?.record('delegate_offered', spec.name);
   const choice = await ws.pick(
     [...local, 'the platform — uses your gamedev.pl quota; /pull afterwards'],
     `Who builds ${ws.slug}?`,
@@ -175,8 +179,9 @@ export async function settleBuilder(input: {
   const selected = ws.adapters[local.indexOf(choice)];
   if (!selected) return ws.builder;
   try {
+    if (ws.env && !ws.runAdapter) preflightAdapter(selected, ws.env);
     const outcome = await handoffBuilder(input.api, ws.token, 'self', ws.builder);
-    if (!outcome.pending && outcome.builder === 'self') ws.selectedAgent = selected.name;
+    ws.selectedAgent = selected.name;
     input.write(handoffLine(outcome, ws.slug));
     return outcome.builder;
   } catch (error) {
@@ -196,7 +201,7 @@ export function pickAdapter(ws: Pick<Workshop, 'adapters' | 'env'>, name?: strin
   const spec = ws.adapters[0];
   if (!spec) {
     throw new CliError(
-      'no local agent on PATH — install claude, codex, gemini or vibe',
+      'no local agent on PATH — run gamedevpl agents to see supported tools',
       EXIT_REFUSED,
       '/builder platform lets the platform build instead',
     );
@@ -229,12 +234,16 @@ export async function runLocalBuild(input: {
   write: (line: string) => void;
 }): Promise<boolean> {
   const { ws, spec } = input;
+  if (!ws.runAdapter) preflightAdapter(spec, ws.env);
   const cwd = spec.cwd === 'game-dir' ? join(ws.root, 'games', ws.slug) : ws.root;
   const controller = new AbortController();
   ws.abort.current = controller;
   input.write(`▸ ${spec.name} is working in games/${ws.slug} — Ctrl+C stops it`);
   let result: { code: number | null };
   try {
+    if (!ws.runAdapter)
+      await prepareWorkspace({ cwd: ws.root, env: ws.env, abort: controller.signal, write: input.write });
+    ws.telemetry?.record('delegate_used', spec.name);
     result = await (ws.runAdapter ?? defaultAdapterRun)({
       spec,
       prompt: input.brief,
@@ -259,6 +268,7 @@ export async function runLocalBuild(input: {
   input.write('verifying — typecheck, check:static');
   const verify = runLadder({ cwd: ws.root, publish: false, run: ws.run });
   if (!verify.ok) {
+    ws.telemetry?.record('verify_failed', spec.name, verify.stage);
     const detail = verify.detail.split('\n').find((line) => line.trim()) ?? '';
     input.write(`verify failed at ${verify.stage}${detail ? `: ${detail}` : ''}\nfix by hand, or ask again`);
     return false;
@@ -285,6 +295,7 @@ export async function offerSubmit(input: {
   }
   try {
     const result = await submitGame({ api: input.api, slug: ws.slug, dest: ws.root, run: ws.run });
+    if (result.kind === 'delivered') ws.telemetry?.record('delivered');
     input.write(formatSubmitLines(result, ws.slug).join('\n'));
   } catch (error) {
     input.write(formatError(error));

--- a/package-lock.json
+++ b/package-lock.json
@@ -95,8 +95,9 @@
     },
     "apps/cli": {
       "name": "@gamedevpl/cli",
-      "version": "0.1.0",
+      "version": "0.3.0",
       "dependencies": {
+        "@gamedevpl/contract": "*",
         "ink": "^5.2.1",
         "react": "^18.3.1"
       },

--- a/packages/contract/src/visit-vocab.test.ts
+++ b/packages/contract/src/visit-vocab.test.ts
@@ -219,7 +219,7 @@ describe('visit vocab', () => {
   it('lists cli dimension vocabularies', () => {
     expect(CLI_INSTALL_CHANNELS).toEqual(['curl', 'ps1', 'update']);
     expect(CLI_PLATFORM_OS).toEqual(['linux', 'darwin', 'win32']);
-    expect(CLI_ADAPTERS).toEqual(['claude', 'codex', 'gemini', 'vibe', 'custom']);
+    expect(CLI_ADAPTERS).toEqual(['claude', 'codex', 'gemini', 'vibe', 'agy', 'cursor', 'copilot', 'custom']);
     expect(CLI_VERIFY_STAGES).toEqual(['typecheck', 'check_static', 'check_game']);
   });
 });

--- a/packages/contract/src/visit-vocab.ts
+++ b/packages/contract/src/visit-vocab.ts
@@ -179,7 +179,7 @@ export type CliInstallChannel = (typeof CLI_INSTALL_CHANNELS)[number];
 export const CLI_PLATFORM_OS = ['linux', 'darwin', 'win32'] as const;
 export type CliPlatformOs = (typeof CLI_PLATFORM_OS)[number];
 
-export const CLI_ADAPTERS = ['claude', 'codex', 'gemini', 'vibe', 'custom'] as const;
+export const CLI_ADAPTERS = ['claude', 'codex', 'gemini', 'vibe', 'agy', 'cursor', 'copilot', 'custom'] as const;
 export type CliAdapter = (typeof CLI_ADAPTERS)[number];
 
 export const CLI_VERIFY_STAGES = ['typecheck', 'check_static', 'check_game'] as const;


### PR DESCRIPTION
Creators can use an installed coding agent for a new game or revision directly from the CLI. The conversation prepares the request, then lets the creator choose a local agent or the platform builder before dispatch. Cancellation leaves the builder unchanged; pending handoffs retain the selected agent and task for `/retry`.

- `gamedevpl agents`, `/agents`, and the startup hint discover executable tools without sign-in. Local adapters cover Claude, Codex, Gemini, Vibe, agy, Cursor, and Copilot. Launch validates required flags against installed help. Cursor's editor launcher is distinguished from its agent CLI.
- Existing checkouts use the local edit → verify → preview-delivery flow. Without a checkout, Claude/Codex/Copilot receive temporary MCP configuration; other agents get a retained checkout with the pinned Creator Kit and toolchain prepared automatically. New games can bootstrap their checkout from the brief before a first delivery exists.
- MCP credentials are temporary, restricted files and removed even on failure. Child environments exclude creator OAuth/PAT credentials. Streamed progress, cancellation, and process-group termination cover setup and agent execution; unresponsive children receive a bounded kill escalation.
- Anonymous delegation and verification events use the existing CLI funnel vocabulary and endpoint, with a random session identifier and closed adapter/stage dimensions. Prompts, paths, game identifiers, inventories, and credentials are excluded.

Validation: npm install; root type-check, lint, test, and build; CLI bundle and bundled `agents --json` smoke check. All 209 CLI tests pass, including delayed cancellation, pending handoff retry, Copilot MCP cleanup, incompatible/help-output handling, fresh workspace preparation, and forced child termination. API tests verify prepare-only requests do not dispatch and undelivered workspaces contain the brief plus pinned kit. The expanded adapter vocabulary contract test passes after updating its expected enum.

Provider commands were checked through installed help for Claude/Codex/agy/Vibe/Copilot and official documentation for Cursor/Gemini. No paid provider sessions were launched. Users authenticate with their chosen provider; automatic MCP wiring is supported for Claude/Codex/Copilot, while all seven agents support local files. This PR requires the accompanying API changes for selection before dispatch and fresh-game checkout bootstrap.
