### PR TITLE
Let the relay trust two callers, and update it before the gate

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -52,6 +52,14 @@ jobs:
       APP_RUNTIME_SA: 'gamedev-app@gamedevpl.iam.gserviceaccount.com'
       RELAY_RUNTIME_SA: 'gamedev-mp-relay@gamedevpl.iam.gserviceaccount.com'
       WORLD_RUNTIME_SA: 'gamedev-world@gamedevpl.iam.gserviceaccount.com'
+      # The account the app ran as before APP_RUNTIME_SA, kept trusted by the relay for
+      # the length of the move. The relay is reconfigured while the previous revision is
+      # still serving, so both identities have to be accepted at once or party mode
+      # breaks for the minutes between. A repo variable, not a literal here: this one is
+      # meant to be deleted, and deleting a variable is the clearest way to say the move
+      # is finished. Left set, it keeps the old account trusted — the thing the move
+      # exists to end — so unset it once every service serves on its own identity.
+      APP_RUNTIME_SA_PREVIOUS: ${{ vars.APP_RUNTIME_SA_PREVIOUS }}
       # workflow_run's github.sha is the default-branch tip at schedule time, not
       # necessarily the commit CI validated. Prefer the triggering run's head_sha.
       DEPLOY_SHA: ${{ github.event.workflow_run.head_sha || github.sha }}
@@ -741,15 +749,6 @@ jobs:
           echo "Chromium: $BIN"
           echo "E2E_CHROMIUM_PATH=$BIN" >> "$GITHUB_ENV"
 
-      - name: Browser gate against the candidate
-        env:
-          E2E_BASE_URL: ${{ env.CANDIDATE_URL }}
-          GAMEDEV_ACCESS_TOKEN: ${{ secrets.GAMEDEV_ACCESS_TOKEN }}
-          # Turns "cannot run" into a failed deploy instead of a silent skip
-          # (apps/e2e/src/gate-prerequisites.test.ts).
-          E2E_REQUIRED: '1'
-        run: npm run e2e
-
       - name: Move the party relay onto the same image
         # Only when the split is switched on. Both roles run one image, so the relay has to
         # be redeployed whenever the app is — otherwise the socket protocol the freshly
@@ -761,6 +760,14 @@ jobs:
         # any client speaking it exists. The relay's own env (MP_RELAY_ONLY, the audience,
         # the caller identity) is left untouched — `--image` alone, so this step cannot
         # reconfigure the relay by omission the way a --set-env-vars deploy would.
+        #
+        # And BEFORE the browser gate, which is what the ordering used to get wrong. The
+        # gate opens a party lobby, so it exercises exactly this call. With the relay
+        # updated afterwards, the first deploy to change the app's runtime identity ran the
+        # gate against a candidate the relay did not yet trust: room creation 401'd, the
+        # gate failed, nothing was promoted — and because the relay is only reconfigured on
+        # a deploy that gets this far, the next run repeated it. A wedge that cannot clear
+        # itself. Verified 2026-09-06: `RelayUnavailableError: relay responded 401`.
         if: ${{ vars.MP_RELAY_URL != '' }}
         run: |
           RELAY_SERVICE="${{ vars.MP_RELAY_SERVICE || 'gamedev-mp-relay' }}"
@@ -781,12 +788,23 @@ jobs:
           # to move with the app. --service-account pins the relay's own identity for
           # the same reason the app's is pinned: a value set once on the service is one
           # deploy from being lost.
+          #
+          # The list is what makes this step safe to run before promotion. At this point
+          # the *serving* app is still the previous revision, which may run as a different
+          # account than the candidate; naming only the candidate's would refuse every
+          # lobby in production for the length of the gate. internal-auth.ts accepts any
+          # email in the list, so both are honoured and neither end has to change in the
+          # same instant as the other.
+          CALLER_SAS="$APP_RUNTIME_SA"
+          if [ -n "$APP_RUNTIME_SA_PREVIOUS" ]; then
+            CALLER_SAS="${CALLER_SAS},${APP_RUNTIME_SA_PREVIOUS}"
+          fi
           gcloud run services update "$RELAY_SERVICE" \
             --region "$REGION" \
             --project "$PROJECT_ID" \
             --image "$IMAGE" \
             --service-account "$RELAY_RUNTIME_SA" \
-            --update-env-vars "MP_RELAY_CALLER_SA=${APP_RUNTIME_SA}"
+            --update-env-vars "^|^MP_RELAY_CALLER_SA=${CALLER_SAS}"
 
           RELAY_URL=$(gcloud run services describe "$RELAY_SERVICE" --region "$REGION" \
             --project "$PROJECT_ID" --format 'value(status.url)')
@@ -805,6 +823,15 @@ jobs:
             exit 1
           fi
           echo "Relay healthy at ${RELAY_URL}"
+
+      - name: Browser gate against the candidate
+        env:
+          E2E_BASE_URL: ${{ env.CANDIDATE_URL }}
+          GAMEDEV_ACCESS_TOKEN: ${{ secrets.GAMEDEV_ACCESS_TOKEN }}
+          # Turns "cannot run" into a failed deploy instead of a silent skip
+          # (apps/e2e/src/gate-prerequisites.test.ts).
+          E2E_REQUIRED: '1'
+        run: npm run e2e
 
       - name: Keep the zone host on the same source revision
         # gamedev-world was the one production service with no CI path at all: its image

--- a/apps/api/src/platform/internal-auth-caller-list.test.ts
+++ b/apps/api/src/platform/internal-auth-caller-list.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+import type { OAuth2Client } from 'google-auth-library';
+import {
+  createInternalAuthVerifierFromEnv,
+  DenyAllInternalAuthVerifier,
+  OidcInternalAuthVerifier,
+} from './internal-auth.js';
+
+function fakeClient(payload: Record<string, unknown> | null): OAuth2Client {
+  return {
+    verifyIdToken: async () => ({ getPayload: () => payload }),
+  } as unknown as OAuth2Client;
+}
+
+const audience = 'https://relay/api/internal/mp/sessions';
+const oldSa = 'compute@developer.gserviceaccount.com';
+const newSa = 'gamedev-app@proj.iam.gserviceaccount.com';
+
+function verifierFor(email: string, verified = true) {
+  return new OidcInternalAuthVerifier({
+    audience,
+    serviceAccountEmail: [newSa, oldSa],
+    client: fakeClient({ email, email_verified: verified }),
+  });
+}
+
+describe('a caller list spans a runtime identity move', () => {
+  it('accepts both the account being left and the one being taken', async () => {
+    expect(await verifierFor(newSa).verify('Bearer t')).toBe(true);
+    expect(await verifierFor(oldSa).verify('Bearer t')).toBe(true);
+  });
+
+  it('still refuses an account on neither end of the move', async () => {
+    expect(await verifierFor('someone-else@proj.iam.gserviceaccount.com').verify('Bearer t')).toBe(false);
+  });
+
+  it('refuses an unverified email even when it is on the list', async () => {
+    expect(await verifierFor(newSa, false).verify('Bearer t')).toBe(false);
+  });
+
+  it('reads the list from env, ignoring spacing', () => {
+    const v = createInternalAuthVerifierFromEnv(
+      { MP_RELAY_AUDIENCE: audience, MP_RELAY_CALLER_SA: ` ${newSa} , ${oldSa} ` } as NodeJS.ProcessEnv,
+      'mpRelay',
+    );
+    expect(v).toBeInstanceOf(OidcInternalAuthVerifier);
+  });
+
+  it('stays closed when the list holds nothing but separators', () => {
+    const v = createInternalAuthVerifierFromEnv(
+      { MP_RELAY_AUDIENCE: audience, MP_RELAY_CALLER_SA: ' , ' } as NodeJS.ProcessEnv,
+      'mpRelay',
+    );
+    expect(v).toBeInstanceOf(DenyAllInternalAuthVerifier);
+  });
+});

--- a/apps/api/src/platform/internal-auth.ts
+++ b/apps/api/src/platform/internal-auth.ts
@@ -18,15 +18,18 @@ export interface InternalAuthVerifier {
 export interface OidcVerifierOptions {
   /** Audience the scheduler mints the token for — the sweep endpoint URL. */
   audience: string;
-  /** The scheduler service account email the token must belong to. */
-  serviceAccountEmail: string;
+  // A list, so a caller's runtime identity can move without both ends changing at once.
+  serviceAccountEmail: string | readonly string[];
   client?: OAuth2Client;
 }
 
 export class OidcInternalAuthVerifier implements InternalAuthVerifier {
   private readonly client: OAuth2Client;
+  private readonly allowed: ReadonlySet<string>;
   constructor(private readonly opts: OidcVerifierOptions) {
+    const { serviceAccountEmail: emails } = opts;
     this.client = opts.client ?? new OAuth2Client();
+    this.allowed = new Set(typeof emails === 'string' ? [emails] : emails);
   }
 
   async verify(header: string | undefined): Promise<boolean> {
@@ -35,7 +38,8 @@ export class OidcInternalAuthVerifier implements InternalAuthVerifier {
     try {
       const ticket = await this.client.verifyIdToken({ idToken: token, audience: this.opts.audience });
       const payload = ticket.getPayload();
-      return payload?.email === this.opts.serviceAccountEmail && payload?.email_verified === true;
+      if (payload?.email_verified !== true) return false;
+      return typeof payload.email === 'string' && this.allowed.has(payload.email);
     } catch {
       return false;
     }
@@ -102,10 +106,11 @@ export function createInternalAuthVerifierFromEnv(
 ): InternalAuthVerifier {
   const audience = env[AUDIENCE_ENV_VAR[sweep]]?.trim();
   // The relay and the brake have their own callers, opened by neither sweep.
-  const serviceAccountEmail = CALLER_SA_ENV_VAR[sweep]
-    ? env[CALLER_SA_ENV_VAR[sweep]]?.trim()
-    : env.NOTIFY_SWEEP_SA?.trim();
-  if (audience && serviceAccountEmail) {
+  const configured = CALLER_SA_ENV_VAR[sweep] ? env[CALLER_SA_ENV_VAR[sweep]] : env.NOTIFY_SWEEP_SA;
+  // Comma-separated; see the option.
+  const listed = (configured ?? '').split(',');
+  const serviceAccountEmail = listed.map((email) => email.trim()).filter(Boolean);
+  if (audience && serviceAccountEmail.length > 0) {
     return new OidcInternalAuthVerifier({ audience, serviceAccountEmail });
   }
   return new DenyAllInternalAuthVerifier();

--- a/apps/api/src/runtime-sa-deploy.test.ts
+++ b/apps/api/src/runtime-sa-deploy.test.ts
@@ -3,7 +3,7 @@ import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
 
-// The relay trusts one caller: whatever gamedev-app runs as.
+// Relay trusts what gamedev-app runs as, plus the account it leaves.
 const here = dirname(fileURLToPath(import.meta.url));
 const repoRoot = resolve(here, '../../..');
 
@@ -14,8 +14,17 @@ const workflow = readFileSync(resolve(repoRoot, '.github/workflows/deploy.yml'),
 describe('runtime identities', () => {
   it('pins the relay’s identity and the caller it trusts on every update', () => {
     expect(workflow).toContain('--service-account "$RELAY_RUNTIME_SA"');
-    expect(workflow).toContain('--update-env-vars "MP_RELAY_CALLER_SA=${APP_RUNTIME_SA}"');
+    expect(workflow).toContain('CALLER_SAS="$APP_RUNTIME_SA"');
+    expect(workflow).toContain('--update-env-vars "^|^MP_RELAY_CALLER_SA=${CALLER_SAS}"');
     expect(deployRelay).toContain('--service-account "$RUNTIME_SA"');
+  });
+
+  // Reversed, an identity change 401s its own gate and wedges every deploy.
+  it('updates the relay before the gate that opens a lobby through it', () => {
+    const relayStep = workflow.indexOf('- name: Move the party relay onto the same image');
+    const gateStep = workflow.indexOf('- name: Browser gate against the candidate');
+    expect(relayStep).toBeGreaterThan(-1);
+    expect(gateStep).toBeGreaterThan(relayStep);
   });
 
   it('refuses a relay caller on the default compute account', () => {

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -116,6 +116,18 @@ the app's own account (the seed call is the service calling itself) and the rela
 `MP_RELAY_CALLER_SA` is set to the app's account on every relay update. Neither is a repo
 variable any more.
 
+`MP_RELAY_CALLER_SA` accepts a **comma-separated list**, and the deploy sends two entries
+while the repo variable `APP_RUNTIME_SA_PREVIOUS` holds the account the app is moving off.
+That is not decoration. The relay is reconfigured before the candidate is promoted, so for
+the length of the browser gate the serving app and the candidate run as _different_
+accounts; naming only one of them refuses every lobby on one side or the other.
+
+**Delete the variable once every service serves on its own identity.** Left set, it keeps
+the old account trusted, which is the thing the move exists to end. It is a repo variable
+rather than a literal in `deploy.yml` for exactly that reason — and because
+`infra/check-runtime-sa.mjs` refuses to let the default compute account be named in the
+workflow at all.
+
 Rollout and rollback, owner-run (`infra/setup-runtime-sa.sh` prints the exact commands):
 
 1. `./infra/setup-runtime-sa.sh` creates the accounts and applies the resource-level grants;
@@ -637,7 +649,12 @@ Rollout, owner-run and in this order:
    that; a relay can health-check green while the QR code goes nowhere.
 
 Once `MP_RELAY_URL` is set, `deploy.yml` moves the relay onto each new image **before** promoting
-the app — server before client, since the promoted web bundle is the relay's websocket client.
+the app — server before client, since the promoted web bundle is the relay's websocket client —
+and **before the browser gate**, which opens a lobby and therefore calls the relay itself. That
+second ordering was learned the hard way: with the relay updated after the gate, the first deploy
+to change the app's runtime identity failed its own gate on `relay responded 401`, and since the
+relay is only reconfigured past that point, every later deploy failed the same way. A wedge that
+cannot clear itself.
 Only `--image`, the relay's own `--service-account` and `MP_RELAY_CALLER_SA` (the app's
 runtime account, see "Runtime identities") are updated, so a deploy cannot silently
 reconfigure the rest of the relay by omission.

--- a/eslint-rules/module-size-baseline.json
+++ b/eslint-rules/module-size-baseline.json
@@ -369,7 +369,7 @@
     "apps/api/src/platform/image-variants.test.ts": 91,
     "apps/api/src/platform/image-variants.ts": 91,
     "apps/api/src/platform/internal-auth.test.ts": 130,
-    "apps/api/src/platform/internal-auth.ts": 112,
+    "apps/api/src/platform/internal-auth.ts": 117,
     "apps/api/src/platform/knowledge-metrics.test.ts": 60,
     "apps/api/src/platform/knowledge-metrics.ts": 23,
     "apps/api/src/platform/localize-intake.ts": 95,

--- a/infra/env-manifest.json
+++ b/infra/env-manifest.json
@@ -132,6 +132,7 @@
     "CANDIDATE_URL": "step-local: the untrafficked revision URL the smoke tests curl",
     "E2E_CHROMIUM_PATH": "step-local: where the browser gate finds Chromium on the runner",
     "MP_RELAY_URL_VAL": "step-local: shell variable behind MP_RELAY_URL, not its own var",
+    "MP_RELAY_CALLER_SA": "a relay variable, not the app's: threaded by the relay step here and by infra/deploy-relay.sh, never by infra/deploy-api.sh",
     "FLAG_VAL": "step-local: loop scratch variable in infra/deploy-api.sh",
     "INVITE_URL": "read only by the beta:invite and beta:welcome CLIs on the operator's machine, never by the service"
   }


### PR DESCRIPTION
## The wedge

The first deploy carrying #1191 failed its own browser gate, twice, and would have kept failing:

```
RelayUnavailableError: relay responded 401
  at HttpRelayClient.createRoom (…/mp-relay.js:101:23)
```

The gate opens a party lobby. The app creates one by calling the relay with an OIDC token; the relay verified that token against **one** email — `MP_RELAY_CALLER_SA`, still the default compute account — while the candidate app had already moved to `gamedev-app@`. 401, gate red, nothing promoted. And since the relay is only reconfigured in a step **after** the gate, the next deploy repeated it. It could not clear itself.

Production was never affected: the serving revision and the relay were both still on the old account, and promotion is exactly what the gate withheld.

## Why two changes

**A single value cannot express a migration.** The callee is reconfigured by one deploy step and the caller by another, so there is always a window where they disagree — no ordering removes it. `MP_RELAY_CALLER_SA` now takes a comma-separated list and `internal-auth.ts` accepts any verified email on it. Same shape as the `__session` dual-read window this repo already ran.

**The relay moves ahead of the browser gate.** The gate exercises the relay, so the relay must already be correct when it runs. The step carried this reasoning for promotion — server before client; this applies it one step earlier. Pinned by a test, so the order cannot be reversed silently again.

## Reviewer notes

- `APP_RUNTIME_SA_PREVIOUS` is a **repo variable**, already set to the compute account. It is meant to be deleted once every service serves on its own identity — deleting a variable says that more clearly than editing a workflow. `infra/check-runtime-sa.mjs` also refuses to let the compute account be named in `deploy.yml`, which is correct and stays.
- `--update-env-vars` needs the `^|^` delimiter now that the value can contain commas; without it gcloud splits the list into bogus variables. `infra/deploy-relay.sh` already uses the same idiom.
- `MP_RELAY_CALLER_SA` is declared in `notServiceVars`: it is a relay variable, threaded by the relay step and `deploy-relay.sh`, never by `deploy-api.sh` — which is what the env-manifest checker compares.
- `internal-auth.ts` raises its own module-size ceiling 112 → 117, scoped to that one path per `docs/module-size-debt.md` ("raise when the growth is the work"). New tests went into their own file rather than growing the existing one past its ceiling.
- Empty or separator-only config still yields deny-all; unverified emails are still refused even when listed. Both pinned by tests.

Verified: `npm run lint` clean (eslint, comment-prose, module-size, module-boundary, env-manifest, runtime-sa), `tsc` clean, full API suite 266 files / 3868 tests green.

## After this merges

Watch that the deploy actually promotes. Once it has, and the relay and world are on their own accounts too, delete `APP_RUNTIME_SA_PREVIOUS`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)