### PR TITLE
fix(cli): accept custom agent names in chat

### DIFF
--- a/apps/api/src/creation/cli-chat-routes.test.ts
+++ b/apps/api/src/creation/cli-chat-routes.test.ts
@@ -134,6 +134,16 @@ describe('POST /api/cli/chat', () => {
     await app.close();
   });
 
+  it('accepts custom adapter display names as bounded context data', async () => {
+    const decide = vi.fn(async () => ({ kind: 'reply' as const, text: 'ok' }));
+    const { app, authHeaders: headers } = await createApp({ intakeAgent: { decide } });
+    const agents = ['Claude_Custom', 'My Agent (local)', 'Żółw.dev'];
+    const response = await chat(app, headers, { text: 'hello', session: { agents } });
+    expect(response.statusCode).toBe(200);
+    expect(decide).toHaveBeenCalledWith(expect.objectContaining({ session: expect.objectContaining({ agents }) }));
+    await app.close();
+  });
+
   it('prepares a game without creating or dispatching until the builder is chosen', async () => {
     const {
       app,

--- a/apps/api/src/creation/cli-chat-routes.ts
+++ b/apps/api/src/creation/cli-chat-routes.ts
@@ -29,14 +29,7 @@ const ChatBodySchema = z.object({
         .regex(/^[a-z0-9]+(?:-[a-z0-9]+)*$/)
         .max(100)
         .optional(),
-      agents: z
-        .array(
-          z
-            .string()
-            .regex(/^[a-z0-9-]+$/)
-            .max(40),
-        )
-        .max(20),
+      agents: z.array(z.string().min(1).max(40)).max(20),
     })
     .strict()
     .optional(),

--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -7,6 +7,10 @@ decides the next version — see [`.claude/skills/cli-release/SKILL.md`](../../.
 
 ## Unreleased
 
+### Fixed
+
+- Custom adapter names no longer block conversational requests; oversized optional agent metadata is omitted (#1189).
+
 ## 0.6.0 — 2026-09-07
 
 ### Breaking
@@ -39,8 +43,6 @@ decides the next version — see [`.claude/skills/cli-release/SKILL.md`](../../.
 ## 0.4.1 — 2026-09-06
 
 ### Fixed
-
-- Custom adapter names no longer block conversational requests; oversized optional agent metadata is omitted (#1189).
 
 - The conversational assistant interprets play, status and edit requests using the active game context, including published checkouts (#1187).
 

--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -40,6 +40,8 @@ decides the next version — see [`.claude/skills/cli-release/SKILL.md`](../../.
 
 ### Fixed
 
+- Custom adapter names no longer block conversational requests; oversized optional agent metadata is omitted.
+
 - The conversational assistant interprets play, status and edit requests using the active game context, including published checkouts (#1187).
 
 ### Internal

--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -40,7 +40,7 @@ decides the next version — see [`.claude/skills/cli-release/SKILL.md`](../../.
 
 ### Fixed
 
-- Custom adapter names no longer block conversational requests; oversized optional agent metadata is omitted.
+- Custom adapter names no longer block conversational requests; oversized optional agent metadata is omitted (#1189).
 
 - The conversational assistant interprets play, status and edit requests using the active game context, including published checkouts (#1187).
 

--- a/apps/cli/src/chat.test.ts
+++ b/apps/cli/src/chat.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { ApiClient } from './api.js';
+import { postCliChat } from './chat.js';
+
+describe('assistant agent metadata', () => {
+  it('preserves custom names and bounds optional metadata without mutating adapters', async () => {
+    const request = vi.fn(async () => ({ kind: 'reply', text: 'ok', conversationId: 'c' }));
+    const agents = [
+      'Claude_Custom',
+      'My Agent (local)',
+      'Żółw.dev',
+      '',
+      'x'.repeat(41),
+      ...Array.from({ length: 30 }, (_, index) => `agent_${index}`),
+    ];
+    const original = [...agents];
+    await postCliChat({ request } as unknown as ApiClient, 'hello', undefined, false, { agents });
+    expect(request).toHaveBeenCalledWith('POST', '/api/cli/chat', {
+      text: 'hello',
+      session: {
+        agents: [
+          'Claude_Custom',
+          'My Agent (local)',
+          'Żółw.dev',
+          ...Array.from({ length: 17 }, (_, index) => `agent_${index}`),
+        ],
+      },
+    });
+    expect(agents).toEqual(original);
+  });
+});

--- a/apps/cli/src/chat.ts
+++ b/apps/cli/src/chat.ts
@@ -16,7 +16,16 @@ export async function postCliChat(
 ): Promise<CliChatResult> {
   const result = await api.request<CliChatResult>('POST', '/api/cli/chat', {
     text,
-    ...(session ? { session } : {}),
+    ...(session
+      ? {
+          session: {
+            ...session,
+            agents: session.agents
+              .filter((name) => typeof name === 'string' && name.length > 0 && name.length <= 40)
+              .slice(0, 20),
+          },
+        }
+      : {}),
     ...(conversationId ? { conversationId } : {}),
     ...(prepareOnly ? { prepareOnly: true } : {}),
   });


### PR DESCRIPTION
A configured adapter such as Claude_Custom or My Agent (local) made every conversational turn fail with HTTP 400. Accept bounded display-name strings in session context. The CLI preserves supported names while omitting oversized optional metadata and limiting the context list; adapter configuration and execution names are unchanged.

Regression tests exercise the API with uppercase, underscores, spaces and Unicode, and verify client size/count bounds without mutating input. Validation passed: npm install; full root type-check, lint, test and build. Addresses the Codex finding on #1187.

CLI 0.4.1 was published while this fix was in review. Its notes are preserved; this fix stays in Unreleased for the next patch. The lockfile is synchronized with the published version.