### PR TITLE
fix(cli): guard Claude billing and show agent state

### DIFF
--- a/.claude/skills/verify-agent-work/SKILL.md
+++ b/.claude/skills/verify-agent-work/SKILL.md
@@ -310,6 +310,11 @@ Two concrete instances of that (observed 2026-07-23):
   well as the parser, and exercise each action on its real lifecycle state. Published
   edits need `/improve` and its new token, not the closed round's `/turn`.
 
+- **Exercise auth variants and partial agent failures.** CLI #1201 initially accepted only
+  `claude.ai`, rejecting subscription `oauth_token` logins, and treated any tool denial as
+  failure of the entire edit. Test each supported login source and an exit-zero run with
+  completed edits plus one denied tool. An agent's denial list is not a task verdict.
+
 ## Read the diff against the spec
 
 A passing test suite doesn't catch scope creep, subtle regressions, or malice.

--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -13,7 +13,13 @@ decides the next version — see [`.claude/skills/cli-release/SKILL.md`](../../.
 
 ### Fixed
 
-- Claude tasks verify subscription authentication and refuse API billing; local agent choices survive failed requests, live status follows new rounds, and verification errors retain their details (#1201).
+- Claude subscription checks accept setup-token logins, stay responsive and explain incompatible CLI versions (#1201).
+- Local agent choices survive failed requests (#1201).
+- Live status follows new rounds and reports the active agent and tool (#1201).
+- Verification errors retain filenames and full diagnostic details (#1201).
+- Antigravity events are readable and an empty run with denied permissions cannot claim success (#1201).
+- Partial Claude tool refusals do not prevent verification of completed edits (#1201).
+- Session resume instructions identify the correct agent (#1201).
 
 ## 0.5.1 — 2026-09-07
 

--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -7,6 +7,14 @@ decides the next version — see [`.claude/skills/cli-release/SKILL.md`](../../.
 
 ## Unreleased
 
+### Breaking
+
+- Claude delegation requires a verified Claude.ai subscription login; inherited API and cloud-provider credentials are no longer used.
+
+### Fixed
+
+- Claude tasks verify subscription authentication and refuse API billing; local agent choices survive failed requests, live status follows new rounds, and verification errors retain their details.
+
 ## 0.5.1 — 2026-09-07
 
 ### Fixed

--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -9,11 +9,11 @@ decides the next version — see [`.claude/skills/cli-release/SKILL.md`](../../.
 
 ### Breaking
 
-- Claude delegation requires a verified Claude.ai subscription login; inherited API and cloud-provider credentials are no longer used.
+- Claude delegation requires a verified Claude.ai subscription login; inherited API and cloud-provider credentials are no longer used (#1201).
 
 ### Fixed
 
-- Claude tasks verify subscription authentication and refuse API billing; local agent choices survive failed requests, live status follows new rounds, and verification errors retain their details.
+- Claude tasks verify subscription authentication and refuse API billing; local agent choices survive failed requests, live status follows new rounds, and verification errors retain their details (#1201).
 
 ## 0.5.1 — 2026-09-07
 

--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -185,10 +185,14 @@ The editor returns when work completes; arrow keys recall prompts or navigate ch
 ### Claude authentication and local sessions
 
 Claude delegation requires Claude.ai subscription authentication. The CLI removes inherited
-Anthropic API/provider environment settings only from the child process and checks
+Anthropic credentials, authentication headers and provider-routing environment settings only from the child process and checks
 `claude auth status --json` in the task directory before launching. An API login, a
 settings-level API override, or an unverifiable login stops the task instead of falling
-back to API billing. Sign in with `claude auth login` using your subscription to continue.
+back to API billing. Both Claude.ai login and `CLAUDE_CODE_OAUTH_TOKEN` from `claude setup-token`
+are accepted. Older versions without `auth status` require a Claude Code update.
+The check is asynchronous and cancellable; local preparation and delegation telemetry wait
+for it. Its result is reused for that launch, then checked afresh for the next task so
+account or settings changes cannot reuse a stale approval. Model-selection settings remain intact.
 Your parent shell and stored credentials are not modified. Subscription limits and any
 extra-usage settings remain controlled by Claude; this check is not a promise of unlimited usage.
 

--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -181,3 +181,18 @@ While a command runs, the TUI replaces the editor with an animated activity pane
 current step and elapsed time. Background round updates stay separate from foreground
 work. Ctrl+C interrupts an active agent or exits when no cancellable agent is running.
 The editor returns when work completes; arrow keys recall prompts or navigate choices.
+
+### Claude authentication and local sessions
+
+Claude delegation requires Claude.ai subscription authentication. The CLI removes inherited
+Anthropic API/provider environment settings only from the child process and checks
+`claude auth status --json` in the task directory before launching. An API login, a
+settings-level API override, or an unverifiable login stops the task instead of falling
+back to API billing. Sign in with `claude auth login` using your subscription to continue.
+Your parent shell and stored credentials are not modified. Subscription limits and any
+extra-usage settings remain controlled by Claude; this check is not a promise of unlimited usage.
+
+These are local `claude -p` tasks, not sessions created in Claude Desktop. When Claude
+emits its session ID, the CLI shows it with a resume command. Resume only after the
+current task finishes. The task panel names the active agent and reports tool activity;
+the CLI runs the checkout validation after the agent exits and retains error details.

--- a/apps/cli/src/agent-events.ts
+++ b/apps/cli/src/agent-events.ts
@@ -1,0 +1,34 @@
+type Event = {
+  event?: string;
+  type?: string;
+  step_update?: { step_type?: string; state?: string; tool_name?: string; response?: string };
+  result?: { response?: string };
+  permission_denials?: unknown[];
+};
+
+export function antigravityText(value: unknown): string | null | undefined {
+  if (!value || typeof value !== 'object') return undefined;
+  const event = value as Event;
+  if (event.event === 'init') return 'Local Antigravity task started';
+  if (event.event === 'step_update') {
+    const step = event.step_update;
+    if (step?.step_type === 'tool' && step.tool_name) {
+      if (step.state === 'ERROR') return `Tool failed: ${step.tool_name}`;
+      if (step.state === 'ACTIVE') return `⚙ ${step.tool_name}`;
+    }
+    return typeof step?.response === 'string' ? step.response.trim() || null : null;
+  }
+  if (event.event === 'result')
+    return typeof event.result?.response === 'string' ? event.result.response.trim() || null : null;
+  return undefined;
+}
+
+export function permissionBlocked(line: string): boolean {
+  if (line.includes('headless mode cannot prompt') && line.includes('auto-denied')) return true;
+  try {
+    const event = JSON.parse(line) as Event;
+    return event?.type === 'result' && Array.isArray(event.permission_denials) && event.permission_denials.length > 0;
+  } catch {
+    return false;
+  }
+}

--- a/apps/cli/src/agent-events.ts
+++ b/apps/cli/src/agent-events.ts
@@ -24,11 +24,11 @@ export function antigravityText(value: unknown): string | null | undefined {
 }
 
 export function permissionBlocked(line: string): boolean {
-  if (line.includes('headless mode cannot prompt') && line.includes('auto-denied')) return true;
-  try {
-    const event = JSON.parse(line) as Event;
-    return event?.type === 'result' && Array.isArray(event.permission_denials) && event.permission_denials.length > 0;
-  } catch {
-    return false;
-  }
+  if (
+    line.includes('no output produced') &&
+    line.includes('headless mode cannot prompt') &&
+    line.includes('auto-denied')
+  )
+    return true;
+  return false;
 }

--- a/apps/cli/src/agents.test.ts
+++ b/apps/cli/src/agents.test.ts
@@ -107,6 +107,7 @@ describe('agent discovery', () => {
     writeFileSync(
       join(dir, 'claude'),
       `#!${process.execPath}
+if (process.argv.includes('auth')) { console.log(JSON.stringify({ loggedIn: true, authMethod: 'claude.ai', apiProvider: 'firstParty' })); process.exit(0); }
 if (process.argv.includes('--help')) { console.log('-p --verbose --permission-mode --output-format'); process.exit(0); }
 const fs = require('node:fs');
 const args = process.argv.slice(2);
@@ -177,6 +178,7 @@ console.log(JSON.stringify({ text: JSON.stringify({ cwd: process.cwd(), config }
     writeFileSync(
       join(dir, 'claude'),
       `#!${process.execPath}
+if (process.argv.includes('auth')) { console.log(JSON.stringify({ loggedIn: true, authMethod: 'claude.ai', apiProvider: 'firstParty' })); process.exit(0); }
 if (process.argv.includes('--help')) { console.log('-p --verbose --permission-mode --output-format'); process.exit(0); }
 process.on('SIGTERM', () => {});
 console.log(JSON.stringify({ text: 'working' }));

--- a/apps/cli/src/agents.test.ts
+++ b/apps/cli/src/agents.test.ts
@@ -109,6 +109,7 @@ describe('agent discovery', () => {
       `#!${process.execPath}
 if (process.argv.includes('auth')) { console.log(JSON.stringify({ loggedIn: true, authMethod: 'claude.ai', apiProvider: 'firstParty' })); process.exit(0); }
 if (process.argv.includes('--help')) { console.log('-p --verbose --permission-mode --output-format'); process.exit(0); }
+if (process.env.ANTHROPIC_API_KEY) process.exit(90);
 const fs = require('node:fs');
 const args = process.argv.slice(2);
 const config = args[args.indexOf('--mcp-config') + 1];
@@ -134,7 +135,7 @@ console.log(JSON.stringify({ text: JSON.stringify({ cwd: process.cwd(), config }
       slug: 'sky-dodge',
       dest: dir,
       agent: 'claude',
-      env: { PATH: dir, HOME: dir },
+      env: { PATH: dir, HOME: dir, ANTHROPIC_API_KEY: 'must-not-reach-child' },
       write: (line) => lines.push(line),
     });
     const report = JSON.parse(lines.find((line) => line.startsWith('claude ▸ {'))!.split(' ▸ ')[1]!) as {

--- a/apps/cli/src/api.ts
+++ b/apps/cli/src/api.ts
@@ -1,5 +1,5 @@
 import { cliUsage } from './bin-name.js';
-import { credentialExpired } from './errors.js';
+import { credentialExpired, moderationRefusal } from './errors.js';
 import { CliError, EXIT_AUTH, EXIT_INPUT, EXIT_REFUSED } from './exit-codes.js';
 import type { StoredTokens, TokenStore } from './keychain.js';
 import { refreshGrant } from './oauth.js';
@@ -19,6 +19,7 @@ export function bearerFrom(tokens: StoredTokens | null, env: NodeJS.ProcessEnv):
 }
 
 function throwForStatus(res: Response, errBody: { error?: string; message?: string }): never {
+  if (res.status === 422 && errBody.error === 'content_rejected') throw moderationRefusal();
   if (res.status === 401) throw credentialExpired();
   if (res.status === 404) throw new CliError('not found', EXIT_REFUSED);
   throw new CliError(errBody.message ?? errBody.error ?? `request failed (${res.status})`, EXIT_REFUSED);

--- a/apps/cli/src/claude-auth.test.ts
+++ b/apps/cli/src/claude-auth.test.ts
@@ -36,3 +36,21 @@ it('accepts a verified subscription in the same cwd and environment as the task'
     expect.objectContaining({ cwd: input.cwd, env: input.env }),
   );
 });
+
+it('checks the same settings overrides as the launched adapter', () => {
+  vi.mocked(spawnSync).mockReturnValue({
+    status: 0,
+    stdout: JSON.stringify({ loggedIn: true, authMethod: 'api_key', apiProvider: 'firstParty' }),
+  } as ReturnType<typeof spawnSync>);
+  expect(() =>
+    requireClaudeSubscription({
+      ...input,
+      args: ['-p', '--settings', '/custom.json', '--setting-sources=user', '--bare'],
+    }),
+  ).toThrow('no agent was started');
+  expect(spawnSync).toHaveBeenCalledWith(
+    'claude',
+    ['--settings', '/custom.json', '--setting-sources=user', '--bare', 'auth', 'status', '--json'],
+    expect.anything(),
+  );
+});

--- a/apps/cli/src/claude-auth.test.ts
+++ b/apps/cli/src/claude-auth.test.ts
@@ -1,0 +1,38 @@
+import { beforeEach, expect, it, vi } from 'vitest';
+import { spawnSync } from 'node:child_process';
+import { requireClaudeSubscription, subscriptionEnv } from './claude-auth.js';
+vi.mock('node:child_process', () => ({ spawnSync: vi.fn() }));
+beforeEach(() => vi.clearAllMocks());
+const input = { command: 'claude', cwd: '/checkout/game', env: { HOME: '/home' } };
+it('removes inherited paid-provider credentials without changing the parent or OAuth login', () => {
+  const parent = {
+    ANTHROPIC_API_KEY: 'secret',
+    ANTHROPIC_AUTH_TOKEN: 'secret',
+    ANTHROPIC_BASE_URL: 'proxy',
+    CLAUDE_CODE_USE_VERTEX: '1',
+    CLAUDE_CODE_OAUTH_TOKEN: 'login',
+    HOME: '/home',
+  };
+  expect(subscriptionEnv(parent)).toEqual({ CLAUDE_CODE_OAUTH_TOKEN: 'login', HOME: '/home' });
+  expect(parent.ANTHROPIC_API_KEY).toBe('secret');
+});
+it.each([
+  { loggedIn: false },
+  { loggedIn: true, authMethod: 'api_key', apiProvider: 'firstParty' },
+  { loggedIn: true, authMethod: 'claude.ai', apiProvider: 'vertex' },
+])('refuses unknown or API authentication: %j', (status) => {
+  vi.mocked(spawnSync).mockReturnValue({ status: 0, stdout: JSON.stringify(status) } as ReturnType<typeof spawnSync>);
+  expect(() => requireClaudeSubscription(input)).toThrow('no agent was started');
+});
+it('accepts a verified subscription in the same cwd and environment as the task', () => {
+  vi.mocked(spawnSync).mockReturnValue({
+    status: 0,
+    stdout: JSON.stringify({ loggedIn: true, authMethod: 'claude.ai', apiProvider: 'firstParty' }),
+  } as ReturnType<typeof spawnSync>);
+  requireClaudeSubscription(input);
+  expect(spawnSync).toHaveBeenCalledWith(
+    'claude',
+    ['auth', 'status', '--json'],
+    expect.objectContaining({ cwd: input.cwd, env: input.env }),
+  );
+});

--- a/apps/cli/src/claude-auth.test.ts
+++ b/apps/cli/src/claude-auth.test.ts
@@ -1,56 +1,76 @@
 import { beforeEach, expect, it, vi } from 'vitest';
-import { spawnSync } from 'node:child_process';
+import { execFile } from 'node:child_process';
 import { requireClaudeSubscription, subscriptionEnv } from './claude-auth.js';
-vi.mock('node:child_process', () => ({ spawnSync: vi.fn() }));
+vi.mock('node:child_process', () => ({ execFile: vi.fn() }));
 beforeEach(() => vi.clearAllMocks());
 const input = { command: 'claude', cwd: '/checkout/game', env: { HOME: '/home' } };
-it('removes inherited paid-provider credentials without changing the parent or OAuth login', () => {
+function respond(status: unknown, stderr = '', error: Error | null = null) {
+  vi.mocked(execFile).mockImplementation(((...args: unknown[]) => {
+    const callback = args.at(-1) as (error: Error | null, stdout: string, stderr: string) => void;
+    queueMicrotask(() => callback(error, JSON.stringify(status), stderr));
+  }) as typeof execFile);
+}
+it('removes provider credentials while retaining model selection and OAuth without mutating the parent', () => {
   const parent = {
     ANTHROPIC_API_KEY: 'secret',
     ANTHROPIC_AUTH_TOKEN: 'secret',
     ANTHROPIC_BASE_URL: 'proxy',
+    ANTHROPIC_CUSTOM_HEADERS: 'Authorization: secret',
     CLAUDE_CODE_USE_VERTEX: '1',
     CLAUDE_CODE_OAUTH_TOKEN: 'login',
+    ANTHROPIC_MODEL: 'sonnet',
     HOME: '/home',
   };
-  expect(subscriptionEnv(parent)).toEqual({ CLAUDE_CODE_OAUTH_TOKEN: 'login', HOME: '/home' });
+  expect(subscriptionEnv(parent)).toEqual({
+    CLAUDE_CODE_OAUTH_TOKEN: 'login',
+    ANTHROPIC_MODEL: 'sonnet',
+    HOME: '/home',
+  });
   expect(parent.ANTHROPIC_API_KEY).toBe('secret');
 });
 it.each([
   { loggedIn: false },
   { loggedIn: true, authMethod: 'api_key', apiProvider: 'firstParty' },
   { loggedIn: true, authMethod: 'claude.ai', apiProvider: 'vertex' },
-])('refuses unknown or API authentication: %j', (status) => {
-  vi.mocked(spawnSync).mockReturnValue({ status: 0, stdout: JSON.stringify(status) } as ReturnType<typeof spawnSync>);
-  expect(() => requireClaudeSubscription(input)).toThrow('no agent was started');
+])('refuses unknown or API authentication: %j', async (status) => {
+  respond(status);
+  await expect(requireClaudeSubscription(input)).rejects.toThrow('no agent was started');
 });
-it('accepts a verified subscription in the same cwd and environment as the task', () => {
-  vi.mocked(spawnSync).mockReturnValue({
-    status: 0,
-    stdout: JSON.stringify({ loggedIn: true, authMethod: 'claude.ai', apiProvider: 'firstParty' }),
-  } as ReturnType<typeof spawnSync>);
-  requireClaudeSubscription(input);
-  expect(spawnSync).toHaveBeenCalledWith(
+it.each(['claude.ai', 'oauth_token'])('accepts verified subscription authentication: %s', async (authMethod) => {
+  respond({ loggedIn: true, authMethod, apiProvider: 'firstParty' });
+  await requireClaudeSubscription(input);
+  expect(execFile).toHaveBeenCalledWith(
     'claude',
     ['auth', 'status', '--json'],
     expect.objectContaining({ cwd: input.cwd, env: input.env }),
+    expect.any(Function),
   );
 });
-
-it('checks the same settings overrides as the launched adapter', () => {
-  vi.mocked(spawnSync).mockReturnValue({
-    status: 0,
-    stdout: JSON.stringify({ loggedIn: true, authMethod: 'api_key', apiProvider: 'firstParty' }),
-  } as ReturnType<typeof spawnSync>);
-  expect(() =>
+it('checks settings overrides and reports obsolete CLI versions separately', async () => {
+  respond(null, 'unknown command: auth', new Error('exit 1'));
+  await expect(
     requireClaudeSubscription({
       ...input,
       args: ['-p', '--settings', '/custom.json', '--setting-sources=user', '--bare'],
     }),
-  ).toThrow('no agent was started');
-  expect(spawnSync).toHaveBeenCalledWith(
+  ).rejects.toThrow('version cannot report');
+  expect(execFile).toHaveBeenCalledWith(
     'claude',
     ['--settings', '/custom.json', '--setting-sources=user', '--bare', 'auth', 'status', '--json'],
+    expect.anything(),
+    expect.any(Function),
+  );
+});
+it('passes cancellation through to the child and rejects cancellation', async () => {
+  const controller = new AbortController();
+  respond({ loggedIn: true, authMethod: 'claude.ai', apiProvider: 'firstParty' });
+  const pending = requireClaudeSubscription({ ...input, abort: controller.signal });
+  controller.abort();
+  await expect(pending).rejects.toThrow('cancelled');
+  expect(execFile).toHaveBeenCalledWith(
+    expect.anything(),
+    expect.anything(),
+    expect.objectContaining({ signal: controller.signal }),
     expect.anything(),
   );
 });

--- a/apps/cli/src/claude-auth.ts
+++ b/apps/cli/src/claude-auth.ts
@@ -35,7 +35,8 @@ export function requireClaudeSubscription(input: {
   });
   let status: { loggedIn?: boolean; authMethod?: string; apiProvider?: string } = {};
   try {
-    status = JSON.parse(result.stdout ?? '') as typeof status;
+    const parsed: unknown = JSON.parse(result.stdout ?? '');
+    if (parsed && typeof parsed === 'object') status = parsed as typeof status;
   } catch {
     // Unknown auth must never fall back to API billing.
   }

--- a/apps/cli/src/claude-auth.ts
+++ b/apps/cli/src/claude-auth.ts
@@ -1,21 +1,34 @@
-import { spawnSync } from 'node:child_process';
+import { execFile } from 'node:child_process';
 import { CliError, EXIT_AUTH } from './exit-codes.js';
 
 // Keep subscription login; never inherit a separately billed API or cloud provider.
 export function subscriptionEnv(parent: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
   const env = { ...parent };
   for (const key of Object.keys(env)) {
-    if (/^ANTHROPIC_|^CLAUDE_CODE_USE_|^CLAUDE_CODE_API_KEY/.test(key)) delete env[key];
+    if (
+      [
+        'ANTHROPIC_API_KEY',
+        'ANTHROPIC_AUTH_TOKEN',
+        'ANTHROPIC_BASE_URL',
+        'ANTHROPIC_CUSTOM_HEADERS',
+        'CLAUDE_CODE_USE_BEDROCK',
+        'CLAUDE_CODE_USE_VERTEX',
+        'CLAUDE_CODE_USE_FOUNDRY',
+        'CLAUDE_CODE_API_KEY',
+      ].includes(key)
+    )
+      delete env[key];
   }
   return env;
 }
 
-export function requireClaudeSubscription(input: {
+export async function requireClaudeSubscription(input: {
   command: string;
   cwd: string;
   env: NodeJS.ProcessEnv;
   args?: string[];
-}): void {
+  abort?: AbortSignal;
+}): Promise<void> {
   const configArgs: string[] = [];
   for (let i = 0; i < (input.args?.length ?? 0); i++) {
     const arg = input.args![i]!;
@@ -25,14 +38,38 @@ export function requireClaudeSubscription(input: {
     }
     if (arg === '--bare') configArgs.push(arg);
   }
-  const result = spawnSync(input.command, [...configArgs, 'auth', 'status', '--json'], {
-    cwd: input.cwd,
-    env: input.env,
-    encoding: 'utf8',
-    timeout: 15_000,
-    killSignal: 'SIGKILL',
-    windowsHide: true,
+  const result = await new Promise<{ code: number; stdout: string; stderr: string }>((resolve, reject) => {
+    execFile(
+      input.command,
+      [...configArgs, 'auth', 'status', '--json'],
+      {
+        cwd: input.cwd,
+        env: input.env,
+        encoding: 'utf8',
+        timeout: 15_000,
+        killSignal: 'SIGKILL',
+        windowsHide: true,
+        signal: input.abort,
+      },
+      (error, stdout, stderr) => {
+        if (input.abort?.aborted) {
+          reject(new CliError('Claude authentication check cancelled.', EXIT_AUTH));
+          return;
+        }
+        resolve({ code: error ? 1 : 0, stdout, stderr });
+      },
+    );
   });
+  if (
+    result.code !== 0 &&
+    /unknown (command|option)|unrecognized (command|option)/i.test(result.stderr + result.stdout)
+  ) {
+    throw new CliError(
+      'This Claude Code version cannot report authentication status.',
+      EXIT_AUTH,
+      'Update Claude Code, then retry. No agent was started.',
+    );
+  }
   let status: { loggedIn?: boolean; authMethod?: string; apiProvider?: string } = {};
   try {
     const parsed: unknown = JSON.parse(result.stdout ?? '');
@@ -41,9 +78,9 @@ export function requireClaudeSubscription(input: {
     // Unknown auth must never fall back to API billing.
   }
   if (
-    result.status !== 0 ||
-    !status.loggedIn ||
-    status.authMethod !== 'claude.ai' ||
+    result.code !== 0 ||
+    status.loggedIn !== true ||
+    !['claude.ai', 'oauth_token'].includes(status.authMethod ?? '') ||
     status.apiProvider !== 'firstParty'
   ) {
     throw new CliError(

--- a/apps/cli/src/claude-auth.ts
+++ b/apps/cli/src/claude-auth.ts
@@ -1,0 +1,54 @@
+import { spawnSync } from 'node:child_process';
+import { CliError, EXIT_AUTH } from './exit-codes.js';
+
+// Keep subscription login; never inherit a separately billed API or cloud provider.
+export function subscriptionEnv(parent: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
+  const env = { ...parent };
+  for (const key of Object.keys(env)) {
+    if (/^ANTHROPIC_|^CLAUDE_CODE_USE_|^CLAUDE_CODE_API_KEY/.test(key)) delete env[key];
+  }
+  return env;
+}
+
+export function requireClaudeSubscription(input: {
+  command: string;
+  cwd: string;
+  env: NodeJS.ProcessEnv;
+  args?: string[];
+}): void {
+  const configArgs: string[] = [];
+  for (let i = 0; i < (input.args?.length ?? 0); i++) {
+    const arg = input.args![i]!;
+    if (/^--(settings|setting-sources|profile)(=|$)/.test(arg)) {
+      configArgs.push(arg);
+      if (!arg.includes('=') && input.args![i + 1]) configArgs.push(input.args![++i]!);
+    }
+    if (arg === '--bare') configArgs.push(arg);
+  }
+  const result = spawnSync(input.command, [...configArgs, 'auth', 'status', '--json'], {
+    cwd: input.cwd,
+    env: input.env,
+    encoding: 'utf8',
+    timeout: 15_000,
+    killSignal: 'SIGKILL',
+    windowsHide: true,
+  });
+  let status: { loggedIn?: boolean; authMethod?: string; apiProvider?: string } = {};
+  try {
+    status = JSON.parse(result.stdout ?? '') as typeof status;
+  } catch {
+    // Unknown auth must never fall back to API billing.
+  }
+  if (
+    result.status !== 0 ||
+    !status.loggedIn ||
+    status.authMethod !== 'claude.ai' ||
+    status.apiProvider !== 'firstParty'
+  ) {
+    throw new CliError(
+      'Claude subscription login could not be verified; no agent was started and API billing is disabled.',
+      EXIT_AUTH,
+      'Sign in with your Claude subscription using claude auth login; remove API overrides from Claude settings, then retry.',
+    );
+  }
+}

--- a/apps/cli/src/connect.ts
+++ b/apps/cli/src/connect.ts
@@ -1,3 +1,4 @@
+import { requireClaudeSubscription, subscriptionEnv } from './claude-auth.js';
 import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
@@ -29,10 +30,11 @@ export type AdapterRun = (input: {
   env: NodeJS.ProcessEnv;
   abort?: AbortSignal;
   onLine?: (line: string) => void;
+  authCheck?: Promise<void>;
 }) => Promise<{ code: number | null; lines: string[] }>;
 
 async function defaultAdapterRun(input: Parameters<AdapterRun>[0]): Promise<{ code: number | null; lines: string[] }> {
-  const child = spawnAdapter({ ...input, timeoutMs: 10 * 60_000 });
+  const child = await spawnAdapter({ ...input, timeoutMs: 10 * 60_000 });
   const lines: string[] = [];
   for (const stream of [child.stdout, child.stderr]) {
     if (stream)
@@ -271,13 +273,26 @@ export async function connectGame(input: {
     if (!local) {
       input.write(`MCP workspace: ${cwd} — scratch files are kept here after the agent exits`);
     }
+    const envForAgent = childEnv(env, '', { url: payload.mcpUrl, authorization: payload.authorizationHeader });
+    const authCheck =
+      spec.name === 'claude' && !input.runAdapter
+        ? requireClaudeSubscription({
+            command: wired.spec.command,
+            args: wired.spec.headless,
+            cwd,
+            env: subscriptionEnv(envForAgent),
+            abort: input.abort,
+          })
+        : undefined;
+    await authCheck;
     input.telemetry?.record('delegate_used', spec.name);
     const result = await (input.runAdapter ?? defaultAdapterRun)({
       spec: wired.spec,
       prompt:
         payload.kickoffPrompt ?? `Edit ${input.slug} in this checkout. The creator will deliver with gamedevpl submit.`,
       cwd,
-      env: childEnv(env, '', { url: payload.mcpUrl, authorization: payload.authorizationHeader }),
+      env: envForAgent,
+      authCheck,
       abort: input.abort,
       onLine: (line) => {
         for (const shown of renderDelegateStream(spec.name, [line], false)) input.write(shown);

--- a/apps/cli/src/delegate.test.ts
+++ b/apps/cli/src/delegate.test.ts
@@ -94,3 +94,9 @@ it('renders Antigravity tools without exposing transport JSON', () => {
   expect(output).not.toContain('SUCCESS');
   expect(output).not.toContain('/private/path');
 });
+
+it('shows Claude resume instructions only for the Claude adapter', () => {
+  const event = JSON.stringify({ type: 'system', session_id: '12345678-1234-1234-1234-123456789abc' });
+  expect(renderDelegateStream('claude', [event], false).join('')).toContain('claude --resume');
+  expect(renderDelegateStream('cursor', [event], false).join('')).not.toContain('claude');
+});

--- a/apps/cli/src/delegate.test.ts
+++ b/apps/cli/src/delegate.test.ts
@@ -76,3 +76,21 @@ describe('delegation event rendering', () => {
     }
   });
 });
+
+it('renders Antigravity tools without exposing transport JSON', () => {
+  const rows = [
+    { event: 'init', init: { cwd: '/private/path' } },
+    { event: 'step_update', step_update: { step_type: 'tool', tool_name: 'read_file', state: 'ACTIVE' } },
+    { event: 'step_update', step_update: { step_type: 'tool', tool_name: 'read_file', state: 'ERROR' } },
+    { event: 'result', result: { status: 'SUCCESS', response: '' } },
+  ];
+  const output = renderDelegateStream(
+    'agy',
+    rows.map((row) => JSON.stringify(row)),
+    false,
+  ).join('\n');
+  expect(output).toContain('⚙ read_file');
+  expect(output).toContain('Tool failed: read_file');
+  expect(output).not.toContain('SUCCESS');
+  expect(output).not.toContain('/private/path');
+});

--- a/apps/cli/src/delegate.ts
+++ b/apps/cli/src/delegate.ts
@@ -1,3 +1,4 @@
+import { antigravityText } from './agent-events.js';
 import { requireClaudeSubscription, subscriptionEnv } from './claude-auth.js';
 import { spawn, type ChildProcess } from 'node:child_process';
 import { formatAdapterEvent, sanitizeEventPayload } from './ansi.js';
@@ -66,6 +67,9 @@ export function parseEventLine(line: string): string | null {
     return trimmed;
   }
   if (!parsed || typeof parsed !== 'object') return trimmed;
+  const agy = antigravityText(parsed);
+  if (agy !== undefined) return agy;
+  if (parsed.type === 'item.started') return null;
   if (parsed.type === 'system' && typeof parsed.session_id === 'string' && /^[a-f0-9-]{36}$/i.test(parsed.session_id)) {
     return `Local session ${parsed.session_id} — after it finishes, resume with claude --resume ${parsed.session_id} in the game directory`;
   }

--- a/apps/cli/src/delegate.ts
+++ b/apps/cli/src/delegate.ts
@@ -1,3 +1,4 @@
+import { requireClaudeSubscription, subscriptionEnv } from './claude-auth.js';
 import { spawn, type ChildProcess } from 'node:child_process';
 import { formatAdapterEvent, sanitizeEventPayload } from './ansi.js';
 import type { AdapterSpec } from './adapters.js';
@@ -32,6 +33,7 @@ type EventShape = {
   text?: unknown;
   message?: unknown;
   type?: unknown;
+  session_id?: unknown;
   result?: unknown;
   item?: { type?: unknown; text?: unknown; command?: unknown };
 };
@@ -64,6 +66,9 @@ export function parseEventLine(line: string): string | null {
     return trimmed;
   }
   if (!parsed || typeof parsed !== 'object') return trimmed;
+  if (parsed.type === 'system' && typeof parsed.session_id === 'string' && /^[a-f0-9-]{36}$/i.test(parsed.session_id)) {
+    return `Local session ${parsed.session_id} — after it finishes, resume with claude --resume ${parsed.session_id} in the game directory`;
+  }
   const direct =
     textOf(parsed.text) ??
     textOf(parsed.message) ??
@@ -79,6 +84,7 @@ export function parseEventLine(line: string): string | null {
   if (command) return `⚙ ${command}`;
   const type = textOf(parsed.type);
   if (!type) return trimmed;
+  if (type === 'assistant') return null;
   return QUIET_EVENT_TYPES.test(type) ? null : type;
 }
 
@@ -100,7 +106,10 @@ export function spawnAdapter(input: {
   timeoutMs: number;
   abort?: AbortSignal;
 }): ChildProcess {
-  return spawnCommand({ ...input, command: input.spec.command, args: [...input.spec.headless, input.prompt] });
+  const env = input.spec.name === 'claude' ? subscriptionEnv(input.env) : input.env;
+  if (input.spec.name === 'claude')
+    requireClaudeSubscription({ command: input.spec.command, cwd: input.cwd, env, args: input.spec.headless });
+  return spawnCommand({ ...input, env, command: input.spec.command, args: [...input.spec.headless, input.prompt] });
 }
 
 export function spawnCommand(input: {

--- a/apps/cli/src/delegate.ts
+++ b/apps/cli/src/delegate.ts
@@ -35,6 +35,7 @@ type EventShape = {
   message?: unknown;
   type?: unknown;
   session_id?: unknown;
+  permission_denials?: unknown;
   result?: unknown;
   item?: { type?: unknown; text?: unknown; command?: unknown };
 };
@@ -57,7 +58,7 @@ function contentText(message: unknown): string | null {
   return parts.length ? parts.join(' ') : null;
 }
 
-export function parseEventLine(line: string): string | null {
+export function parseEventLine(line: string, adapter?: string): string | null {
   const trimmed = line.trim();
   if (!trimmed) return null;
   let parsed: EventShape;
@@ -70,7 +71,12 @@ export function parseEventLine(line: string): string | null {
   const agy = antigravityText(parsed);
   if (agy !== undefined) return agy;
   if (parsed.type === 'item.started') return null;
-  if (parsed.type === 'system' && typeof parsed.session_id === 'string' && /^[a-f0-9-]{36}$/i.test(parsed.session_id)) {
+  if (
+    adapter === 'claude' &&
+    parsed.type === 'system' &&
+    typeof parsed.session_id === 'string' &&
+    /^[a-f0-9-]{36}$/i.test(parsed.session_id)
+  ) {
     return `Local session ${parsed.session_id} — after it finishes, resume with claude --resume ${parsed.session_id} in the game directory`;
   }
   const direct =
@@ -83,6 +89,13 @@ export function parseEventLine(line: string): string | null {
     textOf(parsed.response) ??
     textOf(parsed.data?.content) ??
     textOf(parsed.error?.message);
+  if (
+    adapter === 'claude' &&
+    parsed.type === 'result' &&
+    Array.isArray(parsed.permission_denials) &&
+    parsed.permission_denials.length
+  )
+    return `Some tools were denied; this alone does not mean the task failed.${direct ? ` ${direct}` : ''}`;
   if (direct) return direct;
   const command = textOf(parsed.item?.command);
   if (command) return `⚙ ${command}`;
@@ -96,23 +109,31 @@ export function renderDelegateStream(adapter: string, lines: string[], verbose: 
   const out: string[] = [];
   for (const line of lines) {
     if (verbose) out.push(`${adapter} raw ${sanitizeEventPayload(line)}`);
-    const payload = parseEventLine(line);
+    const payload = parseEventLine(line, adapter);
     if (payload) out.push(formatAdapterEvent(adapter, payload));
   }
   return out;
 }
 
-export function spawnAdapter(input: {
+export async function spawnAdapter(input: {
   spec: AdapterSpec;
   prompt: string;
   cwd: string;
   env: NodeJS.ProcessEnv;
   timeoutMs: number;
   abort?: AbortSignal;
-}): ChildProcess {
+  authCheck?: Promise<void>;
+}): Promise<ChildProcess> {
   const env = input.spec.name === 'claude' ? subscriptionEnv(input.env) : input.env;
   if (input.spec.name === 'claude')
-    requireClaudeSubscription({ command: input.spec.command, cwd: input.cwd, env, args: input.spec.headless });
+    await (input.authCheck ??
+      requireClaudeSubscription({
+        command: input.spec.command,
+        cwd: input.cwd,
+        env,
+        args: input.spec.headless,
+        abort: input.abort,
+      }));
   return spawnCommand({ ...input, env, command: input.spec.command, args: [...input.spec.headless, input.prompt] });
 }
 

--- a/apps/cli/src/execution.test.ts
+++ b/apps/cli/src/execution.test.ts
@@ -137,3 +137,14 @@ it('retains a pending MCP task without a checkout and retries without another pi
   expect(connectGame).toHaveBeenCalledWith(expect.objectContaining({ agent: 'claude' }));
   expect(pendingExecution.current).toBeUndefined();
 });
+
+it('remembers an explicit local choice before any round API request can fail', async () => {
+  const env = environment();
+  const { detectLocalAdapters } = await import('./workshop.js');
+  const workshop = { adapters: detectLocalAdapters(env), env } as import('./workshop.js').Workshop;
+  const pick = vi.fn(async (choices: string[]) => choices[0]!);
+  const first = await chooseExecution({ env, workshop, pick });
+  expect(workshop.selectedAgent).toBe('claude');
+  expect(await chooseExecution({ env, workshop, pick })).toEqual(first);
+  expect(pick).toHaveBeenCalledTimes(1);
+});

--- a/apps/cli/src/execution.ts
+++ b/apps/cli/src/execution.ts
@@ -41,6 +41,7 @@ export async function chooseExecution(input: {
   const choice = local.find((row) => row.label === chosen)?.choice;
   if (!choice) return null;
   if (!input.workshop?.runAdapter) preflightAdapter(choice.spec, input.env);
+  if (input.workshop) input.workshop.selectedAgent = choice.spec.name;
   return choice;
 }
 

--- a/apps/cli/src/tui/host.ts
+++ b/apps/cli/src/tui/host.ts
@@ -62,7 +62,16 @@ export async function runInkRepl(input: {
     paintIdentity();
     const write = (line: string): void => session.writeLine(line);
     const opened = await openWorkshop({ api: input.api, token, ...input.checkout, env: input.env, write });
-    workshop = { ...input.checkout, token, env: input.env, ...opened, pick: session.prompt, abort, telemetry };
+    workshop = {
+      ...input.checkout,
+      token,
+      env: input.env,
+      ...opened,
+      pick: session.prompt,
+      abort,
+      telemetry,
+      onActivity: session.setActivity,
+    };
     workshop.builder = await settleBuilder({ api: input.api, ws: workshop, status: opened.status, write });
     session.writeLine('say what to change, or /help');
   }
@@ -106,6 +115,12 @@ export async function runInkRepl(input: {
           pendingExecution,
           onWorkshop: (opened) => {
             workshop = opened;
+            opened.onActivity = session.setActivity;
+            if (token !== opened.token) {
+              token = opened.token;
+              session.setLive([]);
+              watch.poke();
+            }
           },
           onActivity: (activity) => session.setActivity(activity),
           write: (text) => session.writeLine(text),

--- a/apps/cli/src/tui/host.ts
+++ b/apps/cli/src/tui/host.ts
@@ -118,6 +118,7 @@ export async function runInkRepl(input: {
             opened.onActivity = session.setActivity;
             if (token !== opened.token) {
               token = opened.token;
+              delete pendingExecution.current;
               session.setLive([]);
               watch.poke();
             }

--- a/apps/cli/src/tui/round-watch.test.ts
+++ b/apps/cli/src/tui/round-watch.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { createApi } from '../api.js';
 import { memoryStore } from '../keychain.js';
 import { createRoundWatch } from './round-watch.js';
@@ -59,6 +59,8 @@ describe('round watch', () => {
         throw new Error('should not sleep after published');
       },
     });
+    await vi.waitFor(() => expect(announced).toEqual(['published']));
+    watch.stop();
     await watch.run;
     expect(polls).toBe(1);
     expect(announced).toEqual(['published']);
@@ -105,4 +107,25 @@ describe('round watch', () => {
     await miss.current.run;
     expect(ignored).toEqual([]);
   });
+});
+
+it('wakes for a new round after publication instead of keeping the old live strip', async () => {
+  let token = 'old';
+  const live: string[][] = [];
+  const request = vi.fn(async () => ({ status: token === 'old' ? 'published' : 'building' }));
+  const watch = createRoundWatch({
+    getToken: () => token,
+    api: { origin: 'https://example.test', request } as unknown as import('../api.js').ApiClient,
+    setLive: (lines) => live.push(lines),
+    announce: () => undefined,
+    sleep: () => new Promise(() => undefined),
+  });
+  await vi.waitFor(() => expect(live.at(-1)?.[0]).toBe('published'));
+  expect(request).toHaveBeenCalledTimes(1);
+  token = 'new';
+  watch.poke();
+  await vi.waitFor(() => expect(live.at(-1)?.[0]).toBe('building'));
+  expect(request).toHaveBeenLastCalledWith('GET', '/api/submissions/new');
+  watch.stop();
+  await watch.run;
 });

--- a/apps/cli/src/tui/round-watch.ts
+++ b/apps/cli/src/tui/round-watch.ts
@@ -40,6 +40,7 @@ export function createRoundWatch(input: {
       if (token) {
         try {
           const status = await getStatus(input.api, token);
+          if (token !== input.getToken()) continue;
           lastStatus = status;
           if (status.slug) input.onSlug?.(status.slug);
           input.setLive(formatRoundLive(status, input.api.origin));
@@ -47,10 +48,18 @@ export function createRoundWatch(input: {
           if (shouldAnnounceStatus(status, lastKey, key)) input.announce(formatStatusEvent(status));
           lastKey = key;
           if (isTerminalStatus(status.status)) {
-            stopped = true;
-            break;
+            if (!stopped && token === input.getToken()) {
+              await new Promise<void>((resolve) => {
+                wake = resolve;
+              });
+              wake = null;
+            }
+            lastKey = '';
+            lastStatus = undefined;
+            continue;
           }
         } catch (error) {
+          if (token !== input.getToken()) continue;
           if (!(error instanceof CliError && error.message === 'not found')) {
             input.setLive([describeError(error).message]);
           }

--- a/apps/cli/src/verify.test.ts
+++ b/apps/cli/src/verify.test.ts
@@ -25,3 +25,12 @@ describe('verification ladder', () => {
     expect(result).toEqual({ ok: false, stage: 'check_static', detail: 'static failed' });
   });
 });
+
+it('retains filenames and stdout in a failed verification', () => {
+  const result = runLadder({
+    cwd: '/checkout',
+    publish: false,
+    run: () => ({ status: 1, stderr: 'Forbidden JavaScript:\n  - setup.mjs', stdout: 'Compiler detail' }),
+  });
+  expect(result).toMatchObject({ ok: false, detail: 'Forbidden JavaScript:\n  - setup.mjs\nCompiler detail' });
+});

--- a/apps/cli/src/verify.ts
+++ b/apps/cli/src/verify.ts
@@ -3,7 +3,11 @@ import { CliError, EXIT_RED } from './exit-codes.js';
 
 export type VerifyStage = 'typecheck' | 'check_static' | 'check_game';
 
-type VerifyRun = (cmd: string, args: string[], cwd: string) => { status: number | null; stderr: string };
+type VerifyRun = (
+  cmd: string,
+  args: string[],
+  cwd: string,
+) => { status: number | null; stderr: string; stdout?: string };
 
 export function runLadder(input: {
   cwd: string;
@@ -19,7 +23,11 @@ export function runLadder(input: {
   for (const step of steps) {
     const result = run('npm', step.args, input.cwd);
     if ((result.status ?? 1) !== 0) {
-      return { ok: false, stage: step.stage, detail: result.stderr.slice(0, 500) };
+      return {
+        ok: false,
+        stage: step.stage,
+        detail: [result.stderr, result.stdout].filter(Boolean).join('\n').slice(0, 4000),
+      };
     }
   }
   return { ok: true };

--- a/apps/cli/src/workshop-preview.test.ts
+++ b/apps/cli/src/workshop-preview.test.ts
@@ -1,3 +1,4 @@
+import { requireClaudeSubscription } from './claude-auth.js';
 import { mkdirSync, mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -20,6 +21,10 @@ vi.mock('./delegate.js', async (original) => ({
     return child;
   }),
 }));
+vi.mock('./claude-auth.js', async (original) => ({
+  ...(await original<typeof import('./claude-auth.js')>()),
+  requireClaudeSubscription: vi.fn(async () => undefined),
+}));
 const roots: string[] = [];
 afterEach(() => {
   vi.clearAllMocks();
@@ -30,8 +35,8 @@ it.each([true, false])('starts a preview only in interactive delegation: unatten
   roots.push(root);
   mkdirSync(join(root, 'games/robot'), { recursive: true });
   const spec = {
-    name: 'fixture',
-    command: 'fixture',
+    name: 'claude',
+    command: 'claude',
     headless: [],
     versionFlag: '--help',
     events: { flag: '', dialect: 'ndjson' as const },
@@ -52,12 +57,15 @@ it.each([true, false])('starts a preview only in interactive delegation: unatten
   };
   await expect(runLocalBuild({ ws, spec, brief: 'test', write: () => undefined })).resolves.toBe(true);
   expect(preflightAdapter).toHaveBeenCalled();
+  expect(requireClaudeSubscription).toHaveBeenCalledTimes(1);
+  const { spawnAdapter } = await import('./delegate.js');
+  expect(spawnAdapter).toHaveBeenCalledWith(expect.objectContaining({ authCheck: expect.any(Promise) }));
   expect(startLocalPlay).toHaveBeenCalledTimes(unattended ? 0 : 1);
   if (!unattended)
     expect(startLocalPlay).toHaveBeenCalledWith(expect.objectContaining({ abort: expect.any(AbortSignal) }));
 });
 
-it('refuses an exit-zero task with denied permissions before running verification', async () => {
+it.each([true, false])('distinguishes empty Antigravity runs from partial Claude refusals: empty=%s', async (empty) => {
   const run = vi.fn(() => ({ status: 0, stderr: '' }));
   const write = vi.fn();
   const spec = {
@@ -80,11 +88,53 @@ it('refuses an exit-zero task with denied permissions before running verificatio
     abort: { current: null },
     run,
     runAdapter: async (input) => {
-      input.onLine?.('jetski: no output produced — headless mode cannot prompt, so it was auto-denied.');
+      input.onLine?.(
+        empty
+          ? 'jetski: no output produced — headless mode cannot prompt, so it was auto-denied.'
+          : JSON.stringify({ type: 'result', result: 'Edited hair', permission_denials: [{ tool_name: 'Bash' }] }),
+      );
       return { code: 0 };
     },
   };
-  expect(await runLocalBuild({ ws, spec, brief: 'Fix hair', write })).toBe(false);
-  expect(run).not.toHaveBeenCalled();
-  expect(write).toHaveBeenCalledWith(expect.stringContaining('No successful edit is confirmed'));
+  expect(await runLocalBuild({ ws, spec, brief: 'Fix hair', write })).toBe(!empty);
+  if (empty) {
+    expect(run).not.toHaveBeenCalled();
+    expect(write).toHaveBeenCalledWith(expect.stringContaining('No successful edit is confirmed'));
+  } else {
+    expect(run).toHaveBeenCalled();
+    expect(write).toHaveBeenCalledWith('✓ static ladder green');
+  }
+});
+
+it('checks subscription before preparation, preview, telemetry or agent launch', async () => {
+  const { prepareWorkspace } = await import('./prepare-workspace.js');
+  const { spawnAdapter } = await import('./delegate.js');
+  vi.mocked(requireClaudeSubscription).mockRejectedValueOnce(new Error('subscription refused'));
+  const record = vi.fn();
+  const spec = {
+    name: 'claude',
+    command: 'claude',
+    headless: [],
+    versionFlag: '--help',
+    events: { flag: '', dialect: 'ndjson' as const },
+    cwd: 'game-dir' as const,
+    exit: { success: [0], failure: [1] },
+  };
+  const ws: Workshop = {
+    root: '/checkout',
+    slug: 'robot',
+    token: 'tok',
+    env: {},
+    adapters: [spec],
+    builder: 'self',
+    pick: async () => '',
+    abort: { current: null },
+    telemetry: { record } as unknown as Workshop['telemetry'],
+  };
+  await expect(runLocalBuild({ ws, spec, brief: 'Fix hair', write: vi.fn() })).rejects.toThrow('subscription refused');
+  expect(prepareWorkspace).not.toHaveBeenCalled();
+  expect(startLocalPlay).not.toHaveBeenCalled();
+  expect(spawnAdapter).not.toHaveBeenCalled();
+  expect(record).not.toHaveBeenCalled();
+  expect(ws.abort.current).toBeNull();
 });

--- a/apps/cli/src/workshop-preview.test.ts
+++ b/apps/cli/src/workshop-preview.test.ts
@@ -69,8 +69,8 @@ it.each([true, false])('distinguishes empty Antigravity runs from partial Claude
   const run = vi.fn(() => ({ status: 0, stderr: '' }));
   const write = vi.fn();
   const spec = {
-    name: 'agy',
-    command: 'agy',
+    name: empty ? 'agy' : 'claude',
+    command: empty ? 'agy' : 'claude',
     headless: [],
     versionFlag: '--help',
     events: { flag: '', dialect: 'ndjson' as const },
@@ -103,6 +103,7 @@ it.each([true, false])('distinguishes empty Antigravity runs from partial Claude
   } else {
     expect(run).toHaveBeenCalled();
     expect(write).toHaveBeenCalledWith('✓ static ladder green');
+    expect(write).toHaveBeenCalledWith(expect.stringContaining('Some tools were denied'));
   }
 });
 

--- a/apps/cli/src/workshop-preview.test.ts
+++ b/apps/cli/src/workshop-preview.test.ts
@@ -56,3 +56,35 @@ it.each([true, false])('starts a preview only in interactive delegation: unatten
   if (!unattended)
     expect(startLocalPlay).toHaveBeenCalledWith(expect.objectContaining({ abort: expect.any(AbortSignal) }));
 });
+
+it('refuses an exit-zero task with denied permissions before running verification', async () => {
+  const run = vi.fn(() => ({ status: 0, stderr: '' }));
+  const write = vi.fn();
+  const spec = {
+    name: 'agy',
+    command: 'agy',
+    headless: [],
+    versionFlag: '--help',
+    events: { flag: '', dialect: 'ndjson' as const },
+    cwd: 'game-dir' as const,
+    exit: { success: [0], failure: [1] },
+  };
+  const ws: Workshop = {
+    root: '/checkout',
+    slug: 'robot',
+    token: 'tok',
+    env: {},
+    adapters: [spec],
+    builder: 'self',
+    pick: async () => '',
+    abort: { current: null },
+    run,
+    runAdapter: async (input) => {
+      input.onLine?.('jetski: no output produced — headless mode cannot prompt, so it was auto-denied.');
+      return { code: 0 };
+    },
+  };
+  expect(await runLocalBuild({ ws, spec, brief: 'Fix hair', write })).toBe(false);
+  expect(run).not.toHaveBeenCalled();
+  expect(write).toHaveBeenCalledWith(expect.stringContaining('No successful edit is confirmed'));
+});

--- a/apps/cli/src/workshop.test.ts
+++ b/apps/cli/src/workshop.test.ts
@@ -89,6 +89,7 @@ describe('workshopTurn', () => {
     const root = checkout();
     const seen: string[] = [];
     const lines: string[] = [];
+    const activities: string[] = [];
     const calls: Parameters<AdapterRun>[0][] = [];
     const runAdapter: AdapterRun = async (input) => {
       calls.push(input);
@@ -98,12 +99,15 @@ describe('workshopTurn', () => {
     };
     const ok = await workshopTurn({
       api: platform(seen),
-      ws: workshop(root, { runAdapter }),
+      ws: workshop(root, { runAdapter, onActivity: (stage) => activities.push(stage) }),
       request: 'make the jump floatier',
       ack: 'Floatier jump.',
       write: (line) => lines.push(line),
     });
     expect(ok).toBe(true);
+    expect(activities).toContain('claude is editing locally — input returns when it finishes');
+    expect(activities).toContain('Agent finished — verifying typecheck and static checks');
+    expect(calls[0]!.prompt).toContain('Do not run these checks yourself');
     expect(calls).toHaveLength(1);
     expect(calls[0]!.cwd).toBe(join(root, 'games', SLUG));
     expect(calls[0]!.spec.name).toBe('claude');

--- a/apps/cli/src/workshop.ts
+++ b/apps/cli/src/workshop.ts
@@ -1,3 +1,4 @@
+import { requireClaudeSubscription, subscriptionEnv } from './claude-auth.js';
 import { permissionBlocked } from './agent-events.js';
 import { startLocalPlay } from './play.js';
 import { join } from 'node:path';
@@ -24,6 +25,7 @@ export type AdapterRun = (input: {
   env: NodeJS.ProcessEnv;
   abort?: AbortSignal;
   onLine?: (line: string) => void;
+  authCheck?: Promise<void>;
 }) => Promise<{ code: number | null }>;
 
 type VerifyRun = NonNullable<Parameters<typeof runLadder>[0]['run']>;
@@ -63,7 +65,7 @@ export function detectLocalAdapters(
 }
 
 async function defaultAdapterRun(input: Parameters<AdapterRun>[0]): Promise<{ code: number | null }> {
-  const child = spawnAdapter({ ...input, timeoutMs: ADAPTER_TIMEOUT_MS });
+  const child = await spawnAdapter({ ...input, timeoutMs: ADAPTER_TIMEOUT_MS });
   for (const stream of [child.stdout, child.stderr]) {
     if (stream) createInterface({ input: stream }).on('line', (line: string) => input.onLine?.(line));
   }
@@ -244,10 +246,21 @@ export async function runLocalBuild(input: {
   const cwd = spec.cwd === 'game-dir' ? join(ws.root, 'games', ws.slug) : ws.root;
   const controller = new AbortController();
   ws.abort.current = controller;
-  input.write(`▸ ${spec.name} is working in games/${ws.slug} — Ctrl+C stops it`);
   let result: { code: number | null };
   let blocked = false;
+  let authCheck: Promise<void> | undefined;
   try {
+    if (!ws.runAdapter && spec.name === 'claude') {
+      authCheck = requireClaudeSubscription({
+        command: spec.command,
+        cwd,
+        env: subscriptionEnv(childEnv(ws.env, '')),
+        args: spec.headless,
+        abort: controller.signal,
+      });
+      await authCheck;
+    }
+    input.write(`▸ Preparing ${spec.name} in games/${ws.slug} — Ctrl+C stops it`);
     if (!ws.runAdapter)
       await prepareWorkspace({ cwd: ws.root, env: ws.env, abort: controller.signal, write: input.write });
     if (!ws.runAdapter && !ws.unattended) {
@@ -276,6 +289,7 @@ export async function runLocalBuild(input: {
     result = await (ws.runAdapter ?? defaultAdapterRun)({
       spec,
       prompt: input.brief,
+      authCheck,
       cwd,
       env: childEnv(ws.env, ''),
       abort: controller.signal,

--- a/apps/cli/src/workshop.ts
+++ b/apps/cli/src/workshop.ts
@@ -1,3 +1,4 @@
+import { permissionBlocked } from './agent-events.js';
 import { startLocalPlay } from './play.js';
 import { join } from 'node:path';
 import { createInterface } from 'node:readline';
@@ -245,6 +246,7 @@ export async function runLocalBuild(input: {
   ws.abort.current = controller;
   input.write(`▸ ${spec.name} is working in games/${ws.slug} — Ctrl+C stops it`);
   let result: { code: number | null };
+  let blocked = false;
   try {
     if (!ws.runAdapter)
       await prepareWorkspace({ cwd: ws.root, env: ws.env, abort: controller.signal, write: input.write });
@@ -278,6 +280,7 @@ export async function runLocalBuild(input: {
       env: childEnv(ws.env, ''),
       abort: controller.signal,
       onLine: (line) => {
+        if (permissionBlocked(line)) blocked = true;
         for (const shown of renderDelegateStream(spec.name, [line], false)) {
           if (shown.includes('⚙ ')) ws.onActivity?.(`${spec.name} · ${shown.split('⚙ ')[1]!.slice(0, 90)}`);
           input.write(shown);
@@ -286,6 +289,12 @@ export async function runLocalBuild(input: {
     });
   } finally {
     ws.abort.current = null;
+  }
+  if (blocked) {
+    input.write(
+      `${spec.name} could not obtain tool permissions in headless mode. No successful edit is confirmed; review its permissions for this game directory and retry.`,
+    );
+    return false;
   }
   if (controller.signal.aborted) {
     input.write(`${spec.name} stopped — the tree keeps whatever it wrote; /diff to see`);

--- a/apps/cli/src/workshop.ts
+++ b/apps/cli/src/workshop.ts
@@ -34,6 +34,7 @@ export type Workshop = {
   env: NodeJS.ProcessEnv;
   adapters: AdapterSpec[];
   selectedAgent?: string;
+  onActivity?: (activity: string) => void;
   telemetry?: CliTelemetry;
   builder: string;
   pick: PickChoice;
@@ -80,7 +81,8 @@ export function workshopBrief(slug: string, request: string, ack?: string): stri
     ack ? `Studio understood it as: ${ack}` : '',
     'Change only files in this directory. Do not run git, install packages, or publish — the creator delivers with `gamedevpl submit`.',
     'If the creator wants to play, run `gamedevpl play` in this checkout; it opens a live preview without delivering or publishing. Use --no-open for a link only and --stop to close the server.',
-    'When done, `npm run typecheck` and `npm run check:static` at the checkout root must pass.',
+    'The CLI runs typecheck and check:static after you exit. Do not run these checks yourself.',
+    'This is a non-interactive task: do not wait for replies or approvals. If blocked, report the blocker and finish.',
   ]
     .filter(Boolean)
     .join('\n');
@@ -236,6 +238,7 @@ export async function runLocalBuild(input: {
   write: (line: string) => void;
 }): Promise<boolean> {
   const { ws, spec } = input;
+  ws.onActivity?.(`Preparing ${spec.name}`);
   if (!ws.runAdapter) preflightAdapter(spec, ws.env);
   const cwd = spec.cwd === 'game-dir' ? join(ws.root, 'games', ws.slug) : ws.root;
   const controller = new AbortController();
@@ -261,6 +264,12 @@ export async function runLocalBuild(input: {
       }
     }
     if (controller.signal.aborted) return false;
+    ws.onActivity?.(`${spec.name} is editing locally — input returns when it finishes`);
+    input.write(`${spec.name} controls this local editing task; Ctrl+C stops it.`);
+    if (spec.name === 'claude')
+      input.write(
+        'Claude uses subscription login; API authentication is refused. This local task is not linked to Claude Desktop.',
+      );
     ws.telemetry?.record('delegate_used', spec.name);
     result = await (ws.runAdapter ?? defaultAdapterRun)({
       spec,
@@ -269,7 +278,10 @@ export async function runLocalBuild(input: {
       env: childEnv(ws.env, ''),
       abort: controller.signal,
       onLine: (line) => {
-        for (const shown of renderDelegateStream(spec.name, [line], false)) input.write(shown);
+        for (const shown of renderDelegateStream(spec.name, [line], false)) {
+          if (shown.includes('⚙ ')) ws.onActivity?.(`${spec.name} · ${shown.split('⚙ ')[1]!.slice(0, 90)}`);
+          input.write(shown);
+        }
       },
     });
   } finally {
@@ -283,11 +295,12 @@ export async function runLocalBuild(input: {
     input.write(`${spec.name} exited ${result.code ?? 'null'} — /diff to see what changed`);
     return false;
   }
+  ws.onActivity?.('Agent finished — verifying typecheck and static checks');
   input.write('verifying — typecheck, check:static');
   const verify = runLadder({ cwd: ws.root, publish: false, run: ws.run });
   if (!verify.ok) {
     ws.telemetry?.record('verify_failed', spec.name, verify.stage);
-    const detail = verify.detail.split('\n').find((line) => line.trim()) ?? '';
+    const detail = verify.detail.trim();
     input.write(`verify failed at ${verify.stage}${detail ? `: ${detail}` : ''}\nfix by hand, or ask again`);
     return false;
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -95,7 +95,7 @@
     },
     "apps/cli": {
       "name": "@gamedevpl/cli",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "dependencies": {
         "@gamedevpl/contract": "*",
         "ink": "^5.2.1",


### PR DESCRIPTION
Claude tasks inherited API credentials despite a subscription login, while the TUI lost builder selections after failed requests and kept showing the old published round during editing.

- Remove inherited Anthropic API/cloud-provider environment settings from the Claude child and require a successful Claude.ai or setup-token OAuth / first-party auth status before spawning. Check asynchronously with cancellation in the task cwd with adapter settings flags, before local preparation or delegate telemetry; reuse the result for that launch and recheck on each new task. Preserve model selection, distinguish outdated CLI versions from missing login; unknown/API auth fails closed. This changes the Claude adapter's authentication contract and is documented under Breaking. Parent credentials and shell settings are untouched.
- Remember an explicitly selected local agent before requesting an improvement, including when that request fails.
- Show active local agent/tool and verification stages. Refresh the TUI token when the new workshop opens; terminal round watches sleep until a new round arrives rather than stopping permanently.
- Show local Claude session IDs/resume instructions, hide empty assistant event labels and duplicate Codex start events, render Antigravity events as readable progress, keep full verification diagnostics including stdout, and explain moderation refusals.
- Refuse empty Antigravity runs that report headless permission denial. A partial Claude tool refusal is a warning: exit-zero edits still reach verification and the normal delivery offer.
- Clarify the noninteractive brief: the agent edits, the CLI runs checkout checks after exit. Desktop bridging is not implemented; these remain local print-mode sessions.

Validation passed: npm install, full root type-check/lint/test/build, and focused auth/selection/status/verification tests. A read-only local Claude auth probe with API environment removed confirmed Claude.ai / Max; no model task was launched. Real checkout verification reproduces the separate Creator Kit bug: its no-plain-js checker rejects its own root setup.mjs. Creator Kit fix: https://github.com/gamedevpl/www.gamedev.pl-games/pull/1290. This PR preserves and displays that error; it does not weaken the game's checks or patch the user's checkout. Production moderation logs record only category other, so the cause of that individual refusal remains unknown.

Instrumentation: creator funnel/return (questions 4–5), through existing cli_step and round records. No prompts, keys or paths added to telemetry. Exact token accounting and Desktop session bridging remain outside this fix. Subscription extra-usage limits remain managed by Claude.
