### PR TITLE
fix(cli): make terminal conversations easier to scan

### DIFF
--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -9,6 +9,8 @@ decides the next version — see [`.claude/skills/cli-release/SKILL.md`](../../.
 
 ### Fixed
 
+- Make terminal conversations easier to scan with colored roles, checks, links and compact repeated tool activity (#TBD).
+
 - Recover preview delivery from an open own-agent session with explicit takeover confirmation (#1256).
 
 - Continue existing local checkouts from connect instead of silently using platform sources (#1252).

--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -9,7 +9,9 @@ decides the next version — see [`.claude/skills/cli-release/SKILL.md`](../../.
 
 ### Fixed
 
-- Make terminal conversations easier to scan with colored roles, checks, links and compact repeated tool activity (#TBD).
+- Make terminal conversations easier to scan with colored roles, checks, links and clearer spacing (#1259).
+- Summarize repeated tool activity while preserving every operation in `/logs` (#1259).
+- Wrap clickable preview links within narrow terminals (#1259).
 
 - Recover preview delivery from an open own-agent session with explicit takeover confirmation (#1256).
 

--- a/apps/cli/src/task-output.test.ts
+++ b/apps/cli/src/task-output.test.ts
@@ -30,3 +30,31 @@ it('keeps full details privately while showing readable tools and setup errors',
     rmSync(dirname(output.path), { recursive: true, force: true });
   }
 });
+
+it('groups repeated tools without losing diagnostics or the full transcript', () => {
+  const shown: string[] = [];
+  const output = taskOutput((line) => shown.push(line));
+  try {
+    output.write('codex ▸ ⚙ /bin/zsh -lc "cat game.ts"');
+    output.write('codex ▸ ⚙ /bin/zsh -lc "cat model.ts"');
+    output.write('codex ▸ ⚙ /bin/zsh -lc "cat runtime.ts"');
+    output.write('error: command failed');
+    output.write('codex ▸ ⚙ /bin/zsh -lc "pwd"');
+    output.write('codex ▸ ⚙ /bin/zsh -lc "ls"');
+    output.flush();
+    output.flush();
+    expect(shown).toEqual([
+      'codex · Running a shell command',
+      'codex · +2 more tool operations — /logs',
+      'error: command failed',
+      'codex · Running a shell command',
+      'codex · +1 more tool operations — /logs',
+    ]);
+    const log = readFileSync(output.path, 'utf8');
+    expect(log.match(/\/bin\/zsh/g)).toHaveLength(5);
+    expect(log).toContain('cat model.ts');
+    expect(log).toContain('error: command failed');
+  } finally {
+    rmSync(dirname(output.path), { recursive: true, force: true });
+  }
+});

--- a/apps/cli/src/task-output.ts
+++ b/apps/cli/src/task-output.ts
@@ -19,8 +19,16 @@ export function taskOutput(write: (text: string) => void) {
   const path = join(mkdtempSync(join(tmpdir(), 'gamedev-task-')), 'transcript.txt');
   writeFileSync(path, '', { mode: 0o600 });
   let preparing = false;
+  let lastTool = '';
+  let repeats = 0;
+  const flush = (): void => {
+    if (repeats) write(`${lastTool.split(' · ')[0]} · +${repeats} more tool operations — /logs`);
+    repeats = 0;
+    lastTool = '';
+  };
   return {
     path,
+    flush,
     preparing(value: boolean) {
       preparing = value;
     },
@@ -32,6 +40,13 @@ export function taskOutput(write: (text: string) => void) {
       appendFileSync(path, safe + '\n');
       if (preparing && !/error|failed|refused|cannot/i.test(safe)) return;
       const shown = compactTaskLine(safe);
+      const tool = /^[\w-]+ · (?:Running a shell command|Tool:)/.test(shown);
+      if (tool && shown === lastTool) {
+        repeats += 1;
+        return;
+      }
+      flush();
+      if (tool) lastTool = shown;
       if (shown) write(shown);
     },
   };

--- a/apps/cli/src/tui/app.tsx
+++ b/apps/cli/src/tui/app.tsx
@@ -2,11 +2,10 @@ import { CommandSuggestions, useCommandCompletion } from './completion.js';
 import { BusyPanel } from './busy.js';
 import { useEffect, useState } from 'react';
 import { Box, Static, Text, useInput, useStdout } from 'ink';
-import { linkifyTerminalText } from './links.js';
+import { TranscriptLine, RichText } from './transcript.js';
 import { CLI_BIN } from '../bin-name.js';
 import { glyphs } from '../renderer.js';
 import { CLI_VERSION } from '../update.js';
-import { isMascotLine, MASCOT_COLOR } from './mascot.js';
 import type { TuiSession, TuiState } from './session.js';
 
 export function ReplApp({
@@ -89,19 +88,15 @@ export function ReplApp({
   const liveRows = Math.min(live.length, Math.max(0, rows - panelRows - 4));
   const footer = `${state.identity || CLI_BIN} · ${CLI_VERSION}`;
   return (
-    <Box flexDirection="column">
-      <Static items={state.lines.slice(historyOffset)}>
+    <Box flexDirection="column" width={Math.min(stdout.columns || 80, 110)}>
+      <Static items={state.lines.slice(historyOffset)} style={{ width: Math.min(stdout.columns || 80, 110) }}>
         {(line, index) => (
-          <Box key={index} width={Math.min(stdout.columns || 80, 100)}>
-            <Text bold={line.startsWith('──')} color={color && isMascotLine(line) ? MASCOT_COLOR : undefined}>
-              {linkifyTerminalText(line)}
-            </Text>
-          </Box>
+          <TranscriptLine key={index} line={line} previous={state.lines[historyOffset + index - 1]} color={color} />
         )}
       </Static>
       <Box flexDirection="column" height={liveRows} flexShrink={0}>
         {live.slice(0, liveRows).map((line, index) => (
-          <Text key={`live:${index}:${line.slice(0, 32)}`} dimColor wrap="truncate-end">
+          <Text key={`live:${index}:${line.slice(0, 32)}`} color={color ? 'blue' : undefined} wrap="truncate-end">
             {line}
           </Text>
         ))}
@@ -112,7 +107,7 @@ export function ReplApp({
         <Box flexDirection="column" flexShrink={0} borderStyle={border} borderColor={accent} paddingX={1}>
           {state.mode === 'pick' ? (
             <>
-              <Text bold wrap="truncate-end">
+              <Text bold color={accent} wrap="truncate-end">
                 {state.question || 'Choose an option'}
               </Text>
               {state.choices.slice(choiceStart, choiceStart + choiceCount).map((choice, offset) => {
@@ -120,6 +115,7 @@ export function ReplApp({
                 return (
                   <Text
                     wrap="truncate-end"
+                    bold={index === state.pickIndex}
                     key={`pick:${index}:${choice}`}
                     color={index === state.pickIndex ? accent : undefined}
                   >
@@ -131,7 +127,10 @@ export function ReplApp({
             </>
           ) : (
             <Text wrap="truncate-start">
-              {prompt} {state.draft ? `${state.draft}█` : <Text dimColor>What would you like to do? /help</Text>}
+              <Text color={accent} bold>
+                {prompt}
+              </Text>{' '}
+              {state.draft ? `${state.draft}█` : <Text dimColor>What would you like to do? /help</Text>}
             </Text>
           )}
         </Box>
@@ -154,7 +153,7 @@ export function ReplApp({
             : 'Working — input paused'}
       </Text>
       <Text dimColor wrap="truncate-end">
-        {footer}
+        <RichText text={footer} color={color} />
       </Text>
     </Box>
   );

--- a/apps/cli/src/tui/busy.tsx
+++ b/apps/cli/src/tui/busy.tsx
@@ -25,15 +25,15 @@ export function BusyPanel({
   return (
     <Box flexDirection="column" paddingX={1}>
       <Box>
-        <Text color={color ? 'cyan' : undefined}>{color ? FRAMES[tick % FRAMES.length] : '|/-\\'[tick % 4]} </Text>
+        <Text color={color ? 'yellow' : undefined}>{color ? FRAMES[tick % FRAMES.length] : '|/-\\'[tick % 4]} </Text>
         <Box flexGrow={1} flexShrink={1}>
           <Text bold wrap="truncate-end">
             {activity}
           </Text>
         </Box>
-        <Text dimColor> {duration}</Text>
+        <Text color={color ? 'yellow' : undefined}> {duration}</Text>
       </Box>
-      <Text dimColor wrap="truncate-end">
+      <Text dimColor={silent < 30} color={color && silent >= 30 ? 'yellow' : undefined} wrap="truncate-end">
         {silent >= 30 ? `No new output for ${silent}s — Ctrl+C to stop` : 'Ctrl+C to stop / exit'}
       </Text>
     </Box>

--- a/apps/cli/src/tui/links.ts
+++ b/apps/cli/src/tui/links.ts
@@ -2,6 +2,6 @@ export function linkifyTerminalText(text: string): string {
   return text.replace(/https?:\/\/[^\s<>"']+/g, (url) =>
     [...url].some((ch) => ch.charCodeAt(0) < 32 || (ch.charCodeAt(0) >= 127 && ch.charCodeAt(0) <= 159))
       ? url
-      : `\u001b]8;;${url}\u001b\\${url}\u001b]8;;\u001b\\`,
+      : `\u001b]8;;${url}\u0007${url}\u001b]8;;\u0007`,
   );
 }

--- a/apps/cli/src/tui/transcript.test.tsx
+++ b/apps/cli/src/tui/transcript.test.tsx
@@ -1,6 +1,7 @@
 import { PassThrough } from 'node:stream';
 import { createElement } from 'react';
 import { render } from 'ink';
+import stripAnsi from 'strip-ansi';
 import { afterAll, expect, it, vi } from 'vitest';
 import { ReplApp } from './app.js';
 import { createTuiSession } from './session.js';
@@ -34,7 +35,8 @@ it.each([40, 120])('writes preview hyperlinks once while status animates at widt
     const url = 'http://127.0.0.1:50600/957d84cdc71250b428511a7d2c85639363cbbe3fba57a9cd/';
     session.writeLine(`live preview: ${url}`);
     await new Promise((resolve) => setTimeout(resolve, 200));
-    expect(output).toContain(`\u001b]8;;${url}\u001b\\`);
+    expect(output).toContain(`\u001b]8;;${url}\u0007`);
+    for (const line of stripAnsi(output).split('\n')) expect(line.length).toBeLessThanOrEqual(columns);
     output = '';
     session.setActivity('Muse is editing');
     session.setLive(['queued']);

--- a/apps/cli/src/tui/transcript.tsx
+++ b/apps/cli/src/tui/transcript.tsx
@@ -1,0 +1,78 @@
+import { Box, Text } from 'ink';
+import { linkifyTerminalText } from './links.js';
+import { isMascotLine, MASCOT_COLOR } from './mascot.js';
+
+export function lineStyle(line: string): { label: string; tone?: string; quiet?: boolean; space?: boolean } {
+  if (line.startsWith('› ')) return { label: 'YOU', tone: 'cyan', space: true };
+  if (/^──|^[◆*] gamedevpl/.test(line)) return { label: '◆', tone: 'green', space: true };
+  if (/^(?:✓|✔|\* static)|^static ladder green|^delivery accepted/.test(line))
+    return { label: 'PASS', tone: 'green', space: true };
+  if (
+    /^Validation needs changes|^verify failed|^error:|^Tool failed|^Delivery.*blocked|^this game is mid-round|^\s*- (?:Check \d+ failed|EDITOR)/i.test(
+      line,
+    )
+  )
+    return { label: '!', tone: 'red' };
+  if (/^Sending validation|^No new output|^Warning|^kept locally|^.*permission.*(?:denied|refused)/i.test(line))
+    return { label: '!', tone: 'yellow' };
+  if (/^verifying|^preparing|^Preparing|^installing/.test(line)) return { label: 'CHECK', tone: 'yellow', space: true };
+  if (/^[\w-]+ · (?:Running|Tool:|\+\d+ more)/.test(line) || /^[\w-]+ ▸ [⚙✓]/.test(line))
+    return { label: '·', tone: 'blue', quiet: true };
+  if (/^[\w-]+ ▸ /.test(line)) return { label: '●', tone: 'magenta' };
+  if (/^[\w-]+ · model:/.test(line)) return { label: 'AGENT', tone: 'magenta' };
+  if (/^(?:Settings:|Full (?:transcript|diagnostics):|base |local-only:)/.test(line))
+    return { label: '·', quiet: true };
+  if (/https?:\/\//.test(line)) return { label: '↗', tone: 'cyan' };
+  return { label: ' ' };
+}
+
+export function RichText({ text, color }: { text: string; color: boolean }) {
+  return (
+    <Text>
+      {text.split(/(`[^`\n]+`|https?:\/\/[^\s<>"']+|\/[a-z][\w-]*\b)/g).map((part, index) => {
+        const code = part.startsWith('`') && part.endsWith('`');
+        const linked = /^https?:\/\//.test(part);
+        const command = /^\/[a-z]/.test(part);
+        return (
+          <Text key={index} color={color && (code || linked || command) ? 'cyan' : undefined} bold={code || command}>
+            {linkifyTerminalText(code ? part.slice(1, -1) : part)}
+          </Text>
+        );
+      })}
+    </Text>
+  );
+}
+
+export function TranscriptLine({ line, previous, color }: { line: string; previous?: string; color: boolean }) {
+  if (isMascotLine(line)) return <Text color={color ? MASCOT_COLOR : undefined}>{line}</Text>;
+  const style = lineStyle(line);
+  const agent = /^([\w-]+)( ▸ | · )/.exec(line);
+  const sameSpeaker = agent && previous?.startsWith(`${agent[1]} ▸ `) && line.includes(' ▸ ') && !style.quiet;
+  return (
+    <Box flexDirection="row" marginTop={style.space || (agent && !sameSpeaker && !style.quiet) ? 1 : 0}>
+      <Box width={7} flexShrink={0}>
+        <Text color={color ? style.tone : undefined} bold>
+          {style.label.padEnd(6)}
+        </Text>
+      </Box>
+      <Box flexGrow={1} flexShrink={1}>
+        <Text
+          dimColor={color && style.quiet}
+          bold={style.label === 'YOU' || style.label === 'PASS' || style.label === '◆'}
+        >
+          {agent ? (
+            <>
+              <Text bold color={color ? style.tone : undefined}>
+                {agent[1]}
+              </Text>
+              <Text>{agent[2]}</Text>
+              <RichText text={line.slice(agent[0].length)} color={color} />
+            </>
+          ) : (
+            <RichText text={line} color={color} />
+          )}
+        </Text>
+      </Box>
+    </Box>
+  );
+}

--- a/apps/cli/src/workshop.ts
+++ b/apps/cli/src/workshop.ts
@@ -392,6 +392,7 @@ export async function runLocalBuild(input: {
     });
     return success;
   } finally {
+    output.flush();
     await presence.finish(controller.signal.aborted ? 'stopped' : success ? 'ready' : 'failed');
     if (controller.signal.aborted) input.write(`${spec.name} stopped — the tree keeps whatever it wrote; /diff to see`);
     ws.abort.current = null;


### PR DESCRIPTION
Terminal conversations currently give user input, agent narration, tool activity and validation diagnostics almost identical weight. This adds colored role/status markers, spacing between stages, highlighted commands and code, and a bounded transcript width. Repeated tool operations are summarized while every original line remains in `/logs`.

Preview hyperlinks now use an OSC 8 terminator supported by Ink's line wrapper, so long links fit narrow terminals. History remains append-only in Ink Static; busy updates do not replay links or erase scrollback.

Validation: all 367 CLI tests pass, including narrow-terminal hyperlink wrapping, immutable history, handoff/input recovery and lossless tool grouping. Visually inspected captured Ink output in color and NO_COLOR, with prompt, picker and busy states at 40, 80 and 100 columns. Full repository type-check, lint and tests pass (6,708 tests passed, 4 skipped). Production build passes.
