### PR TITLE
feat(cli): show live TUI activity and progress

### DIFF
--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -9,7 +9,7 @@ decides the next version — see [`.claude/skills/cli-release/SKILL.md`](../../.
 
 ### Added
 
-- The TUI shows animated activity, elapsed time and current steps while working, with persistent controls in compact terminals.
+- The TUI shows animated activity, elapsed time and current steps while working, with persistent controls in compact terminals (#1193).
 
 ## 0.4.1 — 2026-09-06
 

--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -7,6 +7,10 @@ decides the next version — see [`.claude/skills/cli-release/SKILL.md`](../../.
 
 ## Unreleased
 
+### Added
+
+- The TUI shows animated activity, elapsed time and current steps while working, with persistent controls in compact terminals.
+
 ## 0.4.1 — 2026-09-06
 
 ### Fixed

--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -176,3 +176,8 @@ cancellation, including waits for another process to finish setup.
 Natural-language requests go through the server-side assistant, including inside a checkout.
 It uses the active game and conversation context to choose play, status, editing or a new
 game, and asks for clarification when needed. `/play` remains a direct shortcut.
+
+While a command runs, the TUI replaces the editor with an animated activity panel,
+current step and elapsed time. Background round updates stay separate from foreground
+work. Ctrl+C interrupts an active agent or exits when no cancellable agent is running.
+The editor returns when work completes; arrow keys recall prompts or navigate choices.

--- a/apps/cli/src/repl.ts
+++ b/apps/cli/src/repl.ts
@@ -42,6 +42,7 @@ export async function handleReplLine(input: {
   pendingExecution?: PendingExecution;
   onWorkshop?: (ws: Workshop) => void;
   write: (s: string) => void;
+  onActivity?: (activity: string) => void;
 }): Promise<ReplLineResult> {
   const retry = input.line.trim() === '/retry' ? input.pendingExecution?.current : undefined;
   if (input.line.trim() === '/retry' && !retry) {
@@ -62,6 +63,7 @@ export async function handleReplLine(input: {
         parsed.args[0] ??
         input.workshop?.slug ??
         (input.token ? (await getStatus(input.api, input.token)).slug : undefined);
+      input.onActivity?.('Starting game preview');
       await playGame({
         cwd: input.workshop?.root ?? process.cwd(),
         slug,
@@ -229,6 +231,7 @@ export async function handleReplLine(input: {
       input.conversationId = result.conversationId;
       if (result.kind === 'action') {
         if (result.action.name === 'play') {
+          input.onActivity?.('Starting game preview');
           await playGame({
             cwd: input.workshop?.root ?? process.cwd(),
             slug: result.action.slug,
@@ -265,6 +268,7 @@ export async function handleReplLine(input: {
           conversationId: result.conversationId,
         };
         try {
+          input.onActivity?.('Running the selected builder');
           opened.workshop = await executeChoice({
             api: input.api,
             choice,
@@ -346,6 +350,7 @@ export async function handleReplLine(input: {
           return { next: 'continue', conversationId: input.conversationId };
         }
         input.write(`▸ build ${result.roundId}${result.ack ? ` — ${result.ack}` : ''}`);
+        input.onActivity?.('Running the selected builder');
         const workshop = await executeChoice({
           api: input.api,
           choice,
@@ -379,6 +384,7 @@ export async function handleReplLine(input: {
       input.write(`the platform builds this round — /pull when it lands, or /builder self to build here`);
       return { next: 'continue', conversationId: input.conversationId };
     }
+    input.onActivity?.('Running the local builder');
     await workshopTurn({ api: input.api, ws, request: trimmed, ack: result.ack, write: input.write });
     return { next: 'continue', conversationId: input.conversationId };
   } catch (error) {

--- a/apps/cli/src/tui/activity.test.ts
+++ b/apps/cli/src/tui/activity.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { ApiClient } from '../api.js';
+import { activityApi } from './activity.js';
+
+describe('foreground progress', () => {
+  it('shows the pending network step and restores builder activity when it completes', async () => {
+    let finish: (value: unknown) => void = () => {};
+    const restore = vi.fn();
+    const update = vi.fn(() => restore);
+    const api = {
+      origin: 'https://example.test',
+      request: vi.fn(
+        () =>
+          new Promise((resolve) => {
+            finish = resolve;
+          }),
+      ),
+    } as unknown as ApiClient;
+    const pending = activityApi(api, update).request('POST', '/api/cli/chat', { text: 'hello' });
+    expect(update).toHaveBeenCalledWith('Thinking about your request');
+    expect(restore).not.toHaveBeenCalled();
+    finish({ kind: 'reply' });
+    await pending;
+    expect(restore).toHaveBeenCalledOnce();
+  });
+  it('restores activity after a failure without exposing tokens in status text', async () => {
+    const restore = vi.fn();
+    const update = vi.fn(() => restore);
+    const api = {
+      request: vi.fn(async () => {
+        throw new Error('offline');
+      }),
+    } as unknown as ApiClient;
+    await expect(activityApi(api, update).request('POST', '/api/submissions/secret-token/turn')).rejects.toThrow(
+      'offline',
+    );
+    expect(update).toHaveBeenCalledWith('Preparing your changes');
+    expect(restore).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/cli/src/tui/activity.ts
+++ b/apps/cli/src/tui/activity.ts
@@ -1,0 +1,34 @@
+import type { ApiClient } from '../api.js';
+
+export function activityForRequest(method: string, path: string): string {
+  if (path === '/api/cli/chat') return 'Thinking about your request';
+  if (path.endsWith('/improve')) return 'Opening an improvement round';
+  if (path.endsWith('/handoff')) return 'Connecting your builder';
+  if (path.endsWith('/turn')) return 'Preparing your changes';
+  if (path.includes('/tree')) return 'Loading game files';
+  if (method === 'POST' && path === '/api/submissions') return 'Creating your game';
+  if (method === 'GET' && path.startsWith('/api/submissions/')) return 'Checking game status';
+  return method === 'GET' ? 'Loading game information' : 'Working with gamedev.pl';
+}
+
+export function activityApi(api: ApiClient, update: (activity: string) => void | (() => void)): ApiClient {
+  return {
+    origin: api.origin,
+    async request(method, path, body) {
+      const restore = update(activityForRequest(method, path));
+      try {
+        return await api.request(method, path, body);
+      } finally {
+        restore?.();
+      }
+    },
+    async requestBytes(path) {
+      const restore = update('Downloading game files');
+      try {
+        return await api.requestBytes(path);
+      } finally {
+        restore?.();
+      }
+    },
+  };
+}

--- a/apps/cli/src/tui/app.test.tsx
+++ b/apps/cli/src/tui/app.test.tsx
@@ -1,0 +1,76 @@
+import { PassThrough } from 'node:stream';
+import { stripVTControlCharacters } from 'node:util';
+import { createElement } from 'react';
+import { render } from 'ink';
+import { afterEach, describe, expect, it } from 'vitest';
+import { ReplApp } from './app.js';
+import { createTuiSession } from './session.js';
+
+const cleanup: Array<() => void> = [];
+afterEach(() => {
+  for (const close of cleanup.splice(0)) close();
+});
+const wait = (ms = 50) => new Promise((resolve) => setTimeout(resolve, ms));
+function screen(columns: number, rows: number) {
+  const session = createTuiSession('');
+  const input = Object.assign(new PassThrough(), { isTTY: true, setRawMode() {}, ref() {}, unref() {} });
+  const output = Object.assign(new PassThrough(), { columns, rows, isTTY: true });
+  const frames: string[] = [];
+  output.on('data', (chunk) => frames.push(stripVTControlCharacters(String(chunk))));
+  const app = render(createElement(ReplApp, { session, color: false }), {
+    stdin: input as unknown as NodeJS.ReadStream,
+    stdout: output as unknown as NodeJS.WriteStream,
+    debug: true,
+    exitOnCtrlC: false,
+    patchConsole: false,
+  });
+  cleanup.push(() => {
+    app.unmount();
+    session.close();
+    input.end();
+    output.end();
+  });
+  return { session, frame: () => frames.filter((frame) => frame.includes('gamedevpl')).at(-1) ?? '' };
+}
+
+describe('TUI feedback', () => {
+  it('immediately replaces input with an animated activity and returns to a ready prompt', async () => {
+    const view = screen(80, 24);
+    const pending = view.session.prompt();
+    await wait();
+    view.session.setDraft('chce zagrac');
+    view.session.submit();
+    await pending;
+    view.session.setActivity('Thinking about your request');
+    await wait();
+    const first = view.frame();
+    expect(first).toContain('Thinking about your request');
+    expect(first).toContain('input paused');
+    expect(first).not.toContain('What would you like');
+    await wait(150);
+    expect(view.frame()).not.toBe(first);
+    void view.session.prompt();
+    await wait();
+    expect(view.frame()).toContain('What would you like to do?');
+    expect(view.frame()).not.toContain('Thinking about your request');
+  });
+  it.each([
+    [40, 12],
+    [80, 24],
+    [120, 40],
+  ])('keeps controls visible at %i × %i with long text and a long picker', async (columns, rows) => {
+    const view = screen(columns, rows);
+    view.session.writeLine('Bardzo długa odpowiedź o grze i aktualizacji '.repeat(30));
+    view.session.setLive(['published', 'https://www.gamedev.pl/play/airtime']);
+    void view.session.prompt(
+      Array.from({ length: 20 }, (_, i) => `Agent ${i + 1} — dostępne narzędzie z bardzo długą nazwą`),
+      'Które narzędzie ma wykonać zmianę?',
+    );
+    view.session.movePick(19);
+    await wait();
+    const frame = view.frame();
+    expect(frame).toContain('20. Agent 20');
+    expect(frame).toContain('gamedevpl');
+    expect(frame.trimEnd().split('\n').length).toBeLessThanOrEqual(rows);
+  });
+});

--- a/apps/cli/src/tui/app.tsx
+++ b/apps/cli/src/tui/app.tsx
@@ -1,3 +1,4 @@
+import { BusyPanel } from './busy.js';
 import { useEffect, useState } from 'react';
 import { Box, Text, useInput, useStdout } from 'ink';
 import { CLI_BIN } from '../bin-name.js';
@@ -62,43 +63,72 @@ export function ReplApp({ session, color }: { session: TuiSession; color: boolea
   const border = color ? 'round' : 'single';
   const accent = color ? 'cyan' : undefined;
   const prompt = glyphs(color).prompt;
-  const body = Math.max(4, rows - 8);
+  const choiceCount = Math.min(state.choices.length, Math.max(1, rows - 10));
+  const choiceStart = Math.max(
+    0,
+    Math.min(state.pickIndex - Math.floor(choiceCount / 2), state.choices.length - choiceCount),
+  );
+  const panelRows = state.mode === 'pick' ? choiceCount + 3 : state.mode === 'busy' ? 2 : 3;
+  const liveRows = Math.min(state.live.length, Math.max(0, rows - panelRows - 4));
+  const body = Math.max(1, rows - panelRows - liveRows - 2);
   const shown = state.lines.slice(-body);
   const footer = `${state.identity || CLI_BIN} · ${CLI_VERSION}`;
   return (
     <Box flexDirection="column" height={rows}>
-      <Box flexDirection="column" flexGrow={1}>
+      <Box flexDirection="column" height={body} flexShrink={0} overflow="hidden" justifyContent="flex-end">
         {shown.map((line, index) => (
           <Text key={`${index}:${line.slice(0, 32)}`} color={color && isMascotLine(line) ? MASCOT_COLOR : undefined}>
             {line}
           </Text>
         ))}
-        {state.live.map((line, index) => (
-          <Text key={`live:${index}:${line.slice(0, 32)}`} dimColor>
+      </Box>
+      <Box flexDirection="column" height={liveRows} flexShrink={0}>
+        {state.live.slice(0, liveRows).map((line, index) => (
+          <Text key={`live:${index}:${line.slice(0, 32)}`} dimColor wrap="truncate-end">
             {line}
           </Text>
         ))}
       </Box>
-      <Box flexDirection="column" borderStyle={border} borderColor={accent} paddingX={1}>
-        {state.mode === 'pick' ? (
-          <>
-            {state.question ? <Text>{state.question}</Text> : null}
-            {state.choices.map((choice, index) => (
-              <Text key={`pick:${index}:${choice}`} color={index === state.pickIndex ? accent : undefined}>
-                {index === state.pickIndex ? '▸ ' : '  '}
-                {choice}
+      {state.mode === 'busy' ? (
+        <BusyPanel activity={state.activity} since={state.busySince} color={color} />
+      ) : (
+        <Box flexDirection="column" flexShrink={0} borderStyle={border} borderColor={accent} paddingX={1}>
+          {state.mode === 'pick' ? (
+            <>
+              <Text bold wrap="truncate-end">
+                {state.question || 'Choose an option'}
               </Text>
-            ))}
-          </>
-        ) : state.mode === 'busy' ? (
-          <Text dimColor>▸ …</Text>
-        ) : (
-          <Text>
-            {prompt} {state.draft}█
-          </Text>
-        )}
-      </Box>
-      <Text dimColor>{footer}</Text>
+              {state.choices.slice(choiceStart, choiceStart + choiceCount).map((choice, offset) => {
+                const index = choiceStart + offset;
+                return (
+                  <Text
+                    wrap="truncate-end"
+                    key={`pick:${index}:${choice}`}
+                    color={index === state.pickIndex ? accent : undefined}
+                  >
+                    {index === state.pickIndex ? '▸ ' : '  '}
+                    {index + 1}. {choice}
+                  </Text>
+                );
+              })}
+            </>
+          ) : (
+            <Text wrap="truncate-start">
+              {prompt} {state.draft ? `${state.draft}█` : <Text dimColor>What would you like to do? /help</Text>}
+            </Text>
+          )}
+        </Box>
+      )}
+      <Text dimColor wrap="truncate-end">
+        {state.mode === 'pick'
+          ? `↑↓ select · Enter · Esc · ${state.pickIndex + 1}/${state.choices.length}`
+          : state.mode === 'prompt'
+            ? 'Enter send · ↑↓ history · Esc/Ctrl+C'
+            : 'Working — input paused'}
+      </Text>
+      <Text dimColor wrap="truncate-end">
+        {footer}
+      </Text>
     </Box>
   );
 }

--- a/apps/cli/src/tui/busy.tsx
+++ b/apps/cli/src/tui/busy.tsx
@@ -1,0 +1,30 @@
+import { useEffect, useState } from 'react';
+import { Box, Text } from 'ink';
+
+const FRAMES = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'];
+
+export function BusyPanel({ activity, since, color }: { activity: string; since: number; color: boolean }) {
+  const [tick, setTick] = useState(0);
+  useEffect(() => {
+    const timer = setInterval(() => setTick((value) => value + 1), 100);
+    return () => clearInterval(timer);
+  }, []);
+  const elapsed = Math.max(0, Math.floor((Date.now() - since) / 1000));
+  const duration = elapsed < 60 ? `${elapsed}s` : `${Math.floor(elapsed / 60)}m ${elapsed % 60}s`;
+  return (
+    <Box flexDirection="column" paddingX={1}>
+      <Box>
+        <Text color={color ? 'cyan' : undefined}>{color ? FRAMES[tick % FRAMES.length] : '|/-\\'[tick % 4]} </Text>
+        <Box flexGrow={1} flexShrink={1}>
+          <Text bold wrap="truncate-end">
+            {activity}
+          </Text>
+        </Box>
+        <Text dimColor> {duration}</Text>
+      </Box>
+      <Text dimColor wrap="truncate-end">
+        {elapsed >= 15 ? 'Still working — Ctrl+C to stop / exit' : 'Ctrl+C to stop / exit'}
+      </Text>
+    </Box>
+  );
+}

--- a/apps/cli/src/tui/host.ts
+++ b/apps/cli/src/tui/host.ts
@@ -1,3 +1,4 @@
+import { activityApi } from './activity.js';
 import type { PendingExecution } from '../execution.js';
 import { render } from 'ink';
 import { createElement } from 'react';
@@ -34,6 +35,11 @@ export async function runInkRepl(input: {
     session.close();
     host.instance?.unmount();
     process.exit(EXIT_GREEN);
+  });
+  const foregroundApi = activityApi(input.api, (activity) => {
+    const previous = session.get().activity;
+    session.setActivity(activity);
+    return () => session.setActivity(previous);
   });
   host.instance = render(createElement(ReplApp, { session, color }), {
     stdin: input.io.stdin,
@@ -89,7 +95,7 @@ export async function runInkRepl(input: {
       try {
         result = await handleReplLine({
           line,
-          api: input.api,
+          api: foregroundApi,
           token,
           conversationId,
           workshop,
@@ -101,6 +107,7 @@ export async function runInkRepl(input: {
           onWorkshop: (opened) => {
             workshop = opened;
           },
+          onActivity: (activity) => session.setActivity(activity),
           write: (text) => session.writeLine(text),
         });
       } catch (error) {

--- a/apps/cli/src/tui/session.ts
+++ b/apps/cli/src/tui/session.ts
@@ -6,6 +6,8 @@ export type TuiState = {
   identity: string;
   question: string;
   mode: TuiMode;
+  activity: string;
+  busySince: number;
   draft: string;
   choices: string[];
   pickIndex: number;
@@ -17,6 +19,7 @@ export type TuiSession = {
   writeLine: (text: string) => void;
   setLive: (live: string[]) => void;
   setIdentity: (identity: string) => void;
+  setActivity: (activity: string) => void;
   setDraft: (draft: string) => void;
   deleteLast: () => void;
   movePick: (delta: number) => void;
@@ -39,6 +42,8 @@ export function createTuiSession(banner: string, onBusyCancel?: () => void): Tui
     identity: '',
     question: '',
     mode: 'busy',
+    activity: 'Starting gamedevpl',
+    busySince: Date.now(),
     draft: '',
     choices: [],
     pickIndex: 0,
@@ -70,6 +75,11 @@ export function createTuiSession(banner: string, onBusyCancel?: () => void): Tui
     },
     setLive(live) {
       state = { ...state, live: live.slice(0, 4) };
+      emit();
+    },
+    setActivity(activity) {
+      if (state.mode !== 'busy') return;
+      state = { ...state, activity };
       emit();
     },
     setIdentity(identity) {
@@ -143,7 +153,17 @@ export function createTuiSession(banner: string, onBusyCancel?: () => void): Tui
       }
       histIndex = history.length;
       stash = '';
-      state = { ...state, lines: spoken, mode: 'busy', draft: '', choices: [], question: '', pickIndex: 0 };
+      state = {
+        ...state,
+        lines: spoken,
+        mode: 'busy',
+        activity: state.mode === 'pick' ? 'Continuing' : 'Working on your request',
+        busySince: Date.now(),
+        draft: '',
+        choices: [],
+        question: '',
+        pickIndex: 0,
+      };
       emit();
       resolve(line);
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -95,7 +95,7 @@
     },
     "apps/cli": {
       "name": "@gamedevpl/cli",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "dependencies": {
         "@gamedevpl/contract": "*",
         "ink": "^5.2.1",


### PR DESCRIPTION
Submitting a prompt previously left an input-shaped box with a static ellipsis, making the CLI look idle. Replace it during work with an animated activity panel, elapsed time, and interrupt/exit guidance. Show meaningful foreground API stages and local preview/builder activity, then restore the editor when work completes. Background round polling does not overwrite foreground activity.

Keep the transcript, live status and controls within the terminal height. Window long option lists around the selected item, show numbered choices and concise keyboard hints, and keep long input tails visible. Support color and monochrome rendering without extra dependencies.

Validation: npm install, type-check, lint, test and build all passed. Tests render real Ink components at 40×12, 80×24 and 120×40, including long Polish text and 20 options; animation, prompt restoration and foreground request completion/failure are covered. Manually inspected actual Ink frames for busy, picker and prompt.
