### PR TITLE
ci(cli): restore PR-based release workflow with robust label handling

### DIFF
--- a/.claude/skills/cli-release/SKILL.md
+++ b/.claude/skills/cli-release/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: cli-release
-description: How gamedevpl (apps/cli) is versioned and released — the changelog is the source of truth, its categories decide semver, and landing on master automatically cuts and publishes the release. Use whenever you change anything under apps/cli, need to cut or hold a CLI release, or the changelog guard fails in CI.
+description: How gamedevpl (apps/cli) is versioned and released — the changelog is the source of truth, its categories decide semver, and merging the auto-opened release PR is the cutoff. Use whenever you change anything under apps/cli, need to cut or hold a CLI release, or the changelog guard fails in CI.
 ---
 
 # Releasing the gamedevpl CLI
 
 One file drives everything: [`apps/cli/CHANGELOG.md`](../../../apps/cli/CHANGELOG.md).
-You write a line; the machinery derives the version and publishes when your PR lands on master.
-There is no version to remember, no release PR to merge, and no tag to push.
+You write a line; the machinery derives the version, opens the release PR, and publishes
+when a human (or auto-merge) merges it. There is no version to remember and no tag to push.
 
 ## When you change the CLI
 
@@ -32,17 +32,23 @@ header by hand when the CLI is ready to promise stability.
 ## How a release happens
 
 1. Your PR merges to master with an `Unreleased` entry.
-2. `cli-release.yml` runs automatically on master:
-   - checks `release.mjs next` to derive the version from `Breaking`/`Added`/`Fixed`,
-   - executes `release.mjs cut` (moves `Unreleased` under `## X.Y.Z — date`, bumps `apps/cli/package.json` and installer `CLI_VERSION`),
-   - commits back to master with `[skip ci]` and pushes the `cli-vX.Y.Z` tag,
-   - bundles the CLI script, attests build provenance, and publishes the release on GitHub Releases.
-3. `curl | bash` and `gamedevpl update` pick it up immediately. The installer falls back to the
+2. `cli-release-pr.yml` runs `release.mjs cut` on branch `release/cli`: moves
+   `Unreleased` under `## X.Y.Z — date`, bumps `apps/cli/package.json` and the installer's
+   default `CLI_VERSION`, and opens (or refreshes) PR **`release(cli): vX.Y.Z`**. Every
+   later merge to master with more entries updates the same PR — that is batching.
+3. **Merging the release PR is the cutoff commit.** It lands the version on master.
+4. `cli-release.yml` sees `apps/cli/package.json` change, builds the bundle, attests
+   provenance, and publishes `cli-vX.Y.Z` with the changelog section as notes.
+5. `curl | bash` and `gamedevpl update` pick it up. The installer falls back to the
    latest release if its baked-in default is not published yet, so the site deploy and
    the release may land in either order.
 
-To **skip** a release for a change, file it under `### Internal`. To **cut by hand**: push a
-`cli-v*` tag or trigger `workflow_dispatch` on `cli-release.yml`.
+To **hold** a release, leave the release PR open. To **skip** a release for a change,
+file it under `### Internal`. To **cut by hand**: `npm run cli:release -- cut`, commit,
+open a PR — the publish step is the same.
+
+To make it **fully automatic**, set the repository variable `CLI_RELEASE_AUTOMERGE=true`:
+the release PR arms `gh pr merge --auto` and merges itself once checks pass.
 
 ## Local commands
 
@@ -78,7 +84,10 @@ repo in the same session.
 - **No third-party actions in the release workflows.** `softprops/action-gh-release`
   made the workflow fail at startup with zero jobs — every other workflow here uses only
   GitHub-owned actions, and that convention now holds for releases too. `gh` does the job.
-- **The tag is created at publish time**, at the cut commit. Do not pre-push
+- **A PR pushed with `GITHUB_TOKEN` does not trigger CI.** If branch protection requires
+  checks on the release PR, set secret `CLI_RELEASE_TOKEN` (PAT: contents + pull-requests
+  write); the workflow prefers it when present.
+- **The tag is created at publish time**, at the merged cut commit. Do not pre-push
   `cli-v*` tags — a stale tag pointing at an older commit is how `cli-v0.1.0` came to
   label an artifact built from a newer master.
 
@@ -90,5 +99,6 @@ repo in the same session.
 | Parse / bump / cut / notes           | `eslint-rules/cli-changelog-lib.mjs` (+ `.test.mjs`) |
 | PR guard (in `npm run lint` and CI)  | `eslint-rules/cli-changelog-check.mjs`               |
 | `next` / `cut` / `notes` commands    | `apps/cli/scripts/release.mjs`                       |
-| Automated release workflow           | `.github/workflows/cli-release.yml`                  |
+| Release PR proposer                  | `.github/workflows/cli-release-pr.yml`               |
+| Publisher                            | `.github/workflows/cli-release.yml`                  |
 | Installer default version + fallback | `apps/api/src/platform/cli-installers.ts`            |

--- a/.github/workflows/cli-release-pr.yml
+++ b/.github/workflows/cli-release-pr.yml
@@ -1,0 +1,105 @@
+name: CLI release PR
+
+# Proposes the next gamedevpl version whenever master carries unreleased CLI changes.
+# Reads apps/cli/CHANGELOG.md, derives the bump from its Unreleased categories, and
+# keeps one PR on branch release/cli up to date with the cut. Merging that PR is the
+# cutoff commit: it lands the bumped version on master, and cli-release.yml publishes.
+# Nothing to release (only Internal entries, or none) means no PR.
+#
+# Set repository variable CLI_RELEASE_AUTOMERGE=true to let it merge itself once
+# checks pass — the fully automatic mode. Set secret CLI_RELEASE_TOKEN (a PAT with
+# contents + pull-requests write) if branch protection needs CI on the release PR:
+# GITHUB_TOKEN-authored pushes do not trigger workflows.
+on:
+  push:
+    branches: [master]
+    paths:
+      - 'apps/cli/**'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: cli-release-pr
+  cancel-in-progress: true
+
+jobs:
+  propose:
+    name: Propose the next gamedevpl version
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.CLI_RELEASE_TOKEN || github.token }}
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Compute the next version
+        id: next
+        run: |
+          set -euo pipefail
+          version="$(node apps/cli/scripts/release.mjs next)"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          if [ "$version" = "none" ]; then
+            echo "Nothing to release: Unreleased has no Breaking/Added/Fixed entries."
+          else
+            echo "Next: cli-v$version"
+          fi
+      - name: Close a stale release PR
+        if: steps.next.outputs.version == 'none'
+        env:
+          GH_TOKEN: ${{ secrets.CLI_RELEASE_TOKEN || github.token }}
+        run: |
+          set -euo pipefail
+          number="$(gh pr list --head release/cli --state open --json number --jq '.[0].number // empty')"
+          if [ -n "$number" ]; then
+            gh pr close "$number" --comment "Nothing left to release on master; closing. A new PR opens with the next changelog entry." --delete-branch
+          fi
+      - name: Cut on release/cli and open or update the PR
+        if: steps.next.outputs.version != 'none'
+        env:
+          GH_TOKEN: ${{ secrets.CLI_RELEASE_TOKEN || github.token }}
+          VERSION: ${{ steps.next.outputs.version }}
+          AUTOMERGE: ${{ vars.CLI_RELEASE_AUTOMERGE }}
+        run: |
+          set -euo pipefail
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git checkout -B release/cli
+          node apps/cli/scripts/release.mjs cut
+          git add apps/cli/CHANGELOG.md apps/cli/package.json apps/api/src/platform/cli-installers.ts
+          git commit -m "release(cli): v$VERSION" -m "Cut from apps/cli/CHANGELOG.md. Merging publishes cli-v$VERSION."
+          git push --force origin release/cli
+
+          {
+            echo "Merging this PR is the cutoff: it lands \`$VERSION\` on master and publishes \`cli-v$VERSION\` to GitHub Releases."
+            echo
+            echo "Edit the wording in \`apps/cli/CHANGELOG.md\` on this branch if a line reads wrong; the version is derived from the categories, so changing a category changes the number."
+            echo
+            echo "## Notes"
+            echo
+            node apps/cli/scripts/release.mjs notes "$VERSION"
+          } > /tmp/body.md
+
+          gh label create release --description "CLI releases" --color "0e8a16" --force || true
+
+          number="$(gh pr list --head release/cli --state open --json number --jq '.[0].number // empty')"
+          if [ -n "$number" ]; then
+            gh pr edit "$number" --title "release(cli): v$VERSION" --body-file /tmp/body.md
+          else
+            pr_url="$(gh pr create --base master --head release/cli --title "release(cli): v$VERSION" --body-file /tmp/body.md --label release)"
+            number="${pr_url##*/}"
+          fi
+
+          if [ -z "$number" ] || [ "$number" = "null" ]; then
+            echo "::error::Failed to obtain PR number for release/cli"
+            exit 1
+          fi
+
+          echo "Release PR #$number is up to date for cli-v$VERSION."
+          if [ "$AUTOMERGE" = "true" ]; then
+            gh pr merge "$number" --squash --auto || true
+            echo "Auto-merge armed (CLI_RELEASE_AUTOMERGE=true)."
+          fi

--- a/.github/workflows/cli-release.yml
+++ b/.github/workflows/cli-release.yml
@@ -1,35 +1,29 @@
 name: CLI release
 
-# Publishes gamedevpl to GitHub Releases.
-# Runs automatically when master carries unreleased CLI changes:
-#   - reads apps/cli/CHANGELOG.md and derives the version from Breaking/Added/Fixed
-#   - cuts the release and commits back to master with [skip ci]
-#   - bundles the CLI script and attests build provenance
-#   - pushes the cli-v* tag and publishes the GitHub Release
-#   - ensures deploy.yml runs so the updated installer is deployed to Cloud Run
-#
-# Also supports:
-#   - a cli-v* tag push (manual cut)
-#   - workflow_dispatch with a version (manual cut or first-time publish of a specific version)
+# Publishes gamedevpl to GitHub Releases. Three doors, one job:
+#   - master push that changes apps/cli/package.json — the release PR was merged,
+#     so its version is the cutoff (see .claude/skills/cli-release/SKILL.md)
+#   - a cli-v* tag push, for a by-hand cut
+#   - workflow_dispatch with a version, for manual publish
+# A version that already has a release is skipped, so a dependency bump in
+# package.json does not republish.
 on:
   push:
     branches: [master]
     paths:
-      - 'apps/cli/**'
+      - 'apps/cli/package.json'
     tags:
       - 'cli-v*'
   workflow_dispatch:
     inputs:
       version:
-        description: 'CLI version without prefix (e.g. 0.1.0), or "auto" to cut from changelog'
-        required: false
-        default: 'auto'
+        description: 'CLI version without prefix (e.g. 0.1.0)'
+        required: true
 
 permissions:
   contents: write
   id-token: write
   attestations: write
-  actions: write
 
 concurrency:
   group: cli-release
@@ -41,53 +35,26 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          token: ${{ secrets.CLI_RELEASE_TOKEN || github.token }}
-
       - uses: actions/setup-node@v4
         with:
           node-version: '20'
           cache: 'npm'
 
-      - name: Resolve version and cut
+      - name: Resolve the version
         id: version
         env:
-          GH_TOKEN: ${{ secrets.CLI_RELEASE_TOKEN || github.token }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          cut_needed=false
-
           case "${{ github.event_name }}" in
             workflow_dispatch)
-              input_version="${{ github.event.inputs.version }}"
-              if [ -z "$input_version" ] || [ "$input_version" = "auto" ]; then
-                next_version="$(node apps/cli/scripts/release.mjs next)"
-                if [ "$next_version" = "none" ]; then
-                  echo "No release needed: Unreleased has no Breaking/Added/Fixed entries."
-                  echo "skip=true" >> "$GITHUB_OUTPUT"
-                  exit 0
-                fi
-                version="$next_version"
-                cut_needed=true
-              else
-                version="$input_version"
-                cut_needed=false
-              fi
+              version="${{ github.event.inputs.version }}"
               ;;
             push)
               if [[ "$GITHUB_REF" == refs/tags/* ]]; then
                 version="${GITHUB_REF_NAME#cli-v}"
               else
-                # Master push with apps/cli/** changes
-                next_version="$(node apps/cli/scripts/release.mjs next)"
-                if [ "$next_version" = "none" ]; then
-                  echo "No release needed: Unreleased has no Breaking/Added/Fixed entries."
-                  echo "skip=true" >> "$GITHUB_OUTPUT"
-                  exit 0
-                fi
-                version="$next_version"
-                cut_needed=true
+                version="$(node -p "require('./apps/cli/package.json').version")"
               fi
               ;;
             *)
@@ -95,31 +62,12 @@ jobs:
               exit 1
               ;;
           esac
-
           echo "version=$version" >> "$GITHUB_OUTPUT"
-          echo "cut_needed=$cut_needed" >> "$GITHUB_OUTPUT"
-
           if gh release view "cli-v$version" >/dev/null 2>&1; then
             echo "cli-v$version is already published; nothing to do."
             echo "skip=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          echo "skip=false" >> "$GITHUB_OUTPUT"
-
-          if [ "$cut_needed" = "true" ]; then
-            echo "Cutting release cli-v$version..."
-            git checkout master
-            git pull --rebase origin master
-            node apps/cli/scripts/release.mjs cut
-            git config user.name 'github-actions[bot]'
-            git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
-            git add apps/cli/CHANGELOG.md apps/cli/package.json apps/api/src/platform/cli-installers.ts
-            git commit -m "release(cli): v$version [skip ci]"
-            if ! git push origin master; then
-              echo "::error::Failed to push release commit to master. Aborting release."
-              exit 1
-            fi
-            echo "cut_commit=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Install dependencies
@@ -142,18 +90,16 @@ jobs:
       - name: Publish GitHub Release
         if: steps.version.outputs.skip != 'true'
         env:
-          GH_TOKEN: ${{ secrets.CLI_RELEASE_TOKEN || github.token }}
+          GH_TOKEN: ${{ github.token }}
           VERSION: ${{ steps.version.outputs.version }}
-          CUT_COMMIT: ${{ steps.version.outputs.cut_commit }}
         run: |
           set -euo pipefail
-          # Create and push tag only after artifact bundling and attestation succeed
-          target_ref="${CUT_COMMIT:-$GITHUB_SHA}"
+          # Create and push tag at the merged cut commit only after bundling succeeds
           if git ls-remote --tags origin "refs/tags/cli-v$VERSION" | grep -q "cli-v$VERSION"; then
             echo "Tag cli-v$VERSION already exists on origin."
           else
-            echo "Tagging cli-v$VERSION at $target_ref..."
-            git tag "cli-v$VERSION" "$target_ref"
+            echo "Tagging cli-v$VERSION at $GITHUB_SHA..."
+            git tag "cli-v$VERSION" "$GITHUB_SHA"
             git push origin "cli-v$VERSION"
           fi
 
@@ -166,13 +112,3 @@ jobs:
             --latest \
             --notes-file /tmp/notes.md \
             apps/cli/dist/release/*
-
-      - name: Trigger deploy for installer version on master
-        if: steps.version.outputs.skip != 'true' && steps.version.outputs.cut_needed == 'true' && env.HAS_PAT != 'true'
-        env:
-          GH_TOKEN: ${{ github.token }}
-          HAS_PAT: ${{ secrets.CLI_RELEASE_TOKEN != '' }}
-        run: |
-          set -euo pipefail
-          echo "Cut commit was pushed using GITHUB_TOKEN; dispatching deploy workflow so the new installer version takes effect on Cloud Run."
-          gh workflow run deploy.yml --ref master || true

--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -3,7 +3,7 @@
 One line per change, written for a creator reading `gamedevpl update`. The category
 decides the next version — see [`.claude/skills/cli-release/SKILL.md`](../../.claude/skills/cli-release/SKILL.md):
 **Breaking** and **Added** bump minor (major once 1.0 exists), **Fixed** bumps patch,
-**Internal** never cuts a release. Landing on `master` with unreleased entries cuts and publishes.
+**Internal** never cuts a release. Merging the auto-opened `release(cli)` PR is the cutoff.
 
 ## Unreleased
 

--- a/apps/cli/scripts/release.mjs
+++ b/apps/cli/scripts/release.mjs
@@ -4,7 +4,7 @@
 //   node apps/cli/scripts/release.mjs cut [--date D]  move Unreleased under a version, bump versions
 //   node apps/cli/scripts/release.mjs notes 0.2.0     print that version's notes
 //
-// Automatic release on master runs `cut`, commits, tags, and publishes.
+// The auto-opened release PR runs `cut`; merging it is the cutoff commit.
 
 import {
   bumpKind,


### PR DESCRIPTION
## Description
Restores the two-stage PR-based release workflow for `gamedevpl` CLI:
- `cli-release-pr.yml` runs when unreleased entries land on `master` (or via `workflow_dispatch`), computes the version cut from changelog, and opens or updates a single PR on `release/cli` against `master`.
- Merging the `release(cli)` PR lands the version bump on `master` and triggers `cli-release.yml` to build, attest, and publish the GitHub Release and tag.

### Fixes included
- Fixed previous `cli-release-pr.yml` failure where `--label release` failed because the label was missing. Label has been created and the workflow ensures it idempotently with `--force || true`.
- Removed error swallowing (`grep || true`) so errors in PR creation/updating are surfaced cleanly.
- Updated docs (`SKILL.md`, `CHANGELOG.md`, `release.mjs`) to reflect the PR cutoff model.