### PR TITLE
fix(ci): isolate manual games gates

### DIFF
--- a/.github/workflows/games-catalog-gate.yml
+++ b/.github/workflows/games-catalog-gate.yml
@@ -59,7 +59,7 @@ on:
         default: 'main'
 
 concurrency:
-  group: games-catalog-gate
+  group: ${{ github.workflow == 'Games catalog gate' && format('games-catalog-gate-manual-{0}', inputs.ref || 'main') || 'games-catalog-gate' }}
   cancel-in-progress: true
 
 permissions:
@@ -207,20 +207,7 @@ jobs:
           GAME_CAPTURE_CHROME: ${{ steps.chrome.outputs.chrome-path }}
         run: |
           set -euo pipefail
-          npm run check:no-js
-          npm run check:gfx
-          npm run check:ios
-          npm run audio:check
-          npm run audio:plan-check
-          npm run typecheck
-          npm run test
-          npm run validate
-          npm run smoke
-          npm run trace
-          npm run build
-          npm run check:webgl
-          npm run accept
-          npm run agency -- --all --strict -j 4
+          npm run check:pr
           if [ "${{ steps.resolve.outputs.catalog_agent_play }}" = 1 ]; then
             npm run agent-play
           fi


### PR DESCRIPTION
Manual catalog gates were repeatedly canceled by publication runs sharing the `games-catalog-gate` concurrency group. Give direct manual runs a group per games ref, while retaining the existing publication group.

Run the full gate through the games repository’s `npm run check:pr` so newly added checks (including `party-bridge`) and the SHA-bound attestation stay aligned with the repository contract. Existing optional agent-play, playtest and WebKit stages remain.

Validation: type-check, lint and build passed. The full website test run had five failures in two Studio test files; both files passed on an isolated rerun (64/64 tests). A real catalog workflow run from this branch is validating games commit `3f2b8fba47152938fc9c0c34a42749ac3c026f78`.
