### PR TITLE
security: apply HSTS consistently across app responses

### DIFF
--- a/apps/api/src/platform/security-headers.test.ts
+++ b/apps/api/src/platform/security-headers.test.ts
@@ -12,6 +12,7 @@ import {
   PERMISSIONS_POLICY,
   REFERRER_POLICY,
   resolveCspReportOnly,
+  STRICT_TRANSPORT_SECURITY,
   summarizeCspReport,
   X_FRAME_OPTIONS,
 } from './security-headers.js';
@@ -53,11 +54,12 @@ describe('security headers', () => {
     expect(res.headers['x-frame-options']).toBe(X_FRAME_OPTIONS);
   });
 
-  it('puts nosniff and a referrer policy on every response, JSON included', async () => {
+  it('puts baseline hardening headers on every response, JSON included', async () => {
     for (const url of ['/api/health', '/api/auth/me', '/']) {
       const res = await app.inject({ method: 'GET', url });
       expect(res.headers['x-content-type-options'], url).toBe('nosniff');
       expect(res.headers['referrer-policy'], url).toBe(REFERRER_POLICY);
+      expect(res.headers['strict-transport-security'], url).toBe(STRICT_TRANSPORT_SECURITY);
     }
   });
 

--- a/apps/api/src/platform/security-headers.ts
+++ b/apps/api/src/platform/security-headers.ts
@@ -4,6 +4,7 @@ import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
 
 export const X_CONTENT_TYPE_OPTIONS = 'nosniff';
 export const REFERRER_POLICY = 'strict-origin-when-cross-origin';
+export const STRICT_TRANSPORT_SECURITY = 'max-age=31536000';
 export const FRAME_ANCESTORS_NONE = "frame-ancestors 'none'";
 export const X_FRAME_OPTIONS = 'DENY';
 // Never name mic/camera/motion: the game frame delegates them.
@@ -107,6 +108,7 @@ export function registerSecurityHeaders(app: FastifyInstance, options: SecurityH
   app.addHook('onSend', async (_request, reply, payload) => {
     setIfAbsent(reply, 'x-content-type-options', X_CONTENT_TYPE_OPTIONS);
     setIfAbsent(reply, 'referrer-policy', REFERRER_POLICY);
+    setIfAbsent(reply, 'strict-transport-security', STRICT_TRANSPORT_SECURITY);
     if (!isHtmlDocument(reply)) return payload;
     // A route that wrote its own CSP owns its embedding story.
     if (!reply.hasHeader('content-security-policy')) {

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -124,7 +124,9 @@ X-Forwarded-Host is never used to authorize an origin.
 One Cloud Run service serves the API and the web app, so response headers are set in one
 place: `apps/api/src/platform/security-headers.ts`, registered in `app.ts` right after the rate
 limiter, whose annotation its report sink relies on. Every response carries `X-Content-Type-Options: nosniff` and
-`Referrer-Policy: strict-origin-when-cross-origin`. HTML documents — the SPA shell, the OAuth
+`Referrer-Policy: strict-origin-when-cross-origin`. Every response also carries
+`Strict-Transport-Security: max-age=31536000`, rather than relying on an edge layer to add it
+only to some response classes. HTML documents — the SPA shell, the OAuth
 consent and device pages, the CLI page — additionally carry:
 
 - `Content-Security-Policy: frame-ancestors 'none'` and `X-Frame-Options: DENY`. Nothing this


### PR DESCRIPTION
### Motivation

- The production site showed inconsistent HSTS coverage across response classes which weakens transport-security guarantees. 
- The intention is to ensure every response the application emits (HTML, JSON, error pages, authenticated endpoints) carries an application-controlled HSTS policy rather than relying on edge/CDN behaviour. 

### Description

- Add `STRICT_TRANSPORT_SECURITY = 'max-age=31536000'` and set `strict-transport-security` in the global security header hook in `apps/api/src/platform/security-headers.ts`. 
- Extend the security-header regression test to assert HSTS is present on HTML and JSON responses in `apps/api/src/platform/security-headers.test.ts`. 
- Update `docs/security-model.md` to document that HSTS is applied by the application for all response classes. 

### Testing

- Performed passive production checks with `curl` to validate headers and CORS behaviour (responses returned expected CSP, X-Frame-Options and now HSTS). 
- Ran dependency audits (`npm audit --omit=dev` / `npm audit`) and found no reported npm vulnerabilities. 
- Executed the repository green gate: `npm install` then `npm run type-check && npm run lint && npm run test && npm run build`, and all workspace builds and tests completed successfully (including the updated security-headers tests).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6aa0742654a083238fb1be1f8e1e5e1f)