### PR TITLE
fix(cli): recover delivery from an open agent session

### DIFF
--- a/.claude/skills/byoca-mcp/SKILL.md
+++ b/.claude/skills/byoca-mcp/SKILL.md
@@ -1078,3 +1078,7 @@ the Studio live-preview frame, which additionally takes no pointer input and no 
 
 If you change the MCP tool set, submit warnings, stall vocabulary, or handoff rules
 and this file is wrong or missing the new behaviour, update it in the same session.
+
+### Creator takeover for local delivery
+
+`GET /api/me/studio/games/:slug/sources/session` reports a live lock and its job/generation. The owner can explicitly `POST` the same job/generation with `stopAgent: true` to disconnect an own-agent session before delivering local files. The atomic takeover increments generation and marks the session ended, preserving round budgets and published/preview versions. It refuses managed agents, closed rounds, pending handoffs, and changed generations. The old staging remains isolated in the previous generation; the CLI stages a full local snapshot. `/submit --takeover` is explicit authorization; `--force` is not. This revokes session access, not the local OS process.

--- a/apps/api/src/creation/creator-code.ts
+++ b/apps/api/src/creation/creator-code.ts
@@ -1,5 +1,6 @@
 import type { FastifyInstance } from 'fastify';
 import { z } from 'zod';
+import { registerCreatorTakeover } from './creator-takeover.js';
 import {
   assembleGameHtml,
   CredentialLeakError,
@@ -239,6 +240,8 @@ export async function registerCreatorCodeRoutes(
     }
     return { record, slug };
   }
+
+  registerCreatorTakeover(app, { store, resolveForSlug, invalidate: options.invalidateStatusCache, now: options.now });
 
   /**
    * GET /api/me/studio/games/:slug/sources (CE-03).

--- a/apps/api/src/creation/creator-takeover.test.ts
+++ b/apps/api/src/creation/creator-takeover.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it } from 'vitest';
+import { buildOAuthApp, enableCliSurface, mintCreatorTokens, seedSelfRound } from '../platform/oauth-cli-test-app.js';
+import { buildApp } from '../platform/app.js';
+import { InMemoryStore } from '../platform/store.js';
+import { mintAgentToken } from '../platform/agent-token.js';
+import { mintSessionToken, SESSION_COOKIE_NAME } from '../platform/auth.js';
+
+const secret = 'test-takeover-secret';
+const url = '/api/me/studio/games/sky-dodge/sources/session';
+async function setup() {
+  const store = new InMemoryStore();
+  await store.upsertUser({ uid: 'g:creator' });
+  await store.upsertUser({ uid: 'g:other' });
+  await store.createSubmission(10, 'g:creator', 'Sky Dodge');
+  await store.setSubmissionSlug(10, 'sky-dodge');
+  await store.setRoundBuilder(10, 'self');
+  await store.ensureRoundGeneration(10);
+  await store.recordJobTransition(10, { to: 'building', at: new Date().toISOString(), by: 'agent', reason: 'started' });
+  await store.recordDispatch(10, { backend: 'self', ref: 'local-session' });
+  const app = await buildApp({
+    store,
+    sessionSecret: secret,
+    submissionRoutes: { submissionTokenSecret: secret },
+    creatorCodeRoutes: { store },
+  });
+  const headers = { cookie: `${SESSION_COOKIE_NAME}=${mintSessionToken('g:creator', secret)}` };
+  return { app, store, headers };
+}
+describe('creator takeover', () => {
+  it('accepts the CLI creator OAuth grant at the real route boundary', async () => {
+    const restore = enableCliSurface();
+    const store = new InMemoryStore();
+    await store.upsertUser({ uid: 'g:creator' });
+    await seedSelfRound(store);
+    await store.ensureRoundGeneration(42);
+    await store.recordDispatch(42, { backend: 'self', ref: 'cli-agent' });
+    const app = await buildOAuthApp(store);
+    try {
+      const tokens = await mintCreatorTokens(app);
+      const headers = { authorization: `Bearer ${tokens.access_token}` };
+      const route = '/api/me/studio/games/comet-courier/sources/session';
+      expect((await app.inject({ url: route, headers })).statusCode).toBe(200);
+      expect(
+        (
+          await app.inject({
+            method: 'POST',
+            url: route,
+            headers,
+            payload: { jobId: 42, generation: 1, stopAgent: true },
+          })
+        ).statusCode,
+      ).toBe(200);
+    } finally {
+      await app.close();
+      restore();
+    }
+  });
+  it('revokes the old agent key without resetting budgets or publishing', async () => {
+    const { app, store, headers } = await setup();
+    try {
+      await store.incrementRoundDeliveryCount(10);
+      await store.incrementRoundSubmitAttempts(10);
+      await store.setSubmissionPreviewVersion(10, 'existing-preview');
+      const before = (await store.getSubmission(10))!;
+      const probe = await app.inject({ url, headers });
+      expect(probe.json()).toMatchObject({ locked: true, canTakeOver: true, generation: 1 });
+      const response = await app.inject({
+        method: 'POST',
+        url,
+        headers,
+        payload: { jobId: 10, generation: 1, stopAgent: true },
+      });
+      expect(response.statusCode).toBe(200);
+      const after = (await store.getSubmission(10))!;
+      expect(after).toMatchObject({ state: before.state, roundGeneration: 2, agentEndedBy: 'end' });
+      expect(after.roundDeliveryCount).toBe(1);
+      expect(after.roundSubmitAttempts).toBe(1);
+      expect(after.previewVersion).toBe(before.previewVersion);
+      expect((await app.inject({ url, headers })).json().locked).toBe(false);
+      const oldWrite = await app.inject({
+        method: 'POST',
+        url: '/api/agent/build/progress',
+        headers: { authorization: `Bearer ${mintAgentToken(10, secret, { roundGeneration: 1 })}` },
+        payload: { text: 'old agent' },
+      });
+      expect(oldWrite.statusCode).toBe(401);
+      expect(await store.listBuildEvents(10)).toHaveLength(0);
+    } finally {
+      await app.close();
+    }
+  });
+  it('requires ownership, confirmation and the exact round seen by the creator', async () => {
+    const { app, store, headers } = await setup();
+    try {
+      const payload = { jobId: 10, generation: 1, stopAgent: true };
+      expect(
+        (
+          await app.inject({
+            method: 'POST',
+            url,
+            headers: { cookie: `${SESSION_COOKIE_NAME}=${mintSessionToken('g:other', secret)}` },
+            payload,
+          })
+        ).statusCode,
+      ).toBe(404);
+      expect(
+        (await app.inject({ method: 'POST', url, headers, payload: { ...payload, stopAgent: false } })).statusCode,
+      ).toBe(400);
+      await store.bumpRoundGeneration(10);
+      expect((await app.inject({ method: 'POST', url, headers, payload })).statusCode).toBe(409);
+      expect((await store.getSubmission(10))!.agentEndedAt).toBeUndefined();
+    } finally {
+      await app.close();
+    }
+  });
+  it.each(['platform', 'closed', 'pending', 'submitted', 'publishing'] as const)('refuses a %s round', async (kind) => {
+    const { app, store, headers } = await setup();
+    try {
+      if (kind === 'submitted' || kind === 'publishing')
+        await store.recordJobTransition(10, {
+          to: kind,
+          at: new Date().toISOString(),
+          by: 'agent',
+          reason: 'delivery',
+        });
+      if (kind === 'platform') await store.setRoundBuilder(10, 'platform');
+      if (kind === 'closed')
+        await store.recordJobTransition(10, {
+          to: 'ready_for_review',
+          at: new Date().toISOString(),
+          by: 'agent',
+          reason: 'done',
+        });
+      if (kind === 'pending') await store.requestBuilderHandoff(10, 'platform', new Date().toISOString());
+      expect(
+        (await app.inject({ method: 'POST', url, headers, payload: { jobId: 10, generation: 1, stopAgent: true } }))
+          .statusCode,
+      ).toBe(409);
+    } finally {
+      await app.close();
+    }
+  });
+});

--- a/apps/api/src/creation/creator-takeover.ts
+++ b/apps/api/src/creation/creator-takeover.ts
@@ -1,5 +1,6 @@
 import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
 import { z } from 'zod';
+import { resolveJobState } from './job-state.js';
 import type { Store, SubmissionRecord } from '../platform/store.js';
 import { codeSurfaceEnabled, isLiveAgentRound } from './code-surface.js';
 
@@ -32,8 +33,8 @@ export function registerCreatorTakeover(
         locked &&
         (record.builder ?? record.defaultBuilder) === 'self' &&
         !record.builderHandoff &&
-        record.state !== 'submitted' &&
-        record.state !== 'publishing',
+        resolveJobState(record) !== 'submitted' &&
+        resolveJobState(record) !== 'publishing',
     };
   });
   app.post<{ Params: { slug: string } }>(route, config, async (request, reply) => {

--- a/apps/api/src/creation/creator-takeover.ts
+++ b/apps/api/src/creation/creator-takeover.ts
@@ -25,6 +25,7 @@ export function registerCreatorTakeover(
     if (!resolved) return reply;
     const { record } = resolved;
     const locked = isLiveAgentRound(record);
+    const state = resolveJobState(record);
     return {
       locked,
       jobId: record.jobId,
@@ -33,8 +34,8 @@ export function registerCreatorTakeover(
         locked &&
         (record.builder ?? record.defaultBuilder) === 'self' &&
         !record.builderHandoff &&
-        resolveJobState(record) !== 'submitted' &&
-        resolveJobState(record) !== 'publishing',
+        state !== 'submitted' &&
+        state !== 'publishing',
     };
   });
   app.post<{ Params: { slug: string } }>(route, config, async (request, reply) => {

--- a/apps/api/src/creation/creator-takeover.ts
+++ b/apps/api/src/creation/creator-takeover.ts
@@ -1,0 +1,68 @@
+import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
+import { z } from 'zod';
+import type { Store, SubmissionRecord } from '../platform/store.js';
+import { codeSurfaceEnabled, isLiveAgentRound } from './code-surface.js';
+
+type Request = FastifyRequest<{ Params: { slug: string } }>;
+export function registerCreatorTakeover(
+  app: FastifyInstance,
+  options: {
+    store: Store;
+    resolveForSlug: (
+      request: Request,
+      reply: FastifyReply,
+    ) => Promise<{ record: SubmissionRecord; slug: string } | null>;
+    invalidate?: (jobId: number) => void;
+    now?: () => number;
+  },
+): void {
+  const route = '/api/me/studio/games/:slug/sources/session';
+  const config = { config: { rateLimit: { max: 60, timeWindow: '1 minute' } } };
+  app.get<{ Params: { slug: string } }>(route, config, async (request, reply) => {
+    if (!codeSurfaceEnabled()) return reply.code(404).send({ error: 'not found' });
+    const resolved = await options.resolveForSlug(request, reply);
+    if (!resolved) return reply;
+    const { record } = resolved;
+    const locked = isLiveAgentRound(record);
+    return {
+      locked,
+      jobId: record.jobId,
+      generation: record.roundGeneration ?? 1,
+      canTakeOver:
+        locked &&
+        (record.builder ?? record.defaultBuilder) === 'self' &&
+        !record.builderHandoff &&
+        record.state !== 'submitted' &&
+        record.state !== 'publishing',
+    };
+  });
+  app.post<{ Params: { slug: string } }>(route, config, async (request, reply) => {
+    if (!codeSurfaceEnabled()) return reply.code(404).send({ error: 'not found' });
+    const resolved = await options.resolveForSlug(request, reply);
+    if (!resolved) return reply;
+    const parsed = z
+      .object({
+        jobId: z.number().int().positive(),
+        generation: z.number().int().positive(),
+        stopAgent: z.literal(true),
+      })
+      .safeParse(request.body);
+    if (!parsed.success) return reply.code(400).send({ error: 'explicit agent takeover confirmation required' });
+    const { record } = resolved;
+    if (
+      parsed.data.jobId !== record.jobId ||
+      !(await options.store.takeOverAgentRound(
+        record.jobId,
+        request.user!.uid,
+        parsed.data.generation,
+        new Date((options.now ?? Date.now)()).toISOString(),
+      ))
+    )
+      return reply
+        .code(409)
+        .send({ error: 'round_changed', message: 'The round changed; check its status before taking over.' });
+    request.log.info({ jobId: record.jobId }, 'creator disconnected agent session for local delivery');
+    options.invalidate?.(record.jobId);
+    return { accepted: true };
+  });
+}

--- a/apps/api/src/store/firestore.ts
+++ b/apps/api/src/store/firestore.ts
@@ -344,6 +344,10 @@ export class FirestoreStore extends SubmissionFacade implements Store {
     return this.dispatchStore.recordJobTransition(jobId, transition, guard);
   }
 
+  async takeOverAgentRound(jobId: number, uid: string, generation: number, at: string): Promise<boolean> {
+    return this.roundsStore.takeOverAgentRound(jobId, uid, generation, at);
+  }
+
   async bumpRoundGeneration(jobId: number): Promise<number | null> {
     return this.roundsStore.bumpRoundGeneration(jobId);
   }

--- a/apps/api/src/store/in-memory.ts
+++ b/apps/api/src/store/in-memory.ts
@@ -265,6 +265,10 @@ export class InMemoryStore extends SubmissionFacade implements Store {
     return this.dispatchStore.recordJobTransition(jobId, transition, guard);
   }
 
+  async takeOverAgentRound(jobId: number, uid: string, generation: number, at: string): Promise<boolean> {
+    return this.roundsStore.takeOverAgentRound(jobId, uid, generation, at);
+  }
+
   async bumpRoundGeneration(jobId: number): Promise<number | null> {
     return this.roundsStore.bumpRoundGeneration(jobId);
   }

--- a/apps/api/src/store/slices/rounds.ts
+++ b/apps/api/src/store/slices/rounds.ts
@@ -2,7 +2,12 @@ import type { Firestore } from '@google-cloud/firestore';
 import type { AgentTaskState } from '../../platform/agent-state.js';
 import type { SeedFiles } from '../../agent-surface/agent-backend.js';
 import type { BuilderKind } from '../../creation/builder.js';
-import { isActiveBuildRound, nextRoundGeneration, type JobTransition } from '../../creation/job-state.js';
+import {
+  isActiveBuildRound,
+  nextRoundGeneration,
+  resolveJobState,
+  type JobTransition,
+} from '../../creation/job-state.js';
 import { MAX_JOB_TRANSITIONS } from '../records/dispatch.js';
 import type { BuilderHandoff } from '../records/rounds.js';
 import type { SubmissionRecord } from '../records/submission.js';
@@ -26,14 +31,15 @@ export function takeoverRecord(
   generation: number,
   at: string,
 ): SubmissionRecord | null {
+  const state = resolveJobState(sub) ?? 'queued';
   if (
     sub.ownerUid !== uid ||
     (sub.roundGeneration ?? 1) !== generation ||
     sub.abandonedAt ||
     (sub.builder ?? sub.defaultBuilder ?? 'platform') !== 'self' ||
-    !isActiveBuildRound({ state: sub.state ?? 'queued', transitions: sub.transitions }) ||
-    sub.state === 'submitted' ||
-    sub.state === 'publishing' ||
+    !isActiveBuildRound({ state, transitions: sub.transitions }) ||
+    state === 'submitted' ||
+    state === 'publishing' ||
     sub.builderHandoff ||
     sub.agentEndedAt ||
     !sub.dispatch?.refs?.length

--- a/apps/api/src/store/slices/rounds.ts
+++ b/apps/api/src/store/slices/rounds.ts
@@ -2,7 +2,7 @@ import type { Firestore } from '@google-cloud/firestore';
 import type { AgentTaskState } from '../../platform/agent-state.js';
 import type { SeedFiles } from '../../agent-surface/agent-backend.js';
 import type { BuilderKind } from '../../creation/builder.js';
-import { nextRoundGeneration, type JobTransition } from '../../creation/job-state.js';
+import { isActiveBuildRound, nextRoundGeneration, type JobTransition } from '../../creation/job-state.js';
 import { MAX_JOB_TRANSITIONS } from '../records/dispatch.js';
 import type { BuilderHandoff } from '../records/rounds.js';
 import type { SubmissionRecord } from '../records/submission.js';
@@ -20,7 +20,35 @@ export function clearRoundSignals(next: SubmissionRecord): void {
   delete next.roundLastGateMetricKey;
 }
 
+export function takeoverRecord(
+  sub: SubmissionRecord,
+  uid: string,
+  generation: number,
+  at: string,
+): SubmissionRecord | null {
+  if (
+    sub.ownerUid !== uid ||
+    (sub.roundGeneration ?? 1) !== generation ||
+    sub.abandonedAt ||
+    (sub.builder ?? sub.defaultBuilder ?? 'platform') !== 'self' ||
+    !isActiveBuildRound({ state: sub.state ?? 'queued', transitions: sub.transitions }) ||
+    sub.state === 'submitted' ||
+    sub.state === 'publishing' ||
+    sub.builderHandoff ||
+    sub.agentEndedAt ||
+    !sub.dispatch?.refs?.length
+  )
+    return null;
+  return {
+    ...sub,
+    roundGeneration: nextRoundGeneration(sub.roundGeneration ?? 1),
+    agentEndedAt: at,
+    agentEndedBy: 'end',
+  };
+}
+
 export interface RoundsStore {
+  takeOverAgentRound(jobId: number, uid: string, generation: number, at: string): Promise<boolean>;
   // Advances roundGeneration with no state change; null if the job is gone.
   bumpRoundGeneration(jobId: number): Promise<number | null>;
 
@@ -70,6 +98,14 @@ function isSealable(record: Pick<SubmissionRecord, 'state' | 'slug' | 'previewVe
 
 export class InMemoryRoundsStore implements RoundsStore {
   constructor(private submissions: Map<number, SubmissionRecord>) {}
+
+  async takeOverAgentRound(jobId: number, uid: string, generation: number, at: string): Promise<boolean> {
+    const sub = this.submissions.get(jobId);
+    const next = sub && takeoverRecord(sub, uid, generation, at);
+    if (!next) return false;
+    this.submissions.set(jobId, next);
+    return true;
+  }
 
   async bumpRoundGeneration(jobId: number): Promise<number | null> {
     const sub = this.submissions.get(jobId);
@@ -218,6 +254,17 @@ export class FirestoreRoundsStore implements RoundsStore {
 
   private ref(jobId: number) {
     return this.db.collection('submissions').doc(String(jobId));
+  }
+
+  async takeOverAgentRound(jobId: number, uid: string, generation: number, at: string): Promise<boolean> {
+    const ref = this.ref(jobId);
+    return this.db.runTransaction(async (tx) => {
+      const snap = await tx.get(ref);
+      const next = snap.exists && takeoverRecord(snap.data() as SubmissionRecord, uid, generation, at);
+      if (!next) return false;
+      tx.set(ref, next);
+      return true;
+    });
   }
 
   async bumpRoundGeneration(jobId: number): Promise<number | null> {

--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -9,7 +9,7 @@ decides the next version — see [`.claude/skills/cli-release/SKILL.md`](../../.
 
 ### Fixed
 
-- Recover preview delivery from an open own-agent session with explicit takeover confirmation (#TBD).
+- Recover preview delivery from an open own-agent session with explicit takeover confirmation (#1256).
 
 - Continue existing local checkouts from connect instead of silently using platform sources (#1252).
 - Show meaningful Codex MCP and file activity instead of item.completed (#1252).

--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -9,6 +9,8 @@ decides the next version — see [`.claude/skills/cli-release/SKILL.md`](../../.
 
 ### Fixed
 
+- Recover preview delivery from an open own-agent session with explicit takeover confirmation (#TBD).
+
 - Continue existing local checkouts from connect instead of silently using platform sources (#1252).
 - Show meaningful Codex MCP and file activity instead of item.completed (#1252).
 - Open Codex MCP interactively so permission requests can be answered (#1252).

--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -281,3 +281,7 @@ checkout. Logs are private local temporary files; one-shot delegation prints the
 log path. Logs are not sent to gamedev.pl and may contain local source text.
 
 When Antigravity cannot ask for a permission in headless mode, the interactive CLI offers to hand it the terminal and resume that conversation. Answer permissions in Antigravity, then exit it to return to CLI verification. Sandbox settings stay enabled; permissions are not automatically approved. One-shot/unattended runs do not open an interactive session. On macOS and Linux, native interactive output is recorded in `/logs` using the system terminal recorder. On Windows it remains in terminal scrollback. Studio shows local task activity separately from delivery status; game files are sent only by submission.
+
+### Recover an open agent session
+
+If a previous MCP agent stopped without ending its session, preview delivery can remain locked. The interactive delivery prompt offers to disconnect that session and deliver the local checkout. For an explicit retry, use `/submit --takeover` or `gamedevpl submit --takeover [dir]`. This revokes the previous session key and sends the full local file snapshot after checks pass. It does not stop the local agent process, so stop that process first if it is still editing your checkout. Old server staging stays in the previous generation; it is not mixed into your local delivery. Managed agents and pending handoffs must finish through Studio. `--force` alone never takes over an agent session.

--- a/apps/cli/src/argv.ts
+++ b/apps/cli/src/argv.ts
@@ -40,6 +40,7 @@ const BOOLEAN_FLAGS = new Set([
   'force',
   'publish',
   'handoff',
+  'takeover',
   'submit',
   'json',
   'help',

--- a/apps/cli/src/main.ts
+++ b/apps/cli/src/main.ts
@@ -305,6 +305,7 @@ export async function runCli(
         dest,
         force: flags.force === true,
         publish: flags.publish === true,
+        takeover: flags.takeover === true,
       });
       if (asJson) io.stdout.write(`${JSON.stringify(result)}\n`);
       else io.stdout.write(`${formatSubmitLines(result, slug).join('\n')}\n`);

--- a/apps/cli/src/repl.ts
+++ b/apps/cli/src/repl.ts
@@ -159,6 +159,7 @@ export async function handleReplLine(input: {
           dest,
           force: parsed.flags.force === true,
           publish: parsed.flags.publish === true,
+          takeover: parsed.flags.takeover === true,
         });
         input.write(formatSubmitLines(result, slug).join('\n'));
       } catch (error) {

--- a/apps/cli/src/submit-offer.test.ts
+++ b/apps/cli/src/submit-offer.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { ApiClient } from './api.js';
+import { offerSubmit, type Workshop } from './workshop.js';
+
+describe('locked delivery offer', () => {
+  it.each([false, true])('does not take over on decline or unattended=%s', async (unattended) => {
+    const request = vi.fn().mockResolvedValue({ locked: true, canTakeOver: true, jobId: 10, generation: 2 });
+    const pick = vi.fn().mockResolvedValue('not yet — keep editing');
+    const write = vi.fn();
+    const ws = { slug: 'game', pick, ...(unattended ? { unattended: { deliver: true } } : {}) } as unknown as Workshop;
+    await offerSubmit({ api: { request } as unknown as ApiClient, ws, write });
+    expect(request.mock.calls.every(([method]) => method === 'GET')).toBe(true);
+    if (unattended) expect(pick).not.toHaveBeenCalled();
+    else expect(pick.mock.calls[0][0][0]).toContain('disconnect the old agent');
+    expect(write).toHaveBeenCalled();
+  });
+});

--- a/apps/cli/src/submit-session.test.ts
+++ b/apps/cli/src/submit-session.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { ApiClient } from './api.js';
+import { prepareDeliverySession } from './submit-session.js';
+
+const locked = { locked: true, canTakeOver: true, jobId: 10, generation: 3 };
+describe('delivery session', () => {
+  it('does not disconnect an agent during ordinary delivery', async () => {
+    const request = vi.fn().mockResolvedValue(locked);
+    const api = { request } as unknown as ApiClient;
+    await expect(prepareDeliverySession(api, 'game')).rejects.toMatchObject({
+      next: expect.stringContaining('--takeover'),
+    });
+    expect(request.mock.calls.every(([method]) => method === 'GET')).toBe(true);
+  });
+  it('uses the session confirmed by the creator and propagates a conflict', async () => {
+    const request = vi.fn().mockRejectedValue(new Error('round_changed'));
+    const api = { request } as unknown as ApiClient;
+    await expect(prepareDeliverySession(api, 'game', true, locked)).rejects.toThrow('round_changed');
+    expect(request).toHaveBeenCalledExactlyOnceWith('POST', '/api/me/studio/games/game/sources/session', {
+      jobId: 10,
+      generation: 3,
+      stopAgent: true,
+    });
+  });
+  it('never takes a managed agent even with the explicit flag', async () => {
+    const request = vi.fn().mockResolvedValue({ ...locked, canTakeOver: false });
+    await expect(prepareDeliverySession({ request } as unknown as ApiClient, 'game', true)).rejects.toThrow('blocked');
+    expect(request.mock.calls.every(([method]) => method === 'GET')).toBe(true);
+  });
+});

--- a/apps/cli/src/submit-session.ts
+++ b/apps/cli/src/submit-session.ts
@@ -1,0 +1,38 @@
+import type { ApiClient } from './api.js';
+import { CliError, EXIT_REFUSED } from './exit-codes.js';
+
+export type DeliverySession = { locked: boolean; canTakeOver: boolean; jobId: number; generation: number };
+export async function deliverySession(api: ApiClient, slug: string): Promise<DeliverySession | null> {
+  try {
+    return await api.request<DeliverySession>(
+      'GET',
+      `/api/me/studio/games/${encodeURIComponent(slug)}/sources/session`,
+    );
+  } catch (error) {
+    if (error instanceof Error && error.message === 'not found') return null;
+    throw error;
+  }
+}
+export async function prepareDeliverySession(
+  api: ApiClient,
+  slug: string,
+  takeover = false,
+  expected?: DeliverySession,
+): Promise<boolean> {
+  const session = expected ?? (await deliverySession(api, slug));
+  if (!session?.locked) return false;
+  if (!takeover || !session.canTakeOver)
+    throw new CliError(
+      'Delivery is blocked by an open agent session. Your local files are safe.',
+      EXIT_REFUSED,
+      session.canTakeOver
+        ? 'gamedevpl submit --takeover — disconnect that agent and deliver your local checkout'
+        : 'Finish the active agent or its pending handoff in Studio, then retry.',
+    );
+  await api.request('POST', `/api/me/studio/games/${encodeURIComponent(slug)}/sources/session`, {
+    jobId: session.jobId,
+    generation: session.generation,
+    stopAgent: true,
+  });
+  return true;
+}

--- a/apps/cli/src/submit.test.ts
+++ b/apps/cli/src/submit.test.ts
@@ -24,8 +24,11 @@ function checkout(files: Array<{ path: string; content: string }>, version = 'v1
 }
 
 describe('submitGame', () => {
-  it('stages local-only edits and delivers without --force', async () => {
-    const dest = checkout([{ path: 'game.ts', content: 'A' }]);
+  it.each([false, true])('delivers local edits with takeover=%s', async (takeover) => {
+    const dest = checkout([
+      { path: 'game.ts', content: 'A' },
+      { path: 'SPEC.md', content: 'brief' },
+    ]);
     writeFileSync(join(dest, 'games', SLUG, 'game.ts'), 'B');
     const seen: string[] = [];
     const api = createApi({
@@ -37,11 +40,32 @@ describe('submitGame', () => {
         if (path.endsWith('/versions') && !path.includes('/tree')) {
           return json({ versions: [{ version: 'v1', createdAt: '2026-09-01', sourceFiles: ['game.ts'] }] });
         }
-        if (path.includes('/tree')) return json({ version: 'v1', files: [{ path: 'game.ts', content: 'A' }] });
-        if (path.endsWith('/sources')) return json({ files: [{ path: 'game.ts', content: 'A' }] });
+        if (path.includes('/tree'))
+          return json({
+            version: 'v1',
+            files: [
+              { path: 'game.ts', content: 'A' },
+              { path: 'SPEC.md', content: 'brief' },
+            ],
+          });
+        if (path.endsWith('/sources/session'))
+          return json(
+            init?.method === 'POST'
+              ? { accepted: true }
+              : { locked: takeover, canTakeOver: true, jobId: 10, generation: 1 },
+          );
+        if (path.endsWith('/sources'))
+          return json({
+            files: [
+              { path: 'game.ts', content: 'A' },
+              { path: 'SPEC.md', content: 'brief' },
+            ],
+          });
         if (path.endsWith('/sources/stage') && init?.method === 'PUT') {
           const body = JSON.parse(String(init?.body ?? '{}')) as { path: string; content: string };
-          expect(body).toEqual({ path: 'game.ts', content: 'B' });
+          expect(body).toEqual(
+            body.path === 'game.ts' ? { path: 'game.ts', content: 'B' } : { path: 'SPEC.md', content: 'brief' },
+          );
           return json({ accepted: true });
         }
         if (path.endsWith('/sources/deliver')) {
@@ -56,12 +80,13 @@ describe('submitGame', () => {
       api,
       slug: SLUG,
       dest,
+      takeover,
       run: () => ({ status: 0, stderr: '' }),
     });
     expect(result.kind).toBe('delivered');
     if (result.kind === 'delivered') {
       expect(result.gateStarted).toBe(true);
-      expect(result.staged).toEqual(['game.ts']);
+      expect(result.staged).toEqual(takeover ? ['SPEC.md', 'game.ts'] : ['game.ts']);
       expect(result.mode).toBe('preview');
     }
     expect(seen.some((row) => row.startsWith('PUT ') && row.endsWith('/sources/stage'))).toBe(true);

--- a/apps/cli/src/submit.ts
+++ b/apps/cli/src/submit.ts
@@ -108,7 +108,7 @@ export async function submitGame(input: {
 
   const takenOver = await prepareDeliverySession(input.api, input.slug, input.takeover, input.expectedSession);
   const paths = takenOver
-    ? [...new Set([...localGameFiles(input.dest, input.slug), ...latest.tree.files].map((file) => file.path))]
+    ? [...new Set([...localGameFiles(input.dest, input.slug), ...latest.tree.files].map((file) => file.path))].sort()
     : input.force
       ? changedPathsForced(localGameFiles(input.dest, input.slug), latest.tree.files)
       : latest.sync.local;

--- a/apps/cli/src/submit.ts
+++ b/apps/cli/src/submit.ts
@@ -1,9 +1,9 @@
+import { prepareDeliverySession, type DeliverySession } from './submit-session.js';
 import type { ApiClient } from './api.js';
 import { mkdirSync, existsSync, readFileSync, writeFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { inspectGame, localGameFiles, writeBase, fetchLatestTree } from './checkout.js';
 import { hashesOf, hashContent, pathInside, syncRefuse, type SyncResult, type TreeFile } from './checkout-sync.js';
-import { otherBuilder } from './errors.js';
 import { CliError, EXIT_RED, EXIT_REFUSED } from './exit-codes.js';
 import { assertLadderGreen, runLadder } from './verify.js';
 
@@ -54,7 +54,12 @@ async function deletePath(api: ApiClient, slug: string, path: string): Promise<v
 
 function mapHttpError(error: unknown): never {
   const message = error instanceof Error ? error.message : String(error);
-  if (/agent_round|actively building/.test(message)) throw otherBuilder('an agent');
+  if (/agent_round|actively building/.test(message))
+    throw new CliError(
+      'Delivery is blocked by an open agent session. Local files are unchanged.',
+      EXIT_REFUSED,
+      'Use /submit --takeover to disconnect your own agent, or finish the active platform agent in Studio.',
+    );
   if (/no_active_round|no round open/.test(message)) {
     throw new CliError('no round is open to deliver into — start one from Studio or the REPL', EXIT_REFUSED);
   }
@@ -67,10 +72,12 @@ export async function submitGame(input: {
   dest: string;
   force?: boolean;
   publish?: boolean;
+  takeover?: boolean;
+  expectedSession?: DeliverySession;
   run?: Parameters<typeof runLadder>[0]['run'];
 }): Promise<SubmitResult> {
   const first = await inspectGame(input);
-  if (first.sync.kind === 'clean' && !input.publish && !input.force) {
+  if (first.sync.kind === 'clean' && !input.publish && !input.force && !input.takeover) {
     return { kind: 'nothing', sync: first.sync };
   }
   if (
@@ -91,7 +98,7 @@ export async function submitGame(input: {
     const refused = syncRefuse(latest.sync, 'submit');
     throw new CliError(`platform changed during verify — ${refused.message}`, EXIT_REFUSED, refused.next);
   }
-  if (latest.sync.kind === 'clean' && !input.publish && !input.force) {
+  if (latest.sync.kind === 'clean' && !input.publish && !input.force && !input.takeover) {
     return { kind: 'nothing', sync: latest.sync };
   }
   if (!input.force && latest.sync.kind === 'platform_only') {
@@ -99,9 +106,12 @@ export async function submitGame(input: {
     throw new CliError(refused.message, EXIT_REFUSED, refused.next);
   }
 
-  const paths = input.force
-    ? changedPathsForced(localGameFiles(input.dest, input.slug), latest.tree.files)
-    : latest.sync.local;
+  const takenOver = await prepareDeliverySession(input.api, input.slug, input.takeover, input.expectedSession);
+  const paths = takenOver
+    ? [...new Set([...localGameFiles(input.dest, input.slug), ...latest.tree.files].map((file) => file.path))]
+    : input.force
+      ? changedPathsForced(localGameFiles(input.dest, input.slug), latest.tree.files)
+      : latest.sync.local;
   let extra: string[] = [];
   try {
     extra = await extraStagedPaths(input.api, input.slug, paths);

--- a/apps/cli/src/workshop.ts
+++ b/apps/cli/src/workshop.ts
@@ -15,6 +15,7 @@ import { formatSyncLines, inspectGame, type SyncResult } from './checkout.js';
 import { childEnv, createDelegateStream, spawnAdapter } from './delegate.js';
 import { formatError } from './errors.js';
 import { CliError, EXIT_INPUT, EXIT_REFUSED } from './exit-codes.js';
+import { deliverySession } from './submit-session.js';
 import { formatSubmitLines, submitGame } from './submit.js';
 import { getStatus, isTerminalStatus } from './turn.js';
 import { repairLoop } from './repair-loop.js';
@@ -404,7 +405,19 @@ export async function offerSubmit(input: {
   write: (line: string) => void;
 }): Promise<void> {
   const { ws } = input;
-  const deliver = 'deliver a preview';
+  const session = await deliverySession(input.api, ws.slug);
+  const takeover = Boolean(session?.locked && session.canTakeOver);
+  if (session?.locked && (!takeover || ws.unattended)) {
+    input.write(
+      takeover
+        ? 'Delivery blocked; use /submit --takeover to explicitly disconnect your agent.'
+        : 'Delivery blocked; finish the platform agent or pending handoff in Studio, then retry.',
+    );
+    return;
+  }
+  if (takeover)
+    input.write('Delivery uses the full local checkout. The previous server draft stays in the retired session.');
+  const deliver = takeover ? 'disconnect the old agent and deliver this local checkout' : 'deliver a preview';
   const choice = ws.unattended
     ? ws.unattended.deliver
       ? deliver
@@ -415,7 +428,14 @@ export async function offerSubmit(input: {
     return;
   }
   try {
-    const result = await submitGame({ api: input.api, slug: ws.slug, dest: ws.root, run: ws.run });
+    const result = await submitGame({
+      api: input.api,
+      slug: ws.slug,
+      dest: ws.root,
+      run: ws.run,
+      takeover,
+      expectedSession: session ?? undefined,
+    });
     if (result.kind === 'delivered') ws.telemetry?.record('delivered');
     input.write(formatSubmitLines(result, ws.slug).join('\n'));
   } catch (error) {

--- a/apps/cli/src/workshop.ts
+++ b/apps/cli/src/workshop.ts
@@ -405,7 +405,13 @@ export async function offerSubmit(input: {
   write: (line: string) => void;
 }): Promise<void> {
   const { ws } = input;
-  const session = await deliverySession(input.api, ws.slug);
+  let session: Awaited<ReturnType<typeof deliverySession>>;
+  try {
+    session = await deliverySession(input.api, ws.slug);
+  } catch (error) {
+    input.write(formatError(error));
+    return;
+  }
   const takeover = Boolean(session?.locked && session.canTakeOver);
   if (session?.locked && (!takeover || ws.unattended)) {
     input.write(

--- a/eslint-rules/module-boundary-map.mjs
+++ b/eslint-rules/module-boundary-map.mjs
@@ -238,6 +238,7 @@ const FILE_BUCKET = {
   'chat-turns': 'creation',
   'chat-turns-history': 'creation',
   'creator-feedback-handler': 'creation',
+  'creator-takeover': 'creation',
   'creator-code': 'creation',
   'creator-studio': 'creation',
   'creator-versions': 'creation',

--- a/package-lock.json
+++ b/package-lock.json
@@ -95,7 +95,7 @@
     },
     "apps/cli": {
       "name": "@gamedevpl/cli",
-      "version": "0.9.0",
+      "version": "0.12.0",
       "dependencies": {
         "@gamedevpl/contract": "*",
         "ink": "^5.2.1",


### PR DESCRIPTION
A local checkout can pass validation while delivery remains locked by an earlier MCP session that never called `end`. The CLI now checks ownership before offering delivery and asks explicitly to disconnect an own-agent session and deliver the full local checkout. Noninteractive retries use `gamedevpl submit --takeover`; `--force` never takes over a session.

The owner-only API atomically checks the confirmed job and generation, advances the generation to revoke old session keys, and marks the session ended. It preserves round budgets and existing preview/publication records. The old staging remains isolated in its original generation. Managed agents, pending handoffs, and rounds already delivering or publishing cannot be taken over. The local agent process is not killed.

Validation: type-check, lint and build pass. All 366 CLI tests pass on rerun; the final focused API and CLI checks pass (8 + 19 tests). The full workspace run had two failures outside this diff (stage-hints typecheck advisory and an agent-process timeout); both pass when rerun. Web tests pass (1,993). Regression tests cover creator OAuth access, ownership, explicit confirmation, stale generations, old-token rejection, round/budget preservation, full local snapshots, and unattended/declined prompts.
