### PR TITLE
feat(cli): add completion and agent failure recovery

### DIFF
--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -7,6 +7,10 @@ decides the next version — see [`.claude/skills/cli-release/SKILL.md`](../../.
 
 ## Unreleased
 
+### Added
+
+- Interactive slash-command suggestions filter as you type; arrows select and Tab completes without running the command.
+
 ## 0.9.0 — 2026-09-08
 
 ### Added

--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -9,7 +9,7 @@ decides the next version — see [`.claude/skills/cli-release/SKILL.md`](../../.
 
 ### Added
 
-- Interactive slash-command suggestions filter as you type; arrows select and Tab completes without running the command.
+- Interactive slash-command suggestions filter as you type; arrows select and Tab completes without running the command (#1231).
 
 ## 0.9.0 — 2026-09-08
 

--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -11,6 +11,10 @@ decides the next version — see [`.claude/skills/cli-release/SKILL.md`](../../.
 
 - Interactive slash-command suggestions filter as you type; arrows select and Tab completes without running the command (#1231).
 
+### Fixed
+
+- Agent failures explain model capacity errors and offer reconnection to the existing MCP round instead of suggesting submit (#1231).
+
 ## 0.9.0 — 2026-09-08
 
 ### Added

--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -247,3 +247,5 @@ If the game is only an idea and has not been created yet, run `gamedevpl` withou
 arguments and describe it. `connect <slug>` opens an existing owned game; clicking
 Create in Studio establishes its submission even before an agent starts or delivers
 files. A missing game is not silently created by connect.
+
+In the interactive prompt, type `/` to browse commands or `/pu` to find `/pull`. Use ↑/↓ to select, Tab to fill, and Enter to send. Enter on a partial command fills it first. Esc hides suggestions and keeps your text; outside the suggestion list, ↑/↓ browses history. Suggestions run locally and make no model requests.

--- a/apps/cli/src/agent-failure.test.ts
+++ b/apps/cli/src/agent-failure.test.ts
@@ -1,0 +1,58 @@
+import { runLocalBuild, type Workshop } from './workshop.js';
+import { loadAdapters } from './adapters.js';
+import { expect, it } from 'vitest';
+import { trackAgentFailure } from './agent-failure.js';
+
+it.each([
+  'Selected model is at capacity. Please try a different model.',
+  JSON.stringify({ type: 'error', message: 'Selected model is at capacity. Please try a different model.' }),
+  JSON.stringify({ type: 'turn.failed', error: { message: 'Selected model is at capacity.' } }),
+])('explains capacity errors from text and structured events', (line) => {
+  const failure = trackAgentFailure('codex');
+  failure.observe(line);
+  failure.observe('{"type":"item.completed"}');
+  expect(failure.error(1, '/connect sky --agent codex')).toMatchObject({
+    message: expect.stringContaining('selected model is at capacity'),
+    next: expect.stringContaining('/connect sky --agent codex'),
+  });
+});
+
+it('does not infer capacity from arbitrary failures or another run', () => {
+  const failure = trackAgentFailure('codex');
+  failure.observe('Something went wrong');
+  expect(failure.error(null, 'retry')).toMatchObject({
+    message: 'codex stopped (exit unknown). Task completion is not confirmed.',
+    next: 'retry',
+  });
+});
+
+it('explains local model capacity without verifying or offering delivery', async () => {
+  const output: string[] = [];
+  let checked = false;
+  const codex = loadAdapters().adapters.find((spec) => spec.name === 'codex')!;
+  const ws: Workshop = {
+    root: '/tmp',
+    slug: 'sky',
+    token: 'tok',
+    env: {},
+    adapters: [codex],
+    builder: 'self',
+    pick: async () => '/quit',
+    abort: { current: null },
+    runAdapter: async ({ onLine }) => {
+      onLine?.('Selected model is at capacity. Please try a different model.');
+      return { code: 1 };
+    },
+    run: () => {
+      checked = true;
+      return { status: 0, stdout: '', stderr: '' };
+    },
+  };
+  expect(await runLocalBuild({ ws, spec: codex, brief: 'Fix scrolling', write: (line) => output.push(line) })).toBe(
+    false,
+  );
+  expect(checked).toBe(false);
+  expect(output.join('\n')).toContain('selected model is at capacity');
+  expect(output.join('\n')).toContain('/diff');
+  expect(output.join('\n')).not.toContain('static ladder green');
+});

--- a/apps/cli/src/agent-failure.ts
+++ b/apps/cli/src/agent-failure.ts
@@ -1,0 +1,21 @@
+import { parseEventLine } from './delegate.js';
+import { CliError, EXIT_RED } from './exit-codes.js';
+
+export function trackAgentFailure(adapter: string) {
+  let capacity = false;
+  return {
+    observe(line: string) {
+      const text = parseEventLine(line, adapter);
+      if (text && /^selected model is at capacity\b/i.test(text.trim())) capacity = true;
+    },
+    error(code: number | null, retry: string): CliError {
+      return new CliError(
+        capacity
+          ? `${adapter} stopped: the selected model is at capacity. Task completion is not confirmed.`
+          : `${adapter} stopped (exit ${code ?? 'unknown'}). Task completion is not confirmed.`,
+        EXIT_RED,
+        capacity ? `Wait and retry: ${retry}. Or change the model in ${adapter} settings before retrying.` : retry,
+      );
+    },
+  };
+}

--- a/apps/cli/src/connect.test.ts
+++ b/apps/cli/src/connect.test.ts
@@ -430,3 +430,47 @@ it('uses a private temporary Copilot MCP config and removes it on failure', asyn
   expect(configPath).not.toBe('');
   expect(existsSync(configPath)).toBe(false);
 });
+
+it.each(['streamed', 'buffered', 'unknown'] as const)(
+  'offers reconnection instead of submit after %s failure',
+  async (mode) => {
+    const calls: string[] = [];
+    const output: string[] = [];
+    const api = createApi({
+      origin: 'https://example.test',
+      store: memoryStore({ accessToken: 't', tokenType: 'Bearer', scope: 'creator' }),
+      fetch: async (url, init) => {
+        calls.push(`${init?.method ?? 'GET'} ${url}`);
+        if (String(url).includes('/api/me/studio')) return json({ games: [{ slug: 'sky', token: 'tok' }] });
+        return json({ mcpUrl: 'https://example.test/api/mcp', authorizationHeader: 'Bearer gdpl_cak_test' });
+      },
+    });
+    const message = JSON.stringify({
+      type: 'turn.failed',
+      error: { message: 'Selected model is at capacity. Please try a different model.' },
+    });
+    const attempt = () =>
+      connectGame({
+        api,
+        slug: 'sky',
+        dest: '/tmp',
+        env: { PATH: '/usr/bin' },
+        agent: 'codex',
+        which: () => '/usr/bin/codex',
+        runAdapter: async ({ onLine }) => {
+          if (mode === 'streamed') onLine?.(message);
+          return { code: 1, lines: mode === 'buffered' ? [message] : [] };
+        },
+        write: (line) => output.push(line),
+      });
+    for (let i = 0; i < 2; i++) {
+      await expect(attempt()).rejects.toMatchObject({
+        message: expect.stringContaining(mode === 'unknown' ? 'exit 1' : 'selected model is at capacity'),
+        next: expect.stringContaining('/connect sky --agent codex'),
+      });
+    }
+    expect(calls.every((call) => call.startsWith('GET '))).toBe(true);
+    expect(output.join('\n')).not.toContain('adapter finished');
+    await expect(attempt()).rejects.not.toMatchObject({ next: expect.stringContaining('submit') });
+  },
+);

--- a/apps/cli/src/connect.ts
+++ b/apps/cli/src/connect.ts
@@ -1,3 +1,4 @@
+import { trackAgentFailure } from './agent-failure.js';
 import { requireClaudeSubscription, subscriptionEnv } from './claude-auth.js';
 import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
@@ -8,7 +9,7 @@ import type { ApiClient } from './api.js';
 import { detectAdapter, loadAdapters, preflightAdapter, whichOnPath, type AdapterSpec } from './adapters.js';
 import { cliUsage } from './bin-name.js';
 import { CREATOR_TOKEN_PATTERN, childEnv, renderDelegateStream, spawnAdapter } from './delegate.js';
-import { CliError, EXIT_AUTH, EXIT_INPUT, EXIT_RED, EXIT_REFUSED } from './exit-codes.js';
+import { CliError, EXIT_AUTH, EXIT_INPUT, EXIT_REFUSED } from './exit-codes.js';
 import { studioToken } from './studio.js';
 import { adapterMcpSupported } from './agents.js';
 import { findCheckout } from './checkout.js';
@@ -288,6 +289,7 @@ export async function connectGame(input: {
         : undefined;
     await authCheck;
     input.telemetry?.record('delegate_used', { adapter: spec.name });
+    const failure = trackAgentFailure(spec.name);
     const result = await (input.runAdapter ?? defaultAdapterRun)({
       spec: wired.spec,
       prompt:
@@ -297,9 +299,11 @@ export async function connectGame(input: {
       authCheck,
       abort: input.abort,
       onLine: (line) => {
+        failure.observe(line);
         for (const shown of renderDelegateStream(spec.name, [line], false)) input.write(shown);
       },
     });
+    for (const line of result.lines) failure.observe(line);
     for (const line of renderDelegateStream(spec.name, result.lines, false)) input.write(line);
     if (input.abort?.aborted) {
       throw new CliError(
@@ -309,7 +313,10 @@ export async function connectGame(input: {
       );
     }
     if ((result.code ?? 1) !== 0) {
-      throw new CliError(`${spec.name} exited ${result.code ?? 'null'}`, EXIT_RED, cliUsage('submit'));
+      throw failure.error(
+        result.code,
+        `Reconnect to this round with /connect ${input.slug} --agent ${spec.name} (in the shell: ${cliUsage('connect', `${input.slug} --agent ${spec.name}`)})`,
+      );
     }
     input.write(
       local

--- a/apps/cli/src/help.ts
+++ b/apps/cli/src/help.ts
@@ -2,7 +2,7 @@ import { CLI_BIN } from './bin-name.js';
 import { CLI_VERSION } from './update.js';
 import { SLASH_VERBS, type SlashVerb } from './argv.js';
 
-const BLURB: Record<SlashVerb, string> = {
+export const BLURB: Record<SlashVerb, string> = {
   play: 'open the game; live reload in a checkout — play [slug] [--no-open|--stop]',
   kit: 'check or update this checkout’s Creator Kit — kit [update]',
   agents: 'detect local agents and show supported modes',

--- a/apps/cli/src/tui/app.test.tsx
+++ b/apps/cli/src/tui/app.test.tsx
@@ -32,7 +32,7 @@ function screen(columns: number, rows: number) {
     input.end();
     output.end();
   });
-  return { session, frame: () => frames.filter((frame) => frame.includes('gamedevpl')).at(-1) ?? '' };
+  return { session, input, frame: () => frames.filter((frame) => frame.includes('gamedevpl')).at(-1) ?? '' };
 }
 
 describe('TUI feedback', () => {
@@ -114,4 +114,79 @@ it('shows the Kit choice, then installation activity instead of an idle textbox'
   expect(view.frame()).toContain('Downloading Creator Kit');
   expect(view.frame()).toContain('input paused');
   expect(view.frame()).not.toContain('What would you like');
+});
+
+describe('command completion keyboard', () => {
+  it('completes /pu with Tab without submitting, then sends on Enter', async () => {
+    const view = screen(80, 24);
+    const pending = view.session.prompt();
+    await wait();
+    view.input.write('/pu');
+    await wait();
+    expect(view.frame()).toContain('/pull — update a checkout');
+    view.input.write('\t');
+    await wait();
+    expect(view.session.get().draft).toBe('/pull ');
+    expect(view.session.get().mode).toBe('prompt');
+    view.input.write('\r');
+    expect(await pending).toBe('/pull ');
+  });
+
+  it('selects matches with arrows and fills a partial command with Enter', async () => {
+    const view = screen(80, 24);
+    void view.session.prompt();
+    await wait();
+    view.input.write('/p');
+    await wait();
+    expect(view.frame()).toContain('▸ /play');
+    view.input.write('\x1b[B');
+    await wait();
+    expect(view.frame()).toContain('▸ /profile');
+    view.input.write('\r');
+    await wait();
+    expect(view.session.get().draft).toBe('/profile ');
+    expect(view.session.get().mode).toBe('prompt');
+  });
+
+  it('dismisses suggestions without clearing text, preserves history and ignores Tab in prose', async () => {
+    const view = screen(80, 24);
+    void view.session.prompt();
+    view.session.setDraft('previous request');
+    view.session.submit();
+    void view.session.prompt();
+    await wait();
+    view.input.write('/p');
+    await wait();
+    view.input.write('\x1b');
+    await wait();
+    expect(view.session.get().draft).toBe('/p');
+    expect(view.frame()).not.toContain('▸ /play');
+    view.input.write('\x1b[A');
+    await wait();
+    expect(view.session.get().draft).toBe('previous request');
+    view.input.write('\t');
+    await wait();
+    expect(view.session.get().draft).toBe('previous request');
+    view.input.write('\x1b[B');
+    await wait();
+    expect(view.session.get().draft).toBe('/p');
+  });
+
+  it.each([
+    [40, 12],
+    [80, 24],
+    [120, 40],
+  ])('scrolls all commands within %i × %i alongside status', async (columns, rows) => {
+    const view = screen(columns, rows);
+    view.session.setLive(['building', 'gate_not_started', 'live preview', 'czekamy na zakończenie']);
+    void view.session.prompt();
+    await wait();
+    view.input.write('/');
+    await wait();
+    view.input.write('\x1b[A');
+    await wait();
+    expect(view.frame()).toContain('▸ /whoami');
+    expect(view.frame().trimEnd().split('\n').length).toBeLessThanOrEqual(rows);
+    expect(view.frame()).toContain('Tab fill');
+  });
 });

--- a/apps/cli/src/tui/app.tsx
+++ b/apps/cli/src/tui/app.tsx
@@ -1,3 +1,4 @@
+import { CommandSuggestions, useCommandCompletion } from './completion.js';
 import { BusyPanel } from './busy.js';
 import { useEffect, useState } from 'react';
 import { Box, Text, useInput, useStdout } from 'ink';
@@ -9,6 +10,7 @@ import type { TuiSession, TuiState } from './session.js';
 
 export function ReplApp({ session, color }: { session: TuiSession; color: boolean }) {
   const [state, setState] = useState<TuiState>(session.get);
+  const completion = useCommandCompletion(state, session);
   const { stdout } = useStdout();
   const [rows, setRows] = useState(stdout.rows || 24);
   useEffect(() => session.subscribe(setState), [session]);
@@ -24,6 +26,8 @@ export function ReplApp({ session, color }: { session: TuiSession; color: boolea
       if (key.ctrl && input === 'c') session.cancel();
       return;
     }
+    if ((key.escape || (!key.ctrl && !key.meta)) && completion.handleKey(key)) return;
+    if (key.tab) return;
     if (key.escape || (key.ctrl && input === 'c')) {
       session.cancel();
       return;
@@ -68,7 +72,8 @@ export function ReplApp({ session, color }: { session: TuiSession; color: boolea
     0,
     Math.min(state.pickIndex - Math.floor(choiceCount / 2), state.choices.length - choiceCount),
   );
-  const panelRows = state.mode === 'pick' ? choiceCount + 3 : state.mode === 'busy' ? 2 : 3;
+  const suggestionRows = Math.min(completion.suggestions.length, 5, Math.max(0, rows - 9));
+  const panelRows = suggestionRows + (state.mode === 'pick' ? choiceCount + 3 : state.mode === 'busy' ? 2 : 3);
   const liveRows = Math.min(state.live.length, Math.max(0, rows - panelRows - 4));
   const body = Math.max(1, rows - panelRows - liveRows - 2);
   const shown = state.lines.slice(-body);
@@ -119,11 +124,21 @@ export function ReplApp({ session, color }: { session: TuiSession; color: boolea
           )}
         </Box>
       )}
+      {suggestionRows > 0 && (
+        <CommandSuggestions
+          suggestions={completion.suggestions}
+          selected={completion.selected}
+          count={suggestionRows}
+          color={color}
+        />
+      )}
       <Text dimColor wrap="truncate-end">
         {state.mode === 'pick'
           ? `↑↓ select · Enter · Esc · ${state.pickIndex + 1}/${state.choices.length}`
           : state.mode === 'prompt'
-            ? 'Enter send · ↑↓ history · Esc/Ctrl+C'
+            ? completion.suggestions.length
+              ? `↑↓ select · Tab fill · Enter ${completion.suggestions[completion.selected]?.command === state.draft ? 'send' : 'fill'} · Esc hide · ${completion.selected + 1}/${completion.suggestions.length}`
+              : 'Enter send · / commands · Tab fill · ↑↓ history'
             : 'Working — input paused'}
       </Text>
       <Text dimColor wrap="truncate-end">

--- a/apps/cli/src/tui/completion.test.ts
+++ b/apps/cli/src/tui/completion.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+import { commandSuggestions } from './completion.js';
+import { SLASH_VERBS } from '../argv.js';
+
+describe('command suggestions', () => {
+  it('covers every verb and session controls with descriptions', () => {
+    const all = commandSuggestions('/');
+    for (const verb of [...SLASH_VERBS, 'retry', 'quit', 'exit']) {
+      expect(all).toContainEqual({ command: `/${verb}`, description: expect.any(String) });
+    }
+  });
+  it('filters the command name, not prose or arguments', () => {
+    expect(commandSuggestions('/PU').map((item) => item.command)).toEqual(['/pull']);
+    for (const draft of ['', 'play', 'please /pu', '/play airtime', '/play ', '/unknown']) {
+      expect(commandSuggestions(draft)).toEqual([]);
+    }
+  });
+});

--- a/apps/cli/src/tui/completion.tsx
+++ b/apps/cli/src/tui/completion.tsx
@@ -1,0 +1,69 @@
+import { useEffect, useState } from 'react';
+import { Box, Text, type Key } from 'ink';
+import { completeSlash } from '../argv.js';
+import { BLURB } from '../help.js';
+import type { TuiSession, TuiState } from './session.js';
+
+const SESSION_COMMANDS = {
+  retry: 'resume a task waiting for builder handoff',
+  quit: 'leave this session',
+  exit: 'leave this session',
+};
+
+export function commandSuggestions(draft: string) {
+  if (!/^\/[a-z]*$/i.test(draft)) return [];
+  const prefix = draft.slice(1).toLowerCase();
+  return [
+    ...completeSlash(draft).map((verb) => ({ command: `/${verb}`, description: BLURB[verb] })),
+    ...Object.entries(SESSION_COMMANDS)
+      .filter(([verb]) => verb.startsWith(prefix))
+      .map(([verb, description]) => ({ command: `/${verb}`, description })),
+  ].sort((a, b) => a.command.localeCompare(b.command));
+}
+
+export function useCommandCompletion(state: TuiState, session: TuiSession) {
+  const [index, setIndex] = useState(0);
+  const [dismissed, setDismissed] = useState(false);
+  useEffect(() => {
+    setIndex(0);
+    setDismissed(false);
+  }, [state.draft, state.mode]);
+  const suggestions = state.mode === 'prompt' && !dismissed ? commandSuggestions(state.draft) : [];
+  const selected = Math.min(index, Math.max(0, suggestions.length - 1));
+  const handleKey = (key: Key): boolean => {
+    if (!suggestions.length) return false;
+    if (key.escape) setDismissed(true);
+    else if (key.upArrow || key.downArrow) {
+      setIndex((selected + (key.upArrow ? -1 : 1) + suggestions.length) % suggestions.length);
+    } else if (key.tab || (key.return && suggestions[selected]!.command !== state.draft)) {
+      session.setDraft(`${suggestions[selected]!.command} `);
+    } else return false;
+    return true;
+  };
+  return { suggestions, selected, handleKey };
+}
+
+export function CommandSuggestions({
+  suggestions,
+  selected,
+  count,
+  color,
+}: {
+  suggestions: ReturnType<typeof commandSuggestions>;
+  selected: number;
+  count: number;
+  color: boolean;
+}) {
+  const start = Math.max(0, Math.min(selected - Math.floor(count / 2), suggestions.length - count));
+  return (
+    <Box flexDirection="column" height={count} flexShrink={0} paddingX={2}>
+      {suggestions.slice(start, start + count).map((item, offset) => (
+        <Text key={item.command} wrap="truncate-end" color={color && start + offset === selected ? 'cyan' : undefined}>
+          {start + offset === selected ? '▸ ' : '  '}
+          <Text bold={start + offset === selected}>{item.command}</Text>
+          <Text dimColor> — {item.description}</Text>
+        </Text>
+      ))}
+    </Box>
+  );
+}

--- a/apps/cli/src/workshop.ts
+++ b/apps/cli/src/workshop.ts
@@ -1,3 +1,4 @@
+import { trackAgentFailure } from './agent-failure.js';
 import { requireClaudeSubscription, subscriptionEnv } from './claude-auth.js';
 import { permissionBlocked } from './agent-events.js';
 import { startLocalPlay } from './play.js';
@@ -248,6 +249,7 @@ export async function runLocalBuild(input: {
   ws.abort.current = controller;
   let result: { code: number | null };
   let blocked = false;
+  const failure = trackAgentFailure(spec.name);
   let authCheck: Promise<void> | undefined;
   try {
     if (!ws.runAdapter && spec.name === 'claude') {
@@ -294,6 +296,7 @@ export async function runLocalBuild(input: {
       env: childEnv(ws.env, ''),
       abort: controller.signal,
       onLine: (line) => {
+        failure.observe(line);
         if (permissionBlocked(line)) blocked = true;
         for (const shown of renderDelegateStream(spec.name, [line], false)) {
           if (shown.includes('⚙ ')) ws.onActivity?.(`${spec.name} · ${shown.split('⚙ ')[1]!.slice(0, 90)}`);
@@ -315,7 +318,9 @@ export async function runLocalBuild(input: {
     return false;
   }
   if ((result.code ?? 1) !== 0) {
-    input.write(`${spec.name} exited ${result.code ?? 'null'} — /diff to see what changed`);
+    input.write(
+      formatError(failure.error(result.code, '/diff to review partial edits, then repeat your request when ready')),
+    );
     return false;
   }
   ws.onActivity?.('Agent finished — verifying typecheck and static checks');


### PR DESCRIPTION
Adds command suggestions and actionable recovery when an agent fails. Typing `/pu` offers `/pull`; a Codex capacity failure now explains that the agent stopped and offers reconnection to the existing round instead of `submit`.

Typing `/pu` in the interactive prompt now offers `/pull` with its description. `/` shows a scrollable list, typing filters it, arrows select, and Tab fills the command without executing it. Enter fills a partial command first; a complete command keeps the existing send behavior. Esc hides suggestions while preserving the draft, and history remains available outside the menu.

Descriptions reuse `/help`; session commands `/retry`, `/quit`, and `/exit` are included. The menu reserves terminal rows so build status and controls remain visible. Completion is local and sends no model requests.

Validation: 14 focused tests passed, including actual Ink keyboard events, history, completion without execution, and 40×12 / 80×24 / 120×40 terminal layouts. Manually exercised `/pu`, Tab and Enter in a PTY with build status visible. Autocomplete validation passed the full repository gate. After adding agent failure recovery, install/type-check/lint and all 318 CLI tests passed. The full run hit timing failures in 10 files in other workspaces; all affected files passed isolated reruns. The final repository build passed.

Instrumentation: this improves command discovery within the creator funnel (question 4). Existing `cli_step` events grouped by step and visit ID continue to measure executed actions. Suggestion use itself is not measured; no draft text or keystroke telemetry is added.



Agent recovery handles both streamed and buffered MCP errors and streamed local-agent errors. A failed run never enters local verification/delivery. `/connect <slug> --agent <name>` reconnects to the existing MCP round; regression tests verify repeated attempts use GET requests without creating another round. Capacity diagnostics retain only a boolean, not a transcript. Unknown failures retain their exit code and the same recovery guidance. Cancellation keeps its existing behavior.
