### PR TITLE
feat(api): let the Billing budget pull the spend brake

### DIFF
--- a/apps/api/src/platform/spend-brake.test.ts
+++ b/apps/api/src/platform/spend-brake.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { buildApp } from './app.js';
 import { InMemoryStore } from './store.js';
-import { lanesFromNotification, parseLanes } from './spend-brake.js';
+import { budgetFromNotification, lanesFromBudget, lanesFromNotification, parseLanes } from './spend-brake.js';
 
 const sessionSecret = 'dev-session-secret-change-me';
 
@@ -11,6 +11,18 @@ function pushBody(payload: unknown) {
 
 function openIncident(lanes: string, extra: Record<string, unknown> = {}) {
   return { incident: { state: 'OPEN', incident_id: 'inc-1', policy_user_labels: { lanes }, ...extra } };
+}
+
+function budgetPush(extra: Record<string, unknown> = {}) {
+  return {
+    budgetDisplayName: 'zł130 Monthly Budget Alert',
+    costAmount: 61.4,
+    budgetAmount: 130,
+    budgetAmountType: 'SPECIFIED_AMOUNT',
+    currencyCode: 'PLN',
+    costIntervalStart: '2026-09-01T07:00:00Z',
+    ...extra,
+  };
 }
 
 describe('spend brake payload reading', () => {
@@ -84,7 +96,79 @@ describe('spend brake payload reading', () => {
   });
 });
 
+describe('budget payload reading', () => {
+  it('recognises a Billing budget by its amounts, not by an incident', () => {
+    expect(budgetFromNotification(budgetPush())).toEqual({
+      name: 'zł130 Monthly Budget Alert',
+      cost: 61.4,
+      budget: 130,
+      currency: 'PLN',
+    });
+    expect(budgetFromNotification(openIncident('search'))).toBeUndefined();
+    expect(budgetFromNotification(undefined)).toBeUndefined();
+    expect(budgetFromNotification({ costAmount: '61', budgetAmount: 130 })).toBeUndefined();
+  });
+
+  it('pauses only on real spend at or over the budget', () => {
+    expect(lanesFromBudget(budgetFromNotification(budgetPush())!)).toEqual([]);
+    expect(lanesFromBudget(budgetFromNotification(budgetPush({ alertThresholdExceeded: 0.9 }))!)).toEqual([]);
+    expect(lanesFromBudget(budgetFromNotification(budgetPush({ forecastThresholdExceeded: 1.0 }))!)).toEqual([]);
+    expect(lanesFromBudget(budgetFromNotification(budgetPush({ alertThresholdExceeded: 1.0 }))!)).toEqual([
+      'creation',
+      'editing',
+      'chat',
+      'tabComplete',
+      'search',
+    ]);
+    expect(lanesFromBudget(budgetFromNotification(budgetPush({ alertThresholdExceeded: 1.5 }))!)).toHaveLength(5);
+  });
+});
+
 describe('POST /api/internal/spend-brake', () => {
+  it('acks a budget notification under its ceiling without touching anything', async () => {
+    const store = new InMemoryStore();
+    const app = await buildApp({
+      store,
+      sessionSecret,
+      spendBrakeRoutes: { internalAuthVerifier: { verify: async () => true } },
+    });
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/internal/spend-brake',
+      payload: pushBody(budgetPush({ alertThresholdExceeded: 0.9 })),
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toEqual({ paused: [], reason: 'budget_under_ceiling' });
+    expect(await store.getCreationLimits()).toBeNull();
+    await app.close();
+  });
+
+  it('pauses the spend lanes when real spend passes the budget, and names the budget', async () => {
+    const store = new InMemoryStore();
+    const app = await buildApp({
+      store,
+      sessionSecret,
+      spendBrakeRoutes: { internalAuthVerifier: { verify: async () => true } },
+    });
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/internal/spend-brake',
+      payload: pushBody(budgetPush({ costAmount: 131.2, alertThresholdExceeded: 1.0 })),
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json().paused).toEqual(['creation', 'editing', 'chat', 'tabComplete', 'search']);
+    const limits = await store.getCreationLimits();
+    expect(limits?.paused).toBe(true);
+    expect(limits?.searchPaused).toBe(true);
+    expect(limits?.gatePaused).not.toBe(true);
+    expect(limits?.updatedBy).toBe('budget:zł130 Monthly Budget Alert');
+    await app.close();
+  });
+
   it('refuses an unverified caller — it can pause the product', async () => {
     const store = new InMemoryStore();
     const app = await buildApp({

--- a/apps/api/src/platform/spend-brake.ts
+++ b/apps/api/src/platform/spend-brake.ts
@@ -71,6 +71,39 @@ export function lanesFromNotification(body: unknown): BrakeNotification {
   return { lanes, ...context, rawLanes };
 }
 
+// A Billing budget publishes its state several times a day.
+export interface BudgetNotification {
+  name: string;
+  cost: number;
+  budget: number;
+  currency?: string;
+  thresholdExceeded?: number;
+  forecastExceeded?: number;
+}
+
+export function budgetFromNotification(body: unknown): BudgetNotification | undefined {
+  const b = body as Record<string, unknown> | undefined;
+  if (!b || typeof b !== 'object') return undefined;
+  if (typeof b.costAmount !== 'number' || typeof b.budgetAmount !== 'number') return undefined;
+  const num = (v: unknown) => (typeof v === 'number' && Number.isFinite(v) ? v : undefined);
+  return {
+    name: typeof b.budgetDisplayName === 'string' ? b.budgetDisplayName : 'budget',
+    cost: b.costAmount,
+    budget: b.budgetAmount,
+    ...(typeof b.currencyCode === 'string' ? { currency: b.currencyCode } : {}),
+    ...(num(b.alertThresholdExceeded) !== undefined ? { thresholdExceeded: num(b.alertThresholdExceeded) } : {}),
+    ...(num(b.forecastThresholdExceeded) !== undefined ? { forecastExceeded: num(b.forecastThresholdExceeded) } : {}),
+  };
+}
+
+// Real spend at or over the budget; a forecast alone never pauses.
+export const BUDGET_PAUSE_AT = 1.0;
+export const BUDGET_LANES: PauseableLane[] = ['creation', 'editing', 'chat', 'tabComplete', 'search'];
+
+export function lanesFromBudget(budget: BudgetNotification): PauseableLane[] {
+  return budget.thresholdExceeded !== undefined && budget.thresholdExceeded >= BUDGET_PAUSE_AT ? BUDGET_LANES : [];
+}
+
 // Pub/Sub push wraps the payload as base64.
 export function decodePushEnvelope(body: unknown): unknown {
   const data = (body as { message?: { data?: unknown } } | undefined)?.message?.data;
@@ -99,6 +132,19 @@ export async function registerSpendBrakeRoutes(app: FastifyInstance, options: Sp
       if (!store) return reply.status(503).send({ error: 'the spend brake is not configured' });
 
       const payload = decodePushEnvelope(request.body);
+      const budget = budgetFromNotification(payload);
+      if (budget) {
+        const budgetLanes = lanesFromBudget(budget);
+        if (budgetLanes.length === 0) {
+          request.log.info({ ...budget }, 'budget notification under its ceiling');
+          return reply.send({ paused: [], reason: 'budget_under_ceiling' });
+        }
+        const patch: Partial<CreationLimits> = {};
+        for (const lane of budgetLanes) patch[PAUSEABLE[lane]] = true;
+        await store.setCreationLimits(patch, `budget:${budget.name}`);
+        request.log.error({ ...budget, lanes: budgetLanes }, 'spend brake pulled by a billing budget');
+        return reply.send({ paused: budgetLanes });
+      }
       const { lanes, incidentId, policyName, state, rawLanes, reason } = lanesFromNotification(payload);
       if (lanes.length === 0) {
         // Acknowledged, not retried: a redelivery pauses nothing either.


### PR DESCRIPTION
## Why

#1205's richer log answered within one push: `reason=no_incident, decoded=true`. The publisher on the `spend-brake` topic is `billing-budget-alert@system.gserviceaccount.com` — the **zł130 Monthly Budget Alert** budget has `notificationsRule.pubsubTopic = projects/gamedevpl/topics/spend-brake`. Budgets publish their state to Pub/Sub several times a day regardless of thresholds (hence the 20–40 min rhythm), as JSON with `costAmount` / `budgetAmount` / `alertThresholdExceeded` and no `incident`. So the brake acked ~40 pushes a day and A5 paused nothing.

## What

- `budgetFromNotification` recognises a budget payload by its two amounts.
- `lanesFromBudget`: `alertThresholdExceeded >= 1.0` (real spend at or over the budget) pauses `creation, editing, chat, tabComplete, search` — the same set A24/A25 pull. `forecastThresholdExceeded` alone never pauses; 0.5/0.9 never pause.
- Under the ceiling: info log with name/cost/budget/currency, `200 {paused: [], reason: 'budget_under_ceiling'}`. Over: `setCreationLimits` recorded as `budget:<displayName>`, error log `spend brake pulled by a billing budget`.
- Resuming stays a human decision in the admin console, as with the alert-pulled brake. Repeated pushes after a pause are idempotent.

Tests: payload recognition, threshold semantics (under / 0.9 / forecast-only / 1.0 / 1.5), and both route outcomes against the in-memory store.

## After merge

Every budget push now logs at info instead of warn; the first over-budget push pauses the five lanes. The remaining warn (`no recognised lane`) is again meaningful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)