### PR TITLE
Default TRUST_EDGE_CLIENT_IP to true in the hand deploy path

### DIFF
--- a/infra/deploy-api.sh
+++ b/infra/deploy-api.sh
@@ -320,7 +320,11 @@ fi
 if [ -n "${REMIX_DEBUG:-}" ]; then
   ENV_VARS="${ENV_VARS}|REMIX_DEBUG=${REMIX_DEBUG}"
 fi
-ENV_VARS="${ENV_VARS}|TRUST_EDGE_CLIENT_IP=${TRUST_EDGE_CLIENT_IP:-false}"
+# Default true since www moved behind Firebase Hosting (2026-09-06). Off, every per-IP
+# limiter collapses onto Google's frontend addresses; the peer check in client-address.ts
+# keeps the flag inert on the run.app URL, so true is safe on both deploy paths. Until
+# this line, a hand deploy that forgot to export it switched the limiter off in silence.
+ENV_VARS="${ENV_VARS}|TRUST_EDGE_CLIENT_IP=${TRUST_EDGE_CLIENT_IP:-true}"
 
 if [ -n "${CANONICAL_HOST:-}" ]; then
   ENV_VARS="${ENV_VARS}|CANONICAL_HOST=${CANONICAL_HOST}"


### PR DESCRIPTION
Since `www` moved behind Firebase Hosting (2026-09-06), `TRUST_EDGE_CLIENT_IP` is load-bearing: off, every per-IP limiter collapses onto Google's frontend addresses. `deploy.yml` reads it from a repo variable (set to `true`), but `infra/deploy-api.sh` defaulted to `false` — so a hand deploy from a laptop that forgot to `export` it switched the limiter off in silence, and nothing would have said so.

One line plus the comment explaining why. The peer check in `client-address.ts` only trusts `Fastly-Client-IP` behind a Google-owned hop, so `true` is inert on the `run.app` URL and safe on both paths.

`bash -n` clean. No behaviour change for the workflow path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)