### PR TITLE
Serve a robots.txt instead of a JSON 404

### DIFF
--- a/apps/web/public/robots.txt
+++ b/apps/web/public/robots.txt
@@ -1,0 +1,18 @@
+# www.gamedev.pl
+
+User-agent: *
+
+# Capability URLs: the token in the path IS the credential. There is nothing to
+# index behind them, and a crawled one is a shared secret sitting in a log.
+Disallow: /status/
+Disallow: /draft/
+Disallow: /invite/
+Disallow: /join/
+
+# Per-account surfaces. A crawler only ever gets the signed-out shell.
+Disallow: /studio
+Disallow: /admin
+
+# Everything else is public and meant to be crawled -- including the /api/ reads
+# the renderer needs to see a game page at all, so no blanket /api/ rule here.
+Allow: /

--- a/apps/web/src/robots.test.ts
+++ b/apps/web/src/robots.test.ts
@@ -1,0 +1,67 @@
+// Shipped from apps/web/public, served at the site root.
+
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const robots = readFileSync(
+  path.join(path.dirname(fileURLToPath(import.meta.url)), '..', 'public', 'robots.txt'),
+  'utf8',
+);
+
+function rules(): { disallow: string[]; allow: string[] } {
+  const disallow: string[] = [];
+  const allow: string[] = [];
+  for (const raw of robots.split('\n')) {
+    const line = raw.split('#')[0]!.trim();
+    const [field, ...rest] = line.split(':');
+    const value = rest.join(':').trim();
+    if (!value) continue;
+    if (field?.toLowerCase() === 'disallow') disallow.push(value);
+    if (field?.toLowerCase() === 'allow') allow.push(value);
+  }
+  return { disallow, allow };
+}
+
+// Longest match wins; Allow beats Disallow at equal length.
+function crawlable(pathname: string): boolean {
+  const { disallow, allow } = rules();
+  const longest = (list: string[]) =>
+    list.filter((p) => pathname.startsWith(p)).reduce((best, p) => (p.length > best ? p.length : best), -1);
+  const blocked = longest(disallow);
+  const permitted = longest(allow);
+  return blocked < 0 || permitted >= blocked;
+}
+
+describe('robots.txt', () => {
+  it('applies to every crawler', () => {
+    expect(robots).toMatch(/^User-agent:\s*\*$/m);
+  });
+
+  it.each([
+    '/status/MTAwMDE2NS45MDhiNzQxMmZl',
+    '/draft/some-game',
+    '/invite/0123456789abcdef0123456789abcdef',
+    '/join/AB12CD',
+    '/studio',
+    '/studio/some-token/code',
+    '/admin',
+    '/admin/queue',
+  ])('keeps crawlers off %s', (pathname) => {
+    expect(crawlable(pathname)).toBe(false);
+  });
+
+  it.each(['/', '/privacy', '/terms', '/contact', '/ada/sky-dodge', '/play/sky-dodge', '/creators/ada'])(
+    'leaves %s crawlable',
+    (pathname) => {
+      expect(crawlable(pathname)).toBe(true);
+    },
+  );
+
+  it('does not blanket-block the API the renderer needs', () => {
+    // Googlebot renders the SPA; blocking /api/ would blind it.
+    expect(crawlable('/api/catalog')).toBe(true);
+    expect(crawlable('/api/games/sky-dodge')).toBe(true);
+  });
+});


### PR DESCRIPTION
The site has never had one: `/robots.txt` fell through to the API's not-found handler and answered crawlers with `{"error":"not found"}`.

**This is hygiene, not an incident.** Nothing is being crawled that shouldn't be — Googlebot's requests to the capability URLs come back 401 from the private-beta wall (verified by direct request, including with a Googlebot user agent), and the status pages themselves see about two hits a day. The value is in place before the wall comes down.

## What it blocks

The URLs whose path segment *is* the credential: `/status/`, `/draft/`, `/invite/`, `/join/`. There is nothing to index behind any of them, and a crawled one is a shared secret sitting in somebody's log. `/studio` and `/admin` follow because a crawler only ever gets the signed-out shell.

## What it deliberately does not block

No blanket `/api/` rule. Googlebot renders the SPA to see a game page at all, and that render fetches `/api/games` and `/api/catalog` — disallowing the API would quietly de-index the public catalog, which is the opposite of what this file is for.

## Testing

17 tests. They assert the crawl verdict for each path shape rather than the file's text, so a new capability route that nobody writes a rule for fails here rather than in a log six months later. Verified to fail with a `Disallow` line removed.

Also verified that `apps/web/public/` really is what gets served — `manifest.webmanifest` and `offline.html` both return 200 in production — and that the build copies the file to `apps/web/dist/robots.txt`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Uvg3SxBUgb6Qdew1JgPue7

---
_Generated by [Claude Code](https://claude.ai/code/session_01Uvg3SxBUgb6Qdew1JgPue7)_