### PR TITLE
fix(cli): build contract before release bundle

### DIFF
--- a/.claude/skills/cli-release/SKILL.md
+++ b/.claude/skills/cli-release/SKILL.md
@@ -78,6 +78,10 @@ repo in the same session.
 
 ## Traps recorded so far
 
+- **Build the contract before bundling.** CLI telemetry imports runtime values from
+  `@gamedevpl/contract`. `compile-release.sh` builds that workspace so a fresh checkout
+  works; locally cached `packages/contract/dist` can otherwise hide a broken release.
+
 - **`--generate-notes` is never used.** On a first release it wrote the whole repository
   history and hit GitHub's 125 000-character body limit (release run 3, 2026-09-04).
   Notes come from the changelog section.

--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -9,7 +9,7 @@ decides the next version — see [`.claude/skills/cli-release/SKILL.md`](../../.
 
 ### Internal
 
-- Release packaging builds the shared contract before bundling the CLI.
+- Release packaging builds the shared contract before bundling the CLI (#1186).
 
 ## 0.4.0 — 2026-09-06
 

--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -7,6 +7,10 @@ decides the next version — see [`.claude/skills/cli-release/SKILL.md`](../../.
 
 ## Unreleased
 
+### Internal
+
+- Release packaging builds the shared contract before bundling the CLI.
+
 ## 0.4.0 — 2026-09-06
 
 ### Added

--- a/apps/cli/scripts/compile-release.sh
+++ b/apps/cli/scripts/compile-release.sh
@@ -7,6 +7,7 @@ version="${1:-$(node -p "require('$root/package.json').version")}"
 out="$root/dist/release"
 rm -rf "$out"
 mkdir -p "$out"
+npm run build --workspace @gamedevpl/contract --prefix "$root/../.."
 node "$root/scripts/build-binary.mjs"
 install -m 0755 "$root/dist/gamedevpl.mjs" "$out/gamedevpl"
 (cd "$out" && sha256sum gamedevpl > SHA256SUMS)

--- a/package-lock.json
+++ b/package-lock.json
@@ -95,7 +95,7 @@
     },
     "apps/cli": {
       "name": "@gamedevpl/cli",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "dependencies": {
         "@gamedevpl/contract": "*",
         "ink": "^5.2.1",


### PR DESCRIPTION
Release 0.4.0 fails on a fresh runner because CLI telemetry imports runtime values from the unbuilt contract workspace. Build that workspace inside the release packaging script so both local and CI packaging are self-contained. Sync the workspace lockfile version and record the failure mode in the release playbook.

Validation: npm install and full root type-check, lint, test, build passed. Removed the existing contract dist directory, ran compile-release.sh 0.4.0 successfully, and verified the standalone artifact reports 0.4.0 and includes play in help.