### PR TITLE
fix(auth): guard cookie session writes from CSRF

### DIFF
--- a/apps/api/src/platform/auth.ts
+++ b/apps/api/src/platform/auth.ts
@@ -10,6 +10,7 @@ import { isReviewer, isReviewerSession } from '../community/review.js';
 import { resolveAppleAccount } from './apple-account.js';
 import { createAppleAuthVerifierFromEnv, parseAppleClientIds, type AppleAuthVerifier } from './apple-auth.js';
 import { readBearerToken } from './bearer.js';
+import { sessionWriteAllowed } from './session-csrf.js';
 import {
   clearSessionCookies,
   handlerWroteSessionCookie,
@@ -389,7 +390,7 @@ export async function registerAuthPlugin(app: FastifyInstance, options: AuthPlug
   app.decorateRequest('needsSessionRenewal', false);
   app.decorateRequest('authMethod', null);
 
-  app.addHook('onRequest', async (request) => {
+  app.addHook('onRequest', async (request, reply) => {
     if (!isAuthConfigured) return;
     const { user, needsRenewal, fromToken } = await getSessionUser(request);
     if (!user) {
@@ -402,6 +403,7 @@ export async function registerAuthPlugin(app: FastifyInstance, options: AuthPlug
       return;
     }
 
+    if (!sessionWriteAllowed(request)) return reply.status(403).send({ error: 'untrusted request origin' });
     request.user = user;
     request.needsSessionRenewal = needsRenewal;
     // A cookie minted from a PAT still reports 'token': the credential behind this
@@ -409,15 +411,7 @@ export async function registerAuthPlugin(app: FastifyInstance, options: AuthPlug
     // the cookie it was traded for.
     request.authMethod = fromToken ? 'token' : 'session';
 
-    /**
-     * Record that this account was active today.
-     *
-     * `lastLoginAt` cannot stand in for this: sessions last weeks, so a creator who
-     * comes back every day still shows a single login and reads as never returning.
-     * `withActiveDay` returns null when today is already the newest entry, so the
-     * common case costs no write at all — and a failure here must never turn a
-     * working request into an error, hence the swallow.
-     */
+    // Sessions last weeks; record activity separately from sign-in, once per day.
     const today = new Date().toISOString().slice(0, 10);
     const activeDays = withActiveDay(user.activeDays, today);
     if (activeDays) {

--- a/apps/api/src/platform/creator-pat-routes.ts
+++ b/apps/api/src/platform/creator-pat-routes.ts
@@ -43,6 +43,8 @@ export async function registerCreatorPatRoutes(app: FastifyInstance, options: Cr
 
   app.post('/api/me/access-tokens', async (request, reply) => {
     if (!sessionOnly(request)) return reply.status(404).send({ error: 'not found' });
+    const contentType = request.headers['content-type']?.split(';')[0]?.trim().toLowerCase();
+    if (contentType !== 'application/json') return reply.status(415).send({ error: 'application/json required' });
     const parsed = MintSchema.safeParse(request.body ?? {});
     if (!parsed.success) {
       return reply.status(400).send({ error: parsed.error.issues[0]?.message ?? 'invalid request' });

--- a/apps/api/src/platform/session-csrf.test.ts
+++ b/apps/api/src/platform/session-csrf.test.ts
@@ -1,0 +1,199 @@
+import type { FastifyInstance } from 'fastify';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mintAccessTokenFor } from './access-token-service.js';
+import { buildApp } from './app.js';
+import { mintSessionToken, SESSION_COOKIE_NAME } from './auth.js';
+import { InMemoryStore } from './store.js';
+
+const secret = 'local-csrf-regression-secret';
+const cookie = `${SESSION_COOKIE_NAME}=${mintSessionToken('g:alice', secret)}`;
+const mintBody = { name: 'ci', expiresInDays: 1 };
+
+describe('cookie-authenticated write CSRF protection', () => {
+  let app: FastifyInstance;
+  let store: InMemoryStore;
+  let writes: number;
+
+  beforeEach(async () => {
+    vi.stubEnv('APP_BASE_URL', 'https://www.gamedev.pl');
+    vi.stubEnv('CANONICAL_HOST', 'www.gamedev.pl');
+    vi.stubEnv('WEB_ORIGIN', 'https://www.gamedev.pl');
+    store = new InMemoryStore();
+    await store.upsertUser({ uid: 'g:alice' });
+    app = await buildApp({ store, sessionSecret: secret });
+    writes = 0;
+    app.route({
+      method: ['POST', 'PUT', 'PATCH', 'DELETE'],
+      url: '/csrf-probe',
+      handler: async () => ({ writes: ++writes }),
+    });
+  });
+
+  afterEach(async () => {
+    await app.close();
+    vi.unstubAllEnvs();
+  });
+
+  it.each([
+    'https://attacker.invalid',
+    'https://evil.gamedev.pl',
+    'https://www.gamedev.pl.attacker.invalid',
+    'http://www.gamedev.pl',
+    'null',
+    'https://www.gamedev.pl/path',
+    'https://www.gamedev.pl, https://attacker.invalid',
+  ])('refuses a foreign/invalid origin without minting a PAT: %s', async (origin) => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/me/access-tokens',
+      headers: { cookie, origin, 'content-type': 'application/x-www-form-urlencoded' },
+      payload: 'name=forged&expiresInDays=1',
+    });
+    expect(res.statusCode).toBe(403);
+    expect(await store.listAccessTokens('g:alice')).toHaveLength(0);
+  });
+
+  it.each(['application/x-www-form-urlencoded', 'text/plain'])(
+    'requires JSON even without Origin: %s',
+    async (type) => {
+      const res = await app.inject({
+        method: 'POST',
+        url: '/api/me/access-tokens',
+        headers: { cookie, 'content-type': type },
+        payload: type === 'text/plain' ? JSON.stringify(mintBody) : 'name=forged&expiresInDays=1',
+      });
+      expect(res.statusCode).toBe(415);
+      expect(await store.listAccessTokens('g:alice')).toHaveLength(0);
+    },
+  );
+
+  it.each(['POST', 'PUT', 'PATCH', 'DELETE'] as const)('guards %s before any handler writes', async (method) => {
+    const res = await app.inject({
+      method,
+      url: '/csrf-probe',
+      headers: { cookie, origin: 'https://evil.gamedev.pl' },
+      payload: {},
+    });
+    expect(res.statusCode).toBe(403);
+    expect(writes).toBe(0);
+  });
+
+  it('does not allow token revocation from a sibling origin', async () => {
+    const { record } = await mintAccessTokenFor(store, {
+      uid: 'g:alice',
+      name: 'keep',
+      createdByUid: 'g:alice',
+      nowMs: Date.now(),
+    });
+    const res = await app.inject({
+      method: 'DELETE',
+      url: `/api/me/access-tokens/${record.tokenId}`,
+      headers: { cookie, origin: 'https://evil.gamedev.pl' },
+    });
+    expect(res.statusCode).toBe(403);
+    expect(await store.listAccessTokens('g:alice')).toHaveLength(1);
+  });
+
+  it.each([{ origin: 'https://www.gamedev.pl' }, { referer: 'https://www.gamedev.pl/studio?tab=settings' }, {}])(
+    'allows a valid JSON mint from the app or a headerless API client: %j',
+    async (headers) => {
+      const res = await app.inject({
+        method: 'POST',
+        url: '/api/me/access-tokens',
+        headers: { cookie, ...headers, 'content-type': 'application/json; charset=utf-8' },
+        payload: mintBody,
+      });
+      expect(res.statusCode).toBe(201);
+      expect(await store.listAccessTokens('g:alice')).toHaveLength(1);
+    },
+  );
+
+  it('accepts a same-origin candidate without trusting forwarded-host', async () => {
+    const headers = {
+      cookie,
+      host: 'candidate---gamedev-app.run.app',
+      'x-forwarded-proto': 'https',
+      origin: 'https://candidate---gamedev-app.run.app',
+    };
+    expect((await app.inject({ method: 'POST', url: '/csrf-probe', headers })).statusCode).toBe(200);
+    expect(
+      (
+        await app.inject({
+          method: 'POST',
+          url: '/csrf-probe',
+          headers: { ...headers, origin: 'https://evil.gamedev.pl', 'x-forwarded-host': 'evil.gamedev.pl' },
+        })
+      ).statusCode,
+    ).toBe(403);
+    expect(writes).toBe(1);
+  });
+
+  it('accepts configured development origins but not arbitrary loopback ports', async () => {
+    vi.stubEnv('WEB_ORIGIN', 'http://localhost:5173, http://127.0.0.1:5173');
+    for (const origin of ['http://localhost:5173', 'http://127.0.0.1:5173']) {
+      expect((await app.inject({ method: 'POST', url: '/csrf-probe', headers: { cookie, origin } })).statusCode).toBe(
+        200,
+      );
+    }
+    expect(
+      (await app.inject({ method: 'POST', url: '/csrf-probe', headers: { cookie, origin: 'http://127.0.0.1:8769' } }))
+        .statusCode,
+    ).toBe(403);
+  });
+
+  it('accepts the default Vite proxy with its original Host and no configured origin', async () => {
+    vi.stubEnv('WEB_ORIGIN', '');
+    const res = await app.inject({
+      method: 'POST',
+      url: '/csrf-probe',
+      headers: { cookie, host: 'localhost:5173', origin: 'http://localhost:5173' },
+    });
+    expect(res.statusCode).toBe(200);
+    expect(writes).toBe(1);
+  });
+
+  it.each([
+    { referer: 'https://evil.gamedev.pl/form' },
+    { referer: 'not a URL' },
+    { 'sec-fetch-site': 'same-site' },
+    { 'sec-fetch-site': 'cross-site' },
+    { origin: 'null', referer: 'https://www.gamedev.pl/' },
+  ])('does not fall back past an untrusted browser signal: %j', async (headers) => {
+    const res = await app.inject({ method: 'POST', url: '/csrf-probe', headers: { cookie, ...headers } });
+    expect(res.statusCode).toBe(403);
+    expect(writes).toBe(0);
+  });
+
+  it('protects PAT-derived cookies, including when a Bearer header is added', async () => {
+    const tokenCookie = `${SESSION_COOKIE_NAME}=${mintSessionToken('g:alice', secret, 3600, undefined, 'token')}`;
+    for (const held of [cookie, tokenCookie]) {
+      const res = await app.inject({
+        method: 'POST',
+        url: '/csrf-probe',
+        headers: { cookie: held, authorization: 'Bearer anything', origin: 'https://evil.gamedev.pl' },
+      });
+      expect(res.statusCode).toBe(403);
+    }
+    expect(writes).toBe(0);
+  });
+
+  it('leaves Bearer-only clients and safe cookie reads unchanged', async () => {
+    const { token } = await mintAccessTokenFor(store, {
+      uid: 'g:alice',
+      name: 'cli',
+      createdByUid: 'g:alice',
+      nowMs: Date.now(),
+    });
+    const res = await app.inject({
+      method: 'POST',
+      url: '/csrf-probe',
+      headers: { authorization: `Bearer ${token}`, origin: 'https://client.invalid' },
+    });
+    expect(res.statusCode).toBe(200);
+    expect(writes).toBe(1);
+    expect(
+      (await app.inject({ method: 'GET', url: '/api/auth/me', headers: { cookie, origin: 'https://evil.gamedev.pl' } }))
+        .statusCode,
+    ).toBe(200);
+  });
+});

--- a/apps/api/src/platform/session-csrf.ts
+++ b/apps/api/src/platform/session-csrf.ts
@@ -1,0 +1,36 @@
+import type { FastifyRequest } from 'fastify';
+import { canonicalAppBaseUrl } from './canonical-app-url.js';
+
+function originOf(value: string): string | null {
+  try {
+    const url = new URL(value);
+    return url.protocol === 'https:' || url.protocol === 'http:' ? url.origin : null;
+  } catch {
+    return null;
+  }
+}
+
+// Called only after a cookie authenticates, before any account activity write.
+export function sessionWriteAllowed(request: FastifyRequest): boolean {
+  if (['GET', 'HEAD', 'OPTIONS'].includes(request.method)) return true;
+
+  const origin = request.headers.origin;
+  const referer = request.headers.referer;
+  let source: string | null;
+  if (origin !== undefined) {
+    source = typeof origin === 'string' ? originOf(origin) : null;
+    if (!source || source !== origin) return false;
+  } else if (referer !== undefined) {
+    source = typeof referer === 'string' ? originOf(referer) : null;
+    if (!source) return false;
+  } else {
+    // Headerless API clients remain supported; same-site browsers are not same-origin.
+    const site = request.headers['sec-fetch-site'];
+    return site === undefined || site === 'same-origin';
+  }
+
+  // Exact target origin also supports candidate revisions; never trust X-Forwarded-Host.
+  const target = originOf(`${request.protocol}://${request.headers.host}`);
+  const configured = (process.env.WEB_ORIGIN ?? '').split(',').map((entry) => originOf(entry.trim()));
+  return source === target || source === canonicalAppBaseUrl() || configured.includes(source);
+}

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -127,7 +127,8 @@ export default defineConfig({
     proxy: Object.fromEntries(
       ['/api', '/oauth', '/device', '/cli', '/install.sh', '/install.ps1', '/.well-known'].map((p) => [
         p,
-        { target: apiTarget, changeOrigin: true },
+        // Preserve the browser's target origin for the API's session CSRF check.
+        { target: apiTarget, changeOrigin: false },
       ]),
     ),
   },

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -98,6 +98,28 @@ a headless-browser smoke test. The gate complements review; it does not replace 
 
 ## Browser hardening headers
 
+### Session write origins
+
+Before a cookie-authenticated POST/PUT/PATCH/DELETE reaches a handler, the auth hook
+checks its Origin (or Referer when Origin is absent). Only the exact request target,
+the canonical application origin, or an explicitly configured WEB_ORIGIN is accepted.
+A sibling subdomain or another port is not the same origin. Opaque `null` origins
+are refused. This applies to PAT-derived cookies too; adding a Bearer header does
+not bypass the check when the cookie authenticates first.
+
+Clients without Origin/Referer remain supported unless Fetch Metadata identifies a
+non-same-origin browser request. Bearer-only callers and GET/HEAD/OPTIONS retain their
+existing authentication rules. The PAT mint endpoint additionally requires
+application/json; OAuth's shared form parser must not admit token creation by forms.
+OAuth retains its own consent/nonce checks. SameSite cookies and CORS are additional
+controls, not substitutes for this check.
+
+The Vite development proxy preserves Host so its default origin works without extra
+configuration. The exact target origin also admits same-origin candidate revisions;
+X-Forwarded-Host is never used to authorize an origin.
+
+### Response policies
+
 One Cloud Run service serves the API and the web app, so response headers are set in one
 place: `apps/api/src/platform/security-headers.ts`, registered in `app.ts` right after the rate
 limiter, whose annotation its report sink relies on. Every response carries `X-Content-Type-Options: nosniff` and


### PR DESCRIPTION
## Summary

Cookie-authenticated writes now reject untrusted request origins before reaching handlers. Personal access token creation additionally requires JSON, preventing the shared OAuth form parser from accepting browser form submissions at that endpoint.

The guard covers session and PAT-derived cookies, with Origin validation, Referer fallback, and Fetch Metadata checks when neither is present. Same-origin, canonical, and configured frontend origins remain supported, as do Bearer-only clients and headerless API clients. The Vite proxy preserves Host for local development.

## Validation

- `npm install`, type-check, lint, full test suite, and build passed.
- Full suite: 6,433 passed; 4 skipped.
- 27 new regression tests; 22 fail against the previous implementation.
- Local browser CSRF attempt returns 403 and creates no token.
- Legitimate JSON token creation and revocation through the Vite proxy succeed.

Changes have been validated locally; production deployment is not part of this PR creation.
