### PR TITLE
feat(cli): add push alongside pull

### DIFF
--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -7,6 +7,10 @@ decides the next version — see [`.claude/skills/cli-release/SKILL.md`](../../.
 
 ## Unreleased
 
+### Added
+
+- Use `/push` or `gamedevpl push` to deliver local changes as a preview; `/submit` remains supported (#TBD).
+
 ### Fixed
 
 - Make terminal conversations easier to scan with colored roles, checks, links and clearer spacing (#1259).

--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -9,7 +9,7 @@ decides the next version — see [`.claude/skills/cli-release/SKILL.md`](../../.
 
 ### Added
 
-- Use `/push` or `gamedevpl push` to deliver local changes as a preview; `/submit` remains supported (#TBD).
+- Use `/push` or `gamedevpl push` to deliver local changes as a preview; `/submit` remains supported (#1255).
 
 ### Fixed
 

--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -285,3 +285,7 @@ When Antigravity cannot ask for a permission in headless mode, the interactive C
 ### Recover an open agent session
 
 If a previous MCP agent stopped without ending its session, preview delivery can remain locked. The interactive delivery prompt offers to disconnect that session and deliver the local checkout. For an explicit retry, use `/submit --takeover` or `gamedevpl submit --takeover [dir]`. This revokes the previous session key and sends the full local file snapshot after checks pass. It does not stop the local agent process, so stop that process first if it is still editing your checkout. Old server staging stays in the previous generation; it is not mixed into your local delivery. Managed agents and pending handoffs must finish through Studio. `--force` alone never takes over an agent session.
+
+### Push local changes
+
+Use `/push` in the checkout session, or `gamedevpl push [dir]`, to run checks and deliver a preview. `/pull` brings platform changes into the checkout. `/submit` remains an alias for `/push`; neither publishes publicly unless you explicitly pass `--publish`.

--- a/apps/cli/src/argv.ts
+++ b/apps/cli/src/argv.ts
@@ -21,6 +21,7 @@ export const SLASH_VERBS = [
   'whoami',
   'submit',
   'pull',
+  'push',
   'diff',
   'update',
 ] as const;

--- a/apps/cli/src/help.test.ts
+++ b/apps/cli/src/help.test.ts
@@ -8,7 +8,7 @@ describe('formatHelp', () => {
     expect(out).not.toMatch(/gamedevpl <[a-z]+\|/);
     expect(out).toContain('open a browser and sign in');
     expect(out).toContain('interactive conversation');
-    expect(out).toMatch(/submit\s+deliver sources after the local ladder/);
+    expect(out).toMatch(/push\s+send local changes as a preview/);
     for (const verb of SLASH_VERBS) {
       expect(out).toMatch(new RegExp(`^  ${verb}\\s+\\S`, 'm'));
     }

--- a/apps/cli/src/help.ts
+++ b/apps/cli/src/help.ts
@@ -23,7 +23,8 @@ export const BLURB: Record<SlashVerb, string> = {
   login: 'open a browser and sign in',
   logout: 'forget the stored grant',
   whoami: 'print the signed-in identity',
-  submit: 'deliver sources after the local ladder',
+  submit: 'alias for push — deliver a preview from local files',
+  push: 'send local changes as a preview after checks — push [dir] [--publish]',
   pull: 'update a checkout from the platform',
   diff: 'three-way sync against the checkout base',
   update: 'install a newer CLI',
@@ -37,7 +38,7 @@ export function formatHelp(slash = false): string {
         `${CLI_BIN} ${CLI_VERSION}`,
         '',
         '  type to talk — a game starts when you ask · /quit to leave',
-        '  in a checkout: say what to change; a local agent edits it, /submit delivers',
+        '  in a checkout: say what to change; a local agent edits it, /push delivers a preview',
         '  /retry resumes a task waiting for builder handoff',
         '',
       ]

--- a/apps/cli/src/main.ts
+++ b/apps/cli/src/main.ts
@@ -295,10 +295,10 @@ export async function runCli(
       }
       return EXIT_GREEN;
     }
-    if (verb === 'submit') {
+    if (verb === 'submit' || verb === 'push') {
       const dest = args[0] ?? process.cwd();
       const slug = (typeof flags.slug === 'string' ? flags.slug : null) ?? readCheckoutSlug(dest);
-      if (!slug) throw new CliError(cliUsage('submit', '[dir]'), EXIT_INPUT, '--slug');
+      if (!slug) throw new CliError(cliUsage(verb, '[dir]'), EXIT_INPUT, '--slug');
       const result = await submitGame({
         api,
         slug,

--- a/apps/cli/src/repl.test.ts
+++ b/apps/cli/src/repl.test.ts
@@ -207,7 +207,7 @@ describe('repl turn loop', () => {
     expect(lines.join('\n')).toContain('gamedevpl login');
   });
 
-  it('treats /submit dest like the one-shot verb, not as a slug', async () => {
+  it.each(['submit', 'push'])('treats /%s dest like the one-shot verb, not as a slug', async (verb) => {
     const dest = mkdtempSync(join(tmpdir(), 'gdpl-repl-sub-'));
     writeGameFiles(dest, 'ghost-roads', [{ path: 'game.ts', content: 'A' }]);
     writeBase(dest, 'v1', [{ path: 'game.ts', content: 'A' }]);
@@ -235,7 +235,7 @@ describe('repl turn loop', () => {
       },
     });
     const delivered = await handleReplLine({
-      line: `/submit --slug ghost-roads ${dest}`,
+      line: `/${verb} --slug ghost-roads ${dest}`,
       api,
       token: 'tok',
       write: (s) => lines.push(s),
@@ -246,13 +246,13 @@ describe('repl turn loop', () => {
 
     lines.length = 0;
     const missing = await handleReplLine({
-      line: '/submit not-a-checkout',
+      line: `/${verb} not-a-checkout`,
       api,
       token: 'tok',
       write: (s) => lines.push(s),
     });
     expect(missing.next).toBe('continue');
-    expect(lines.join('\n')).toContain('gamedevpl submit [dir]');
+    expect(lines.join('\n')).toContain(`gamedevpl ${verb} [dir]`);
     expect(seen.some((path) => path.includes('/studio/games/not-a-checkout/'))).toBe(false);
   });
 

--- a/apps/cli/src/repl.ts
+++ b/apps/cli/src/repl.ts
@@ -144,13 +144,13 @@ export async function handleReplLine(input: {
       }
       return { next: 'continue', conversationId: input.conversationId };
     }
-    if (cmd === 'submit') {
+    if (cmd === 'submit' || cmd === 'push') {
       try {
-        const parsed = parseArgv(['node', 'cli', 'submit', ...rest]);
+        const parsed = parseArgv(['node', 'cli', cmd, ...rest]);
         const dest = parsed.args[0] ?? input.workshop?.root ?? process.cwd();
         const slug = (typeof parsed.flags.slug === 'string' ? parsed.flags.slug : null) ?? readCheckoutSlug(dest);
         if (!slug) {
-          input.write(`run it as ${cliUsage('submit', '[dir]')}`);
+          input.write(`run it as ${cliUsage(cmd, '[dir]')}`);
           return { next: 'continue', conversationId: input.conversationId };
         }
         const result = await submitGame({

--- a/apps/cli/src/tui/completion.test.ts
+++ b/apps/cli/src/tui/completion.test.ts
@@ -10,7 +10,7 @@ describe('command suggestions', () => {
     }
   });
   it('filters the command name, not prose or arguments', () => {
-    expect(commandSuggestions('/PU').map((item) => item.command)).toEqual(['/pull']);
+    expect(commandSuggestions('/PU').map((item) => item.command)).toEqual(['/pull', '/push']);
     for (const draft of ['', 'play', 'please /pu', '/play airtime', '/play ', '/unknown']) {
       expect(commandSuggestions(draft)).toEqual([]);
     }


### PR DESCRIPTION
Adds `/push` and `gamedevpl push [dir]` alongside `/pull`. Push runs the existing submission checks and delivers a preview; `/submit` remains supported and explicit `--publish` keeps its existing behavior. Help and completion expose both commands.

Validation: full type-check, lint, test suite and build pass. CLI: 361 tests. Regression coverage checks both REPL names and completion.
