### PR TITLE
fix(infra): stop setup-monitoring.sh from erasing the spend brake's wiring

### DIFF
--- a/infra/setup-monitoring.sh
+++ b/infra/setup-monitoring.sh
@@ -872,11 +872,38 @@ for FILE in "${POLICY_DIR}"/*.json; do
   # to be in the file — including notificationChannels. Omitting it there would leave the
   # policies present and visibly "enabled" while silently emailing nobody, which is the
   # one failure mode worse than having no alerting at all.
+  #
+  # Wholesale also means this script erases decoration it does not know about. On
+  # 2026-09-07 a re-run stripped the Spend brake channel and the `lanes` user labels that
+  # setup-spend-brake.sh had attached to A24/A25/A26, leaving the alerts emailing an
+  # operator while pausing nothing — the brake's Monitoring half was dead for an hour and
+  # nothing said so. So the live policy's channels and labels are merged in below: this
+  # script stays authoritative for the policy body, and anything another script added to
+  # the same policy survives.
   if [ -n "$EXISTING" ]; then
+    LIVE="$(mktemp)"
+    MERGED="$(mktemp)"
+    gcloud alpha monitoring policies describe "$EXISTING" --project "$PROJECT_ID" --format=json >"$LIVE"
+    python3 - "$FILE" "$LIVE" >"$MERGED" <<'MERGE_POLICY'
+import json, sys
+
+want = json.load(open(sys.argv[1]))
+live = json.load(open(sys.argv[2]))
+# Ours first, so the email channel keeps its place; dict.fromkeys dedupes in order.
+channels = list(dict.fromkeys(want.get('notificationChannels', []) + live.get('notificationChannels', [])))
+if channels:
+    want['notificationChannels'] = channels
+# The file wins on a key it sets; everything else another script wrote is kept.
+labels = {**live.get('userLabels', {}), **want.get('userLabels', {})}
+if labels:
+    want['userLabels'] = labels
+json.dump(want, sys.stdout)
+MERGE_POLICY
     gcloud alpha monitoring policies update "$EXISTING" \
       --project "$PROJECT_ID" \
-      --policy-from-file="$FILE" \
+      --policy-from-file="$MERGED" \
       >/dev/null
+    rm -f "$LIVE" "$MERGED"
     echo "    Updated: ${DISPLAY}"
   else
     gcloud alpha monitoring policies create \


### PR DESCRIPTION
## What happened

At 22:09Z on 2026-09-07 a re-run of `setup-monitoring.sh` stripped, from A24/A25/A26:

- the **Spend brake** Pub/Sub notification channel, and
- the **`lanes` user labels** that tell the brake which lanes each alert pauses.

The policies stayed `enabled: true` and kept emailing the operator, so nothing looked wrong from the console. But the brake's Monitoring half was disconnected: a Vertex or Discovery Engine runaway would have emailed and paused nothing. It was live for over an hour and surfaced only because the policies were read for an unrelated reason.

(The billing-budget half was unaffected — that publishes to the topic directly, which is why the graded budget pull at 23:53Z still worked.)

## Why

`gcloud alpha monitoring policies update --policy-from-file` replaces the policy **wholesale**, so this script erases every field it does not itself know about. The comment two lines above the call already says exactly this about `notificationChannels` — it just never followed through for anything a *different* script had attached to the same policy.

This is the same shape as the env-var kill switches that evaporate on redeploy: two owner-run scripts touching one resource, and the one that runs second wins by omission.

## Fix

Before updating, read the live policy and merge its `notificationChannels` and `userLabels` into the file. `setup-monitoring.sh` stays authoritative for the policy body — conditions, thresholds, documentation — while decoration owned by `setup-spend-brake.sh` (or anything else) survives a re-run. The file still wins on any key it sets, and the merge only runs on the update path, so a freshly created policy is unaffected.

Verified the merge against a fixture pair: the brake channel and `lanes=creation_seeding` both survive, ours keeps first place in the channel list, and no `describe`-only fields (`name`, `mutationRecord`) leak into the payload — only the two keys are copied across.

## Production is still broken until this is applied

The three policies currently have no brake channel and no labels. The repair is one owner-run command, which re-attaches both and is otherwise idempotent:

```
./infra/setup-spend-brake.sh
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
