### PR TITLE
perf(reads): cut the lookup floor under the per-window caches

### DIFF
--- a/apps/api/src/store/firestore.ts
+++ b/apps/api/src/store/firestore.ts
@@ -292,6 +292,8 @@ export class FirestoreStore extends SubmissionFacade implements Store {
       for (const write of writes.slice(start, start + BATCH_SIZE)) write(batch);
       await batch.commit();
     }
+    // The read above seeded the session window; an erased account must not survive it.
+    this.identityStore.forgetUser(uid);
 
     return { publishedSlugs, unpublishedSlugs };
   }

--- a/apps/api/src/store/slices/identity-user-cache.test.ts
+++ b/apps/api/src/store/slices/identity-user-cache.test.ts
@@ -1,0 +1,100 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { fakeFirestore } from '../fake-firestore.js';
+import { FirestoreIdentityStore } from './identity.js';
+
+// The read floor: tier and blocks live here, window stays short.
+function withUser(tier = 'standard') {
+  const { db } = fakeFirestore();
+  const store = new FirestoreIdentityStore(db);
+  return {
+    db,
+    store,
+    seed: async (fields: Record<string, unknown> = {}) =>
+      db
+        .collection('users')
+        .doc('u1')
+        .set({ uid: 'u1', createdAt: '2026-01-01T00:00:00Z', tier, ...fields }),
+    // Writing behind the store makes a stale window visible.
+    behindTheStore: async (fields: Record<string, unknown>) =>
+      db
+        .collection('users')
+        .doc('u1')
+        .set({ uid: 'u1', ...fields }, { merge: true }),
+  };
+}
+
+describe('FirestoreIdentityStore user cache', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-09-09T10:00:00Z'));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('serves a repeat read from the window instead of Firestore', async () => {
+    const { store, seed, behindTheStore } = withUser();
+    await seed();
+    expect((await store.getUser('u1'))?.tier).toBe('standard');
+
+    await behindTheStore({ tier: 'blocked' });
+
+    expect((await store.getUser('u1'))?.tier).toBe('standard');
+  });
+
+  it('re-reads once the window is over', async () => {
+    const { store, seed, behindTheStore } = withUser();
+    await seed();
+    await store.getUser('u1');
+    await behindTheStore({ tier: 'blocked' });
+
+    vi.setSystemTime(new Date('2026-09-09T10:00:31Z'));
+
+    expect((await store.getUser('u1'))?.tier).toBe('blocked');
+  });
+
+  // A write this instance made must never be answered from before it.
+  it('drops the window on every write through the store', async () => {
+    const { store, seed } = withUser();
+    await seed();
+    await store.getUser('u1');
+
+    await store.upsertUser({ uid: 'u1', tier: 'blocked' });
+
+    expect((await store.getUser('u1'))?.tier).toBe('blocked');
+  });
+
+  it('drops it on a profile edit, a deletion request and its cancellation', async () => {
+    const { store, seed } = withUser();
+    await seed({ handle: 'ada' });
+    await store.getUser('u1');
+    await store.updateCreatorProfile('u1', { profileName: 'Ada' });
+    expect((await store.getUser('u1'))?.profileName).toBe('Ada');
+
+    await store.scheduleAccountDeletion('u1', '2026-09-09T10:00:00Z', '2026-10-09T10:00:00Z');
+    expect((await store.getUser('u1'))?.deletionScheduledFor).toBe('2026-10-09T10:00:00Z');
+
+    await store.cancelAccountDeletion('u1');
+    expect((await store.getUser('u1'))?.deletionScheduledFor).not.toBe('2026-10-09T10:00:00Z');
+  });
+
+  it('hands out copies, so a caller cannot edit what the next request reads', async () => {
+    const { store, seed } = withUser();
+    await seed();
+    const first = await store.getUser('u1');
+    first!.tier = 'admin';
+
+    expect((await store.getUser('u1'))?.tier).toBe('standard');
+  });
+
+  // Caching a missing user would hide a fresh sign-up.
+  it('never caches a missing user', async () => {
+    const { store, seed } = withUser();
+    expect(await store.getUser('u1')).toBeNull();
+
+    await seed();
+
+    expect((await store.getUser('u1'))?.uid).toBe('u1');
+  });
+});

--- a/apps/api/src/store/slices/identity-user-cache.test.ts
+++ b/apps/api/src/store/slices/identity-user-cache.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { FirestoreStore } from '../../platform/store.js';
 import { fakeFirestore } from '../fake-firestore.js';
 import { FirestoreIdentityStore } from './identity.js';
 
@@ -96,5 +97,48 @@ describe('FirestoreIdentityStore user cache', () => {
     await seed();
 
     expect((await store.getUser('u1'))?.uid).toBe('u1');
+  });
+
+  // A read in flight must not restore what a write removed.
+  it('does not repopulate from a read that started before the write', async () => {
+    const { db } = fakeFirestore();
+    await db.collection('users').doc('u1').set({ uid: 'u1', tier: 'standard' });
+
+    let release = (): void => undefined;
+    const held = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const users = db.collection('users');
+    const slow = {
+      ...db,
+      collection: (name: string) =>
+        name === 'users'
+          ? {
+              ...users,
+              doc: (id: string) => ({ ...users.doc(id), get: async () => (await held, users.doc(id).get()) }),
+            }
+          : db.collection(name),
+    } as unknown as typeof db;
+    const slowStore = new FirestoreIdentityStore(slow);
+
+    const inFlight = slowStore.getUser('u1');
+    slowStore.forgetUser('u1');
+    release();
+    await inFlight;
+
+    await db.collection('users').doc('u1').set({ uid: 'u1', tier: 'blocked' });
+    expect((await slowStore.getUser('u1'))?.tier).toBe('blocked');
+  });
+
+  // Erasure reads the user first, seeding the window it outlives.
+  it('forgets an erased account instead of authenticating it for another window', async () => {
+    const { db } = fakeFirestore();
+    const store = new FirestoreStore(db);
+    await db.collection('users').doc('u1').set({ uid: 'u1', tier: 'standard' });
+    expect((await store.getUser('u1'))?.uid).toBe('u1');
+
+    await store.deleteAccountIdentity('u1', '2026-09-09T10:00:00Z');
+
+    expect(await store.getUser('u1')).toBeNull();
   });
 });

--- a/apps/api/src/store/slices/identity.ts
+++ b/apps/api/src/store/slices/identity.ts
@@ -190,14 +190,35 @@ export class InMemoryIdentityStore implements IdentityStore {
   }
 }
 
+// Every authenticated request reads this user; it is the floor.
+const USER_CACHE_TTL_MS = 30_000;
+
+// A long-lived instance would otherwise hold every uid it ever served.
+const USER_CACHE_MAX = 2_000;
+
 export class FirestoreIdentityStore implements IdentityStore {
+  private userCache = new Map<string, { user: User; at: number }>();
+
   constructor(private db: Firestore) {}
 
+  // Tier and blocks live here, so every write drops it.
+  private dropUser(uid: string): void {
+    this.userCache.delete(uid);
+  }
+
   async getUser(uid: string): Promise<User | null> {
+    const hit = this.userCache.get(uid);
+    if (hit && Date.now() - hit.at < USER_CACHE_TTL_MS) return { ...hit.user };
     const docRef = this.db.collection('users').doc(uid);
     const snap = await docRef.get();
-    if (!snap.exists) return null;
-    return snap.data() as User;
+    if (!snap.exists) {
+      this.dropUser(uid);
+      return null;
+    }
+    const user = snap.data() as User;
+    if (this.userCache.size >= USER_CACHE_MAX) this.userCache.clear();
+    this.userCache.set(uid, { user, at: Date.now() });
+    return { ...user };
   }
 
   async getUserByHandle(handle: string): Promise<User | null> {
@@ -219,7 +240,9 @@ export class FirestoreIdentityStore implements IdentityStore {
   }
 
   async claimHandle(uid: string, handle: string, at: string): Promise<ClaimHandleResult> {
-    return claimHandleFirestore(this.db, uid, handle, at);
+    const result = await claimHandleFirestore(this.db, uid, handle, at);
+    this.dropUser(uid);
+    return result;
   }
 
   async updateCreatorProfile(
@@ -235,6 +258,7 @@ export class FirestoreIdentityStore implements IdentityStore {
       ...(patch.avatarMode !== undefined ? { avatarMode: patch.avatarMode } : {}),
     };
     await this.db.collection('users').doc(uid).set(stripUndefined(updated), { merge: true });
+    this.dropUser(uid);
     return updated;
   }
 
@@ -269,6 +293,7 @@ export class FirestoreIdentityStore implements IdentityStore {
     }
     if (released.size > 0 || user?.handle) {
       await batch.commit();
+      this.dropUser(uid);
     }
     void at;
     return [...released].sort();
@@ -285,6 +310,7 @@ export class FirestoreIdentityStore implements IdentityStore {
         deletionScheduledFor: scheduledFor,
       };
       transaction.set(ref, { deletionRequestedAt: requestedAt, deletionScheduledFor: scheduledFor }, { merge: true });
+      this.dropUser(uid);
       return updated;
     });
   }
@@ -299,6 +325,7 @@ export class FirestoreIdentityStore implements IdentityStore {
         { deletionRequestedAt: FieldValue.delete(), deletionScheduledFor: FieldValue.delete() },
         { merge: true },
       );
+      this.dropUser(uid);
       return true;
     });
   }
@@ -367,15 +394,18 @@ export class FirestoreIdentityStore implements IdentityStore {
       }
 
       transaction.set(docRef, stripUndefined(user), { merge: true });
+      this.dropUser(userData.uid);
       return user;
     });
   }
 
   async setEmailUnsubscribed(uid: string, at: string | null): Promise<void> {
     await this.db.collection('users').doc(uid).set({ emailUnsubscribedAt: at }, { merge: true });
+    this.dropUser(uid);
   }
 
   async setDigestOptOut(uid: string, at: string | null): Promise<void> {
     await this.db.collection('users').doc(uid).set({ digestOptOutAt: at }, { merge: true });
+    this.dropUser(uid);
   }
 }

--- a/apps/api/src/store/slices/identity.ts
+++ b/apps/api/src/store/slices/identity.ts
@@ -199,23 +199,29 @@ const USER_CACHE_MAX = 2_000;
 export class FirestoreIdentityStore implements IdentityStore {
   private userCache = new Map<string, { user: User; at: number }>();
 
+  // Bumped by every drop; a read in flight then stores nothing.
+  private generation = 0;
+
   constructor(private db: Firestore) {}
 
   // Tier and blocks live here, so every write drops it.
-  private dropUser(uid: string): void {
+  forgetUser(uid: string): void {
     this.userCache.delete(uid);
+    this.generation += 1;
   }
 
   async getUser(uid: string): Promise<User | null> {
     const hit = this.userCache.get(uid);
     if (hit && Date.now() - hit.at < USER_CACHE_TTL_MS) return { ...hit.user };
+    const generation = this.generation;
     const docRef = this.db.collection('users').doc(uid);
     const snap = await docRef.get();
     if (!snap.exists) {
-      this.dropUser(uid);
+      this.forgetUser(uid);
       return null;
     }
     const user = snap.data() as User;
+    if (this.generation !== generation) return { ...user };
     if (this.userCache.size >= USER_CACHE_MAX) this.userCache.clear();
     this.userCache.set(uid, { user, at: Date.now() });
     return { ...user };
@@ -241,7 +247,7 @@ export class FirestoreIdentityStore implements IdentityStore {
 
   async claimHandle(uid: string, handle: string, at: string): Promise<ClaimHandleResult> {
     const result = await claimHandleFirestore(this.db, uid, handle, at);
-    this.dropUser(uid);
+    this.forgetUser(uid);
     return result;
   }
 
@@ -258,7 +264,7 @@ export class FirestoreIdentityStore implements IdentityStore {
       ...(patch.avatarMode !== undefined ? { avatarMode: patch.avatarMode } : {}),
     };
     await this.db.collection('users').doc(uid).set(stripUndefined(updated), { merge: true });
-    this.dropUser(uid);
+    this.forgetUser(uid);
     return updated;
   }
 
@@ -293,7 +299,7 @@ export class FirestoreIdentityStore implements IdentityStore {
     }
     if (released.size > 0 || user?.handle) {
       await batch.commit();
-      this.dropUser(uid);
+      this.forgetUser(uid);
     }
     void at;
     return [...released].sort();
@@ -301,7 +307,7 @@ export class FirestoreIdentityStore implements IdentityStore {
 
   async scheduleAccountDeletion(uid: string, requestedAt: string, scheduledFor: string): Promise<User | null> {
     const ref = this.db.collection('users').doc(uid);
-    return this.db.runTransaction(async (transaction) => {
+    const outcome = await this.db.runTransaction(async (transaction) => {
       const snap = await transaction.get(ref);
       if (!snap.exists) return null;
       const updated = {
@@ -310,14 +316,15 @@ export class FirestoreIdentityStore implements IdentityStore {
         deletionScheduledFor: scheduledFor,
       };
       transaction.set(ref, { deletionRequestedAt: requestedAt, deletionScheduledFor: scheduledFor }, { merge: true });
-      this.dropUser(uid);
       return updated;
     });
+    this.forgetUser(uid);
+    return outcome;
   }
 
   async cancelAccountDeletion(uid: string): Promise<boolean> {
     const ref = this.db.collection('users').doc(uid);
-    return this.db.runTransaction(async (transaction) => {
+    const cancelled = await this.db.runTransaction(async (transaction) => {
       const snap = await transaction.get(ref);
       if (!snap.exists || !(snap.data() as User).deletionScheduledFor) return false;
       transaction.set(
@@ -325,9 +332,10 @@ export class FirestoreIdentityStore implements IdentityStore {
         { deletionRequestedAt: FieldValue.delete(), deletionScheduledFor: FieldValue.delete() },
         { merge: true },
       );
-      this.dropUser(uid);
       return true;
     });
+    this.forgetUser(uid);
+    return cancelled;
   }
 
   async listAccountsDueForDeletion(at: string, limit: number): Promise<User[]> {
@@ -362,7 +370,7 @@ export class FirestoreIdentityStore implements IdentityStore {
     const now = new Date().toISOString();
     const docRef = this.db.collection('users').doc(userData.uid);
 
-    return await this.db.runTransaction(async (transaction) => {
+    const written = await this.db.runTransaction(async (transaction) => {
       const snap = await transaction.get(docRef);
       let user: User;
 
@@ -394,18 +402,19 @@ export class FirestoreIdentityStore implements IdentityStore {
       }
 
       transaction.set(docRef, stripUndefined(user), { merge: true });
-      this.dropUser(userData.uid);
       return user;
     });
+    this.forgetUser(userData.uid);
+    return written;
   }
 
   async setEmailUnsubscribed(uid: string, at: string | null): Promise<void> {
     await this.db.collection('users').doc(uid).set({ emailUnsubscribedAt: at }, { merge: true });
-    this.dropUser(uid);
+    this.forgetUser(uid);
   }
 
   async setDigestOptOut(uid: string, at: string | null): Promise<void> {
     await this.db.collection('users').doc(uid).set({ digestOptOutAt: at }, { merge: true });
-    this.dropUser(uid);
+    this.forgetUser(uid);
   }
 }

--- a/apps/web/src/surfaces/studio/LocalActivityStatus.test.tsx
+++ b/apps/web/src/surfaces/studio/LocalActivityStatus.test.tsx
@@ -1,9 +1,15 @@
 // @vitest-environment jsdom
 import { act, createElement } from 'react';
 import { createRoot } from 'react-dom/client';
-import { expect, it, vi } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import i18n from '../../i18n/index.js';
 import { LocalActivityStatus } from './LocalActivityStatus.js';
+import {
+  LOCAL_ACTIVITY_FAST_MS,
+  LOCAL_ACTIVITY_IDLE_AFTER,
+  LOCAL_ACTIVITY_IDLE_MS,
+  nextLocalActivityDelay,
+} from './localActivityPoll.js';
 it('shows local progress, lost contact and a completed task distinctly', async () => {
   await i18n.changeLanguage('en');
   const host = document.createElement('div');
@@ -24,6 +30,54 @@ it('shows local progress, lost contact and a completed task distinctly', async (
     expect(host.textContent).toContain('Ready to send with /submit');
     expect(host.textContent).not.toContain('Contact with the CLI was lost');
   } finally {
+    await act(async () => root.unmount());
+    vi.unstubAllGlobals();
+  }
+});
+
+// An unattended guide used to poll every ten seconds forever.
+describe('nextLocalActivityDelay', () => {
+  const live = { runId: 'r', agent: 'agy', phase: 'editing', at: '2026-09-09T10:00:00Z' } as const;
+
+  it('keeps the fast cadence while a task is running', () => {
+    expect(nextLocalActivityDelay({ ...live }, 0)).toBe(LOCAL_ACTIVITY_FAST_MS);
+  });
+
+  it('stays fast for the first empty polls, so a slow start is still caught', () => {
+    expect(nextLocalActivityDelay(null, 0)).toBe(LOCAL_ACTIVITY_FAST_MS);
+    expect(nextLocalActivityDelay(null, LOCAL_ACTIVITY_IDLE_AFTER - 1)).toBe(LOCAL_ACTIVITY_FAST_MS);
+  });
+
+  it('widens once nothing has been happening', () => {
+    expect(nextLocalActivityDelay(null, LOCAL_ACTIVITY_IDLE_AFTER)).toBe(LOCAL_ACTIVITY_IDLE_MS);
+  });
+
+  // Slowly, not never: the next task appears in the same guide.
+  it('widens after a finished task rather than stopping', () => {
+    for (const phase of ['ready', 'failed', 'stopped']) {
+      expect(nextLocalActivityDelay({ ...live, phase } as typeof live, 0)).toBe(LOCAL_ACTIVITY_IDLE_MS);
+    }
+  });
+});
+
+it('asks nothing while the tab is hidden, and asks at once when it comes back', async () => {
+  await i18n.changeLanguage('en');
+  const host = document.createElement('div');
+  const root = createRoot(host);
+  const fetched = vi.fn(async () => ({ ok: true, json: async () => ({ activity: null }) }));
+  vi.stubGlobal('fetch', fetched);
+  const visibility = vi.spyOn(document, 'visibilityState', 'get').mockReturnValue('hidden');
+  try {
+    await act(async () => root.render(createElement(LocalActivityStatus, { token: 'hidden-tab' })));
+    expect(fetched).not.toHaveBeenCalled();
+
+    visibility.mockReturnValue('visible');
+    await act(async () => {
+      document.dispatchEvent(new Event('visibilitychange'));
+    });
+    expect(fetched).toHaveBeenCalledTimes(1);
+  } finally {
+    visibility.mockRestore();
     await act(async () => root.unmount());
     vi.unstubAllGlobals();
   }

--- a/apps/web/src/surfaces/studio/LocalActivityStatus.tsx
+++ b/apps/web/src/surfaces/studio/LocalActivityStatus.tsx
@@ -1,6 +1,8 @@
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import type { LocalActivity } from '@gamedevpl/contract';
+import { LOCAL_ACTIVITY_TERMINAL, nextLocalActivityDelay } from './localActivityPoll.js';
+
 export function LocalActivityStatus({ token }: { token: string }) {
   const { t } = useTranslation();
   const [activity, setActivity] = useState<LocalActivity | null>(null);
@@ -8,7 +10,19 @@ export function LocalActivityStatus({ token }: { token: string }) {
   useEffect(() => {
     let disposed = false;
     let controller: AbortController | undefined;
-    const poll = async () => {
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    let empty = 0;
+    let latest: LocalActivity | null = null;
+
+    const hidden = (): boolean => typeof document !== 'undefined' && document.visibilityState === 'hidden';
+
+    const schedule = (): void => {
+      if (disposed || hidden()) return;
+      timer = setTimeout(() => void poll(), nextLocalActivityDelay(latest, empty));
+    };
+
+    const poll = async (): Promise<void> => {
+      if (disposed || hidden()) return;
       setNow(Date.now());
       controller?.abort();
       controller = new AbortController();
@@ -19,23 +33,39 @@ export function LocalActivityStatus({ token }: { token: string }) {
         });
         if (!response.ok) return;
         const body = (await response.json()) as { activity: LocalActivity | null };
+        latest = body.activity;
+        empty = body.activity ? 0 : empty + 1;
         if (!disposed) setActivity(body.activity);
       } catch {
         // Preserve the last observation and its age.
       } finally {
         clearTimeout(timeout);
+        schedule();
       }
     };
+
+    // A tab coming back asks at once, at the fast cadence.
+    const onVisible = (): void => {
+      if (hidden()) {
+        clearTimeout(timer);
+        return;
+      }
+      empty = 0;
+      clearTimeout(timer);
+      void poll();
+    };
+
     void poll();
-    const timer = setInterval(() => void poll(), 10_000);
+    document.addEventListener('visibilitychange', onVisible);
     return () => {
       disposed = true;
       controller?.abort();
-      clearInterval(timer);
+      clearTimeout(timer);
+      document.removeEventListener('visibilitychange', onVisible);
     };
   }, [token]);
   if (!activity) return null;
-  const terminal = ['ready', 'failed', 'stopped'].includes(activity.phase);
+  const terminal = LOCAL_ACTIVITY_TERMINAL.includes(activity.phase);
   const phase = !terminal && now - Date.parse(activity.at) > 45_000 ? 'offline' : activity.phase;
   return (
     <div className="connect-guide-wait" role="status">

--- a/apps/web/src/surfaces/studio/localActivityPoll.ts
+++ b/apps/web/src/surfaces/studio/localActivityPoll.ts
@@ -1,0 +1,18 @@
+import type { LocalActivity } from '@gamedevpl/contract';
+
+// Fast enough to catch a start, slow enough to idle cheaply.
+export const LOCAL_ACTIVITY_FAST_MS = 10_000;
+export const LOCAL_ACTIVITY_IDLE_MS = 60_000;
+
+// Widen only after a run of empty polls, never immediately.
+export const LOCAL_ACTIVITY_IDLE_AFTER = 6;
+
+export const LOCAL_ACTIVITY_TERMINAL = ['ready', 'failed', 'stopped'];
+
+// A finished task still polls slowly; the next one appears here.
+export function nextLocalActivityDelay(activity: LocalActivity | null, emptyPolls: number): number {
+  if (activity) {
+    return LOCAL_ACTIVITY_TERMINAL.includes(activity.phase) ? LOCAL_ACTIVITY_IDLE_MS : LOCAL_ACTIVITY_FAST_MS;
+  }
+  return emptyPolls >= LOCAL_ACTIVITY_IDLE_AFTER ? LOCAL_ACTIVITY_IDLE_MS : LOCAL_ACTIVITY_FAST_MS;
+}

--- a/docs/firestore-read-cost.md
+++ b/docs/firestore-read-cost.md
@@ -30,6 +30,7 @@ Two corollaries, both of which have been got wrong here:
 | notify sweep health scan   | 2 min | 10 min | recording a verdict (`notify-sweep-routes.ts`)                                              |
 | `/api/review/status` badge | 2 min | 10 min | the reviewer's own verdict; an operator's sweep change or requeue (`review-queue-cache.ts`) |
 | `/api/notifications` bell  | 1 min | 5 min  | creating, reading or clearing a notification (`notification-cache.ts`)                      |
+| Studio connect guide       | 10 s  | —      | reads one document by id; cadence widens instead (`LocalActivityStatus.tsx`)                |
 
 Per-user surfaces — the reviewer badge and the bell — key their windows by uid, and the
 bell keys by store as well, so one person's queue can never answer another's poll. That
@@ -45,17 +46,44 @@ that needs that, and do not write it down as a guarantee. Making own-write fresh
 across instances needs shared invalidation (a durable version key both instances read),
 which is not what a badge is worth.
 
+## The floor underneath the windows
+
+Every one of those windows removes a _collection scan_. None of them removes the read that
+happens before the route runs: `getSessionUser` reads `users/{uid}` on **every
+authenticated request**, so a signed-in tab pays one document lookup per poll, per
+surface, forever. Four polled surfaces on one open tab is a few thousand reads a day
+before any route does its own work.
+
+Two things bound it:
+
+1. **`FirestoreIdentityStore` holds the session user for 30 seconds** and drops the entry
+   on every write through the store — profile edits, tier changes, deletion requests. It
+   is deliberately much shorter than the content windows above, because `tier` and the
+   block live on that document. The cost is real and must be stated: a block applied
+   **outside** the app, or on another instance, is enforced up to 30 seconds late. A block
+   applied through the API is immediate on the instance that applied it.
+2. **A poll that has nothing to report widens itself.** The connect guide asked every ten
+   seconds whether a local agent was running, whether or not one existed, and rendered
+   nothing when the answer was no — an invisible ~17K reads a day for one forgotten tab.
+   It now polls fast while a task runs, widens to a minute once six polls in a row come
+   back empty or the task finishes, and stops entirely while the tab is hidden.
+
+The general rule this leaves: **a poll's cost is its cadence times its cheapest possible
+answer, and "nothing to show" is the answer it will give most of the time.**
+
 ## Measuring
 
 ```bash
-gcloud monitoring time-series list \
-  --filter='metric.type="firestore.googleapis.com/document/read_count"' \
-  --format=json
+infra/read-cost-report.sh        # trailing day, split by type
+infra/read-cost-report.sh 7d     # a full working week
 ```
 
-Split by `metric.label.type` (QUERY / LOOKUP / NOT_FOUND). QUERY is where polling shows
-up; a flat per-minute count with no cadence means browser tabs, not Cloud Scheduler —
-check the request log for the route before going looking for a job.
+The split by `metric.label.type` (QUERY / LOOKUP / NOT_FOUND) is the whole point, and it
+decides which half of this document the next fix belongs in. QUERY is a collection scan —
+a cache window is missing or a window got dropped. LOOKUP is per-document fan-out on a
+request path: the session read, or a route fetching documents by id. A flat per-minute
+count with no cadence means browser tabs, not Cloud Scheduler — check the request log for
+the route before going looking for a job.
 
 ## Alerting
 
@@ -68,11 +96,13 @@ fires for a regression the size of the one it was written for.
 Rate alone is not enough. A30 evaluates a rate in two windows (ten minutes for a spike,
 three hours for drift), and both are blind to the shape that actually produced the 2026-09
 bill: a regression that adds a couple of reads a second, never peaks, and never stops. So
-`setup-monitoring.sh` also defines **A31**, the *daily total* — `ALIGN_DELTA` over 86400s
+`setup-monitoring.sh` also defines **A31**, the _daily total_ — `ALIGN_DELTA` over 86400s
 with `REDUCE_SUM`, firing above **600K reads in the trailing day**, roughly 1.6× the
 ~364K/day pace measured on 2026-09-08 and well under the ~800K/day the incident billed. It
 is the slowest signal in the file on purpose: if it fires while A30 stayed quiet, nothing
 spiked — something got permanently more expensive per request, so compare the day against
 the previous week to find the step change and match it to a deploy. Both thresholds are
 calibrated against a floor the badge fix above removes; **re-derive them together** from a
-full working week of post-fix numbers rather than from an estimate.
+full working week of post-fix numbers rather than from an estimate — `read-cost-report.sh`
+is what that measurement looks like, and the type split belongs in the PR that moves a
+threshold.

--- a/infra/read-cost-report.sh
+++ b/infra/read-cost-report.sh
@@ -18,7 +18,28 @@
 # re-deriving either, and record the numbers in the PR that changes them.
 set -euo pipefail
 
+# GNU date rejects "-1d"; BSD date rejects "1 day ago". Take a plain shorthand and
+# hand each the form it understands.
 WINDOW="${1:-1d}"
+AMOUNT="${WINDOW%[dh]}"
+UNIT="day"
+case "$WINDOW" in
+  *h) UNIT="hour" ;;
+  *d | *[0-9]) UNIT="day" ;;
+  *)
+    echo "Window must look like 1d, 7d or 12h" >&2
+    exit 1
+    ;;
+esac
+if ! [ "$AMOUNT" -gt 0 ] 2>/dev/null; then
+  echo "Window must look like 1d, 7d or 12h" >&2
+  exit 1
+fi
+
+started_at() {
+  date -u -d "$AMOUNT $UNIT ago" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null ||
+    date -u -v"-${AMOUNT}${UNIT:0:1}" +%Y-%m-%dT%H:%M:%SZ
+}
 PROJECT_ID="${PROJECT_ID:-$(gcloud config get-value project 2>/dev/null || true)}"
 
 if [ -z "$PROJECT_ID" ] || [ "$PROJECT_ID" = "(unset)" ]; then
@@ -35,7 +56,7 @@ gcloud monitoring time-series list \
   --project "$PROJECT_ID" \
   --filter='metric.type="firestore.googleapis.com/document/read_count"' \
   --interval-end-time="$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
-  --interval-start-time="$(date -u -d "-$WINDOW" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u -v"-$WINDOW" +%Y-%m-%dT%H:%M:%SZ)" \
+  --interval-start-time="$(started_at)" \
   --format=json |
   node -e '
     let raw = "";

--- a/infra/read-cost-report.sh
+++ b/infra/read-cost-report.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+#
+# Splits Firestore document reads by type, so a recalibration is done against measurement
+# rather than an estimate. Read-only: it lists time series and prints totals.
+#
+#   infra/read-cost-report.sh                 # the trailing day, per type
+#   infra/read-cost-report.sh 7d              # the trailing week
+#   PROJECT_ID=other infra/read-cost-report.sh
+#
+# Why the split matters. docs/firestore-read-cost.md fixed QUERY reads: a collection scan
+# on a polled path, once per request. What no per-window cache removes is the LOOKUP
+# floor -- one users/{uid} read per authenticated request, plus whatever documents the
+# route itself fetches by id. If the day is mostly LOOKUP, the next fix is the session
+# read and the poll cadences, not another cache; if it is mostly QUERY, a scan came back.
+#
+# A30 (read rate) and A31 (daily total) in setup-monitoring.sh are both calibrated against
+# a floor that the badge and poll fixes move. Run this over a full working week before
+# re-deriving either, and record the numbers in the PR that changes them.
+set -euo pipefail
+
+WINDOW="${1:-1d}"
+PROJECT_ID="${PROJECT_ID:-$(gcloud config get-value project 2>/dev/null || true)}"
+
+if [ -z "$PROJECT_ID" ] || [ "$PROJECT_ID" = "(unset)" ]; then
+  echo "Set PROJECT_ID, or run: gcloud config set project <id>" >&2
+  exit 1
+fi
+
+echo "Firestore document reads, project $PROJECT_ID, trailing $WINDOW"
+echo
+
+# ALIGN_DELTA + REDUCE_SUM per type is the same shape A31 alerts on, so the number here
+# and the number that fires are derived the same way.
+gcloud monitoring time-series list \
+  --project "$PROJECT_ID" \
+  --filter='metric.type="firestore.googleapis.com/document/read_count"' \
+  --interval-end-time="$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+  --interval-start-time="$(date -u -d "-$WINDOW" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u -v"-$WINDOW" +%Y-%m-%dT%H:%M:%SZ)" \
+  --format=json |
+  node -e '
+    let raw = "";
+    process.stdin.on("data", (chunk) => (raw += chunk));
+    process.stdin.on("end", () => {
+      const series = JSON.parse(raw || "[]");
+      const totals = new Map();
+      for (const row of series) {
+        const type = row.metric?.labels?.type ?? "UNKNOWN";
+        const sum = (row.points ?? []).reduce((acc, point) => acc + Number(point.value?.int64Value ?? 0), 0);
+        totals.set(type, (totals.get(type) ?? 0) + sum);
+      }
+      const all = [...totals.values()].reduce((acc, value) => acc + value, 0);
+      if (all === 0) {
+        console.log("No points in this window. Check the project and that the API is serving traffic.");
+        return;
+      }
+      for (const [type, value] of [...totals].sort((a, b) => b[1] - a[1])) {
+        console.log(`${type.padEnd(10)} ${String(value).padStart(12)}  ${Math.round((value / all) * 100)}%`);
+      }
+      console.log(`${"TOTAL".padEnd(10)} ${String(all).padStart(12)}`);
+      console.log();
+      console.log("LOOKUP is per-document fan-out on a request path (session reads, reads by id).");
+      console.log("QUERY is a collection scan. The free tier is 50K reads/day.");
+    });
+  '


### PR DESCRIPTION
Follow-up to the read-cost work (#1237, #1244, #1240, A30/A31). Those removed **collection scans** — a query on a polled path, once per request. This removes the floor underneath them, which no per-window cache touches.

`getSessionUser` reads `users/{uid}` on **every authenticated request** (`apps/api/src/platform/auth.ts:371` → `FirestoreIdentityStore.getUser`, an uncached `doc.get()`). A signed-in tab therefore pays one document lookup per poll, per surface, before the route does any work of its own.

## 1. The poll that cost the most and showed the least

`LocalActivityStatus` (from #1243) polled `/api/me/studio/local-activity/:token` **every 10 seconds, unconditionally while mounted** — it sits at the top of the connect guide, and renders `null` when there is no activity, so the cost was invisible. Each poll is 2 reads (session user + submission): **~17K reads/day for one forgotten tab, about a third of the 50K/day free tier.**

Now: fast (10s) while a task is running, widened to 60s after six empty polls or a finished task, and **nothing at all while the tab is hidden** (immediate poll when it comes back). It widens rather than stops, because the creator's *next* local task appears in that same guide — stopping on `ready` would have been a silent regression.

## 2. A short window on the session user

`FirestoreIdentityStore` now holds the user for **30 seconds** and drops the entry on every write through the store (profile edit, upsert, handle claim/release, deletion request and cancellation, email/digest flags). Copies go out, so a caller mutating the result cannot poison the next request's answer; a missing user is never cached, so a fresh sign-up is not hidden for a window.

**The cost, stated plainly:** `tier` and the block live on that document. A block applied through the API is immediate on the instance that applied it; a block applied **outside** the app, or served by one of the other instances (`--max-instances 4`), is enforced **up to 30 seconds late**. That is why the window is 30s and not the minutes the content caches use. If that trade is not acceptable, the honest alternative is widening the poll cadences instead, and this half can be dropped — the poll fix stands on its own.

## 3. Measuring, before the 2026-09-15 recalibration

`infra/read-cost-report.sh` splits `document/read_count` by `metric.label.type` for a chosen window. The split decides where the next fix belongs: **QUERY** means a scan came back, **LOOKUP** means a request path fans out per document (the session read, reads by id). A30 and A31 are both calibrated against a floor that the two changes above move, and the doc already says to re-derive them together from a full working week — this is what that measurement looks like. I could not run it from here (no `gcloud` in this environment), so the numbers still have to come from a real run.

`docs/firestore-read-cost.md` gains the floor as its own section, the connect guide as a row in the surface table, and the rule this left behind:

> A poll's cost is its cadence times its cheapest possible answer, and "nothing to show" is the answer it will give most of the time.

## Verified

- 6 new store tests: the window serves a repeat read, expires after 30s, is dropped by writes (upsert, profile, deletion request and cancellation), hands out copies, and never caches a missing user.
- 5 new web tests: the cadence table (`nextLocalActivityDelay`), and a hidden tab that asks nothing until it is shown.
- `apps/api` 4032 tests green (the 40 logged errors are moderation fail-closed paths asserting themselves, not failures) · store + auth + studio 158 green · API and web type-check green · `npm run lint` green.
- Note, unrelated to this diff: `CodeSurfaceAgentMode` (2) and `EditorSurface` (2) fail identically on a clean master checkout in this environment — the same four #1202 recorded. Not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AJNcxBU2JJg3mPykeMqLGw

---
_Generated by [Claude Code](https://claude.ai/code/session_01AJNcxBU2JJg3mPykeMqLGw)_