### PR TITLE
release(cli): v0.9.0

### DIFF
--- a/.claude/skills/cli-release/SKILL.md
+++ b/.claude/skills/cli-release/SKILL.md
@@ -78,6 +78,12 @@ repo in the same session.
 
 ## Traps recorded so far
 
+- **Rebase can put unreleased entries below an already-published header.** Before a
+  cut, compare the release tag with the feature merge. If `next` says `none` but the
+  published artifact predates the feature, move that feature's entries back to
+  Unreleased, preserving the released section from its tag, then cut a new version.
+  Never republish the existing tag. Observed with #1223 after cli-v0.8.0.
+
 - **Check the workspace version in `package-lock.json`.** The release cut currently
   updates the two version sources but leaves the CLI workspace lock entry stale.
   Run `npm install` and include that version-only lockfile change in the release PR.

--- a/apps/api/src/platform/cli-installers.ts
+++ b/apps/api/src/platform/cli-installers.ts
@@ -1,4 +1,4 @@
-export const CLI_VERSION = '0.8.0';
+export const CLI_VERSION = '0.9.0';
 
 export const CLI_RELEASE_PREFIX = 'cli-v';
 

--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -7,19 +7,23 @@ decides the next version — see [`.claude/skills/cli-release/SKILL.md`](../../.
 
 ## Unreleased
 
-## 0.8.0 — 2026-09-07
+## 0.9.0 — 2026-09-08
 
 ### Added
 
-- The pilot funnel records signing in, a first turn, a publish it watched happen, and one install per machine — the operator page reads them (#1222).
 - Connect opens an interactive game session with local checkout, chat and agent choices; `--manual` prints MCP setup (#1223).
 
 ### Fixed
 
 - Missing-game errors explain how to start creating a new game (#1223).
-
 - `/checkout` opens the downloaded game in the current session and supports games before their first delivery (#1223).
 - Checkout refuses non-empty destinations to preserve existing files (#1223).
+
+## 0.8.0 — 2026-09-07
+
+### Added
+
+- The pilot funnel records signing in, a first turn, a publish it watched happen, and one install per machine — the operator page reads them (#1222).
 
 ## 0.7.0 — 2026-09-07
 

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gamedevpl/cli",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "private": true,
   "type": "module",
   "bin": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -95,7 +95,7 @@
     },
     "apps/cli": {
       "name": "@gamedevpl/cli",
-      "version": "0.7.0",
+      "version": "0.9.0",
       "dependencies": {
         "@gamedevpl/contract": "*",
         "ink": "^5.2.1",


### PR DESCRIPTION
Releases CLI 0.9.0 with interactive `connect`, checkout activation inside the session, guidance for games without a first build, and protection against overwriting nonempty checkout destinations.

Version 0.8.0 was published before #1223 merged. Its release section accidentally acquired those later changes, leaving the release generator with an empty Unreleased section. This restores the published 0.8.0 notes from its tag and assigns the new features to 0.9.0. The release playbook now documents this rebase trap.

Updated the package version, installer default, and workspace lockfile using the release script and npm install. Local type-check, lint, and build passed. The full test run hit six web Studio failures (including timeouts); all three affected files passed on isolated rerun: 65/65 tests. All other workspace tests passed. CI must pass before merge.
