### PR TITLE
IAM audit waves 2–3: no fallback secret in production, narrower grants

### DIFF
--- a/apps/api/src/platform/app.ts
+++ b/apps/api/src/platform/app.ts
@@ -1079,7 +1079,12 @@ export async function buildApp(options: BuildAppOptions = {}): Promise<FastifyIn
   // token and it is configured — see openai-apps-challenge.ts.
   registerOpenAiAppsChallengeRoute(app);
 
-  const oauthSessionSecret = options.sessionSecret ?? process.env.SESSION_SECRET ?? 'dev-session-secret-change-me';
+  const configuredSessionSecret = options.sessionSecret ?? process.env.SESSION_SECRET;
+  // A forgeable session is an account takeover; refuse to serve rather than fall back.
+  if (!configuredSessionSecret && process.env.NODE_ENV === 'production') {
+    throw new Error('SESSION_SECRET is required to sign sessions in production');
+  }
+  const oauthSessionSecret = configuredSessionSecret ?? 'dev-session-secret-change-me';
   const oauthSessionSecretPrev = options.sessionSecretPrev ?? process.env.SESSION_SECRET_PREV;
   registerOAuthAuthorizationServerRoutes(app, {
     store,

--- a/apps/api/src/platform/auth.test.ts
+++ b/apps/api/src/platform/auth.test.ts
@@ -524,7 +524,7 @@ describe('Auth API Routes', () => {
     process.env.NODE_ENV = 'production';
     const store = new InMemoryStore();
     const app = Fastify();
-    await registerAuthPlugin(app, { store });
+    await registerAuthPlugin(app, { store, sessionSecret: 'test-secret-key' });
 
     const res = await app.inject({
       method: 'POST',

--- a/apps/api/src/platform/auth.ts
+++ b/apps/api/src/platform/auth.ts
@@ -333,6 +333,10 @@ export async function registerAuthPlugin(app: FastifyInstance, options: AuthPlug
   const googleClientId = options.googleClientId ?? process.env.GOOGLE_OAUTH_CLIENT_ID ?? '';
   const isAuthConfigured = Boolean(sessionSecret && (googleClientId || options.googleAuthVerifier)) || !isProd;
 
+  // Same rule as the zones and room registries: no fallback secret in production.
+  if (!sessionSecret && isProd) {
+    throw new Error('SESSION_SECRET is required to sign sessions in production');
+  }
   const effectiveSessionSecret = sessionSecret ?? 'dev-session-secret-change-me';
   const adminUids = options.adminUids;
   const reviewerUids = options.reviewerUids;

--- a/apps/api/src/platform/session-secret-production.test.ts
+++ b/apps/api/src/platform/session-secret-production.test.ts
@@ -1,0 +1,38 @@
+import Fastify from 'fastify';
+import { afterEach, describe, expect, it } from 'vitest';
+import { buildApp } from './app.js';
+import { registerAuthPlugin } from './auth.js';
+import { InMemoryStore } from './store.js';
+
+const originalEnv = process.env.NODE_ENV;
+const originalSecret = process.env.SESSION_SECRET;
+
+afterEach(() => {
+  process.env.NODE_ENV = originalEnv;
+  if (originalSecret === undefined) delete process.env.SESSION_SECRET;
+  else process.env.SESSION_SECRET = originalSecret;
+});
+
+// The fallback secret is public; in production it would sign forgeable sessions.
+describe('SESSION_SECRET in production', () => {
+  it('refuses to build the app without one', async () => {
+    process.env.NODE_ENV = 'production';
+    delete process.env.SESSION_SECRET;
+    await expect(buildApp({ store: new InMemoryStore() })).rejects.toThrow(/SESSION_SECRET is required/);
+  });
+
+  it('refuses to register the auth plugin without one', async () => {
+    process.env.NODE_ENV = 'production';
+    delete process.env.SESSION_SECRET;
+    const app = Fastify();
+    await expect(registerAuthPlugin(app, { store: new InMemoryStore() })).rejects.toThrow(/SESSION_SECRET is required/);
+    await app.close();
+  });
+
+  it('still starts outside production, where the dev fallback is the point', async () => {
+    process.env.NODE_ENV = 'test';
+    delete process.env.SESSION_SECRET;
+    const app = await buildApp({ store: new InMemoryStore() });
+    await app.close();
+  });
+});

--- a/docs/agent-gcp-access.md
+++ b/docs/agent-gcp-access.md
@@ -33,7 +33,9 @@ state rather than user data.
 `logging.viewer`, `monitoring.viewer`, `run.viewer`, `cloudbuild.builds.viewer`,
 `artifactregistry.reader`, `errorreporting.viewer`, `cloudscheduler.viewer`,
 `workflows.viewer`, `secretmanager.viewer`, `serviceusage.serviceUsageViewer`, plus
-`storage.objectViewer` on `gamedevpl-games-snapshots` and `gamedevpl-games-store` only.
+`storage.objectViewer` on `gamedevpl-games-snapshots` only. The store bucket was dropped
+from that grant on 2026-09-08: it holds creator sources and unpublished work under
+public-access prevention, so "already served publicly" was never true of it.
 
 That covers most of [`site-down-triage.md`](./runbooks/site-down-triage.md): revision
 history, service config, error logs, latency metrics, build history, and the published

--- a/infra/setup-agent-readonly.sh
+++ b/infra/setup-agent-readonly.sh
@@ -71,20 +71,30 @@ for ROLE in \
     >/dev/null
 done
 
-echo "==> 3/6 Granting object read on the two public-content buckets only"
-# These hold published game snapshots and store artifacts — content that is already served
-# publicly, so reading it discloses nothing. The backup bucket is pointedly absent.
-for BUCKET in "$SNAPSHOT_BUCKET" "$STORE_BUCKET"; do
-  if gcloud storage buckets describe "gs://${BUCKET}" --project "$PROJECT_ID" >/dev/null 2>&1; then
-    echo "    - gs://${BUCKET}"
-    gcloud storage buckets add-iam-policy-binding "gs://${BUCKET}" \
-      --member="serviceAccount:${SA_EMAIL}" \
-      --role="roles/storage.objectViewer" \
-      >/dev/null
-  else
-    echo "    (gs://${BUCKET} not found, skipping)"
-  fi
-done
+echo "==> 3/6 Granting object read on the published-snapshot bucket only"
+# The snapshot bucket holds assembled published games — content the site serves to every
+# signed-in player, so reading it discloses nothing. The store bucket is pointedly NOT
+# here: it carries creator sources, staged and unpublished work, and is created with
+# --public-access-prevention because the privacy policy promises those are not public.
+# An earlier version of this script granted it under the same "already public" claim,
+# which was true of the snapshot bucket and false of the store; the binding was removed
+# from the live bucket on 2026-09-08 and the step below takes it away on older projects.
+# The backup bucket has never been granted.
+if gcloud storage buckets describe "gs://${SNAPSHOT_BUCKET}" --project "$PROJECT_ID" >/dev/null 2>&1; then
+  echo "    - gs://${SNAPSHOT_BUCKET}"
+  gcloud storage buckets add-iam-policy-binding "gs://${SNAPSHOT_BUCKET}" \
+    --member="serviceAccount:${SA_EMAIL}" \
+    --role="roles/storage.objectViewer" \
+    >/dev/null
+else
+  echo "    (gs://${SNAPSHOT_BUCKET} not found, skipping)"
+fi
+if gcloud storage buckets describe "gs://${STORE_BUCKET}" --project "$PROJECT_ID" >/dev/null 2>&1; then
+  gcloud storage buckets remove-iam-policy-binding "gs://${STORE_BUCKET}" \
+    --member="serviceAccount:${SA_EMAIL}" \
+    --role="roles/storage.objectViewer" \
+    >/dev/null 2>&1 && echo "    - gs://${STORE_BUCKET}: stale read grant removed" || true
+fi
 
 echo "==> 4/6 Allowing your own account to impersonate ${SA_NAME}"
 # This is how local Claude Code should reach GCP: no key at all, just

--- a/infra/setup-backups.sh
+++ b/infra/setup-backups.sh
@@ -116,9 +116,13 @@ else
   gcloud storage buckets create "gs://${BACKUP_BUCKET}" \
     --location="$FIRESTORE_REGION" \
     --uniform-bucket-level-access \
+    --public-access-prevention \
     --project="$PROJECT_ID"
   echo "    Created in ${FIRESTORE_REGION} (must match the database's location)."
 fi
+# "NOT public by any path" above was a comment until 2026-09-08; this makes it a property
+# the platform enforces, on buckets that already existed as well as new ones.
+gcloud storage buckets update "gs://${BACKUP_BUCKET}" --public-access-prevention --project="$PROJECT_ID" >/dev/null
 
 # Retention costs pennies at this data volume, and the window is what decides whether a
 # corruption discovered late is recoverable. 30 days is well past the point where anyone

--- a/infra/setup-gcp.sh
+++ b/infra/setup-gcp.sh
@@ -33,12 +33,18 @@ else
   gcloud firestore databases create --location="$REGION" --type=firestore-native --project="$PROJECT_ID"
 fi
 
-echo "==> 3/10 Granting datastore.user role to Deployer SA (${DEPLOYER_SA})"
-gcloud projects add-iam-policy-binding "$PROJECT_ID" \
+echo "==> 3/10 Ensuring the Deployer SA (${DEPLOYER_SA}) holds no Firestore role"
+# This step used to grant datastore.user, contradicting setup-wif.sh, which keeps the
+# nightly erasure proof on a separate account precisely because "the deployer
+# deliberately does not have" Firestore. No deploy step reads or writes Firestore — the
+# publish job writes GCS only — and Firestore IAM has no collection scope, so the grant
+# meant a leaked deploy credential could read every player record. Removed 2026-09-08;
+# this reconciles rather than skips, so a re-run on an older project takes it away too.
+gcloud projects remove-iam-policy-binding "$PROJECT_ID" \
   --member="serviceAccount:${DEPLOYER_SA}" \
   --role="roles/datastore.user" \
   --condition=None \
-  >/dev/null
+  >/dev/null 2>&1 || echo "    (no datastore.user binding to remove)"
 
 echo "==> 4/10 Ensuring the Cloud Run runtime identities exist, with datastore.user and aiplatform.user"
 # The app runs as its own account, never the project's default compute one (which holds
@@ -198,9 +204,15 @@ else
   gcloud storage buckets create "gs://${SNAPSHOT_BUCKET}" \
     --location="$SNAPSHOT_BUCKET_REGION" \
     --uniform-bucket-level-access \
+    --public-access-prevention \
     --project="$PROJECT_ID"
   echo "    Created bucket in ${SNAPSHOT_BUCKET_REGION}."
 fi
+# Enforced on existing buckets too: the API reads with its own identity through the JSON
+# API and the web client never fetches this bucket directly, so nothing legitimate needs
+# an allUsers grant — and without this a single mis-click makes every game public at
+# the storage layer, bypassing the beta wall the bucket comment above relies on.
+gcloud storage buckets update "gs://${SNAPSHOT_BUCKET}" --public-access-prevention --project="$PROJECT_ID" >/dev/null
 
 # The publish job (github-actions-deployer via WIF) writes; Cloud Run only reads.
 # Splitting the two means a compromised runtime cannot rewrite what it serves.

--- a/infra/setup-wif.sh
+++ b/infra/setup-wif.sh
@@ -60,10 +60,20 @@ POOL_ID=$(gcloud iam workload-identity-pools describe "$POOL_NAME" \
   --format="value(name)" \
   --project="$PROJECT_ID")
 
-# Which repositories may mint a token against this provider at all. Everything downstream
-# is a subset of this list: passing the condition only gets a workflow to the point where
-# a per-account principalSet binding decides what, if anything, it may impersonate.
-ATTR_CONDITION="assertion.repository in ['${REPO}', '${GAMES_REPO}']"
+# Which repositories may mint a token against this provider at all, and from which ref.
+# Everything downstream is a subset of this list: passing the condition only gets a
+# workflow to the point where a per-account principalSet binding decides what, if
+# anything, it may impersonate.
+#
+# The ref half is what keeps a pull request — from a fork or from a branch anyone with
+# write access can push — from minting deployer credentials. Every workflow that uses
+# this provider runs off the default branch: deploy.yml and publish-games.yml on
+# workflow_run / schedule / dispatch (the token's ref is the default branch for all
+# three), verify-erase.yml on schedule, and the games repo's three publish workflows on
+# push to main. Nothing authenticates from a pull_request event, so no PR workflow loses
+# anything here. Each repo is pinned to its own default branch rather than allowing either
+# name for both, because the website has no `main` and the games repo has no `master`.
+ATTR_CONDITION="(assertion.repository == '${REPO}' && assertion.ref == 'refs/heads/master') || (assertion.repository == '${GAMES_REPO}' && assertion.ref == 'refs/heads/main')"
 
 echo "==> 4/8 Reconciling Workload Identity Provider '${PROVIDER_NAME}' (repos: ${REPO}, ${GAMES_REPO})"
 # create-oidc on an existing provider fails with "already exists" and changes nothing — so a


### PR DESCRIPTION
Closes the code-level half of the IAM audit's waves 2–3. Each item is small; they ship together because they were found together and reviewing the boundary once is cheaper than five times.

## SEC-06 — no fallback session secret in production

`auth.ts` and `app.ts` (the OAuth authorization server's secret) fell back to `dev-session-secret-change-me`, a literal anyone can read here. The deploy script only wires `SESSION_SECRET` *if* the secret exists, so a missing or failed mount would have deployed a service whose sessions are forgeable: account takeover → admin takeover. Both sites now throw under `NODE_ENV=production` without a secret — the same rule `zones.ts` and `mp.ts` already apply. New test file pins it; the existing "503 when unconfigured" test now supplies a secret so it tests what it meant to (no Google client), not process death.

## SEC-04 — the deployer no longer holds Firestore

`setup-gcp.sh` granted `datastore.user` to the deploy identity while `setup-wif.sh` kept the erasure proof on a separate account *because* the deployer must not have Firestore. No deploy step touches Firestore (the publish job writes GCS only), and Firestore IAM has no collection scope. The script now removes the grant rather than adding it. **Live binding already removed** (2026-09-08), read back.

## SEC-05 — a pull request cannot mint deployer credentials

The WIF provider condition was `repository in [...]` with no ref. Every workflow that authenticates runs off the default branch — `deploy.yml` / `publish-games.yml` on `workflow_run`/schedule/dispatch (token ref is the default branch), `verify-erase.yml` on schedule, and the games repo's three publish workflows on push to `main`; nothing authenticates from `pull_request`. The condition now pins each repo to its own default branch.

**Live apply is an owner command** — the permission classifier blocks the provider update for the agent — followed by one dispatched deploy to prove the `workflow_run`/dispatch path still authenticates:

```
gcloud iam workload-identity-pools providers update-oidc github-provider --location=global --workload-identity-pool=github-pool --project=gamedevpl --attribute-condition="(assertion.repository == 'gamedevpl/www.gamedev.pl' && assertion.ref == 'refs/heads/master') || (assertion.repository == 'gamedevpl/www.gamedev.pl-games' && assertion.ref == 'refs/heads/main')"
```

Rollback is the same command with `--attribute-condition="assertion.repository in ['gamedevpl/www.gamedev.pl', 'gamedevpl/www.gamedev.pl-games']"`.

## SEC-07 — the read-only agent identity loses the store bucket

`setup-agent-readonly.sh` granted `objectViewer` on the store bucket under "already served publicly". That is true of the snapshot bucket and false of the store, which holds creator sources under public-access prevention. Snapshot only now; the script also removes the stale grant. **Live binding removal needs an owner command** — the classifier blocks bucket IAM writes:

```
gcloud storage buckets remove-iam-policy-binding gs://gamedevpl-games-store --member="serviceAccount:agent-investigator@gamedevpl.iam.gserviceaccount.com" --role="roles/storage.objectViewer"
```

## SEC-09 — public-access prevention on snapshot and backup buckets

Added at creation and reconciled on existing buckets. The API reads the snapshot bucket with its own identity through the JSON API and the web client never fetches it directly, so nothing legitimate needs an `allUsers` grant. **Live enforcement needs an owner command** for the same reason:

```
gcloud storage buckets update gs://gamedevpl-games-snapshots --public-access-prevention --project=gamedevpl
```
```
gcloud storage buckets update gs://gamedevpl-firestore-backups --public-access-prevention --project=gamedevpl
```

## Not in this PR

SEC-10 (gate egress) and SEC-11 (verdict writes through the API identity) are design work — a private worker pool or VPC egress policy, and a new write path — not a script edit. Recorded in the ops plan.

Verified: full API suite 268 files / 3894 tests green, `tsc` clean, `npm run lint` clean, `bash -n` on all four scripts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
