### PR TITLE
fix(cli): sort release versions by semver during update

### DIFF
--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -7,6 +7,10 @@ decides the next version — see [`.claude/skills/cli-release/SKILL.md`](../../.
 
 ## Unreleased
 
+### Fixed
+
+- `gamedevpl update` sorts release versions by semver instead of tag list order (#1238).
+
 ## 0.10.0 — 2026-09-08
 
 ### Added

--- a/apps/cli/src/update.test.ts
+++ b/apps/cli/src/update.test.ts
@@ -3,7 +3,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { createHash } from 'node:crypto';
 import { describe, expect, it } from 'vitest';
-import { assetName, expectedHash, helperDest, updateCli } from './update.js';
+import { assetName, compareSemver, expectedHash, helperDest, resolveUpdateVersion, updateCli } from './update.js';
 import { CliError } from './exit-codes.js';
 
 describe('updateCli', () => {
@@ -76,5 +76,27 @@ describe('updateCli', () => {
         },
       }),
     ).rejects.toBeInstanceOf(CliError);
+  });
+
+  it('compares semver numerically across segments', () => {
+    expect(compareSemver('0.9.0', '0.10.0')).toBeLessThan(0);
+    expect(compareSemver('0.10.0', '0.9.0')).toBeGreaterThan(0);
+    expect(compareSemver('0.10.0', '0.10.0')).toBe(0);
+    expect(compareSemver('0.10.1', '0.10.0')).toBeGreaterThan(0);
+    expect(compareSemver('1.0.0', '0.10.0')).toBeGreaterThan(0);
+  });
+
+  it('resolves the newest semver release even when GitHub returns tags out of semver order', async () => {
+    const mockReleases = [
+      { tag_name: 'cli-v0.9.0' },
+      { tag_name: 'cli-v0.8.0' },
+      { tag_name: 'cli-v0.10.0' },
+      { tag_name: 'cli-v0.7.0' },
+      { tag_name: 'untagged-build' },
+    ];
+    const version = await resolveUpdateVersion({
+      fetchImpl: async () => new Response(JSON.stringify(mockReleases), { status: 200 }),
+    });
+    expect(version).toBe('0.10.0');
   });
 });

--- a/apps/cli/src/update.ts
+++ b/apps/cli/src/update.ts
@@ -51,6 +51,16 @@ export function helperDest(binPath: string): string {
   return join(dirname(binPath), `${GIT_REMOTE_HELPER}${ext}`);
 }
 
+export function compareSemver(a: string, b: string): number {
+  const pa = a.split('.').map((x) => Number.parseInt(x, 10) || 0);
+  const pb = b.split('.').map((x) => Number.parseInt(x, 10) || 0);
+  for (let i = 0; i < 3; i++) {
+    const diff = (pa[i] ?? 0) - (pb[i] ?? 0);
+    if (diff !== 0) return diff;
+  }
+  return 0;
+}
+
 export async function resolveUpdateVersion(input: { version?: string; fetchImpl: FetchLike }): Promise<string> {
   if (input.version) return input.version.replace(/^cli-v/, '');
   const res = await input.fetchImpl(CLI_RELEASES_API, {
@@ -58,8 +68,12 @@ export async function resolveUpdateVersion(input: { version?: string; fetchImpl:
   });
   if (!res.ok) return CLI_VERSION;
   const rows = (await res.json()) as Array<{ tag_name?: string }>;
-  const tags = rows.map((row) => row.tag_name ?? '').filter((tag) => tag.startsWith(CLI_RELEASE_PREFIX));
-  const newest = tags[0]?.slice(CLI_RELEASE_PREFIX.length);
+  const versions = rows
+    .map((row) => row.tag_name ?? '')
+    .filter((tag) => tag.startsWith(CLI_RELEASE_PREFIX))
+    .map((tag) => tag.slice(CLI_RELEASE_PREFIX.length))
+    .sort(compareSemver);
+  const newest = versions[versions.length - 1];
   return newest || CLI_VERSION;
 }
 


### PR DESCRIPTION
Sort GitHub release tags by semver when resolving the latest version in `gamedevpl update`, preventing lexicographical ordering issues (e.g. `0.9.0` > `0.10.0`).