### PR TITLE
fix(infra): guard the remaining owner-run setup scripts against a stale checkout

### DIFF
--- a/infra/setup-account-deletion.sh
+++ b/infra/setup-account-deletion.sh
@@ -13,6 +13,9 @@
 # time zone, and OIDC identity without changing whether an operator has paused it.
 set -euo pipefail
 
+# An old copy of this script does not fail; it reverts what a newer copy fixed.
+source "$(dirname "${BASH_SOURCE[0]}")/require-current-checkout.sh"
+
 export CLOUDSDK_CORE_DISABLE_PROMPTS=1
 
 PROJECT_ID="${PROJECT_ID:-gamedevpl}"

--- a/infra/setup-agent-readonly.sh
+++ b/infra/setup-agent-readonly.sh
@@ -14,6 +14,9 @@
 # Override via env: PROJECT_ID, SA_NAME, POOL_NAME, REPO, KEY_OUT.
 set -euo pipefail
 
+# An old copy of this script does not fail; it reverts what a newer copy fixed.
+source "$(dirname "${BASH_SOURCE[0]}")/require-current-checkout.sh"
+
 PROJECT_ID="${PROJECT_ID:-gamedevpl}"
 SA_NAME="${SA_NAME:-agent-investigator}"
 SA_EMAIL="${SA_NAME}@${PROJECT_ID}.iam.gserviceaccount.com"

--- a/infra/setup-backups.sh
+++ b/infra/setup-backups.sh
@@ -30,6 +30,9 @@
 # This script is idempotent — safe to re-run after changing any of the knobs above.
 set -euo pipefail
 
+# An old copy of this script does not fail; it reverts what a newer copy fixed.
+source "$(dirname "${BASH_SOURCE[0]}")/require-current-checkout.sh"
+
 # Every gcloud call here is GA, so none should prompt — but the existence checks below
 # discard both streams, so any prompt that did appear would be invisible and the script
 # would wait on stdin forever. setup-monitoring.sh hung exactly that way. Prompts off.

--- a/infra/setup-dispatch-reaper.sh
+++ b/infra/setup-dispatch-reaper.sh
@@ -18,6 +18,9 @@
 # a day later. 4 calls/hour stays well under the endpoint's own 24/hour rate cap.
 set -euo pipefail
 
+# An old copy of this script does not fail; it reverts what a newer copy fixed.
+source "$(dirname "${BASH_SOURCE[0]}")/require-current-checkout.sh"
+
 export CLOUDSDK_CORE_DISABLE_PROMPTS=1
 
 PROJECT_ID="${PROJECT_ID:-gamedevpl}"

--- a/infra/setup-gcp.sh
+++ b/infra/setup-gcp.sh
@@ -10,6 +10,9 @@
 # APP_SA_NAME, WORLD_SA_NAME.
 set -euo pipefail
 
+# An old copy of this script does not fail; it reverts what a newer copy fixed.
+source "$(dirname "${BASH_SOURCE[0]}")/require-current-checkout.sh"
+
 PROJECT_ID="${PROJECT_ID:-gamedevpl}"
 REGION="${REGION:-europe-central2}"
 APP_REGION="${APP_REGION:-europe-west1}"

--- a/infra/setup-runtime-sa.sh
+++ b/infra/setup-runtime-sa.sh
@@ -57,6 +57,9 @@
 # WORLD_SA_NAME, RELAY_SA_NAME, GATE_SA_NAME.
 set -euo pipefail
 
+# An old copy of this script does not fail; it reverts what a newer copy fixed.
+source "$(dirname "${BASH_SOURCE[0]}")/require-current-checkout.sh"
+
 export CLOUDSDK_CORE_DISABLE_PROMPTS=1
 
 PROJECT_ID="${PROJECT_ID:-gamedevpl}"

--- a/infra/setup-sweeps.sh
+++ b/infra/setup-sweeps.sh
@@ -28,6 +28,9 @@
 # token must not be replayable against another sweep's endpoint.
 set -euo pipefail
 
+# An old copy of this script does not fail; it reverts what a newer copy fixed.
+source "$(dirname "${BASH_SOURCE[0]}")/require-current-checkout.sh"
+
 export CLOUDSDK_CORE_DISABLE_PROMPTS=1
 
 PROJECT_ID="${PROJECT_ID:-gamedevpl}"

--- a/infra/setup-wif.sh
+++ b/infra/setup-wif.sh
@@ -15,6 +15,9 @@
 # GAMES_REPO, SA_NAME.
 set -euo pipefail
 
+# An old copy of this script does not fail; it reverts what a newer copy fixed.
+source "$(dirname "${BASH_SOURCE[0]}")/require-current-checkout.sh"
+
 PROJECT_ID="${PROJECT_ID:-gamedevpl}"
 POOL_NAME="${POOL_NAME:-github-pool}"
 PROVIDER_NAME="${PROVIDER_NAME:-github-provider}"


### PR DESCRIPTION
Follow-up to #1245, which wired `infra/require-current-checkout.sh` into `setup-monitoring.sh` and `setup-spend-brake.sh` — the pair whose stale run silently disarmed the spend brake for twelve hours on 2026-09-08.

The reasoning was never specific to those two. Every script in `infra/` writes whole objects — IAM bindings, service accounts, scheduler jobs, WIF providers, uptime checks, lifecycle rules — so an old copy does not fail. It reverts whatever the newer copy fixed, and leaves everything looking enabled afterwards.

Same single sourced line in the other eight:

```
infra/setup-account-deletion.sh
infra/setup-agent-readonly.sh
infra/setup-backups.sh
infra/setup-dispatch-reaper.sh
infra/setup-gcp.sh
infra/setup-runtime-sa.sh
infra/setup-sweeps.sh
infra/setup-wif.sh
```

No behaviour change for anyone running a current tree: an identical script is silent, a tree that contains master with local edits gets a note and proceeds, and only a tree *behind* master running a *differing* script is refused. `ALLOW_STALE_CHECKOUT=1` still overrides.

## Verification

`bash -n` passes on all ten scripts. In each one the guard is sourced before the first real `gcloud`/`gsutil` call (comment mentions excluded), so nothing can be written before the check runs:

| script | guard | first cloud call |
| --- | --- | --- |
| setup-account-deletion.sh | 17 | 29 |
| setup-agent-readonly.sh | 18 | 30 |
| setup-backups.sh | 34 | 61 |
| setup-dispatch-reaper.sh | 22 | 34 |
| setup-gcp.sh | 14 | 26 |
| setup-runtime-sa.sh | 61 | 85 |
| setup-sweeps.sh | 32 | 42 |
| setup-wif.sh | 19 | 46 |

The guard's own behaviour was exercised end-to-end in #1245 against a throwaway origin and clone; this change only adds call sites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)