### PR TITLE
feat(cli): open interactive game sessions from connect

### DIFF
--- a/.claude/skills/product-instrumentation/SKILL.md
+++ b/.claude/skills/product-instrumentation/SKILL.md
@@ -345,3 +345,8 @@ Creator Kit updates emit `kit_update_available`, `kit_update_started`,
 return / funnel questions 4–5). No signed URLs, checkout paths or source content
 are recorded. Completion means the staged toolchain was installed, not that the
 game has passed its publishing checks.
+
+CLI connection onboarding records `connect_opened` when the interactive choices open,
+and `checkout_opened` after downloading or reusing a checkout. Neither event carries
+slugs, paths, credentials or prompts. Existing adapter offer/use events still describe
+agent launches; opening a session does not count as a build.

--- a/apps/api/src/telemetry/visit-cli-funnel.test.ts
+++ b/apps/api/src/telemetry/visit-cli-funnel.test.ts
@@ -37,6 +37,8 @@ describe('cli funnel', () => {
       { step: 'delivered', visits: 1 },
       { step: 'published', visits: 0 },
       { step: 'play_requested', visits: 0 },
+      { step: 'connect_opened', visits: 0 },
+      { step: 'checkout_opened', visits: 0 },
       { step: 'kit_update_available', visits: 0 },
       { step: 'kit_update_started', visits: 0 },
       { step: 'kit_update_completed', visits: 0 },

--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -14,6 +14,8 @@ decides the next version — see [`.claude/skills/cli-release/SKILL.md`](../../.
 
 ### Fixed
 
+- Missing-game errors explain how to start creating a new game (#1223).
+
 - `/checkout` opens the downloaded game in the current session and supports games before their first delivery (#1223).
 - Checkout refuses non-empty destinations to preserve existing files (#1223).
 

--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -10,6 +10,12 @@ decides the next version — see [`.claude/skills/cli-release/SKILL.md`](../../.
 ### Added
 
 - The pilot funnel records signing in, a first turn, a publish it watched happen, and one install per machine — the operator page reads them (#1222).
+- Connect opens an interactive game session with local checkout, chat and agent choices; `--manual` prints MCP setup.
+
+### Fixed
+
+- `/checkout` opens the downloaded game in the current session and supports games before their first delivery.
+- Checkout refuses non-empty destinations to preserve existing files.
 
 ## 0.7.0 — 2026-09-07
 

--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -10,12 +10,12 @@ decides the next version — see [`.claude/skills/cli-release/SKILL.md`](../../.
 ### Added
 
 - The pilot funnel records signing in, a first turn, a publish it watched happen, and one install per machine — the operator page reads them (#1222).
-- Connect opens an interactive game session with local checkout, chat and agent choices; `--manual` prints MCP setup.
+- Connect opens an interactive game session with local checkout, chat and agent choices; `--manual` prints MCP setup (#1223).
 
 ### Fixed
 
-- `/checkout` opens the downloaded game in the current session and supports games before their first delivery.
-- Checkout refuses non-empty destinations to preserve existing files.
+- `/checkout` opens the downloaded game in the current session and supports games before their first delivery (#1223).
+- Checkout refuses non-empty destinations to preserve existing files (#1223).
 
 ## 0.7.0 — 2026-09-07
 

--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -242,3 +242,8 @@ how to enter the local interactive session. It refuses non-empty destinations;
 For manual MCP configuration use `gamedevpl connect <slug> --manual`. Redirected
 output also retains the manual setup behavior. `--agent <name>` explicitly starts
 an MCP agent. Automated agent launches do not print the manual credential snippet.
+
+If the game is only an idea and has not been created yet, run `gamedevpl` without
+arguments and describe it. `connect <slug>` opens an existing owned game; clicking
+Create in Studio establishes its submission even before an agent starts or delivers
+files. A missing game is not silently created by connect.

--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -222,3 +222,23 @@ through `/kit`). Other local preparation refuses to use a pending installation.
 Updates stop the old preview; `/play` starts it with the new tools. An updated Kit
 is not a passing game validation or a delivery: the regular play/build/submit checks
 still run on your game. No sources are pulled or published by a Kit update.
+
+### Open an existing game
+
+Run `gamedevpl connect <slug>` in a terminal to enter an interactive session. Choose
+**Open a local checkout** to download the game (or reuse its checkout in the current
+directory), **Continue chatting** to work without local files, or an installed MCP
+agent to start that agent. The session stays open after the agent finishes.
+
+`gamedevpl repl <slug>` opens the same guided session. Inside it, `/checkout` uses
+the current game and switches subsequent edits, `/play` and `/submit` to its local
+files. Games without a delivery can be checked out too: they start with the brief,
+so an agent must build the game before it can be played.
+
+`gamedevpl checkout <slug> [directory]` downloads files from the shell and prints
+how to enter the local interactive session. It refuses non-empty destinations;
+`/checkout` can reuse an existing checkout of the same game without overwriting it.
+
+For manual MCP configuration use `gamedevpl connect <slug> --manual`. Redirected
+output also retains the manual setup behavior. `--agent <name>` explicitly starts
+an MCP agent. Automated agent launches do not print the manual credential snippet.

--- a/apps/cli/src/agents.test.ts
+++ b/apps/cli/src/agents.test.ts
@@ -98,7 +98,13 @@ describe('agent discovery', () => {
       pick,
       write: () => undefined,
     });
-    expect(pick.mock.calls[0]?.[0]).toEqual(['claude', 'codex', 'show manual MCP setup']);
+    expect(pick.mock.calls[0]?.[0]).toEqual([
+      'Open a local checkout — edit and play here',
+      'Continue chatting about this game',
+      'claude',
+      'codex',
+      'Show manual MCP setup',
+    ]);
     expect(request).not.toHaveBeenCalled();
   });
 

--- a/apps/cli/src/argv.ts
+++ b/apps/cli/src/argv.ts
@@ -30,7 +30,18 @@ export function completeSlash(prefix: string): SlashVerb[] {
   return SLASH_VERBS.filter((verb) => verb.startsWith(needle));
 }
 
-const BOOLEAN_FLAGS = new Set(['no-open', 'stop', 'force', 'publish', 'handoff', 'submit', 'json', 'help', 'platform']);
+const BOOLEAN_FLAGS = new Set([
+  'manual',
+  'no-open',
+  'stop',
+  'force',
+  'publish',
+  'handoff',
+  'submit',
+  'json',
+  'help',
+  'platform',
+]);
 
 export function parseArgv(argv: string[]): { verb: string; args: string[]; flags: Record<string, string | boolean> } {
   const rest = argv.slice(2);

--- a/apps/cli/src/checkout.ts
+++ b/apps/cli/src/checkout.ts
@@ -113,6 +113,18 @@ export async function checkoutGame(input: {
   allowUndelivered?: boolean;
 }): Promise<{ dest: string; remote: string }> {
   const run = input.run ?? defaultRun;
+  if (
+    existsSync(input.dest) &&
+    (lstatSync(input.dest).isSymbolicLink() ||
+      !lstatSync(input.dest).isDirectory() ||
+      readdirSync(input.dest).length > 0)
+  ) {
+    throw new CliError(
+      'Checkout destination is not empty; your files were left untouched.',
+      EXIT_REFUSED,
+      `Choose another directory: ${cliUsage('checkout', `${input.slug} <new-directory>`)}`,
+    );
+  }
   mkdirSync(input.dest, { recursive: true });
   const archive = input.fetchBuffer
     ? await input.fetchBuffer(`${input.api.origin}/api/me/studio/games/${input.slug}/workspace`)

--- a/apps/cli/src/connect-entry.test.ts
+++ b/apps/cli/src/connect-entry.test.ts
@@ -54,6 +54,21 @@ describe('connect entry points', () => {
     expect(await runCli(['node', 'cli', 'repl', 'sky'], env, streams())).toBe(0);
     expect(runInkRepl).toHaveBeenCalledWith(expect.objectContaining({ token: 'tok', slug: 'sky' }));
   });
+  it('explains how to create a game when the requested game does not exist', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response(JSON.stringify({ games: [] }))),
+    );
+    const io = streams();
+    let error = '';
+    io.stderr.on('data', (chunk) => {
+      error += String(chunk);
+    });
+    expect(await runCli(['node', 'cli', 'connect', 'new-idea'], env, io)).toBe(4);
+    expect(error).toContain('to create a new game, run gamedevpl and describe your idea');
+    expect(runInkRepl).not.toHaveBeenCalled();
+  });
+
   it.each([true, false])('keeps explicit manual setup noninteractive (tty=%s)', async (tty) => {
     backend();
     const io = streams(tty);

--- a/apps/cli/src/connect-entry.test.ts
+++ b/apps/cli/src/connect-entry.test.ts
@@ -1,0 +1,66 @@
+import { PassThrough } from 'node:stream';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { runCli } from './main.js';
+import { runInkRepl } from './tui/host.js';
+
+vi.mock('./tui/host.js', () => ({ runInkRepl: vi.fn(async () => 0) }));
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+  vi.clearAllMocks();
+});
+function streams(tty = true) {
+  const stdin = Object.assign(new PassThrough(), { isTTY: tty });
+  const stdout = Object.assign(new PassThrough(), { isTTY: tty });
+  const stderr = new PassThrough();
+  let output = '';
+  stdout.on('data', (value) => {
+    output += String(value);
+  });
+  return {
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    stdout: stdout as unknown as NodeJS.WriteStream,
+    stderr: stderr as unknown as NodeJS.WriteStream,
+    output: () => output,
+  };
+}
+function backend() {
+  const fetch = vi.fn(
+    async (url: string) =>
+      new Response(
+        JSON.stringify(
+          url.includes('/connect')
+            ? { mcpUrl: 'https://example.test/mcp', kickoffPrompt: 'Build sky' }
+            : { games: [{ slug: 'sky', token: 'tok' }] },
+        ),
+        { headers: { 'content-type': 'application/json' } },
+      ),
+  );
+  vi.stubGlobal('fetch', fetch);
+  return fetch;
+}
+const env = { GAMEDEV_TOKEN: 'test-token' };
+describe('connect entry points', () => {
+  it('opens the interactive choices instead of fetching manual MCP credentials', async () => {
+    const fetch = backend();
+    expect(await runCli(['node', 'cli', 'connect', 'sky'], env, streams())).toBe(0);
+    expect(runInkRepl).toHaveBeenCalledWith(
+      expect.objectContaining({ token: 'tok', slug: 'sky', initialLine: '/connect sky' }),
+    );
+    expect(fetch.mock.calls.every(([url]) => !url.endsWith('/connect'))).toBe(true);
+  });
+  it('can open an existing game directly in the interactive mode', async () => {
+    backend();
+    expect(await runCli(['node', 'cli', 'repl', 'sky'], env, streams())).toBe(0);
+    expect(runInkRepl).toHaveBeenCalledWith(expect.objectContaining({ token: 'tok', slug: 'sky' }));
+  });
+  it.each([true, false])('keeps explicit manual setup noninteractive (tty=%s)', async (tty) => {
+    backend();
+    const io = streams(tty);
+    expect(await runCli(['node', 'cli', 'connect', 'sky', '--manual'], env, io)).toBe(0);
+    expect(runInkRepl).not.toHaveBeenCalled();
+    expect(io.output()).toContain('gamedevpl repl sky');
+    expect(io.output()).toContain('gamedevpl checkout sky');
+    expect(io.output()).toContain('No agent has been started');
+  });
+});

--- a/apps/cli/src/connect-flow.test.ts
+++ b/apps/cli/src/connect-flow.test.ts
@@ -1,0 +1,117 @@
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { createApi } from './api.js';
+import { memoryStore } from './keychain.js';
+import { connectSession } from './connect-flow.js';
+import { handleReplLine } from './repl.js';
+import { checkoutGame } from './checkout.js';
+
+const dirs: string[] = [];
+const directory = () => {
+  const dir = mkdtempSync(join(tmpdir(), 'connect-flow-'));
+  dirs.push(dir);
+  return dir;
+};
+afterEach(() => {
+  vi.restoreAllMocks();
+  for (const dir of dirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+});
+function fixture() {
+  const source = directory();
+  mkdirSync(join(source, 'games', 'sky'), { recursive: true });
+  writeFileSync(join(source, 'games', 'sky', 'SPEC.md'), 'A game to build');
+  const archive = execFileSync('tar', ['-czf', '-', '-C', source, '.']);
+  const fetch = vi.fn(async (url: string) => {
+    if (url.includes('/workspace')) return new Response(new Uint8Array(archive));
+    const body = url.includes('/api/me/studio?')
+      ? { games: [{ slug: 'sky', token: 'tok' }] }
+      : url.endsWith('/versions')
+        ? { versions: [] }
+        : { slug: 'sky', status: 'dispatched', builder: 'self' };
+    return new Response(JSON.stringify(body), { headers: { 'content-type': 'application/json' } });
+  });
+  const api = createApi({
+    origin: 'https://example.test',
+    store: memoryStore({ accessToken: 't', tokenType: 'Bearer', scope: 'creator' }),
+    fetch,
+  });
+  return { api, fetch };
+}
+
+describe('interactive game connection', () => {
+  it('opens choices without contacting MCP or starting an agent when cancelled', async () => {
+    const { api, fetch } = fixture();
+    const pick = vi.fn(async () => '');
+    expect(
+      await connectSession({ api, slug: 'sky', env: { PATH: '' }, pick, abort: { current: null }, write: () => {} }),
+    ).toBeNull();
+    expect(pick.mock.calls.length).toBe(1);
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it('enters chat for the selected game without minting MCP credentials', async () => {
+    const { api, fetch } = fixture();
+    const result = await connectSession({
+      api,
+      slug: 'sky',
+      env: { PATH: '' },
+      pick: async () => 'Continue chatting about this game',
+      abort: { current: null },
+      write: () => {},
+    });
+    expect(result).toMatchObject({ slug: 'sky', token: 'tok', conversationId: '' });
+    expect(fetch.mock.calls.every(([url]) => !url.includes('/connect'))).toBe(true);
+  });
+
+  it('downloads an undelivered game and switches the active REPL workshop', async () => {
+    const { api, fetch } = fixture();
+    const dest = join(directory(), 'sky');
+    const result = await handleReplLine({
+      line: `/checkout sky ${dest}`,
+      api,
+      token: null,
+      env: { PATH: '' },
+      write: () => {},
+    });
+    expect(result).toMatchObject({
+      slug: 'sky',
+      token: 'tok',
+      workshop: { root: dest, slug: 'sky', token: 'tok', builder: 'self' },
+    });
+    expect(fetch.mock.calls.some(([url]) => url.endsWith('/workspace?allowUndelivered=true'))).toBe(true);
+    expect(readFileSync(join(dest, 'games', 'sky', 'SPEC.md'), 'utf8')).toBe('A game to build');
+    const again = await handleReplLine({
+      line: '/checkout',
+      api,
+      token: 'tok',
+      workshop: result.workshop,
+      write: () => {},
+    });
+    expect(again.workshop?.root).toBe(dest);
+    expect(fetch.mock.calls.filter(([url]) => url.includes('/workspace'))).toHaveLength(1);
+  });
+
+  it('uses the remote session game instead of another checkout in the working directory', async () => {
+    const { api } = fixture();
+    const parent = directory();
+    const other = join(parent, 'other');
+    mkdirSync(other);
+    writeFileSync(join(other, '.gamedev-slug'), 'other');
+    vi.spyOn(process, 'cwd').mockReturnValue(other);
+    const result = await handleReplLine({ line: '/checkout', api, token: 'tok', env: { PATH: '' }, write: () => {} });
+    expect(result.workshop).toMatchObject({ slug: 'sky', root: join(parent, 'sky') });
+    expect(readFileSync(join(other, '.gamedev-slug'), 'utf8')).toBe('other');
+  });
+
+  it('refuses an occupied destination before downloading or modifying it', async () => {
+    const { api, fetch } = fixture();
+    const dest = directory();
+    writeFileSync(join(dest, 'mine.ts'), 'local edits');
+    await expect(checkoutGame({ api, slug: 'sky', dest })).rejects.toThrow('not empty');
+    expect(fetch).not.toHaveBeenCalled();
+    expect(readFileSync(join(dest, 'mine.ts'), 'utf8')).toBe('local edits');
+  });
+});

--- a/apps/cli/src/connect-flow.ts
+++ b/apps/cli/src/connect-flow.ts
@@ -1,0 +1,96 @@
+import { dirname, join, resolve } from 'node:path';
+import type { ApiClient } from './api.js';
+import { discoverAgents } from './agents.js';
+import { checkoutGame, findCheckout, localGameFiles } from './checkout.js';
+import { connectGame } from './connect.js';
+import { studioToken } from './studio.js';
+import { openWorkshop, type Workshop, type PickChoice } from './workshop.js';
+import type { CliTelemetry } from './telemetry.js';
+
+export type GameSession = { token: string; slug: string; workshop?: Workshop; conversationId: string };
+type Input = {
+  api: ApiClient;
+  slug: string;
+  dest?: string;
+  env: NodeJS.ProcessEnv;
+  pick?: PickChoice;
+  abort: Workshop['abort'];
+  workshop?: Workshop;
+  write: (line: string) => void;
+  onActivity?: (text: string) => void;
+  telemetry?: CliTelemetry;
+};
+
+export async function checkoutSession(input: Input): Promise<GameSession> {
+  const token = await studioToken(input.api, input.slug);
+  const current = input.workshop ?? findCheckout(process.cwd());
+  const root = resolve(
+    input.dest ??
+      (current ? (current.slug === input.slug ? current.root : join(dirname(current.root), input.slug)) : input.slug),
+  );
+  const existing = findCheckout(root);
+  if (existing?.root !== root || existing.slug !== input.slug) {
+    input.onActivity?.(`Downloading ${input.slug}`);
+    await checkoutGame({ api: input.api, slug: input.slug, dest: root, allowUndelivered: true });
+  }
+  input.telemetry?.record('checkout_opened');
+  const opened = await openWorkshop({ ...input, token, root });
+  const workshop: Workshop = {
+    ...opened,
+    token,
+    slug: input.slug,
+    root,
+    env: input.env,
+    pick: input.pick ?? (async () => ''),
+    abort: input.abort,
+    telemetry: input.telemetry,
+    onActivity: input.onActivity,
+  };
+  if (localGameFiles(root, input.slug).every((file) => file.path.endsWith('.md'))) {
+    input.write('This game has a brief but no playable build yet. Tell the agent what to build first.');
+  }
+  input.write(`Working in ${root}. Say what to change; /play previews, /submit delivers.`);
+  return { token, slug: input.slug, workshop, conversationId: '' };
+}
+
+export async function connectSession(
+  input: Input & { agent?: string; handoff?: boolean; manual?: boolean },
+): Promise<GameSession | null> {
+  let agent = input.agent;
+  input.telemetry?.record('connect_opened');
+  if (!agent && !input.manual && input.pick) {
+    const agents = discoverAgents(input.env).filter((row) => row.installed && row.mcp);
+    for (const row of agents) input.telemetry?.record('delegate_offered', { adapter: row.name });
+    const checkout = 'Open a local checkout — edit and play here';
+    const chat = 'Continue chatting about this game';
+    const manual = 'Show manual MCP setup';
+    const choice = await input.pick(
+      [checkout, chat, ...agents.map((row) => row.name), manual],
+      `${input.slug} — how would you like to work?`,
+    );
+    if (choice === checkout) return checkoutSession(input);
+    if (choice === chat) {
+      input.write(`Talking about ${input.slug}. Say what you want to change, or /checkout to work locally.`);
+      return { token: await studioToken(input.api, input.slug), slug: input.slug, conversationId: '' };
+    }
+    if (choice !== manual && !agents.some((row) => row.name === choice)) return null;
+    if (choice !== manual) agent = choice;
+  }
+  const controller = new AbortController();
+  input.abort.current = controller;
+  try {
+    if (agent) input.onActivity?.(`${agent} is working on ${input.slug} through MCP`);
+    await connectGame({
+      ...input,
+      agent,
+      dest: input.dest ?? input.workshop?.root ?? process.cwd(),
+      abort: controller.signal,
+    });
+    input.write(
+      `You are in the interactive session for ${input.slug}. /checkout downloads files; /help shows actions.`,
+    );
+    return { token: await studioToken(input.api, input.slug), slug: input.slug, conversationId: '' };
+  } finally {
+    input.abort.current = null;
+  }
+}

--- a/apps/cli/src/connect.ts
+++ b/apps/cli/src/connect.ts
@@ -237,7 +237,7 @@ export async function connectGame(input: {
   }
   checkCancelled();
 
-  if (payload?.mcpUrl) {
+  if (payload?.mcpUrl && !input.agent) {
     for (const line of formatHandoff(payload, input.slug)) input.write(line);
   }
 
@@ -249,6 +249,8 @@ export async function connectGame(input: {
         `${cliUsage('connect', input.slug)} --handoff`,
       );
     }
+    input.write(`No agent has been started. Open an interactive session: ${cliUsage('repl', input.slug)}`);
+    input.write(`Or download local files: ${cliUsage('checkout', input.slug)}`);
     return { spawned: false, mcp: true };
   }
   if (!spec) {

--- a/apps/cli/src/help.test.ts
+++ b/apps/cli/src/help.test.ts
@@ -7,7 +7,7 @@ describe('formatHelp', () => {
     const out = formatHelp();
     expect(out).not.toMatch(/gamedevpl <[a-z]+\|/);
     expect(out).toContain('open a browser and sign in');
-    expect(out).toContain('interactive REPL');
+    expect(out).toContain('interactive conversation');
     expect(out).toMatch(/submit\s+deliver sources after the local ladder/);
     for (const verb of SLASH_VERBS) {
       expect(out).toMatch(new RegExp(`^  ${verb}\\s+\\S`, 'm'));

--- a/apps/cli/src/help.ts
+++ b/apps/cli/src/help.ts
@@ -12,9 +12,9 @@ const BLURB: Record<SlashVerb, string> = {
   profile: 'signed-in profile',
   handle: 'get or set handle',
   builder: 'who builds — builder <slug>, or self|platform here',
-  connect: 'MCP handoff, or --agent',
+  connect: 'open a game session — connect <slug>; --manual for MCP setup',
   delegate: 'local agent edits the checkout — delegate <task>',
-  checkout: 'clone a game — checkout <slug>',
+  checkout: 'download and open local files — checkout [slug]',
   quota: "today's submission budget",
   notifications: 'unread notifications',
   help: 'this list',
@@ -42,8 +42,9 @@ export function formatHelp(slash = false): string {
     : [
         `${CLI_BIN} ${CLI_VERSION} — Studio from a terminal`,
         '',
-        `  ${CLI_BIN.padEnd(18)}interactive REPL`,
-        `  ${`${CLI_BIN} <verb>`.padEnd(18)}one-shot command`,
+        `  ${CLI_BIN.padEnd(24)}interactive conversation`,
+        `  ${`${CLI_BIN} repl <slug>`.padEnd(24)}interactive session for an existing game`,
+        `  ${`${CLI_BIN} <verb>`.padEnd(24)}one-shot command`,
         '',
       ];
   return [...intro, ...rows].join('\n');

--- a/apps/cli/src/main.ts
+++ b/apps/cli/src/main.ts
@@ -259,8 +259,11 @@ export async function runCli(
       const slug = args[0];
       if (!slug) throw new CliError(cliUsage('checkout', '<slug>'), EXIT_INPUT, '<slug>');
       const dest = args[1] ?? slug;
-      const result = await checkoutGame({ api, slug, dest });
+      const result = await checkoutGame({ api, slug, dest, allowUndelivered: true });
       io.stdout.write(`checked out ${slug} → ${result.dest} (origin ${result.remote})\n`);
+      io.stdout.write(
+        `Next: cd ${JSON.stringify(resolvePath(result.dest))} and run gamedevpl to edit interactively.\n`,
+      );
       return EXIT_GREEN;
     }
     if (verb === 'pull') {
@@ -305,6 +308,17 @@ export async function runCli(
     if (verb === 'connect') {
       const slug = args[0] ?? readCheckoutSlug(process.cwd());
       if (!slug) throw new CliError(cliUsage('connect', '<slug>'), EXIT_INPUT, '<slug>');
+      if (tty && io.stdout.isTTY && !asJson && !flags.agent && !flags.manual && !args[1]) {
+        const { runInkRepl } = await import('./tui/host.js');
+        return runInkRepl({
+          api,
+          env,
+          io,
+          token: await studioToken(api, slug),
+          slug,
+          initialLine: `/connect ${slug}${flags.handoff ? ' --handoff' : ''}`,
+        });
+      }
       const dest = args[1] ?? process.cwd();
       await connectGame({
         api,
@@ -334,12 +348,25 @@ export async function runCli(
     if (verb === 'repl') {
       if (!tty || !io.stdout.isTTY) throw pipeNeedsFlag(`a verb such as ${cliUsage('whoami')}`);
       const { runInkRepl } = await import('./tui/host.js');
-      const opened = typeof flags.token === 'string' ? null : await openCheckoutGame(api, process.cwd());
+      const requestedSlug = args[0];
+      const local = findCheckout(process.cwd());
+      const opened =
+        typeof flags.token === 'string' || (requestedSlug && local?.slug !== requestedSlug)
+          ? null
+          : await openCheckoutGame(api, process.cwd());
+      const token =
+        typeof flags.token === 'string'
+          ? flags.token
+          : requestedSlug
+            ? await studioToken(api, requestedSlug)
+            : (opened?.token ?? null);
       return runInkRepl({
         api,
         env,
         io,
-        token: typeof flags.token === 'string' ? flags.token : (opened?.token ?? null),
+        token,
+        slug: requestedSlug,
+        initialLine: requestedSlug && !opened ? `/connect ${requestedSlug}` : undefined,
         ...(opened ? { checkout: { slug: opened.slug, root: opened.root } } : {}),
       });
     }

--- a/apps/cli/src/repl.ts
+++ b/apps/cli/src/repl.ts
@@ -7,8 +7,8 @@ import { completeSlash, parseArgv, SLASH_VERBS, type SlashVerb } from './argv.js
 import { getStatus, postTurn, prepareTurn } from './turn.js';
 import { formatStatusLines } from './status-watch.js';
 import type { ApiClient } from './api.js';
-import { checkoutGame, diffGame, formatSyncLines, pullGame, readCheckoutSlug } from './checkout.js';
-import { connectGame } from './connect.js';
+import { diffGame, formatSyncLines, pullGame, readCheckoutSlug } from './checkout.js';
+import { connectSession, checkoutSession } from './connect-flow.js';
 import { formatSubmitLines, submitGame } from './submit.js';
 import { dispatchReadVerb } from './verbs.js';
 import { postCliChat } from './chat.js';
@@ -157,55 +157,40 @@ export async function handleReplLine(input: {
       try {
         const parsed = parseArgv(['node', 'cli', cmd, ...rest]);
         const cwd = input.workshop?.root ?? process.cwd();
-        const slug = parsed.args[0] || (cmd === 'checkout' ? undefined : readCheckoutSlug(cwd));
+        const sessionSlug =
+          (cmd === 'connect' || cmd === 'checkout') && !parsed.args[0] && !input.workshop && input.token
+            ? (await getStatus(input.api, input.token)).slug
+            : undefined;
+        const slug = parsed.args[0] ?? input.workshop?.slug ?? sessionSlug ?? readCheckoutSlug(cwd);
         if (!slug) {
-          input.write(`run it as ${cliUsage(cmd)}`);
+          input.write(`Choose a game: /${cmd} <slug>. /games lists your games.`);
           return { next: 'continue', conversationId: input.conversationId };
         }
-        if (cmd === 'checkout') {
-          const dest = parsed.args[1] ?? slug;
-          const result = await checkoutGame({ api: input.api, slug, dest });
-          input.write(`checked out ${slug} → ${result.dest}`);
-        } else if (cmd === 'pull') {
-          const dest = parsed.args[1] ?? cwd;
+        if (cmd === 'connect' || cmd === 'checkout') {
+          const options = {
+            ...input,
+            slug,
+            dest: parsed.args[1],
+            env: input.env ?? process.env,
+            abort: input.abort ?? { current: null },
+          };
+          const opened =
+            cmd === 'checkout'
+              ? await checkoutSession(options)
+              : await connectSession({
+                  ...options,
+                  agent: typeof parsed.flags.agent === 'string' ? parsed.flags.agent : undefined,
+                  handoff: parsed.flags.handoff === true,
+                  manual: parsed.flags.manual === true,
+                });
+          return { next: 'continue', ...(opened ?? {}) };
+        }
+        const dest = parsed.args[1] ?? cwd;
+        if (cmd === 'pull') {
           const pulled = await pullGame({ api: input.api, slug, dest, force: parsed.flags.force === true });
           input.write(`pulled ${slug} @ ${pulled.version}`);
-        } else if (cmd === 'diff') {
-          const dest = parsed.args[1] ?? cwd;
-          input.write(formatSyncLines(await diffGame({ api: input.api, slug, dest })).join('\n'));
         } else {
-          let agent = typeof parsed.flags.agent === 'string' ? parsed.flags.agent : undefined;
-          if (!agent && input.pick) {
-            const agents = discoverAgents(input.env).filter((row) => row.installed && row.mcp);
-            if (agents.length) {
-              for (const agent of agents) input.telemetry?.record('delegate_offered', { adapter: agent.name });
-              const manual = 'show manual MCP setup';
-              const choice = await input.pick(
-                [...agents.map((row) => row.name), manual],
-                `Connect ${slug} — local agents use their own credentials and billing`,
-              );
-              if (choice !== manual && !agents.some((row) => row.name === choice))
-                return { next: 'continue', conversationId: input.conversationId };
-              if (choice !== manual) agent = choice;
-            }
-          }
-          const controller = new AbortController();
-          if (input.abort) input.abort.current = controller;
-          try {
-            await connectGame({
-              api: input.api,
-              slug,
-              dest: cwd,
-              agent,
-              env: input.env,
-              handoff: parsed.flags.handoff === true,
-              write: input.write,
-              abort: controller.signal,
-              telemetry: input.telemetry,
-            });
-          } finally {
-            if (input.abort) input.abort.current = null;
-          }
+          input.write(formatSyncLines(await diffGame({ api: input.api, slug, dest })).join('\n'));
         }
       } catch (error) {
         input.write(formatError(error));

--- a/apps/cli/src/studio.ts
+++ b/apps/cli/src/studio.ts
@@ -8,7 +8,12 @@ export async function studioToken(api: ApiClient, slug: string): Promise<string>
     `/api/me/studio?game=${encodeURIComponent(slug)}`,
   );
   const row = (studio.games ?? []).find((game) => game.slug === slug);
-  if (!row?.token) throw new CliError(`no owned game ${slug}`, EXIT_INPUT, cliUsage('games'));
+  if (!row?.token)
+    throw new CliError(
+      `no owned game ${slug}`,
+      EXIT_INPUT,
+      `${cliUsage('games')} lists existing games; to create a new game, run gamedevpl and describe your idea`,
+    );
   return row.token;
 }
 

--- a/apps/cli/src/tui/app.test.tsx
+++ b/apps/cli/src/tui/app.test.tsx
@@ -3,6 +3,8 @@ import { stripVTControlCharacters } from 'node:util';
 import { createElement } from 'react';
 import { render } from 'ink';
 import { afterEach, describe, expect, it } from 'vitest';
+import { connectSession } from '../connect-flow.js';
+import type { ApiClient } from '../api.js';
 import { ReplApp } from './app.js';
 import { createTuiSession } from './session.js';
 
@@ -34,6 +36,27 @@ function screen(columns: number, rows: number) {
 }
 
 describe('TUI feedback', () => {
+  it('shows connection choices and returns to chat for the selected game', async () => {
+    const view = screen(80, 24);
+    const opened = connectSession({
+      api: { request: async () => ({ games: [{ slug: 'sky', token: 'tok' }] }) } as unknown as ApiClient,
+      slug: 'sky',
+      env: { PATH: '' },
+      pick: view.session.prompt,
+      abort: { current: null },
+      write: view.session.writeLine,
+    });
+    await wait();
+    expect(view.frame()).toContain('how would you like to work?');
+    expect(view.frame()).toContain('Open a local checkout');
+    view.session.movePick(1);
+    view.session.submit();
+    expect(await opened).toMatchObject({ slug: 'sky', token: 'tok' });
+    void view.session.prompt();
+    await wait();
+    expect(view.frame()).toContain('What would you like to do?');
+    expect(view.frame()).toContain('/checkout');
+  });
   it('immediately replaces input with an animated activity and returns to a ready prompt', async () => {
     const view = screen(80, 24);
     const pending = view.session.prompt();

--- a/apps/cli/src/tui/host.ts
+++ b/apps/cli/src/tui/host.ts
@@ -22,6 +22,8 @@ export async function runInkRepl(input: {
   env: NodeJS.ProcessEnv;
   io: { stdin: NodeJS.ReadStream; stdout: NodeJS.WriteStream };
   token: string | null;
+  slug?: string;
+  initialLine?: string;
   // Set when a checkout in the working directory opened this session.
   checkout?: { slug: string; root: string };
 }): Promise<number> {
@@ -56,7 +58,8 @@ export async function runInkRepl(input: {
   let token = input.token;
   let conversationId: string | undefined;
   let who = '';
-  let slug = input.checkout?.slug ?? '';
+  let slug = input.checkout?.slug ?? input.slug ?? '';
+  let initialLine = input.initialLine;
   const paintIdentity = (): void => session.setIdentity(formatSessionIdentity(who, slug));
   let workshop: Workshop | undefined;
   const pendingExecution: PendingExecution = {};
@@ -130,7 +133,8 @@ export async function runInkRepl(input: {
   );
   try {
     for (;;) {
-      const line = await session.prompt();
+      const line = initialLine ?? (await session.prompt());
+      initialLine = undefined;
       if (!spoke && line.trim() && !line.trim().startsWith('/')) {
         spoke = true;
         telemetry.record('first_turn');

--- a/apps/web/src/CliFunnelBlock.tsx
+++ b/apps/web/src/CliFunnelBlock.tsx
@@ -8,6 +8,8 @@ const CLI_LABELS: Record<CliStep, string> & Record<string, string> = {
   build_requested: 'asked for a build',
   delivered: 'delivered',
   published: 'published',
+  connect_opened: 'opened connection choices',
+  checkout_opened: 'opened local checkout',
   kit_update_available: 'kit update available',
   kit_update_started: 'started kit update',
   kit_update_completed: 'updated kit',

--- a/apps/web/src/ConnectAgentsPage.test.tsx
+++ b/apps/web/src/ConnectAgentsPage.test.tsx
@@ -81,6 +81,21 @@ describe('ConnectAgentsPage', () => {
     expect(container.textContent).toMatch(/login opens your browser/i);
   });
 
+  it.each(['en', 'pl'])('separates a new idea from an existing game in %s', async (language) => {
+    await i18n.changeLanguage(language);
+    await draw(true);
+    const headings = Array.from(container.querySelectorAll('#cli h3'));
+    expect(headings.map((node) => node.textContent)).toEqual([
+      i18n.t('connectAgents.cli.newTitle'),
+      i18n.t('connectAgents.cli.existingTitle'),
+    ]);
+    const snippets = Array.from(container.querySelectorAll('#cli pre')).map((node) => node.textContent);
+    expect(snippets[0]).toContain('gamedevpl login');
+    expect(snippets[1]).toBe('gamedevpl');
+    expect(snippets[2]).toBe('gamedevpl games\ngamedevpl connect <slug>');
+    expect(container.textContent).toContain(i18n.t('connectAgents.cli.existingDraft'));
+  });
+
   it('scrolls the hashed section into view on mount', async () => {
     if (!Object.getOwnPropertyDescriptor(Element.prototype, 'scrollIntoView')) {
       Object.defineProperty(Element.prototype, 'scrollIntoView', {

--- a/apps/web/src/ConnectAgentsPage.tsx
+++ b/apps/web/src/ConnectAgentsPage.tsx
@@ -81,19 +81,28 @@ export function ConnectAgentsPage({ onBack, onStudio }: { onBack: () => void; on
         {cliOn ? (
           <>
             <pre className="connect-snippet" tabIndex={0}>
-              {install}
+              {`${install}\ngamedevpl login`}
             </pre>
             <p className="connect-hint">{t('connectAgents.cli.installHint')}</p>
+            <p>{t('connectAgents.cli.login')}</p>
+            <h3>{t('connectAgents.cli.newTitle')}</h3>
+            <p>{t('connectAgents.cli.newHint')}</p>
+            <pre className="connect-snippet" tabIndex={0}>
+              gamedevpl
+            </pre>
+            <p>{t('connectAgents.cli.newPrompt')}</p>
+            <h3>{t('connectAgents.cli.existingTitle')}</h3>
+            <p>{t('connectAgents.cli.existingHint')}</p>
+            <pre className="connect-snippet" tabIndex={0}>
+              {'gamedevpl games\ngamedevpl connect <slug>'}
+            </pre>
+            <p>{t('connectAgents.cli.existingDraft')}</p>
+            <p>{t('connectAgents.cli.afterConnect')}</p>
+            <p>{t('connectAgents.cli.checkout')}</p>
           </>
         ) : (
           <p className="connect-hint">{t('connectAgents.cli.installPending')}</p>
         )}
-        <ul className="connect-list">
-          <li>{t('connectAgents.cli.login')}</li>
-          <li>{t('connectAgents.cli.repl')}</li>
-          <li>{t('connectAgents.cli.checkout')}</li>
-          <li>{t('connectAgents.cli.ci')}</li>
-        </ul>
       </section>
     </article>
   );

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -1250,7 +1250,7 @@
   },
   "connectAgents": {
     "title": "Connect an agent",
-    "intro": "Two doors, same games. Point a coding agent at gamedev.pl over MCP, or talk in a terminal with the gamedevpl CLI. Neither has a model of its own — coding happens on the platform or in a tool you already installed.",
+    "intro": "Create games in a conversation with gamedevpl CLI, or connect your own agent through MCP. Follow the steps below for a new idea or a game you already have in Studio.",
     "back": "Back to the site",
     "jump": "On this page",
     "beta": "Creating games is in closed beta. The connection loads for anyone; the calls need an approved creator account.",
@@ -1267,13 +1267,20 @@
     "cli": {
       "nav": "gamedevpl CLI",
       "title": "gamedevpl CLI — a terminal",
-      "lead": "A conversational front door. Talk first; a game starts when you ask for one. Checkout uses your editor; git push is not a delivery path.",
-      "installHint": "Needs Node 20+ — same as a game checkout. Windows: irm https://www.gamedev.pl/install.ps1 | iex. The script checksum-verifies before it writes ~/.local/bin.",
+      "lead": "Start with an idea or open a game from your Studio. The CLI guides the conversation and helps you choose an agent to build it.",
+      "installHint": "Requires Node 20.19 or newer. Already installed? Run gamedevpl update. On Windows, install with PowerShell: irm https://www.gamedev.pl/install.ps1 | iex.",
       "installPending": "Installers are not public yet. The client lives in this repo at apps/cli; bundle it locally with npm run bundle -w @gamedevpl/cli.",
-      "login": "gamedevpl login opens your browser. Approve once — no token to copy.",
+      "login": "gamedevpl login opens your browser. Sign in with the same account as Studio — no copying tokens.",
       "repl": "gamedevpl with no verb opens a REPL: talk first, then start a game when you are ready.",
-      "checkout": "gamedevpl checkout <slug> for your own editor. Deliver with gamedevpl submit.",
-      "ci": "CI: GAMEDEV_TOKEN from secrets. Never pass the creator OAuth token to a sub-agent."
+      "checkout": "In the session, choose a local checkout or type /checkout. Before the first build you get the brief to start from; after building, /play opens the preview and /submit delivers your changes.",
+      "ci": "CI: GAMEDEV_TOKEN from secrets. Never pass the creator OAuth token to a sub-agent.",
+      "newTitle": "I have an idea for a new game",
+      "newHint": "You do not need a game in Studio or a game identifier yet. Start a conversation:",
+      "newPrompt": "For example: “I want to create a game about an acrobat jumping between rooftops.” The CLI gathers your idea and offers a choice of builder.",
+      "existingTitle": "I already have a game in Studio",
+      "existingHint": "List your games, then replace <slug> with the identifier of the game you want:",
+      "existingDraft": "The game can still be waiting for its first build. It only needs to have been created in Studio — publication and finished game files are not required.",
+      "afterConnect": "Connect opens an interactive session. Choose a local checkout, a conversation about the game, or an available agent. No manual MCP setup is needed."
     }
   },
   "contact": {
@@ -1684,7 +1691,9 @@
     },
     "gamedevCli": {
       "title": "gamedevpl CLI",
-      "hint": "Needs Node 20. Run gamedevpl login (browser opens), then connect this game. Same round as MCP."
+      "hint": "Install or update the CLI, sign in with the same account as Studio, then open this game. Requires Node 20.19 or newer.",
+      "next": "Choose “Open a local checkout” to work on files, or choose chat or an agent. The session stays open; /checkout downloads this game and /help shows available actions.",
+      "draft": "You do not need to wait for the first build. If there is no game code yet, the checkout contains the brief. Tell the agent what to build; /play works once the game has been built."
     },
     "rotate": {
       "start": "Rotate key",

--- a/apps/web/src/i18n/locales/pl.json
+++ b/apps/web/src/i18n/locales/pl.json
@@ -1264,7 +1264,7 @@
   },
   "connectAgents": {
     "title": "Podłącz agenta",
-    "intro": "Dwoje drzwi, te same gry. Wskaż agenta kodującego na gamedev.pl przez MCP albo rozmawiaj w terminalu przez gamedevpl CLI. Żadne nie ma własnego modelu — kod powstaje na platformie albo w narzędziu, które już masz.",
+    "intro": "Twórz gry w rozmowie z gamedevpl CLI albo podłącz własnego agenta przez MCP. Poniżej znajdziesz instrukcje zarówno dla nowego pomysłu, jak i gry, którą masz już w Studio.",
     "back": "Wróć do serwisu",
     "jump": "Na tej stronie",
     "beta": "Tworzenie gier jest w zamkniętej becie. Połączenie ładuje się dla każdego; wywołania wymagają zatwierdzonego konta twórcy.",
@@ -1281,13 +1281,20 @@
     "cli": {
       "nav": "gamedevpl CLI",
       "title": "gamedevpl CLI — terminal",
-      "lead": "Rozmowny front door. Najpierw rozmowa; gra startuje, kiedy o nią poprosisz. Checkout idzie do Twojego edytora; git push nie jest ścieżką oddania.",
-      "installHint": "Potrzebujesz Node 20+ — tak jak przy kopii roboczej. Windows: irm https://www.gamedev.pl/install.ps1 | iex. Skrypt weryfikuje sumę kontrolną zanim zapisze ~/.local/bin.",
+      "lead": "Zacznij od pomysłu albo otwórz grę ze swojego Studio. CLI prowadzi rozmowę i pomaga wybrać agenta do budowy.",
+      "installHint": "Potrzebujesz Node 20.19 lub nowszego. Masz już CLI? Uruchom gamedevpl update. Na Windows zainstaluj przez PowerShell: irm https://www.gamedev.pl/install.ps1 | iex.",
       "installPending": "Instalatory nie są jeszcze publiczne. Klient jest w tym repozytorium w apps/cli; zbierz go lokalnie: npm run bundle -w @gamedevpl/cli.",
-      "login": "gamedevpl login otwiera przeglądarkę. Zatwierdzasz raz — bez kopiowania tokenu.",
+      "login": "gamedevpl login otwiera przeglądarkę. Zaloguj się na to samo konto co w Studio — bez kopiowania tokenów.",
       "repl": "gamedevpl bez czasownika otwiera REPL: najpierw rozmowa, gra dopiero gdy o nią poprosisz.",
-      "checkout": "gamedevpl checkout <slug> do własnego edytora. Oddajesz poleceniem gamedevpl submit.",
-      "ci": "CI: GAMEDEV_TOKEN z secrets. Nigdy nie przekazuj tokenu OAuth twórcy do sub-agenta."
+      "checkout": "W sesji wybierz lokalny checkout albo wpisz /checkout. Gdy nie ma jeszcze builda, pobierzesz brief do rozpoczęcia pracy; po zbudowaniu /play uruchomi podgląd, a /submit odda zmiany.",
+      "ci": "CI: GAMEDEV_TOKEN z secrets. Nigdy nie przekazuj tokenu OAuth twórcy do sub-agenta.",
+      "newTitle": "Mam dopiero pomysł",
+      "newHint": "Nie potrzebujesz jeszcze gry w Studio ani jej identyfikatora. Uruchom rozmowę:",
+      "newPrompt": "Napisz na przykład: „Chcę stworzyć grę o akrobacie skaczącym między dachami”. CLI zbierze pomysł i zaproponuje, kto zbuduje grę.",
+      "existingTitle": "Mam już grę w Studio",
+      "existingHint": "Wyświetl swoje gry, a potem zastąp <slug> identyfikatorem wybranej gry:",
+      "existingDraft": "Gra może dopiero czekać na pierwszy build. Wystarczy, że została już utworzona w Studio — nie musi być opublikowana ani mieć gotowych plików.",
+      "afterConnect": "Connect otwiera interaktywną sesję. Wybierz lokalny checkout, rozmowę o grze albo dostępnego agenta. Nie musisz ręcznie konfigurować MCP."
     }
   },
   "contact": {
@@ -1698,7 +1705,9 @@
     },
     "gamedevCli": {
       "title": "gamedevpl CLI",
-      "hint": "Potrzebujesz Node 20. gamedevpl login otwiera przeglądarkę, potem podłącz tę grę. Ta sama runda co MCP."
+      "hint": "Zainstaluj lub zaktualizuj CLI, zaloguj się na to samo konto co w Studio i otwórz tę grę. Potrzebujesz Node 20.19 lub nowszego.",
+      "next": "Wybierz „Open a local checkout”, aby pracować na plikach, lub rozmowę albo agenta. Sesja pozostanie otwarta; /checkout pobierze tę grę, /help pokaże dostępne działania.",
+      "draft": "Nie musisz czekać na pierwszy build. Jeśli nie ma jeszcze kodu gry, checkout zawiera brief. Opisz agentowi, co ma zbudować; /play będzie dostępne po powstaniu gry."
     },
     "rotate": {
       "start": "Obróć klucz",

--- a/apps/web/src/surfaces/studio/GamedevCliConnectTab.test.tsx
+++ b/apps/web/src/surfaces/studio/GamedevCliConnectTab.test.tsx
@@ -27,7 +27,8 @@ describe('GamedevCliConnectTab', () => {
       await Promise.resolve();
       await Promise.resolve();
     });
-    expect(host.textContent).toContain('gamedevpl connect ghost-roads');
+    expect(host.textContent).toContain('gamedevpl login\ngamedevpl connect ghost-roads');
+    expect(host.textContent).toContain('do not need to wait for the first build');
     expect(host.textContent).toContain(`${window.location.origin}/install.sh`);
     await act(async () => root.unmount());
   });

--- a/apps/web/src/surfaces/studio/GamedevCliConnectTab.tsx
+++ b/apps/web/src/surfaces/studio/GamedevCliConnectTab.tsx
@@ -5,7 +5,7 @@ export function GamedevCliConnectTab({ slug }: { slug: string }) {
   const { t } = useTranslation();
   const on = useCliSurfaceEnabled();
   if (!on) return null;
-  const snippet = `curl -fsSL ${window.location.origin}/install.sh | bash\ngamedevpl connect ${slug}`;
+  const snippet = `curl -fsSL ${window.location.origin}/install.sh | bash\ngamedevpl login\ngamedevpl connect ${slug}`;
   return (
     <div className="studio-connect-step" data-testid="gamedev-cli-connect">
       <h4 className="studio-connect-step-title">{t('connect.gamedevCli.title')}</h4>
@@ -13,6 +13,8 @@ export function GamedevCliConnectTab({ slug }: { slug: string }) {
       <pre className="studio-connect-snippet" tabIndex={0}>
         {snippet}
       </pre>
+      <p className="studio-connect-same">{t('connect.gamedevCli.next')}</p>
+      <p className="studio-connect-same">{t('connect.gamedevCli.draft')}</p>
     </div>
   );
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -95,7 +95,7 @@
     },
     "apps/cli": {
       "name": "@gamedevpl/cli",
-      "version": "0.5.1",
+      "version": "0.6.1",
       "dependencies": {
         "@gamedevpl/contract": "*",
         "ink": "^5.2.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -95,7 +95,7 @@
     },
     "apps/cli": {
       "name": "@gamedevpl/cli",
-      "version": "0.6.1",
+      "version": "0.7.0",
       "dependencies": {
         "@gamedevpl/contract": "*",
         "ink": "^5.2.1",

--- a/packages/contract/src/visit-vocab.test.ts
+++ b/packages/contract/src/visit-vocab.test.ts
@@ -211,6 +211,8 @@ describe('visit vocab', () => {
       'delivered',
       'published',
       'play_requested',
+      'connect_opened',
+      'checkout_opened',
       'kit_update_available',
       'kit_update_started',
       'kit_update_completed',

--- a/packages/contract/src/visit-vocab.ts
+++ b/packages/contract/src/visit-vocab.ts
@@ -185,6 +185,8 @@ export const CLI_STEPS = [
   'delivered',
   'published',
   'play_requested',
+  'connect_opened',
+  'checkout_opened',
   'kit_update_available',
   'kit_update_started',
   'kit_update_completed',


### PR DESCRIPTION
`gamedevpl connect <slug>` previously printed an MCP installation command and exited. Creators had to discover how to start an interactive session, and `/checkout` downloaded files without switching the active game.

Interactive terminals now open a game session with choices to download/reuse a local checkout, continue chatting, run an installed MCP agent, or view manual setup. `/checkout` uses the selected game, returns its workshop to the TUI and preserves existing local files. A different game gets a sibling checkout when launched from another game's directory. Games without a delivery can download their brief; the UI explains that they need a build before playing.

`gamedevpl repl <slug>` opens the same guided entry. `--manual`, redirected output and explicit `--agent` retain one-shot behavior. Automated agent launches no longer print the manual credential snippet. Checkout refuses occupied destinations; shell checkout prints how to enter the interactive session.

The public /connect page and Studio CLI tab now explain the two starting points in Polish and English: run gamedevpl to create from an idea, or connect an existing Studio game even before its first build. Install instructions include login with the Studio account. A missing-game error links both paths instead of implying a game must already exist. The website guidance ships alongside the new CLI behavior and should be followed by its CLI release.

Validation: root install/type-check/lint/test/build passed, including 291 CLI tests and 76 repository rule tests. Tests cover terminal routing, cancellation before MCP access, undelivered checkout, missing-game guidance, active-game switching, existing-file preservation, and actual Ink picker-to-chat rendering. Website instructions are covered in Polish and English; verified the public page in the browser at desktop and 390px widths, plus the Studio CLI component in a temporary local preview. CLI bundle/help were smoke-tested during implementation.

Adds anonymous connect/checkout funnel steps with dashboard labels. No slugs, paths, prompts or credentials are included. No new dependencies; npm install synchronizes the existing CLI workspace lock version. Merge/release remain separate from this PR.
