### PR TITLE
feat(studio): guide creators through agent setup

### DIFF
--- a/.claude/skills/product-instrumentation/SKILL.md
+++ b/.claude/skills/product-instrumentation/SKILL.md
@@ -350,3 +350,6 @@ CLI connection onboarding records `connect_opened` when the interactive choices 
 and `checkout_opened` after downloading or reusing a checkout. Neither event carries
 slugs, paths, credentials or prompts. Existing adapter offer/use events still describe
 agent launches; opening a session does not count as a build.
+
+Muse Code uses the `muse` adapter dimension for local checkout delegation.
+`CLI_ADAPTERS` drives the pilot aggregation and its adapter table directly.

--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -7,6 +7,10 @@ decides the next version — see [`.claude/skills/cli-release/SKILL.md`](../../.
 
 ## Unreleased
 
+### Added
+
+- Detect Muse Code and delegate local checkout tasks with `--agent muse` (#1234)
+
 ## 0.10.1 — 2026-09-08
 
 ### Fixed

--- a/apps/cli/adapters.json
+++ b/apps/cli/adapters.json
@@ -6,38 +6,85 @@
       "command": "claude",
       "versionFlag": "--version",
       "headless": ["-p", "--output-format", "stream-json"],
-      "events": { "flag": "--output-format=stream-json", "dialect": "ndjson" },
-      "budget": { "turns": "--max-turns" },
+      "events": {
+        "flag": "--output-format=stream-json",
+        "dialect": "ndjson"
+      },
+      "budget": {
+        "turns": "--max-turns"
+      },
       "cwd": "game-dir",
-      "exit": { "success": [0], "failure": [1] }
+      "exit": {
+        "success": [0],
+        "failure": [1]
+      }
     },
     {
       "name": "codex",
       "command": "codex",
       "versionFlag": "--version",
       "headless": ["exec", "--json"],
-      "events": { "flag": "--json", "dialect": "jsonl" },
+      "events": {
+        "flag": "--json",
+        "dialect": "jsonl"
+      },
       "cwd": "game-dir",
-      "exit": { "success": [0], "failure": [1] }
+      "exit": {
+        "success": [0],
+        "failure": [1]
+      }
     },
     {
       "name": "gemini",
       "command": "gemini",
       "versionFlag": "--version",
       "headless": ["-p"],
-      "events": { "flag": "", "dialect": "ndjson" },
+      "events": {
+        "flag": "",
+        "dialect": "ndjson"
+      },
       "cwd": "game-dir",
-      "exit": { "success": [0], "failure": [1] }
+      "exit": {
+        "success": [0],
+        "failure": [1]
+      }
     },
     {
       "name": "vibe",
       "command": "vibe",
       "versionFlag": "--version",
       "headless": ["--prompt"],
-      "events": { "flag": "--output", "dialect": "ndjson" },
-      "budget": { "turns": "--max-turns", "price": "--max-price" },
+      "events": {
+        "flag": "--output",
+        "dialect": "ndjson"
+      },
+      "budget": {
+        "turns": "--max-turns",
+        "price": "--max-price"
+      },
       "cwd": "game-dir",
-      "exit": { "success": [0], "failure": [1] }
+      "exit": {
+        "success": [0],
+        "failure": [1]
+      }
+    },
+    {
+      "name": "muse",
+      "command": "muse",
+      "versionFlag": "--version",
+      "headless": ["exec", "--trust-workspace"],
+      "events": {
+        "flag": "",
+        "dialect": "ndjson"
+      },
+      "budget": {
+        "turns": "--max-model-steps"
+      },
+      "cwd": "game-dir",
+      "exit": {
+        "success": [0],
+        "failure": [1]
+      }
     }
   ]
 }

--- a/apps/cli/src/adapters.json
+++ b/apps/cli/src/adapters.json
@@ -112,6 +112,24 @@
         "success": [0],
         "failure": [1]
       }
+    },
+    {
+      "name": "muse",
+      "command": "muse",
+      "versionFlag": "--version",
+      "headless": ["exec", "--trust-workspace"],
+      "events": {
+        "flag": "",
+        "dialect": "ndjson"
+      },
+      "budget": {
+        "turns": "--max-model-steps"
+      },
+      "cwd": "game-dir",
+      "exit": {
+        "success": [0],
+        "failure": [1]
+      }
     }
   ]
 }

--- a/apps/cli/src/adapters.test.ts
+++ b/apps/cli/src/adapters.test.ts
@@ -14,6 +14,7 @@ describe('adapter registry', () => {
       'copilot',
       'cursor',
       'gemini',
+      'muse',
       'vibe',
     ]);
   });
@@ -39,6 +40,22 @@ it('validates flags even when a CLI exits before its output pipe flushes', () =>
     expect(() => preflightAdapter({ ...base, command, headless: ['--missing'] }, process.env)).toThrow(
       'does not support --missing',
     );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+it('probes Muse exec help without starting a paid session', () => {
+  const root = mkdtempSync(join(tmpdir(), 'gdpl-muse-help-'));
+  const command = join(root, 'muse');
+  const spec = loadAdapters({ HOME: root }).adapters.find((row) => row.name === 'muse')!;
+  try {
+    writeFileSync(
+      command,
+      `#!${process.execPath}\nif (process.argv.slice(2).join(' ') !== 'exec --help') process.exit(1); console.log('--trust-workspace');`,
+      { mode: 0o700 },
+    );
+    expect(() => preflightAdapter({ ...spec, command }, process.env)).not.toThrow();
   } finally {
     rmSync(root, { recursive: true, force: true });
   }

--- a/apps/cli/src/adapters.ts
+++ b/apps/cli/src/adapters.ts
@@ -77,7 +77,7 @@ export function detectAdapter(
 }
 
 export function preflightAdapter(spec: AdapterSpec, env: NodeJS.ProcessEnv): void {
-  const args = spec.name === 'codex' ? ['exec', '--help'] : ['--help'];
+  const args = ['codex', 'muse'].includes(spec.name) ? ['exec', '--help'] : ['--help'];
   const help = probeHelp(spec.command, args, env);
   if (help === null) {
     throw new CliError(`cannot run ${spec.name} --help`, EXIT_REFUSED, `check ${spec.command} in your terminal`);

--- a/apps/cli/src/agents.test.ts
+++ b/apps/cli/src/agents.test.ts
@@ -39,7 +39,7 @@ describe('agent discovery', () => {
     const agents = discoverAgents({ HOME: directory() }, (cmd) => `/bin/${cmd}`);
     expect(agents.find((row) => row.name === 'claude')).toMatchObject({ installed: true, local: true, mcp: true });
     expect(agents.find((row) => row.name === 'vibe')).toMatchObject({ installed: true, local: true, mcp: false });
-    for (const name of ['agy', 'cursor']) {
+    for (const name of ['agy', 'cursor', 'muse']) {
       expect(agents.find((row) => row.name === name)).toMatchObject({ installed: true, local: true, mcp: false });
     }
     expect(formatAgents(agents)).toContain('launch verifies required CLI flags');

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -879,7 +879,7 @@
     "dialogLabel": "Connect your coding agent",
     "stepLabel": "Connect",
     "eyebrow": "Your agent",
-    "lede": "This round waits for your coding agent. Add gamedev.pl, then paste the build prompt — stay here until it checks in, or open Studio anytime.",
+    "lede": "Choose how you want to work. We’ll guide you through the next steps.",
     "ledeConnected": "Your agent checked in. Open Studio to watch progress and steer the build.",
     "preparing": "Preparing your connect steps…",
     "loadError": "We couldn't refresh status just now. Retrying…",
@@ -1994,5 +1994,52 @@
     "diffTruncated": "This file's diff is long — showing the first part.",
     "diffOmitted": "{{count}} more changed files not shown.",
     "diffUnavailable": "Couldn't load the changes. You can still play it and read the description."
+  },
+  "connectGuide": {
+    "choose": "How would you like to build?",
+    "platformTitle": "Let gamedev.pl take over",
+    "tool": "Which tool do you use?",
+    "start": "Start working on your game",
+    "setup": "Connect your tool",
+    "back": "← Change choice",
+    "progress": "Step {{step}} of {{total}}",
+    "copy": "Copy",
+    "retry": "Try again",
+    "platformBody": "The gamedev.pl agent will continue this round using your platform quota. You can follow its progress in Studio.",
+    "cliStart": "Choose a local checkout, a conversation, or an agent in the terminal. Describe what to build. You can return to Studio at any time.",
+    "agentStart": "Paste this message into your agent’s chat. It identifies this game and asks the agent to start the current round.",
+    "waiting": "Connection is not confirmed yet. This screen will update when your agent checks in. You can also open Studio below.",
+    "cliSetup": "Run these commands in your terminal. You need Node.js 20.19 or newer. Sign in with the same account you use here.",
+    "toolSetup": "Set up gamedev.pl in {{tool}}, then continue to the starting message.",
+    "cliDraft": "No code yet? That’s fine — the checkout starts with your game brief.",
+    "signin": "Finish signing in when your tool opens the browser. The install link contains no credentials.",
+    "manual": "Sign-in did not work / manual setup",
+    "oauth": "Back to browser sign-in",
+    "configHint": "Add this configuration to your tool. The secret is hidden here; Copy includes the actual credential. Keep it private.",
+    "add": "Add to {{tool}}",
+    "next": "Setup done — continue",
+    "copyError": "Could not copy. Allow clipboard access and try again.",
+    "routes": {
+      "cli": {
+        "title": "gamedevpl CLI",
+        "body": "Create from your terminal. Choose an agent or work on local files."
+      },
+      "agent": {
+        "title": "I have my own agent",
+        "body": "Connect Cursor, VS Code, Claude Code, Codex or another tool."
+      },
+      "platform": {
+        "title": "Not sure? Build it for me",
+        "body": "Use the gamedev.pl agent. No tools to install."
+      }
+    },
+    "tools": {
+      "cursor": "Cursor",
+      "vscode": "VS Code / Copilot",
+      "claudeCode": "Claude Code",
+      "codex": "Codex",
+      "kimi": "Kimi",
+      "other": "Another MCP tool"
+    }
   }
 }

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -2039,7 +2039,9 @@
       "claudeCode": "Claude Code",
       "codex": "Codex",
       "kimi": "Kimi",
-      "other": "Another MCP tool"
-    }
+      "other": "Another MCP tool",
+      "muse": "Muse Code (Meta)"
+    },
+    "museStart": "In the terminal, choose “Open a local checkout”, then Muse. Muse works on local files; this path does not configure MCP. Install Muse Code from dev.meta.ai if it is not available yet."
   }
 }

--- a/apps/web/src/i18n/locales/pl.json
+++ b/apps/web/src/i18n/locales/pl.json
@@ -2053,7 +2053,9 @@
       "claudeCode": "Claude Code",
       "codex": "Codex",
       "kimi": "Kimi",
-      "other": "Inne narzędzie MCP"
-    }
+      "other": "Inne narzędzie MCP",
+      "muse": "Muse Code (Meta)"
+    },
+    "museStart": "W terminalu wybierz „Open a local checkout”, a następnie Muse. Muse pracuje na lokalnych plikach; ta ścieżka nie konfiguruje MCP. Jeśli nie masz jeszcze Muse Code, zainstaluj je z dev.meta.ai."
   }
 }

--- a/apps/web/src/i18n/locales/pl.json
+++ b/apps/web/src/i18n/locales/pl.json
@@ -889,7 +889,7 @@
     "dialogLabel": "Podłącz swojego agenta",
     "stepLabel": "Połączenie",
     "eyebrow": "Twój agent",
-    "lede": "Ta runda czeka na Twojego agenta. Dodaj gamedev.pl, wklej prompt budowy — zostań tu, aż się odezwie, albo otwórz Studio kiedy chcesz.",
+    "lede": "Wybierz sposób pracy. Przeprowadzimy Cię przez kolejne kroki.",
     "ledeConnected": "Twój agent się odezwał. Otwórz Studio, żeby śledzić postęp i sterować budową.",
     "preparing": "Przygotowuję kroki połączenia…",
     "loadError": "Nie udało się odświeżyć statusu. Próbuję ponownie…",
@@ -2008,5 +2008,52 @@
     "diffTruncated": "Różnica w tym pliku jest długa — pokazujemy początek.",
     "diffOmitted": "Nie pokazano kolejnych zmienionych plików: {{count}}.",
     "diffUnavailable": "Nie udało się wczytać zmian. Nadal możesz zagrać i przeczytać opis."
+  },
+  "connectGuide": {
+    "choose": "Jak chcesz tworzyć grę?",
+    "platformTitle": "Niech gamedev.pl przejmie pracę",
+    "tool": "Z jakiego narzędzia korzystasz?",
+    "start": "Zacznij pracę nad grą",
+    "setup": "Połącz swoje narzędzie",
+    "back": "← Zmień wybór",
+    "progress": "Krok {{step}} z {{total}}",
+    "copy": "Kopiuj",
+    "retry": "Spróbuj ponownie",
+    "platformBody": "Agent gamedev.pl będzie kontynuował tę rundę, korzystając z Twojego limitu na platformie. Postęp zobaczysz w Studio.",
+    "cliStart": "W terminalu wybierz lokalne pliki, rozmowę lub agenta. Opisz, co zbudować. Do Studio możesz wrócić w każdej chwili.",
+    "agentStart": "Wklej tę wiadomość w rozmowie ze swoim agentem. Wskaże mu tę grę i poprosi o rozpoczęcie bieżącej rundy.",
+    "waiting": "Połączenie nie jest jeszcze potwierdzone. Ten ekran zaktualizuje się, gdy agent się odezwie. Możesz też otworzyć Studio poniżej.",
+    "cliSetup": "Uruchom te polecenia w terminalu. Potrzebujesz Node.js 20.19 lub nowszego. Zaloguj się na to samo konto co tutaj.",
+    "toolSetup": "Dodaj gamedev.pl w {{tool}}, a potem przejdź do wiadomości rozpoczynającej pracę.",
+    "cliDraft": "Nie ma jeszcze kodu? To w porządku — lokalne pliki zaczną się od opisu Twojej gry.",
+    "signin": "Dokończ logowanie, gdy narzędzie otworzy przeglądarkę. Link instalacyjny nie zawiera danych dostępu.",
+    "manual": "Logowanie nie działa / konfiguracja ręczna",
+    "oauth": "Wróć do logowania w przeglądarce",
+    "configHint": "Dodaj tę konfigurację w swoim narzędziu. Sekret jest tutaj ukryty; przycisk Kopiuj pobiera właściwe dane dostępu. Nie udostępniaj ich innym.",
+    "add": "Dodaj do {{tool}}",
+    "next": "Gotowe — przejdź dalej",
+    "copyError": "Nie udało się skopiować. Zezwól na dostęp do schowka i spróbuj ponownie.",
+    "routes": {
+      "cli": {
+        "title": "gamedevpl CLI",
+        "body": "Twórz w terminalu. Wybierz agenta lub pracuj na lokalnych plikach."
+      },
+      "agent": {
+        "title": "Mam własnego agenta",
+        "body": "Podłącz Cursor, VS Code, Claude Code, Codex lub inne narzędzie."
+      },
+      "platform": {
+        "title": "Nie wiem — zbuduj za mnie",
+        "body": "Skorzystaj z agenta gamedev.pl. Nie musisz niczego instalować."
+      }
+    },
+    "tools": {
+      "cursor": "Cursor",
+      "vscode": "VS Code / Copilot",
+      "claudeCode": "Claude Code",
+      "codex": "Codex",
+      "kimi": "Kimi",
+      "other": "Inne narzędzie MCP"
+    }
   }
 }

--- a/apps/web/src/surfaces/studio/StudioConnectGuide.test.tsx
+++ b/apps/web/src/surfaces/studio/StudioConnectGuide.test.tsx
@@ -61,6 +61,9 @@ it('starts with choices and progressively shows only the selected agent setup an
     (host.querySelectorAll('.connect-guide-option')[1] as HTMLButtonElement).click();
   });
   await click('Codex');
+  expect(host.textContent).toContain('https://example.test/mcp');
+  expect(host.textContent).not.toContain('MASK');
+  await click('Sign-in did not work / manual setup');
   expect(host.textContent).toContain('header = "Bearer MASK"');
   expect(host.textContent).not.toContain('Build sky');
   expect(host.textContent).not.toContain('SECRET');
@@ -95,4 +98,20 @@ it('keeps generic manual credentials masked and copies the real header only on r
   expect(host.textContent).not.toContain('SECRET');
   await click('Copy');
   expect(clipboard).toHaveBeenCalledWith('URL: https://example.test/mcp\nAuthorization: Bearer SECRET');
+});
+
+it('offers browser sign-in for Claude Code before manual credentials', async () => {
+  await act(async () => (host.querySelectorAll('.connect-guide-option')[1] as HTMLButtonElement).click());
+  await click('Claude Code');
+  expect(host.textContent).toContain('https://example.test/mcp');
+  expect(host.textContent).not.toContain('MASK');
+});
+it('routes Muse through a local CLI checkout instead of claiming MCP support', async () => {
+  await act(async () => (host.querySelectorAll('.connect-guide-option')[1] as HTMLButtonElement).click());
+  await click('Muse Code (Meta)');
+  expect(host.textContent).toContain('gamedevpl connect sky');
+  expect(host.textContent).not.toContain('MASK');
+  await click('Setup done — continue');
+  expect(host.textContent).toContain('Open a local checkout');
+  expect(host.textContent).toContain('does not configure MCP');
 });

--- a/apps/web/src/surfaces/studio/StudioConnectGuide.test.tsx
+++ b/apps/web/src/surfaces/studio/StudioConnectGuide.test.tsx
@@ -1,0 +1,98 @@
+// @vitest-environment jsdom
+import { act, createElement } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, expect, it, vi } from 'vitest';
+import i18n from '../../i18n/index.js';
+import { StudioConnectGuide } from './StudioConnectGuide.js';
+import { getConnectPayload, type ConnectPayload } from './connectApi.js';
+vi.mock('./connectApi.js', async (original) => ({
+  ...(await original<typeof import('./connectApi.js')>()),
+  getConnectPayload: vi.fn(),
+}));
+vi.mock('../../useCliSurfaceEnabled.js', () => ({ useCliSurfaceEnabled: () => true }));
+let root: Root;
+let host: HTMLDivElement;
+const clipboard = vi.fn(async () => {});
+const payload: ConnectPayload = {
+  slug: 'sky',
+  mcpUrl: 'https://example.test/mcp',
+  authorizationHeader: 'Authorization: Bearer SECRET',
+  authorizationHeaderMasked: 'Authorization: Bearer MASK',
+  installSnippets: {
+    codex: 'header = "Bearer MASK"',
+    cursor: 'Authorization: Bearer MASK',
+    claudeCode: 'Authorization: Bearer MASK',
+    kimi: 'Authorization: Bearer MASK',
+    cli: '',
+  },
+  installLinks: { cursor: 'cursor://url-only', vscode: 'vscode://url-only' },
+  kickoffPrompt: 'Build sky',
+  expiresAt: 2000000000,
+  keyGeneration: 1,
+  fingerprint: 'MASK',
+  canSwitchToPlatform: true,
+};
+async function click(text: string) {
+  const button = Array.from(host.querySelectorAll('button')).find((el) => el.textContent === text);
+  expect(button, text).toBeTruthy();
+  await act(async () => {
+    button!.click();
+  });
+}
+beforeEach(async () => {
+  await i18n.changeLanguage('en');
+  vi.mocked(getConnectPayload).mockResolvedValue(payload);
+  Object.defineProperty(navigator, 'clipboard', { value: { writeText: clipboard }, configurable: true });
+  host = document.createElement('div');
+  document.body.append(host);
+  root = createRoot(host);
+  await act(async () => {
+    root.render(createElement(StudioConnectGuide, { token: 'tok', pending: false, onSwitchToPlatform: vi.fn() }));
+  });
+});
+afterEach(async () => {
+  await act(async () => root.unmount());
+  host.remove();
+  vi.clearAllMocks();
+});
+it('starts with choices and progressively shows only the selected agent setup and prompt', async () => {
+  expect(host.querySelector('pre')).toBeNull();
+  await act(async () => {
+    (host.querySelectorAll('.connect-guide-option')[1] as HTMLButtonElement).click();
+  });
+  await click('Codex');
+  expect(host.textContent).toContain('header = "Bearer MASK"');
+  expect(host.textContent).not.toContain('Build sky');
+  expect(host.textContent).not.toContain('SECRET');
+  await click('Copy');
+  expect(clipboard).toHaveBeenCalledWith('header = "Bearer SECRET"');
+  await click('Setup done — continue');
+  expect(host.textContent).toContain('Build sky');
+  expect(host.textContent).not.toContain('header =');
+  expect(host.textContent).toContain('not confirmed');
+  await click('← Change choice');
+  expect(host.textContent).toContain('header =');
+});
+it('offers terminal commands separately, including Windows and a game without sources', async () => {
+  await act(async () => {
+    (host.querySelector('.connect-guide-option') as HTMLButtonElement).click();
+  });
+  expect(host.textContent).toContain('gamedevpl connect sky');
+  expect(host.textContent).toContain('No code yet?');
+  expect(host.textContent).not.toContain('Build sky');
+  await click('Windows');
+  expect(host.textContent).toContain('install.ps1');
+  expect(host.textContent).not.toContain('install.sh');
+});
+it('keeps generic manual credentials masked and copies the real header only on request', async () => {
+  await act(async () => {
+    (host.querySelectorAll('.connect-guide-option')[1] as HTMLButtonElement).click();
+  });
+  await click('Another MCP tool');
+  expect(host.textContent).not.toContain('MASK');
+  await click('Sign-in did not work / manual setup');
+  expect(host.textContent).toContain('Authorization: Bearer MASK');
+  expect(host.textContent).not.toContain('SECRET');
+  await click('Copy');
+  expect(clipboard).toHaveBeenCalledWith('URL: https://example.test/mcp\nAuthorization: Bearer SECRET');
+});

--- a/apps/web/src/surfaces/studio/StudioConnectGuide.tsx
+++ b/apps/web/src/surfaces/studio/StudioConnectGuide.tsx
@@ -1,0 +1,238 @@
+import { useEffect, useRef, useState, type ComponentProps } from 'react';
+import { useTranslation } from 'react-i18next';
+import { getConnectPayload, type ConnectClient, type ConnectPayload } from './connectApi.js';
+import { SwitchToPlatformControl } from './StudioConnectCard.js';
+import { useCliSurfaceEnabled } from '../../useCliSurfaceEnabled.js';
+import { recordStudioStep } from '../../visitTelemetry.js';
+import './studio-connect-guide.css';
+
+type Route = 'cli' | 'agent' | 'platform';
+type Tool = Exclude<ConnectClient, 'cli'> | 'vscode' | 'other';
+const TOOLS: Tool[] = ['cursor', 'vscode', 'claudeCode', 'codex', 'kimi', 'other'];
+
+export function StudioConnectGuide({
+  token,
+  onSwitchToPlatform,
+  pending,
+}: {
+  token: string;
+  onSwitchToPlatform: ComponentProps<typeof SwitchToPlatformControl>['onSwitchToPlatform'];
+  pending: boolean;
+}) {
+  const { t } = useTranslation();
+  const cliEnabled = useCliSurfaceEnabled();
+  const [payload, setPayload] = useState<ConnectPayload | null>(null);
+  const [error, setError] = useState(false);
+  const [attempt, setAttempt] = useState(0);
+  const [route, setRoute] = useState<Route | null>(null);
+  const [tool, setTool] = useState<Tool | null>(null);
+  const [stage, setStage] = useState<'setup' | 'start'>('setup');
+  const [manual, setManual] = useState(false);
+  const [windows, setWindows] = useState(false);
+  const [copied, setCopied] = useState('');
+  const heading = useRef<HTMLHeadingElement>(null);
+  useEffect(() => {
+    let cancelled = false;
+    setError(false);
+    void getConnectPayload(token)
+      .then((value) => {
+        if (!cancelled) setPayload(value);
+      })
+      .catch(() => {
+        if (!cancelled) setError(true);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [token, attempt]);
+  useEffect(() => {
+    heading.current?.focus();
+    setCopied('');
+  }, [route, tool, stage]);
+
+  const copy = async (text: string, id: string, detail: 'install' | 'kickoff') => {
+    try {
+      await navigator.clipboard.writeText(text);
+      setCopied(id);
+      recordStudioStep('connect_copied', 'self', detail);
+    } catch {
+      setCopied('error');
+    }
+  };
+  const copyButton = (text: string, id: string, detail: 'install' | 'kickoff' = 'install') => (
+    <button type="button" className="btn btn-secondary" onClick={() => void copy(text, id, detail)}>
+      {copied === id ? t('connect.copied') : t('connectGuide.copy')}
+    </button>
+  );
+  const back = () => {
+    if (stage === 'start') setStage('setup');
+    else if (tool) {
+      setTool(null);
+      setManual(false);
+    } else setRoute(null);
+  };
+  if (error)
+    return (
+      <div role="alert">
+        <p>{t('connectWizard.loadError')}</p>
+        <button className="btn btn-secondary" onClick={() => setAttempt(attempt + 1)}>
+          {t('connectGuide.retry')}
+        </button>
+      </div>
+    );
+  if (!payload) return <p role="status">{t('connect.loading')}</p>;
+  const cliSnippet = windows
+    ? `irm ${window.location.origin}/install.ps1 | iex\ngamedevpl login\ngamedevpl connect ${payload.slug}`
+    : `curl -fsSL ${window.location.origin}/install.sh | bash\ngamedevpl login\ngamedevpl connect ${payload.slug}`;
+  const keyClient = tool && tool !== 'vscode' && tool !== 'other' ? tool : 'cursor';
+  const masked =
+    tool === 'vscode' || tool === 'other'
+      ? `URL: ${payload.mcpUrl}\n${payload.authorizationHeaderMasked}`
+      : payload.installSnippets[keyClient];
+  const realSnippet = masked
+    .split(payload.authorizationHeaderMasked)
+    .join(payload.authorizationHeader)
+    .split(payload.authorizationHeaderMasked.replace(/^Authorization:\s*/i, ''))
+    .join(payload.authorizationHeader.replace(/^Authorization:\s*/i, ''));
+  const oauth = tool === 'cursor' || tool === 'vscode' || tool === 'other';
+  const step = !route ? 1 : route === 'agent' && !tool ? 2 : stage === 'start' ? 4 : 3;
+  const title = !route
+    ? 'choose'
+    : route === 'platform'
+      ? 'platformTitle'
+      : route === 'agent' && !tool
+        ? 'tool'
+        : stage === 'start'
+          ? 'start'
+          : 'setup';
+  return (
+    <section className="connect-guide" aria-labelledby="connect-guide-title">
+      <div className="connect-guide-nav">
+        {route && (
+          <button type="button" className="studio-connect-skip" onClick={back}>
+            {t('connectGuide.back')}
+          </button>
+        )}
+        <span>
+          {t('connectGuide.progress', {
+            step: route === 'cli' ? (stage === 'start' ? 3 : 2) : route === 'platform' ? 2 : step,
+            total: route === 'cli' ? 3 : route === 'platform' ? 2 : 4,
+          })}
+        </span>
+      </div>
+      <h3 id="connect-guide-title" ref={heading} tabIndex={-1}>
+        {t(`connectGuide.${title}`)}
+      </h3>
+      {!route ? (
+        <div className="connect-guide-options">
+          {(['cli', 'agent', 'platform'] as const)
+            .filter((id) => (id === 'cli' ? cliEnabled : id === 'platform' ? payload.canSwitchToPlatform : true))
+            .map((id) => (
+              <button type="button" className="connect-guide-option" key={id} onClick={() => setRoute(id)}>
+                <strong>{t(`connectGuide.routes.${id}.title`)}</strong>
+                <span>{t(`connectGuide.routes.${id}.body`)}</span>
+                <span aria-hidden="true">→</span>
+              </button>
+            ))}
+        </div>
+      ) : route === 'platform' ? (
+        <>
+          <p>{t('connectGuide.platformBody')}</p>
+          <SwitchToPlatformControl onSwitchToPlatform={onSwitchToPlatform} pending={pending} />
+        </>
+      ) : route === 'agent' && !tool ? (
+        <div className="connect-guide-tools">
+          {TOOLS.map((id) => (
+            <button type="button" className="connect-guide-option" key={id} onClick={() => setTool(id)}>
+              <strong>{t(`connectGuide.tools.${id}`)}</strong>
+            </button>
+          ))}
+        </div>
+      ) : stage === 'start' ? (
+        <>
+          <p>{t(route === 'cli' ? 'connectGuide.cliStart' : 'connectGuide.agentStart')}</p>
+          {route === 'agent' && (
+            <>
+              <pre className="studio-connect-snippet" tabIndex={0}>
+                {payload.kickoffPrompt}
+              </pre>
+              {copyButton(payload.kickoffPrompt, 'kickoff', 'kickoff')}
+            </>
+          )}
+          <p className="connect-guide-wait" role="status">
+            {t('connectGuide.waiting')}
+          </p>
+        </>
+      ) : (
+        <>
+          <p>
+            {route === 'cli'
+              ? t('connectGuide.cliSetup')
+              : t('connectGuide.toolSetup', { tool: t(`connectGuide.tools.${tool}`) })}
+          </p>
+          {route === 'cli' ? (
+            <>
+              <div className="connect-guide-tools">
+                <button className="btn btn-secondary" aria-pressed={!windows} onClick={() => setWindows(false)}>
+                  macOS / Linux
+                </button>
+                <button className="btn btn-secondary" aria-pressed={windows} onClick={() => setWindows(true)}>
+                  Windows
+                </button>
+              </div>
+              <pre className="studio-connect-snippet" tabIndex={0}>
+                {cliSnippet}
+              </pre>
+              {copyButton(cliSnippet, 'cli')}
+              <p>{t('connectGuide.cliDraft')}</p>
+            </>
+          ) : (
+            <>
+              {oauth && !manual ? (
+                <>
+                  {(tool === 'cursor' || tool === 'vscode') && payload.installLinks?.[tool] ? (
+                    <a
+                      className="btn btn-primary"
+                      href={payload.installLinks[tool]}
+                      onClick={() => recordStudioStep('connect_deeplink', 'self', tool)}
+                    >
+                      {t('connectGuide.add', { tool: t(`connectGuide.tools.${tool}`) })}
+                    </a>
+                  ) : (
+                    <>
+                      <pre className="studio-connect-snippet" tabIndex={0}>
+                        {payload.mcpUrl}
+                      </pre>
+                      {copyButton(payload.mcpUrl, 'url')}
+                    </>
+                  )}
+                  <p>{t('connectGuide.signin')}</p>
+                  <button type="button" className="studio-connect-skip" onClick={() => setManual(true)}>
+                    {t('connectGuide.manual')}
+                  </button>
+                </>
+              ) : (
+                <>
+                  <p>{t('connectGuide.configHint')}</p>
+                  <pre className="studio-connect-snippet" tabIndex={0}>
+                    {masked}
+                  </pre>
+                  {copyButton(realSnippet, 'config')}
+                  {oauth && (
+                    <button className="studio-connect-skip" onClick={() => setManual(false)}>
+                      {t('connectGuide.oauth')}
+                    </button>
+                  )}
+                </>
+              )}
+            </>
+          )}
+          <button type="button" className="btn btn-primary" onClick={() => setStage('start')}>
+            {t('connectGuide.next')}
+          </button>
+        </>
+      )}
+      {copied === 'error' && <p role="alert">{t('connectGuide.copyError')}</p>}
+    </section>
+  );
+}

--- a/apps/web/src/surfaces/studio/StudioConnectGuide.tsx
+++ b/apps/web/src/surfaces/studio/StudioConnectGuide.tsx
@@ -7,8 +7,8 @@ import { recordStudioStep } from '../../visitTelemetry.js';
 import './studio-connect-guide.css';
 
 type Route = 'cli' | 'agent' | 'platform';
-type Tool = Exclude<ConnectClient, 'cli'> | 'vscode' | 'other';
-const TOOLS: Tool[] = ['cursor', 'vscode', 'claudeCode', 'codex', 'kimi', 'other'];
+type Tool = Exclude<ConnectClient, 'cli'> | 'vscode' | 'other' | 'muse';
+const TOOLS: Tool[] = ['cursor', 'vscode', 'claudeCode', 'codex', 'kimi', 'muse', 'other'];
 
 export function StudioConnectGuide({
   token,
@@ -81,10 +81,11 @@ export function StudioConnectGuide({
       </div>
     );
   if (!payload) return <p role="status">{t('connect.loading')}</p>;
+  const local = route === 'cli' || tool === 'muse';
   const cliSnippet = windows
     ? `irm ${window.location.origin}/install.ps1 | iex\ngamedevpl login\ngamedevpl connect ${payload.slug}`
     : `curl -fsSL ${window.location.origin}/install.sh | bash\ngamedevpl login\ngamedevpl connect ${payload.slug}`;
-  const keyClient = tool && tool !== 'vscode' && tool !== 'other' ? tool : 'cursor';
+  const keyClient = tool && tool !== 'vscode' && tool !== 'other' && tool !== 'muse' ? tool : 'cursor';
   const masked =
     tool === 'vscode' || tool === 'other'
       ? `URL: ${payload.mcpUrl}\n${payload.authorizationHeaderMasked}`
@@ -94,7 +95,7 @@ export function StudioConnectGuide({
     .join(payload.authorizationHeader)
     .split(payload.authorizationHeaderMasked.replace(/^Authorization:\s*/i, ''))
     .join(payload.authorizationHeader.replace(/^Authorization:\s*/i, ''));
-  const oauth = tool === 'cursor' || tool === 'vscode' || tool === 'other';
+  const oauth = tool !== 'kimi' && tool !== 'muse';
   const step = !route ? 1 : route === 'agent' && !tool ? 2 : stage === 'start' ? 4 : 3;
   const title = !route
     ? 'choose'
@@ -150,8 +151,12 @@ export function StudioConnectGuide({
         </div>
       ) : stage === 'start' ? (
         <>
-          <p>{t(route === 'cli' ? 'connectGuide.cliStart' : 'connectGuide.agentStart')}</p>
-          {route === 'agent' && (
+          <p>
+            {t(
+              tool === 'muse' ? 'connectGuide.museStart' : local ? 'connectGuide.cliStart' : 'connectGuide.agentStart',
+            )}
+          </p>
+          {!local && (
             <>
               <pre className="studio-connect-snippet" tabIndex={0}>
                 {payload.kickoffPrompt}
@@ -166,11 +171,11 @@ export function StudioConnectGuide({
       ) : (
         <>
           <p>
-            {route === 'cli'
+            {local
               ? t('connectGuide.cliSetup')
               : t('connectGuide.toolSetup', { tool: t(`connectGuide.tools.${tool}`) })}
           </p>
-          {route === 'cli' ? (
+          {local ? (
             <>
               <div className="connect-guide-tools">
                 <button className="btn btn-secondary" aria-pressed={!windows} onClick={() => setWindows(false)}>

--- a/apps/web/src/surfaces/studio/StudioConnectWizard.test.tsx
+++ b/apps/web/src/surfaces/studio/StudioConnectWizard.test.tsx
@@ -86,8 +86,6 @@ describe('StudioConnectWizard', () => {
     await act(async () => {
       createRoot(container).render(createElement(StudioConnectWizard, { game: 'bastion-wave', onOpenStudio }));
       await Promise.resolve();
-      await Promise.resolve();
-      await Promise.resolve();
     });
 
     const dialog = document.querySelector('.studio-connect-wizard');
@@ -118,8 +116,6 @@ describe('StudioConnectWizard', () => {
     await act(async () => {
       createRoot(container).render(createElement(StudioConnectWizard, { game: 'bastion-wave', onOpenStudio }));
       await Promise.resolve();
-      await Promise.resolve();
-      await Promise.resolve();
     });
 
     const dialog = document.querySelector('.studio-connect-wizard');
@@ -137,10 +133,15 @@ describe('StudioConnectWizard', () => {
     await act(async () => {
       createRoot(container).render(createElement(StudioConnectWizard, { game: 'bastion-wave', onOpenStudio }));
       await Promise.resolve();
-      await Promise.resolve();
-      await Promise.resolve();
     });
 
+    await act(async () => {
+      (
+        Array.from(document.querySelectorAll('button')).find((button) =>
+          button.textContent?.includes('Build it for me'),
+        ) as HTMLButtonElement
+      ).click();
+    });
     const control = document.querySelector('[data-testid="connect-switch-builder"]');
     expect(control).toBeTruthy();
     const start = control?.querySelector('button') as HTMLButtonElement;
@@ -165,10 +166,15 @@ describe('StudioConnectWizard', () => {
     await act(async () => {
       createRoot(container).render(createElement(StudioConnectWizard, { game: 'bastion-wave', onOpenStudio }));
       await Promise.resolve();
-      await Promise.resolve();
-      await Promise.resolve();
     });
 
+    await act(async () => {
+      (
+        Array.from(document.querySelectorAll('button')).find((button) =>
+          button.textContent?.includes('Build it for me'),
+        ) as HTMLButtonElement
+      ).click();
+    });
     const control = document.querySelector('[data-testid="connect-switch-builder"]');
     await act(async () => {
       (control?.querySelector('button') as HTMLButtonElement).click();
@@ -204,8 +210,6 @@ describe('StudioConnectWizard', () => {
     await act(async () => {
       createRoot(container).render(createElement(StudioConnectWizard, { game: 'bastion-wave', onOpenStudio: vi.fn() }));
       await Promise.resolve();
-      await Promise.resolve();
-      await Promise.resolve();
     });
 
     const feed = document.querySelector('[data-testid="connect-wizard-feed"]');
@@ -225,8 +229,6 @@ describe('StudioConnectWizard', () => {
 
     await act(async () => {
       createRoot(container).render(createElement(StudioConnectWizard, { game: 'bastion-wave', onOpenStudio: vi.fn() }));
-      await Promise.resolve();
-      await Promise.resolve();
       await Promise.resolve();
     });
 
@@ -248,8 +250,6 @@ describe('StudioConnectWizard', () => {
     await act(async () => {
       createRoot(container).render(createElement(StudioConnectWizard, { game: 'bastion-wave', onOpenStudio }));
       await Promise.resolve();
-      await Promise.resolve();
-      await Promise.resolve();
     });
 
     expect(onOpenStudio).toHaveBeenCalledWith('/studio/bastion-wave?from=handoff', { replace: true });
@@ -268,8 +268,6 @@ describe('StudioConnectWizard', () => {
     await act(async () => {
       createRoot(container).render(createElement(StudioConnectWizard, { game: 'bastion-wave', onOpenStudio }));
       await Promise.resolve();
-      await Promise.resolve();
-      await Promise.resolve();
     });
 
     expect(onOpenStudio).toHaveBeenCalledWith('/studio/bastion-wave?from=handoff', { replace: true });
@@ -281,8 +279,6 @@ describe('StudioConnectWizard', () => {
 
     await act(async () => {
       createRoot(container).render(createElement(StudioConnectWizard, { game: 'bastion-wave', onOpenStudio }));
-      await Promise.resolve();
-      await Promise.resolve();
       await Promise.resolve();
     });
 
@@ -300,8 +296,6 @@ describe('StudioConnectWizard', () => {
 
     await act(async () => {
       createRoot(container).render(createElement(StudioConnectWizard, { game: 'bastion-wave', onOpenStudio: vi.fn() }));
-      await Promise.resolve();
-      await Promise.resolve();
       await Promise.resolve();
     });
 

--- a/apps/web/src/surfaces/studio/StudioConnectWizard.tsx
+++ b/apps/web/src/surfaces/studio/StudioConnectWizard.tsx
@@ -6,6 +6,7 @@ import { PixelIcon } from '../../PixelIcon.js';
 import { studioPath } from '../../core/router.js';
 import { connectCardMode, shouldShowConnectCard, type SelfBuildCopyInput } from '../../selfBuildCopy.js';
 import { StudioConnectCard } from './StudioConnectCard.js';
+import { StudioConnectGuide } from './StudioConnectGuide.js';
 import { markStudioOnboarded, resolveWelcomeToken } from './studioWelcome.js';
 import { pollDelayMs } from './studioStatusPoll.js';
 import {
@@ -19,14 +20,10 @@ import { recordCreateStep, recordStudioStep } from '../../visitTelemetry.js';
 import './studio-connect.css';
 import './studio-connect-wizard.css';
 
-// Studio owns the full transcript; this step shows only the newest few.
 const FEED_LIMIT = 4;
-
-// Focusable controls in the connect dialog.
 const FOCUSABLE = 'a[href], button:not([disabled]), input:not([disabled]), [tabindex]:not([tabindex="-1"])';
 
 type StudioConnectWizardProps = {
-  // Slug or capability token from the URL.
   game: string;
   onOpenStudio: (path: string, options?: { replace?: boolean }) => void;
 };
@@ -41,7 +38,6 @@ function copyInputFromStatus(status: SubmissionStatus | null): SelfBuildCopyInpu
   };
 }
 
-// The round left the agent's hands: delivered or finished.
 const PAST_CONNECT_PHASES: ReadonlySet<string> = new Set([
   'submitted',
   'ready_for_review',
@@ -73,7 +69,6 @@ function stillNeedsConnect(status: SubmissionStatus | null): boolean {
   return shouldShowConnectCard(copyInputFromStatus(status));
 }
 
-// Full-screen BYOCA connect after Create Now.
 export function StudioConnectWizard({ game, onOpenStudio }: StudioConnectWizardProps) {
   const { t, i18n } = useTranslation();
   const wizardRef = useRef<HTMLDivElement>(null);
@@ -209,13 +204,11 @@ export function StudioConnectWizard({ game, onOpenStudio }: StudioConnectWizardP
     goStudioRef.current = goStudio;
   });
 
-  // Replace: Back would land on this finished round and bounce forward.
   useEffect(() => {
     if (!chapterOver) return;
     goStudioRef.current(false, roundBuilder, true);
   }, [chapterOver, roundBuilder]);
 
-  // Change of mind: hand the round to the Gamedev.pl agent.
   const switchToPlatform = async () => {
     if (!token) return;
     const result = await handoffToPlatform(token);
@@ -224,7 +217,6 @@ export function StudioConnectWizard({ game, onOpenStudio }: StudioConnectWizardP
     return result;
   };
 
-  const cardMode = connectCardMode(copyInputFromStatus(status)) ?? 'setup';
   const feed: BuildEvent[] = (status?.events ?? []).slice(0, FEED_LIMIT);
   const reportedProgress = (status?.events ?? []).find((event) => event.progress)?.progress;
   const latestShot = status?.media?.[0];
@@ -303,14 +295,22 @@ export function StudioConnectWizard({ game, onOpenStudio }: StudioConnectWizardP
             </div>
           ) : token ? (
             <div className="studio-connect-wizard-card">
-              <StudioConnectCard
-                token={token}
-                collapsible={false}
-                agentConnected={false}
-                mode={cardMode}
-                onSwitchToPlatform={switchToPlatform}
-                builderHandoffPending={status?.builderHandoff?.target === 'platform'}
-              />
+              {connectCardMode(copyInputFromStatus(status)) === 'resume' ? (
+                <StudioConnectCard
+                  token={token}
+                  collapsible={false}
+                  mode="resume"
+                  onSwitchToPlatform={switchToPlatform}
+                  builderHandoffPending={status?.builderHandoff?.target === 'platform'}
+                />
+              ) : (
+                <StudioConnectGuide
+                  key={token}
+                  token={token}
+                  onSwitchToPlatform={switchToPlatform}
+                  pending={status?.builderHandoff?.target === 'platform'}
+                />
+              )}
             </div>
           ) : (
             <p className="studio-welcome-primer-one">{t('connectWizard.preparing')}</p>

--- a/apps/web/src/surfaces/studio/studio-connect-guide.css
+++ b/apps/web/src/surfaces/studio/studio-connect-guide.css
@@ -83,10 +83,50 @@
   outline-offset: 3px;
 }
 
+.connect-guide .btn {
+  appearance: none;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  min-height: 44px;
+  padding: 11px 18px;
+  border: 1px solid var(--panel-border);
+  border-radius: 10px;
+  background: var(--bg);
+  color: var(--text);
+  font: inherit;
+  font-size: 0.9rem;
+  font-weight: 600;
+  line-height: 1.4;
+  text-decoration: none;
+  white-space: normal;
+  cursor: pointer;
+}
+
 .connect-guide > .btn {
   align-self: flex-start;
-  white-space: normal;
-  min-height: 44px;
+}
+
+.connect-guide .btn:hover {
+  border-color: var(--turquoise);
+}
+
+.connect-guide .btn-primary {
+  background: var(--turquoise);
+  border-color: var(--turquoise);
+  color: #08251e;
+}
+
+.connect-guide .btn[aria-pressed='true'] {
+  background: rgba(0, 228, 172, 0.12);
+  border-color: var(--turquoise);
+  color: var(--turquoise);
+}
+
+.connect-guide .btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
 }
 
 .connect-guide .studio-connect-snippet {

--- a/apps/web/src/surfaces/studio/studio-connect-guide.css
+++ b/apps/web/src/surfaces/studio/studio-connect-guide.css
@@ -1,0 +1,108 @@
+.studio-connect-wizard .qa-stage {
+  max-width: 760px;
+}
+
+.connect-guide {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  padding: 24px;
+  border: 1px solid var(--panel-border);
+  border-radius: 16px;
+  background: var(--panel-bg, #141b20);
+  margin-bottom: 24px;
+}
+
+.connect-guide h3,
+.connect-guide p {
+  margin: 0;
+}
+
+.connect-guide p {
+  color: var(--muted);
+  line-height: 1.6;
+}
+
+.connect-guide-nav {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  justify-content: space-between;
+  color: var(--muted);
+  font-size: 0.8rem;
+}
+
+.connect-guide-options,
+.connect-guide-tools {
+  display: grid;
+  gap: 12px;
+}
+
+.connect-guide-tools {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.connect-guide-option {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  position: relative;
+  padding: 18px 36px 18px 18px;
+  border: 1px solid var(--panel-border);
+  border-radius: 12px;
+  background: var(--bg);
+  color: var(--text);
+  text-align: left;
+  font: inherit;
+  cursor: pointer;
+  min-height: 52px;
+  overflow-wrap: anywhere;
+}
+
+.connect-guide-option > span:not([aria-hidden]) {
+  color: var(--muted);
+  line-height: 1.5;
+  font-size: 0.9rem;
+}
+
+.connect-guide-option > span[aria-hidden] {
+  position: absolute;
+  right: 16px;
+  top: 20px;
+  color: var(--turquoise);
+}
+
+.connect-guide-option:hover,
+.connect-guide [aria-pressed='true'] {
+  border-color: var(--turquoise);
+  background: rgba(0, 228, 172, 0.06);
+}
+
+.connect-guide :focus-visible {
+  outline: 2px solid var(--turquoise);
+  outline-offset: 3px;
+}
+
+.connect-guide > .btn {
+  align-self: flex-start;
+  white-space: normal;
+  min-height: 44px;
+}
+
+.connect-guide .studio-connect-snippet {
+  margin: 0;
+  max-width: 100%;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
+.connect-guide-wait {
+  border-left: 3px solid var(--turquoise);
+  padding-left: 16px;
+}
+
+@media (max-width: 600px) {
+  .connect-guide {
+    padding: 16px;
+  }
+}

--- a/eslint-rules/module-size-baseline.json
+++ b/eslint-rules/module-size-baseline.json
@@ -867,7 +867,7 @@
     "apps/web/src/surfaces/studio/studioChatSheet.ts": 30,
     "apps/web/src/surfaces/studio/StudioConnectCard.test.tsx": 827,
     "apps/web/src/surfaces/studio/StudioConnectCard.tsx": 812,
-    "apps/web/src/surfaces/studio/StudioConnectWizard.test.tsx": 311,
+    "apps/web/src/surfaces/studio/StudioConnectWizard.test.tsx": 305,
     "apps/web/src/surfaces/studio/StudioConnectWizard.tsx": 335,
     "apps/web/src/surfaces/studio/StudioCreatorAgentKeyPanel.test.tsx": 105,
     "apps/web/src/surfaces/studio/StudioCreatorAgentKeyPanel.tsx": 267,

--- a/packages/contract/src/visit-vocab.test.ts
+++ b/packages/contract/src/visit-vocab.test.ts
@@ -226,7 +226,7 @@ describe('visit vocab', () => {
   it('lists cli dimension vocabularies', () => {
     expect(CLI_INSTALL_CHANNELS).toEqual(['curl', 'ps1', 'update']);
     expect(CLI_PLATFORM_OS).toEqual(['linux', 'darwin', 'win32']);
-    expect(CLI_ADAPTERS).toEqual(['claude', 'codex', 'gemini', 'vibe', 'agy', 'cursor', 'copilot', 'custom']);
+    expect(CLI_ADAPTERS).toEqual(['claude', 'codex', 'gemini', 'vibe', 'agy', 'cursor', 'copilot', 'muse', 'custom']);
     expect(CLI_VERIFY_STAGES).toEqual(['typecheck', 'check_static', 'check_game']);
   });
 });

--- a/packages/contract/src/visit-vocab.ts
+++ b/packages/contract/src/visit-vocab.ts
@@ -203,7 +203,17 @@ export type CliInstallChannel = (typeof CLI_INSTALL_CHANNELS)[number];
 export const CLI_PLATFORM_OS = ['linux', 'darwin', 'win32'] as const;
 export type CliPlatformOs = (typeof CLI_PLATFORM_OS)[number];
 
-export const CLI_ADAPTERS = ['claude', 'codex', 'gemini', 'vibe', 'agy', 'cursor', 'copilot', 'custom'] as const;
+export const CLI_ADAPTERS = [
+  'claude',
+  'codex',
+  'gemini',
+  'vibe',
+  'agy',
+  'cursor',
+  'copilot',
+  'muse',
+  'custom',
+] as const;
 export type CliAdapter = (typeof CLI_ADAPTERS)[number];
 
 export const CLI_VERIFY_STAGES = ['typecheck', 'check_static', 'check_game'] as const;


### PR DESCRIPTION
Creators currently see MCP configuration, CLI installation, authentication alternatives and the kickoff prompt on the same screen. Replace initial setup with a guided choice: terminal, an existing agent, or the gamedev.pl builder. Show only the selected tool's setup, then the kickoff step.

- Include Cursor/VS Code install links, manual authentication fallback, and separate macOS/Linux and Windows CLI instructions. Credentials stay masked on screen and are copied only on request.
- Keep the returning-agent resume flow, platform handoff, live connection progress, and Studio navigation. Continuing setup does not claim that an agent has connected.
- Add Polish/English copy, responsive choices, keyboard focus, and regression coverage for progressive disclosure, clipboard credentials, and existing wizard transitions.

Validation: npm install, type-check and lint passed. All 1,971 web tests, 319 CLI tests, contract/zone/world suites and 76 rule tests passed. All 3,975 API tests passed on a complete rerun with two workers (the initial default-concurrency run hit nine 5-second timeouts). Production build passed. Browser checks used the actual wizard with fixture responses on desktop and mobile, Polish and English, including a 390×420 viewport and both install/update overlays; footer actions remain reachable and there is no horizontal overflow.

Instrumentation: affects creator funnel question 4. Existing `connect_copied` (install/kickoff), `connect_deeplink`, and wizard/Studio steps remain. Query visit funnel steps by visit and builder, together with creator build/publication records, to measure progression. Route-choice abandonment is not separately instrumented; that remains an explicit gap. No credentials, game identifiers or prompts are added to visit telemetry.



Follow-up: restore URL/browser OAuth as the default for Claude Code and Codex; manual bearer configuration remains a fallback. Add Muse Code (Meta) to the wizard and CLI discovery for local checkout delegation (`muse exec --trust-workspace`). Preserve Muse authentication, approval and sandbox defaults; no MCP support is advertised for this adapter. Use plain output instead of exposing Muse's raw event envelopes. The adapter help and echo mode were checked against installed Muse Code 1.0.3-R2198.1 without a paid model call; a real paid editing run was not performed.

The `muse` telemetry adapter value flows through the shared vocabulary into the existing pilot table. Full type-check, lint, workspace tests, rule tests and production build pass after this follow-up.
