### PR TITLE
Retire the gamedev_session fallback cookie

### DIFF
--- a/apps/api/src/platform/access-token-routes.test.ts
+++ b/apps/api/src/platform/access-token-routes.test.ts
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, it } from 'vitest';
 import { generateAccessToken } from './access-token.js';
 import { DEFAULT_EXPIRY_DAYS, MAX_TOKENS_PER_UID, mintAccessTokenFor } from './access-token-service.js';
 import { buildApp } from './app.js';
-import { LEGACY_SESSION_COOKIE_NAME, mintSessionToken, SESSION_COOKIE_NAME } from './auth.js';
+import { mintSessionToken, SESSION_COOKIE_NAME } from './auth.js';
 import { InMemoryStore } from './store.js';
 
 // Every test drives the fully assembled app, never the route plugin.
@@ -388,8 +388,8 @@ describe('authenticating with a personal access token', () => {
     expect(res.json().user.uid).toBe('g:boss');
   });
 
-  // A replacement session must retire the old cookie beside it.
-  it('retires a pre-rename cookie when the exchange replaces the session', async () => {
+  // A replacement session must be the only session cookie on the response.
+  it('issues exactly one session cookie when the exchange replaces a session', async () => {
     const app = await appWith(store, { betaAllowedUids: 'g:boss' });
     const { token } = (await mintFor(app, 'bot:e2e')).json();
 
@@ -398,7 +398,7 @@ describe('authenticating with a personal access token', () => {
       url: '/api/auth/session',
       headers: {
         ...bearer(token),
-        cookie: `${LEGACY_SESSION_COOKIE_NAME}=${mintSessionToken('g:boss', sessionSecret)}`,
+        cookie: `${SESSION_COOKIE_NAME}=${mintSessionToken('g:boss', sessionSecret)}`,
       },
     });
 
@@ -407,9 +407,6 @@ describe('authenticating with a personal access token', () => {
 
     const issued = res.cookies.filter((entry) => entry.name === SESSION_COOKIE_NAME);
     expect(issued).toHaveLength(1);
-    // The old name must not outlive its replacement.
-    const legacy = res.cookies.find((entry) => entry.name === LEGACY_SESSION_COOKIE_NAME);
-    expect(legacy?.value).toBe('');
   });
 
   it('exchanges for a session cookie so a real browser can be driven', async () => {

--- a/apps/api/src/platform/account-deletion-routes.test.ts
+++ b/apps/api/src/platform/account-deletion-routes.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it } from 'vitest';
 import { buildApp } from './app.js';
-import { LEGACY_SESSION_COOKIE_NAME, mintSessionToken, SESSION_COOKIE_NAME } from './auth.js';
+import { mintSessionToken, SESSION_COOKIE_NAME } from './auth.js';
 import type { InternalAuthVerifier } from './internal-auth.js';
 import { DELETED_ACCOUNT_UID, InMemoryStore } from './store.js';
 
@@ -63,8 +63,6 @@ describe('account deletion routes', () => {
     expect(response.json()).toEqual({ scheduled: true, deleteAfter: '2026-08-18T00:00:00.000Z' });
     const cleared = [response.headers['set-cookie'] ?? []].flat().join('\n');
     expect(cleared).toContain(`${SESSION_COOKIE_NAME}=;`);
-    // The old name still authenticates, so deletion must clear it too.
-    expect(cleared).toContain(`${LEGACY_SESSION_COOKIE_NAME}=;`);
     expect(await store.getUser('g:leaver')).toMatchObject({
       deletionRequestedAt: '2026-08-04T00:00:00.000Z',
       deletionScheduledFor: '2026-08-18T00:00:00.000Z',

--- a/apps/api/src/platform/auth.test.ts
+++ b/apps/api/src/platform/auth.test.ts
@@ -3,7 +3,6 @@ import { afterEach, describe, expect, it } from 'vitest';
 import {
   DEFAULT_SESSION_DURATION_SECONDS,
   InvalidSessionError,
-  LEGACY_SESSION_COOKIE_NAME,
   mintSessionToken,
   registerAuthPlugin,
   SESSION_COOKIE_NAME,
@@ -360,8 +359,8 @@ describe('Auth API Routes', () => {
     expect(JSON.parse(meRes.body).user.uid).toBe('g:10002');
   });
 
-  // An old cookie must survive and come back renamed.
-  it('authenticates a pre-rename cookie and re-mints it under the new name', async () => {
+  // The old name is dead: a browser carrying only it is anonymous.
+  it('ignores the retired gamedev_session cookie', async () => {
     const { app, store } = await setupTestServer();
     await store.upsertUser({ uid: 'g:10009', email: 'legacy@example.com' });
 
@@ -369,38 +368,14 @@ describe('Auth API Routes', () => {
       method: 'GET',
       url: '/api/auth/me',
       headers: {
-        // Long-lived: proves the re-mint follows the name, not expiry.
-        cookie: `${LEGACY_SESSION_COOKIE_NAME}=${mintSessionToken('g:10009', 'test-secret-key', DEFAULT_SESSION_DURATION_SECONDS)}`,
+        cookie: `gamedev_session=${mintSessionToken('g:10009', 'test-secret-key', DEFAULT_SESSION_DURATION_SECONDS)}`,
       },
     });
 
-    expect(res.statusCode).toBe(200);
-    expect(JSON.parse(res.body).user.uid).toBe('g:10009');
-
+    expect(res.statusCode).toBe(401);
     const setCookie = [res.headers['set-cookie'] ?? []].flat().join('\n');
-    expect(setCookie).toContain(`${SESSION_COOKIE_NAME}=`);
-    // Retired here, or the browser keeps a stripped name.
-    expect(setCookie).toContain(`${LEGACY_SESSION_COOKIE_NAME}=;`);
-  });
-
-  it('prefers the new cookie when a browser carries both', async () => {
-    const { app, store } = await setupTestServer();
-    await store.upsertUser({ uid: 'g:10010', email: 'current@example.com' });
-    await store.upsertUser({ uid: 'g:10011', email: 'stale@example.com' });
-
-    const res = await app.inject({
-      method: 'GET',
-      url: '/api/auth/me',
-      headers: {
-        cookie: [
-          `${SESSION_COOKIE_NAME}=${mintSessionToken('g:10010', 'test-secret-key')}`,
-          `${LEGACY_SESSION_COOKIE_NAME}=${mintSessionToken('g:10011', 'test-secret-key')}`,
-        ].join('; '),
-      },
-    });
-
-    expect(res.statusCode).toBe(200);
-    expect(JSON.parse(res.body).user.uid).toBe('g:10010');
+    // Nothing minted for an identity the request did not prove.
+    expect(setCookie).not.toContain(`${SESSION_COOKIE_NAME}=`);
   });
 
   it('blocks old credentials while deletion is pending and restores the account on sign-in', async () => {
@@ -461,8 +436,8 @@ describe('Auth API Routes', () => {
     expect(JSON.parse(login.body).user).not.toHaveProperty('admin');
   });
 
-  // Renewal must not append the old identity after a sign-in.
-  it('does not re-mint the previous identity when signing in with a pre-rename cookie', async () => {
+  // Renewal must not append the arriving identity after a different sign-in.
+  it('does not re-mint the previous identity when signing in over an existing session', async () => {
     const { app, store } = await setupTestServer({ 'newcomer-token': { sub: '20002', email: 'b@example.com' } });
     await store.upsertUser({ uid: 'g:20001', email: 'a@example.com' });
 
@@ -471,7 +446,7 @@ describe('Auth API Routes', () => {
       url: '/api/auth/google',
       payload: { idToken: 'newcomer-token' },
       headers: {
-        cookie: `${LEGACY_SESSION_COOKIE_NAME}=${mintSessionToken('g:20001', 'test-secret-key')}`,
+        cookie: `${SESSION_COOKIE_NAME}=${mintSessionToken('g:20001', 'test-secret-key')}`,
       },
     });
 
@@ -485,22 +460,22 @@ describe('Auth API Routes', () => {
   });
 
   // Logout must not re-mint the session it just cleared.
-  it('does not re-mint a session when logging out with a pre-rename cookie', async () => {
+  it('does not re-mint a session when logging out with a near-expiry cookie', async () => {
     const { app, store } = await setupTestServer();
-    await store.upsertUser({ uid: 'g:10012', email: 'legacy-logout@example.com' });
+    await store.upsertUser({ uid: 'g:10012', email: 'logout@example.com' });
 
     const res = await app.inject({
       method: 'POST',
       url: '/api/auth/logout',
       headers: {
-        cookie: `${LEGACY_SESSION_COOKIE_NAME}=${mintSessionToken('g:10012', 'test-secret-key')}`,
+        // Short-lived, so the renewal hook would want to re-mint it.
+        cookie: `${SESSION_COOKIE_NAME}=${mintSessionToken('g:10012', 'test-secret-key', 60)}`,
       },
     });
 
     expect(res.statusCode).toBe(200);
     const setCookie = [res.headers['set-cookie'] ?? []].flat().join('\n');
     expect(setCookie).toContain(`${SESSION_COOKIE_NAME}=;`);
-    expect(setCookie).toContain(`${LEGACY_SESSION_COOKIE_NAME}=;`);
     // Guards a second, non-empty __session from the renewal hook.
     expect(setCookie).not.toMatch(new RegExp(`${SESSION_COOKIE_NAME}=[^;\\s]`));
   });
@@ -514,10 +489,8 @@ describe('Auth API Routes', () => {
     });
 
     expect(res.statusCode).toBe(200);
-    // Both names: the old one still authenticates.
     const setCookie = [res.headers['set-cookie'] ?? []].flat().join('\n');
     expect(setCookie).toContain(`${SESSION_COOKIE_NAME}=;`);
-    expect(setCookie).toContain(`${LEGACY_SESSION_COOKIE_NAME}=;`);
   });
 
   it('returns 503 when authentication is unconfigured in production', async () => {

--- a/apps/api/src/platform/auth.ts
+++ b/apps/api/src/platform/auth.ts
@@ -14,10 +14,9 @@ import {
   clearSessionCookies,
   handlerWroteSessionCookie,
   readSessionCookie,
-  retireLegacyCookie,
   SESSION_COOKIE_NAME,
 } from './session-cookie.js';
-export { LEGACY_SESSION_COOKIE_NAME, readSessionCookie, SESSION_COOKIE_NAME } from './session-cookie.js';
+export { readSessionCookie, SESSION_COOKIE_NAME } from './session-cookie.js';
 import { createMailerFromEnv } from '../notifications/mailer.js';
 import { emitWaitlistJoined } from '../notifications/notify.js';
 import { createPusherFromEnv } from '../notifications/pusher.js';
@@ -359,7 +358,7 @@ export async function registerAuthPlugin(app: FastifyInstance, options: AuthPlug
   const getSessionUser = async (
     request: FastifyRequest,
   ): Promise<{ user: User | null; needsRenewal: boolean; fromToken: boolean }> => {
-    const { token: cookieToken, legacy } = readSessionCookie(request.cookies);
+    const cookieToken = readSessionCookie(request.cookies);
     if (!cookieToken) return { user: null, needsRenewal: false, fromToken: false };
 
     try {
@@ -371,9 +370,7 @@ export async function registerAuthPlugin(app: FastifyInstance, options: AuthPlug
 
       const nowSeconds = Math.floor(Date.now() / 1000);
       const needsRenewal = exp - nowSeconds < sessionRenewalThresholdSeconds(src);
-
-      // A legacy cookie always renews: that re-mint is the migration.
-      return { user, needsRenewal: needsRenewal || legacy, fromToken: src === 'token' };
+      return { user, needsRenewal, fromToken: src === 'token' };
     } catch {
       return { user: null, needsRenewal: false, fromToken: false };
     }
@@ -430,8 +427,12 @@ export async function registerAuthPlugin(app: FastifyInstance, options: AuthPlug
   app.addHook('onSend', async (request, reply) => {
     if (!isAuthConfigured) return;
     // The handler's own session cookie always wins; see handlerWroteSessionCookie.
-    const handlerWroteSession = handlerWroteSessionCookie(reply);
-    if (request.user && request.needsSessionRenewal && request.user.tier !== 'blocked' && !handlerWroteSession) {
+    if (
+      request.user &&
+      request.needsSessionRenewal &&
+      request.user.tier !== 'blocked' &&
+      !handlerWroteSessionCookie(reply)
+    ) {
       // Provenance survives renewal, or a token-derived cookie would quietly become a
       // genuine one after six hours and regain exactly the authority it was denied.
       // `needsSessionRenewal` is only ever set on the cookie path, so 'token' here
@@ -452,11 +453,6 @@ export async function registerAuthPlugin(app: FastifyInstance, options: AuthPlug
         sameSite: 'lax',
         maxAge: durationSeconds,
       });
-    }
-
-    // Retired by whichever half wrote the replacement; see session-cookie.ts.
-    if (handlerWroteSession || handlerWroteSessionCookie(reply)) {
-      retireLegacyCookie(request.cookies, reply);
     }
   });
 

--- a/apps/api/src/platform/oauth-as.ts
+++ b/apps/api/src/platform/oauth-as.ts
@@ -99,7 +99,7 @@ function noteDcrHit(ip: string, nowMs: number): void {
 }
 
 function readUidFromSession(request: FastifyRequest, sessionSecret: string, sessionSecretPrev?: string): string | null {
-  const { token: cookie } = readSessionCookie(request.cookies);
+  const cookie = readSessionCookie(request.cookies);
   if (!cookie) return null;
   try {
     const payload = readSessionToken(cookie, sessionSecret, sessionSecretPrev);

--- a/apps/api/src/platform/session-cookie.ts
+++ b/apps/api/src/platform/session-cookie.ts
@@ -1,45 +1,23 @@
 import type { FastifyReply, FastifyRequest } from 'fastify';
 
-// Firebase Hosting forwards only this name; see docs/deployment.md before renaming.
+// Hosting's one guaranteed cookie name; see docs/deployment.md before renaming.
 export const SESSION_COOKIE_NAME = '__session';
 
-// Pre-rename name: read, never written. Retire per docs/deployment.md.
-export const LEGACY_SESSION_COOKIE_NAME = 'gamedev_session';
-
-// The session cookie under either name, current one first.
-export function readSessionCookie(cookies: Record<string, string | undefined>): {
-  token: string | undefined;
-  legacy: boolean;
-} {
+// The session cookie, or undefined when the browser sent none.
+export function readSessionCookie(cookies: Record<string, string | undefined>): string | undefined {
   const current = cookies[SESSION_COOKIE_NAME];
-  if (typeof current === 'string' && current) return { token: current, legacy: false };
-  const legacy = cookies[LEGACY_SESSION_COOKIE_NAME];
-  if (typeof legacy === 'string' && legacy) return { token: legacy, legacy: true };
-  return { token: undefined, legacy: false };
+  return typeof current === 'string' && current ? current : undefined;
 }
 
-// Ends the session: both names, and no renewal behind it.
+// Ends the session, and no renewal behind it.
 export function clearSessionCookies(request: FastifyRequest, reply: FastifyReply): void {
   request.needsSessionRenewal = false;
   reply.clearCookie(SESSION_COOKIE_NAME, { path: '/' });
-  reply.clearCookie(LEGACY_SESSION_COOKIE_NAME, { path: '/' });
 }
 
 // A handler's session cookie decides identity; renewal must not overwrite.
 export function handlerWroteSessionCookie(reply: FastifyReply): boolean {
-  return wroteCookieNamed(reply, SESSION_COOKIE_NAME);
-}
-
-// Set-Cookie is one value or many; this flattens both shapes.
-function wroteCookieNamed(reply: FastifyReply, name: string): boolean {
   const header = reply.getHeader('set-cookie');
   const values = Array.isArray(header) ? header : header === undefined ? [] : [header];
-  return values.some((value) => String(value).startsWith(`${name}=`));
-}
-
-// Left standing, the old name outlives the session that replaced it. Idempotent.
-export function retireLegacyCookie(cookies: Record<string, string | undefined>, reply: FastifyReply): void {
-  if (!cookies[LEGACY_SESSION_COOKIE_NAME]) return;
-  if (wroteCookieNamed(reply, LEGACY_SESSION_COOKIE_NAME)) return;
-  reply.clearCookie(LEGACY_SESSION_COOKIE_NAME, { path: '/' });
+  return values.some((value) => String(value).startsWith(`${SESSION_COOKIE_NAME}=`));
 }

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -265,30 +265,24 @@ draft, and creation routes remain gated.
 ## The session cookie is named `__session`
 
 `apps/api/src/platform/session-cookie.ts` owns the name, and the name is a constraint
-rather than a style choice. Firebase Hosting drops every cookie except one called exactly
-`__session` before a request reaches a Cloud Run backend, so if Hosting is ever put in
-front of this service any other name becomes invisible to the app and every browser
-session silently stops authenticating. Do not "tidy" it back to something descriptive.
+rather than a style choice: `__session` is the one cookie name Firebase Hosting documents
+as guaranteed to reach a backend. Measured on the live site on 2026-09-06, Hosting does in
+fact forward other cookies to a Cloud Run rewrite too — the token-login CSRF cookie
+round-trips through it — but that is observed behaviour, not a documented promise, and the
+session is the one cookie that must never depend on an undocumented one. Do not "tidy" it
+back to something descriptive.
 
-**`gamedev_session` is the pre-rename name, still read and never written.** Sessions last
-30 days, so flipping the name outright would sign out every live account the moment the
-deploy promoted. Instead a request carrying only the old cookie is authenticated from it
-and re-minted under the current name on the same response, so an account migrates on its
-next request rather than whenever its session neared expiry.
-
-That fallback only helps **before** a DNS cutover to Hosting: afterwards the old cookie is
-stripped at the edge and never arrives, so anyone who has not visited since the rename
-shipped is signed out then. The longer the gap between the rename and any cutover, the
-fewer people that happens to. Delete the constant and the branches reading it once a
-cutover is done and the last 30-day session minted under the old name has expired — or
-once it is decided that Hosting is not coming, in which case the fallback is simply dead
-weight.
+The pre-rename name `gamedev_session` was read as a fallback from 2026-09-02 until it was
+removed on 2026-09-08, after the cutover to Hosting and once every active account had
+been re-minted under the new name. A browser that still carries only the old cookie is
+simply anonymous now, and the API never writes or clears that name. If a sign-out storm
+ever coincides with a cookie rename again, the shape to reach for is the same dual-read
+window with a re-mint on the response, not a flag day.
 
 **One invariant holds the whole thing together:** session renewal runs on `onSend`, after
 the handler, and mints for whoever the request _arrived_ as. A response that already wrote
 the session cookie has decided who the browser is — signing in as someone else, or signing
-out — so renewal must never overwrite it, and the old name must be retired by whichever
-half wrote the replacement. Three separate defects came from breaking one half of that
+out — so renewal must never overwrite it. Three separate defects came from breaking one half of that
 (logout re-minting the session it cleared; a sign-in leaving the previous identity's
 cookie last; a replacement leaving the 30-day old cookie standing beside a 12-hour new
 one). The tests in `auth.test.ts` and `access-token-routes.test.ts` pin each case.


### PR DESCRIPTION
## What

Removes the `gamedev_session` read-fallback that carried accounts across the rename to `__session`.

- `readSessionCookie` returns the token or `undefined`; the `legacy` flag and the forced re-mint on a legacy cookie are gone.
- `clearSessionCookies` clears one name. `retireLegacyCookie` and `LEGACY_SESSION_COOKIE_NAME` are deleted.
- Tests that exercised the fallback are rewritten to exercise the same invariants with the current name — a handler that wrote the session cookie wins over renewal; logout never re-mints; a sign-in as someone else never leaves the previous identity last — plus one new test pinning that a browser carrying only the old cookie is anonymous and gets nothing minted.

## Why now

The fallback existed for a sign-out storm that would otherwise have happened at the flag day. `www` has been behind Firebase Hosting since 2026-09-06 and every active session has been re-minted under `__session` since the rename shipped on 2026-09-02, so there is nothing left for it to migrate. Left in, it is a second authentication path nobody exercises.

## Reviewer notes

- `docs/deployment.md` is corrected while being edited: Hosting does forward cookies other than `__session` to a Cloud Run rewrite (the token-login CSRF cookie round-trips through it, measured 2026-09-06). `__session` stays because it is the one *documented* guarantee, not because the rest are dropped.
- No web/client change: nothing outside `apps/api` referenced the old name.
- Verified: full API suite green (three unrelated timeouts under full-suite load pass in isolation — `self-build`, `agent-channel`, `catalog-search`), `tsc` clean, `npm run lint` clean including the prose and size ratchets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)