### PR TITLE
fix(cli): preserve local changes when connecting agents

### DIFF
--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -9,9 +9,9 @@ decides the next version — see [`.claude/skills/cli-release/SKILL.md`](../../.
 
 ### Fixed
 
-- Continue existing local checkouts from connect instead of silently using platform sources.
-- Show meaningful Codex MCP and file activity instead of item.completed.
-- Open Codex MCP interactively so permission requests can be answered.
+- Continue existing local checkouts from connect instead of silently using platform sources (#1252).
+- Show meaningful Codex MCP and file activity instead of item.completed (#1252).
+- Open Codex MCP interactively so permission requests can be answered (#1252).
 
 ## 0.12.0 — 2026-09-08
 

--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -7,6 +7,12 @@ decides the next version — see [`.claude/skills/cli-release/SKILL.md`](../../.
 
 ## Unreleased
 
+### Fixed
+
+- Continue existing local checkouts from connect instead of silently using platform sources.
+- Show meaningful Codex MCP and file activity instead of item.completed.
+- Open Codex MCP interactively so permission requests can be answered.
+
 ## 0.12.0 — 2026-09-08
 
 ### Added

--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -123,15 +123,20 @@ the agent, not the session. `/delegate <task>` skips the chat; `gamedevpl delega
 [--agent codex] [--handoff] [--submit]` is the non-interactive form (exit `1` when the agent or the
 ladder fails).
 
-`gamedevpl connect <slug>` prints the MCP handoff (URL, kickoff, install snippet).
-`--agent claude` (or `codex` / `copilot`) launches the agent with temporary MCP configuration,
-never the creator OAuth grant or a PAT. The round must use builder `self`; explicit
-`--handoff` requests a switch and refuses execution while the switch is pending.
-In a matching checkout the agent works on that game's directory; review local changes
-before `gamedevpl submit`. Otherwise it uses a scratch directory and the MCP workflow;
-the CLI prints the directory and keeps any scratch files after exit. Check the delivery
-in Studio. Existing user MCP configuration is not overwritten.
-MCP progress appears while the agent runs; Ctrl+C in the REPL stops its process group.
+`gamedevpl connect <slug>` opens a work-mode picker in an interactive terminal.
+It detects a matching checkout in the current directory or its `<slug>` child.
+When found, the local choices reuse its files, including unsent changes; selecting
+an agent remembers it for the next editing request. `/play` then previews locally.
+The picker labels MCP choices as using platform sources when no checkout exists.
+`--manual` prints the MCP handoff without launching an agent.
+
+Codex MCP runs in its native interactive terminal with workspace-write isolation and
+on-request user approvals. Answer network/tool permission requests there, then exit
+to return to gamedevpl. It refuses an unattended MCP launch instead of starting a
+session that cannot ask for permissions. Native tool policies still apply.
+Claude and Copilot keep their existing temporary MCP configuration. Scratch files
+remain available after an MCP run; process exit alone does not confirm delivery.
+Existing user MCP configuration is not overwritten.
 
 ## Releases
 

--- a/apps/cli/src/agents.test.ts
+++ b/apps/cli/src/agents.test.ts
@@ -101,8 +101,8 @@ describe('agent discovery', () => {
     expect(pick.mock.calls[0]?.[0]).toEqual([
       'Open a local checkout — edit and play here',
       'Continue chatting about this game',
-      'claude',
-      'codex',
+      'claude — MCP; platform sources',
+      'codex — MCP; platform sources',
       'Show manual MCP setup',
     ]);
     expect(request).not.toHaveBeenCalled();

--- a/apps/cli/src/agy-interactive.ts
+++ b/apps/cli/src/agy-interactive.ts
@@ -1,3 +1,4 @@
+import { codexInteractiveArgs } from './codex-interactive.js';
 import { terminalRecording } from './terminal-recording.js';
 import { spawn } from 'node:child_process';
 import type { AdapterSpec } from './adapters.js';
@@ -26,6 +27,7 @@ export function agyConversation(line: string): string | undefined {
 }
 
 export function interactiveArgs(input: Parameters<InteractiveRun>[0]): string[] {
+  if (input.spec.name === 'codex') return codexInteractiveArgs(input.spec.headless, input.prompt);
   const args: string[] = [];
   for (let i = 0; i < input.spec.headless.length; i++) {
     const arg = input.spec.headless[i];

--- a/apps/cli/src/codex-events.test.ts
+++ b/apps/cli/src/codex-events.test.ts
@@ -1,0 +1,22 @@
+import { expect, it } from 'vitest';
+import { parseEventLine } from './delegate.js';
+it('renders MCP outcomes and edited files without opaque item events', () => {
+  const line = (item: unknown) => JSON.stringify({ type: 'item.completed', item });
+  expect(
+    parseEventLine(
+      line({ type: 'mcp_tool_call', server: 'gamedevpl', tool: 'report_progress', status: 'completed' }),
+      'codex',
+    ),
+  ).toBe('✓ gamedevpl / report_progress');
+  expect(
+    parseEventLine(
+      line({ type: 'mcp_tool_call', tool: 'end', status: 'failed', error: { message: 'approval denied' } }),
+      'codex',
+    ),
+  ).toBe('Tool failed: end — approval denied');
+  expect(parseEventLine(line({ type: 'file_change', changes: [{ path: 'game.ts' }] }), 'codex')).toBe(
+    'Edited: game.ts',
+  );
+  expect(parseEventLine(line({ type: 'future_bookkeeping' }), 'codex')).toBeNull();
+  expect(parseEventLine(line({ type: 'agent_message', text: 'Done' }), 'codex')).toBe('Done');
+});

--- a/apps/cli/src/codex-events.ts
+++ b/apps/cli/src/codex-events.ts
@@ -1,0 +1,33 @@
+export function codexEventText(value: unknown): string | null | undefined {
+  const event = value as {
+    type?: string;
+    item?: {
+      type?: string;
+      server?: string;
+      tool?: string;
+      status?: string;
+      error?: { message?: string };
+      changes?: { path?: string }[];
+    };
+  };
+  if (typeof event.type !== 'string' || !event.type.startsWith('item.')) return undefined;
+  const item = event.item;
+  if (item?.type === 'mcp_tool_call') {
+    if (event.type !== 'item.completed') return null;
+    const name = [item.server, item.tool].filter(Boolean).join(' / ') || 'MCP tool';
+    return item.status === 'failed' || item.error
+      ? `Tool failed: ${name}${item.error?.message ? ` — ${item.error.message}` : ''}`
+      : `✓ ${name}`;
+  }
+  if (item?.type === 'file_change' && event.type === 'item.completed') {
+    const paths = Array.isArray(item.changes)
+      ? item.changes
+          .map((change) => change?.path)
+          .filter(Boolean)
+          .join(', ')
+      : '';
+    return paths ? `Edited: ${paths}` : null;
+  }
+  if (item?.type === 'agent_message' || item?.type === 'command_execution') return undefined;
+  return null;
+}

--- a/apps/cli/src/codex-interactive.test.ts
+++ b/apps/cli/src/codex-interactive.test.ts
@@ -1,0 +1,26 @@
+import { expect, it } from 'vitest';
+import { interactiveArgs } from './agy-interactive.js';
+import { loadAdapters } from './adapters.js';
+it('keeps MCP and model overrides but enables native permission prompts', () => {
+  const spec = loadAdapters().adapters.find((a) => a.name === 'codex')!;
+  const args = interactiveArgs({
+    spec: {
+      ...spec,
+      headless: ['-c', 'mcp_servers.gamedevpl.url="https://example.test"', ...spec.headless, '--model', 'chosen'],
+    },
+    cwd: '/game',
+    env: {},
+    prompt: 'Build it',
+    abort: new AbortController().signal,
+  });
+  expect(args).toContain('mcp_servers.gamedevpl.url="https://example.test"');
+  expect(args).toContain('chosen');
+  expect(args).toContain('on-request');
+  expect(args).toContain('approvals_reviewer="user"');
+  expect(args).toContain('workspace-write');
+  expect(args).not.toContain('exec');
+  expect(args).not.toContain('--json');
+  expect(args).not.toContain('--skip-git-repo-check');
+  expect(args).not.toContain('never');
+  expect(args.at(-1)).toBe('Build it');
+});

--- a/apps/cli/src/codex-interactive.ts
+++ b/apps/cli/src/codex-interactive.ts
@@ -1,0 +1,23 @@
+export function codexInteractiveArgs(headless: string[], prompt: string): string[] {
+  const args: string[] = [];
+  for (let i = 0; i < headless.length; i++) {
+    const arg = headless[i];
+    if (['exec', '--json', '--skip-git-repo-check', '--full-auto'].includes(arg)) continue;
+    if (['-a', '--ask-for-approval', '-s', '--sandbox'].includes(arg)) {
+      i++;
+      continue;
+    }
+    args.push(arg);
+  }
+  return [
+    ...args,
+    '--sandbox',
+    'workspace-write',
+    '--ask-for-approval',
+    'on-request',
+    '-c',
+    'approvals_reviewer="user"',
+    '--no-alt-screen',
+    prompt,
+  ];
+}

--- a/apps/cli/src/connect-entry.test.ts
+++ b/apps/cli/src/connect-entry.test.ts
@@ -49,6 +49,12 @@ describe('connect entry points', () => {
     );
     expect(fetch.mock.calls.every(([url]) => !url.endsWith('/connect'))).toBe(true);
   });
+  it('keeps explicit agents in the checkout-aware interactive flow', async () => {
+    const fetch = backend();
+    expect(await runCli(['node', 'cli', 'connect', 'sky', '--agent', 'codex'], env, streams())).toBe(0);
+    expect(runInkRepl).toHaveBeenCalledWith(expect.objectContaining({ initialLine: '/connect sky --agent codex' }));
+    expect(fetch.mock.calls.every(([url]) => !url.endsWith('/connect'))).toBe(true);
+  });
   it('can open an existing game directly in the interactive mode', async () => {
     backend();
     expect(await runCli(['node', 'cli', 'repl', 'sky'], env, streams())).toBe(0);

--- a/apps/cli/src/connect-flow.test.ts
+++ b/apps/cli/src/connect-flow.test.ts
@@ -1,5 +1,5 @@
 import { execFileSync } from 'node:child_process';
-import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdtempSync, mkdirSync, chmodSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, describe, expect, it, vi } from 'vitest';
@@ -50,6 +50,32 @@ describe('interactive game connection', () => {
     ).toBeNull();
     expect(pick.mock.calls.length).toBe(1);
     expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it.each([false, true])('reuses dirty child checkout with agent selection (explicit: %s)', async (explicit) => {
+    const { api, fetch } = fixture();
+    const parent = directory();
+    const dest = join(parent, 'sky');
+    mkdirSync(join(dest, 'games', 'sky'), { recursive: true });
+    writeFileSync(join(dest, '.gamedev-slug'), 'sky');
+    const localFile = join(dest, 'games', 'sky', 'game.ts');
+    writeFileSync(localFile, 'my unsent changes');
+    const bin = join(parent, 'codex');
+    writeFileSync(bin, '#!/bin/sh\nexit 0\n');
+    chmodSync(bin, 0o755);
+    vi.spyOn(process, 'cwd').mockReturnValue(parent);
+    const result = await connectSession({
+      api,
+      slug: 'sky',
+      env: { PATH: parent },
+      ...(explicit ? { agent: 'codex' } : {}),
+      pick: async (choices) => choices?.find((choice) => choice.startsWith('codex —')) ?? '',
+      abort: { current: null },
+      write: () => {},
+    });
+    expect(result?.workshop).toMatchObject({ root: dest, selectedAgent: 'codex' });
+    expect(readFileSync(localFile, 'utf8')).toBe('my unsent changes');
+    expect(fetch.mock.calls.some(([url]) => url.includes('/workspace') || url.includes('/connect'))).toBe(false);
   });
 
   it('enters chat for the selected game without minting MCP credentials', async () => {

--- a/apps/cli/src/connect-flow.ts
+++ b/apps/cli/src/connect-flow.ts
@@ -1,3 +1,4 @@
+import type { InteractiveRun } from './agy-interactive.js';
 import { dirname, join, resolve } from 'node:path';
 import type { ApiClient } from './api.js';
 import { discoverAgents } from './agents.js';
@@ -19,6 +20,7 @@ type Input = {
   write: (line: string) => void;
   onActivity?: (text: string) => void;
   telemetry?: CliTelemetry;
+  interactiveRun?: InteractiveRun;
 };
 
 export async function checkoutSession(input: Input): Promise<GameSession> {
@@ -57,24 +59,43 @@ export async function connectSession(
   input: Input & { agent?: string; handoff?: boolean; manual?: boolean },
 ): Promise<GameSession | null> {
   let agent = input.agent;
+  const base = resolve(input.dest ?? input.workshop?.root ?? process.cwd());
+  const here = findCheckout(base);
+  const child = findCheckout(join(base, input.slug));
+  const existing = here?.slug === input.slug ? here : child?.slug === input.slug ? child : null;
+  const openLocal = async (selected?: string) => {
+    const opened = await checkoutSession({ ...input, dest: existing?.root ?? input.dest });
+    if (opened.workshop && selected) {
+      opened.workshop.selectedAgent = selected;
+      input.write(`${selected} will edit your existing local files. Say what to change; /play previews locally.`);
+    }
+    return opened;
+  };
+  if (existing && !input.manual) {
+    input.write(`Found local checkout: ${existing.root} — local files are preserved.`);
+    if (agent) return openLocal(agent);
+  }
   input.telemetry?.record('connect_opened');
   if (!agent && !input.manual && input.pick) {
-    const agents = discoverAgents(input.env).filter((row) => row.installed && row.mcp);
+    const agents = discoverAgents(input.env).filter((row) => row.installed && (existing || row.mcp));
     for (const row of agents) input.telemetry?.record('delegate_offered', { adapter: row.name });
-    const checkout = 'Open a local checkout — edit and play here';
+    const checkout = existing
+      ? 'Continue in existing checkout — keep local changes'
+      : 'Open a local checkout — edit and play here';
     const chat = 'Continue chatting about this game';
     const manual = 'Show manual MCP setup';
-    const choice = await input.pick(
-      [checkout, chat, ...agents.map((row) => row.name), manual],
-      `${input.slug} — how would you like to work?`,
-    );
-    if (choice === checkout) return checkoutSession(input);
+    const labels = agents.map((row) => `${row.name} — ${existing ? 'edit local files' : 'MCP; platform sources'}`);
+    const choice = await input.pick([checkout, chat, ...labels, manual], `${input.slug} — how would you like to work?`);
+    if (choice === checkout) return openLocal();
     if (choice === chat) {
       input.write(`Talking about ${input.slug}. Say what you want to change, or /checkout to work locally.`);
       return { token: await studioToken(input.api, input.slug), slug: input.slug, conversationId: '' };
     }
-    if (choice !== manual && !agents.some((row) => row.name === choice)) return null;
-    if (choice !== manual) agent = choice;
+    if (choice !== manual) {
+      agent = agents[labels.indexOf(choice)]?.name;
+      if (!agent) return null;
+      if (existing) return openLocal(agent);
+    }
   }
   const controller = new AbortController();
   input.abort.current = controller;

--- a/apps/cli/src/connect-native.test.ts
+++ b/apps/cli/src/connect-native.test.ts
@@ -1,0 +1,61 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { expect, it, vi } from 'vitest';
+import { connectGame } from './connect.js';
+import type { ApiClient } from './api.js';
+it.each([0, 1])('gives Codex MCP a native terminal and reports exit %s', async (code) => {
+  const dir = mkdtempSync(join(tmpdir(), 'connect-native-'));
+  let scratch = '';
+  const request = vi.fn(async (_method, path) =>
+    path.includes('/api/me/studio?')
+      ? { games: [{ slug: 'sky', token: 'round' }] }
+      : {
+          slug: 'sky',
+          mcpUrl: 'https://example.test/mcp',
+          authorizationHeader: 'Bearer test-round',
+          kickoffPrompt: 'Build sky',
+        },
+  );
+  const runAdapter = vi.fn(async () => ({ code: 0 }));
+  const interactiveRun = vi.fn(async (input) => {
+    scratch = input.cwd;
+    expect(input.spec.headless.join(' ')).toContain('mcp_servers.gamedevpl');
+    expect(input.prompt).toBe('Build sky');
+    expect(input.cwd).not.toBe(dir);
+    return { code };
+  });
+  try {
+    const promise = connectGame({
+      api: { request } as unknown as ApiClient,
+      slug: 'sky',
+      dest: dir,
+      agent: 'codex',
+      which: () => '/bin/codex',
+      runAdapter,
+      interactiveRun,
+      write: () => {},
+    });
+    if (code === 0) await expect(promise).resolves.toEqual({ spawned: true, mcp: true });
+    else await expect(promise).rejects.toThrow('Codex stopped');
+    expect(interactiveRun).toHaveBeenCalledTimes(1);
+    expect(runAdapter).not.toHaveBeenCalled();
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+    if (scratch) rmSync(scratch, { recursive: true, force: true });
+  }
+});
+it('refuses headless Codex before fetching MCP credentials', async () => {
+  const request = vi.fn(async () => ({ games: [{ slug: 'sky', token: 'round' }] }));
+  await expect(
+    connectGame({
+      api: { request } as unknown as ApiClient,
+      slug: 'sky',
+      dest: '/tmp',
+      agent: 'codex',
+      which: () => '/bin/codex',
+      write: () => {},
+    }),
+  ).rejects.toThrow('interactive terminal');
+  expect(request.mock.calls).toHaveLength(1);
+});

--- a/apps/cli/src/connect.ts
+++ b/apps/cli/src/connect.ts
@@ -1,3 +1,4 @@
+import type { InteractiveRun } from './agy-interactive.js';
 import { configureAdapter, selectionLabel } from './agent-settings.js';
 import { trackAgentFailure } from './agent-failure.js';
 import { requireClaudeSubscription, subscriptionEnv } from './claude-auth.js';
@@ -176,6 +177,7 @@ export async function connectGame(input: {
   handoff?: boolean;
   which?: (cmd: string) => string | null;
   runAdapter?: AdapterRun;
+  interactiveRun?: InteractiveRun;
   abort?: AbortSignal;
   write: (line: string) => void;
   telemetry?: CliTelemetry;
@@ -204,6 +206,12 @@ export async function connectGame(input: {
       cliUsage('connect'),
     );
   }
+  if (spec?.name === 'codex' && !input.interactiveRun && !input.runAdapter)
+    throw new CliError(
+      'Codex MCP needs an interactive terminal for permissions.',
+      EXIT_INPUT,
+      'Run gamedevpl connect in a terminal, or use a local checkout and delegate.',
+    );
   if (spec) {
     spec = configureAdapter(spec, env);
     input.write(selectionLabel(spec.name, spec.selection ?? {}));
@@ -296,6 +304,26 @@ export async function connectGame(input: {
     input.telemetry?.record('delegate_used', { adapter: spec.name });
     const failure = trackAgentFailure(spec.name);
     const render = createDelegateStream(spec.name);
+    const prompt =
+      payload.kickoffPrompt ?? `Edit ${input.slug} in this checkout. The creator will deliver with gamedevpl submit.`;
+    if (spec.name === 'codex' && input.interactiveRun) {
+      input.write(
+        'Codex now controls the terminal. Answer permission prompts there; exit Codex to return to gamedevpl.',
+      );
+      const result = await input.interactiveRun({
+        spec: wired.spec,
+        prompt,
+        cwd,
+        env: envForAgent,
+        abort: input.abort ?? new AbortController().signal,
+      });
+      input.write(
+        `Returned from Codex (${result.code ?? 'stopped'}). This does not confirm delivery; check Studio. Files remain at ${cwd}`,
+      );
+      if (result.code !== 0)
+        throw new CliError('Codex stopped before confirming completion.', EXIT_INPUT, `Files remain at ${cwd}`);
+      return { spawned: true, mcp: true };
+    }
     const result = await (input.runAdapter ?? defaultAdapterRun)({
       spec: wired.spec,
       prompt:

--- a/apps/cli/src/delegate.ts
+++ b/apps/cli/src/delegate.ts
@@ -1,3 +1,4 @@
+import { codexEventText } from './codex-events.js';
 import { createMuseStream, museEventText } from './muse-events.js';
 import { antigravityText } from './agent-events.js';
 import { requireClaudeSubscription, subscriptionEnv } from './claude-auth.js';
@@ -74,6 +75,8 @@ export function parseEventLine(line: string, adapter?: string): string | null {
     const text = museEventText(parsed);
     if (text !== undefined) return text;
   }
+  const codex = codexEventText(parsed);
+  if (codex !== undefined) return codex;
   const agy = antigravityText(parsed);
   if (agy !== undefined) return agy;
   if (parsed.type === 'item.started') return null;

--- a/apps/cli/src/main.ts
+++ b/apps/cli/src/main.ts
@@ -313,7 +313,7 @@ export async function runCli(
     if (verb === 'connect') {
       const slug = args[0] ?? readCheckoutSlug(process.cwd());
       if (!slug) throw new CliError(cliUsage('connect', '<slug>'), EXIT_INPUT, '<slug>');
-      if (tty && io.stdout.isTTY && !asJson && !flags.agent && !flags.manual && !args[1]) {
+      if (tty && io.stdout.isTTY && !asJson && !flags.manual && !args[1]) {
         const { runInkRepl } = await import('./tui/host.js');
         return runInkRepl({
           api,
@@ -321,7 +321,7 @@ export async function runCli(
           io,
           token: await studioToken(api, slug),
           slug,
-          initialLine: `/connect ${slug}${flags.handoff ? ' --handoff' : ''}`,
+          initialLine: `/connect ${slug}${flags.handoff ? ' --handoff' : ''}${typeof flags.agent === 'string' ? ` --agent ${flags.agent}` : ''}`,
         });
       }
       const dest = args[1] ?? process.cwd();
@@ -330,6 +330,7 @@ export async function runCli(
         slug,
         dest,
         env,
+        interactiveRun: tty && io.stdout.isTTY ? (await import('./agy-interactive.js')).runInteractive : undefined,
         agent: typeof flags.agent === 'string' ? flags.agent : undefined,
         handoff: flags.handoff === true,
         write: (line) => io.stdout.write(`${line}\n`),

--- a/apps/cli/src/repl.ts
+++ b/apps/cli/src/repl.ts
@@ -1,3 +1,4 @@
+import type { InteractiveRun } from './agy-interactive.js';
 import { readFileSync } from 'node:fs';
 import { modelCommand } from './model-command.js';
 import { offerKitUpdate, updateKit } from './kit-update.js';
@@ -44,6 +45,7 @@ export async function handleReplLine(input: {
   abort?: Workshop['abort'];
   telemetry?: CliTelemetry;
   pendingExecution?: PendingExecution;
+  interactiveRun?: InteractiveRun;
   onWorkshop?: (ws: Workshop) => void;
   write: (s: string) => void;
   onActivity?: (activity: string) => void;

--- a/apps/cli/src/tui/host.ts
+++ b/apps/cli/src/tui/host.ts
@@ -167,6 +167,7 @@ export async function runInkRepl(input: {
           abort,
           telemetry,
           pendingExecution,
+          interactiveRun,
           onWorkshop: (opened) => {
             workshop = opened;
             opened.onActivity = session.setActivity;


### PR DESCRIPTION
Running `gamedevpl connect linia-ognia` from its parent directory offered an ambiguous agent choice and launched MCP in scratch space, ignoring the existing checkout. Connect now detects that checkout, labels local versus platform-source work, preserves unsent files, and remembers the chosen local agent. Explicit `--agent` in an interactive terminal follows the same flow. Local `/play` remains attached to that workshop.

Codex MCP now uses native interactive terminal control with workspace-write isolation and on-request user approvals, so network and MCP permission requests can be answered. It returns control to gamedevpl after exit and does not equate process completion with delivery. Headless Codex MCP is refused with guidance before minting MCP credentials. Local headless delegation remains available.

Render Codex MCP tool outcomes and edited paths instead of opaque `item.completed` bookkeeping. Unknown item bookkeeping stays quiet; agent messages and shell operations retain their existing rendering.

Validation: 359 CLI tests pass, including dirty child-checkout preservation through picker and explicit-agent paths, no workspace download/MCP call on local reuse, native MCP routing and failure handling, headless refusal, argument conversion, and event rendering. Type-check, lint and production build pass. Installed Codex accepts the native argument combination through `--help`; no paid model task or real platform write was used. Full repository tests were run; three API tests timed out on the first run. Two passed on retry; the remaining quiet-handoff timeout reproduces on clean master e7c82521c in an isolated checkout. No API code is changed.
