### PR TITLE
fix(api): say why the spend brake paused nothing

### DIFF
--- a/apps/api/src/platform/spend-brake.test.ts
+++ b/apps/api/src/platform/spend-brake.test.ts
@@ -48,6 +48,40 @@ describe('spend brake payload reading', () => {
     expect(lanesFromNotification({ incident: null }).lanes).toEqual([]);
     expect(lanesFromNotification({ incident: { state: 'OPEN' } }).lanes).toEqual([]);
   });
+
+  it('says why it paused nothing, with the policy that sent it', () => {
+    expect(lanesFromNotification(undefined).reason).toBe('no_incident');
+    expect(lanesFromNotification({ incident: null }).reason).toBe('no_incident');
+    expect(
+      lanesFromNotification({
+        incident: {
+          state: 'CLOSED',
+          incident_id: 'inc-9',
+          policy_name: 'A24',
+          policy_user_labels: { lanes: 'search' },
+        },
+      }),
+    ).toEqual({ lanes: [], incidentId: 'inc-9', policyName: 'A24', state: 'CLOSED', reason: 'closed' });
+    expect(lanesFromNotification({ incident: { state: 'OPEN', policy_name: 'A1 uptime' } })).toEqual({
+      lanes: [],
+      policyName: 'A1 uptime',
+      state: 'OPEN',
+      reason: 'no_lanes_label',
+    });
+    expect(lanesFromNotification(openIncident('everything'))).toEqual({
+      lanes: [],
+      incidentId: 'inc-1',
+      state: 'OPEN',
+      rawLanes: 'everything',
+      reason: 'unrecognised_lanes',
+    });
+    expect(lanesFromNotification(openIncident('search'))).toEqual({
+      lanes: ['search'],
+      incidentId: 'inc-1',
+      state: 'OPEN',
+      rawLanes: 'search',
+    });
+  });
 });
 
 describe('POST /api/internal/spend-brake', () => {

--- a/apps/api/src/platform/spend-brake.ts
+++ b/apps/api/src/platform/spend-brake.ts
@@ -37,16 +37,38 @@ export function parseLanes(raw: unknown): PauseableLane[] {
 }
 
 // An unrecognised lane pauses nothing, which is right.
-export function lanesFromNotification(body: unknown): { lanes: PauseableLane[]; incidentId?: string } {
+
+// `reason` says why nothing paused; the log answers instead of asking.
+export type BrakeSkipReason = 'no_incident' | 'closed' | 'no_lanes_label' | 'unrecognised_lanes';
+
+export interface BrakeNotification {
+  lanes: PauseableLane[];
+  incidentId?: string;
+  policyName?: string;
+  state?: string;
+  rawLanes?: string;
+  reason?: BrakeSkipReason;
+}
+
+export function lanesFromNotification(body: unknown): BrakeNotification {
   const incident = (body as { incident?: Record<string, unknown> } | undefined)?.incident;
-  if (!incident || typeof incident !== 'object') return { lanes: [] };
-  const state = incident.state;
-  // A closing notification must never pause anything.
-  if (state !== undefined && state !== 'OPEN' && state !== 'open') return { lanes: [] };
-  const labels = incident.policy_user_labels ?? incident.policyUserLabels;
-  const lanes = parseLanes((labels as Record<string, unknown> | undefined)?.lanes);
+  if (!incident || typeof incident !== 'object') return { lanes: [], reason: 'no_incident' };
+  const state = typeof incident.state === 'string' ? incident.state : undefined;
+  const policyName = typeof incident.policy_name === 'string' ? incident.policy_name : undefined;
   const incidentId = typeof incident.incident_id === 'string' ? incident.incident_id : undefined;
-  return { lanes, ...(incidentId ? { incidentId } : {}) };
+  const context = {
+    ...(incidentId ? { incidentId } : {}),
+    ...(policyName ? { policyName } : {}),
+    ...(state ? { state } : {}),
+  };
+  // A closing notification must never pause anything.
+  if (state !== undefined && state !== 'OPEN' && state !== 'open') return { lanes: [], ...context, reason: 'closed' };
+  const labels = incident.policy_user_labels ?? incident.policyUserLabels;
+  const rawLanes = (labels as Record<string, unknown> | undefined)?.lanes;
+  if (typeof rawLanes !== 'string') return { lanes: [], ...context, reason: 'no_lanes_label' };
+  const lanes = parseLanes(rawLanes);
+  if (lanes.length === 0) return { lanes: [], ...context, rawLanes, reason: 'unrecognised_lanes' };
+  return { lanes, ...context, rawLanes };
 }
 
 // Pub/Sub push wraps the payload as base64.
@@ -77,17 +99,20 @@ export async function registerSpendBrakeRoutes(app: FastifyInstance, options: Sp
       if (!store) return reply.status(503).send({ error: 'the spend brake is not configured' });
 
       const payload = decodePushEnvelope(request.body);
-      const { lanes, incidentId } = lanesFromNotification(payload);
+      const { lanes, incidentId, policyName, state, rawLanes, reason } = lanesFromNotification(payload);
       if (lanes.length === 0) {
         // Acknowledged, not retried: a redelivery pauses nothing either.
-        request.log.warn({ incidentId }, 'spend brake fired with no recognised lane');
-        return reply.send({ paused: [] });
+        request.log.warn(
+          { incidentId, policyName, state, rawLanes, reason, decoded: payload !== undefined },
+          'spend brake fired with no recognised lane',
+        );
+        return reply.send({ paused: [], reason });
       }
 
       const patch: Partial<CreationLimits> = {};
       for (const lane of lanes) patch[PAUSEABLE[lane]] = true;
       await store.setCreationLimits(patch, `alert:${incidentId ?? 'unknown'}`);
-      request.log.error({ incidentId, lanes }, 'spend brake pulled by a monitoring alert');
+      request.log.error({ incidentId, policyName, lanes }, 'spend brake pulled by a monitoring alert');
       return reply.send({ paused: lanes });
     },
   );


### PR DESCRIPTION
## Why

Since 2026-09-07 12:02 UTC the Pub/Sub push subscription has delivered a notification to `/api/internal/spend-brake` every 20–40 minutes, each acked with `spend brake fired with no recognised lane`. Nothing is paused (`opsConfig/creationLimits` clean), A24/A25/A26 have correct `lanes` labels, and the Vertex metrics are nowhere near their thresholds — so these are not open A2x incidents. The log could not say more: the warn carried only `incidentId`, which was undefined.

## What

`lanesFromNotification` now returns, alongside `lanes`:

- `reason`: `no_incident` | `closed` | `no_lanes_label` | `unrecognised_lanes`
- `policyName` (`incident.policy_name`), `state`, `rawLanes`

The warn logs all of them plus `decoded` (whether the Pub/Sub envelope parsed at all), and the "pulled" error log carries `policyName`. The HTTP response echoes `reason`. Behaviour is unchanged: nothing new pauses, closing notifications still never pause.

Tests cover each reason and the exact shape of the returned object.

## After merge

Read the next few warns:

```bash
gcloud logging read 'resource.type=cloud_run_revision AND resource.labels.service_name=gamedev-app AND textPayload:recognised' --project gamedevpl --freshness=2h --format='value(timestamp,textPayload)'
```

`reason=closed` with a policy name means an alert is flapping; `no_incident` with `decoded=true` means something other than Monitoring publishes to the `spend-brake` topic; `decoded=false` means the envelope is not JSON.

🤖 Generated with [Claude Code](https://claude.com/claude-code)