### PR TITLE
fix(cli): announce available updates at startup

### DIFF
--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -15,7 +15,7 @@ decides the next version — see [`.claude/skills/cli-release/SKILL.md`](../../.
 
 ### Fixed
 
-- Notify about newer CLI releases when an interactive session starts, without blocking work (#TBD).
+- Notify about newer CLI releases when an interactive session starts, without blocking work (#1260).
 
 - Make terminal conversations easier to scan with colored roles, checks, links and clearer spacing (#1259).
 - Summarize repeated tool activity while preserving every operation in `/logs` (#1259).

--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -15,6 +15,8 @@ decides the next version — see [`.claude/skills/cli-release/SKILL.md`](../../.
 
 ### Fixed
 
+- Notify about newer CLI releases when an interactive session starts, without blocking work (#TBD).
+
 - Make terminal conversations easier to scan with colored roles, checks, links and clearer spacing (#1259).
 - Summarize repeated tool activity while preserving every operation in `/logs` (#1259).
 - Wrap clickable preview links within narrow terminals (#1259).

--- a/apps/cli/src/main.ts
+++ b/apps/cli/src/main.ts
@@ -322,6 +322,7 @@ export async function runCli(
           io,
           token: await studioToken(api, slug),
           slug,
+          currentPath: argv[1],
           initialLine: `/connect ${slug}${flags.handoff ? ' --handoff' : ''}${typeof flags.agent === 'string' ? ` --agent ${flags.agent}` : ''}`,
         });
       }
@@ -350,7 +351,7 @@ export async function runCli(
         telemetry,
       });
     }
-    const read = await dispatchReadVerb({ verb, args, flags, api, io, env });
+    const read = await dispatchReadVerb({ verb, args, flags, api, io, env, currentPath: argv[1] });
     if (read !== null) return read;
     if (verb === 'repl') {
       if (!tty || !io.stdout.isTTY) throw pipeNeedsFlag(`a verb such as ${cliUsage('whoami')}`);
@@ -374,6 +375,7 @@ export async function runCli(
         token,
         slug: requestedSlug,
         initialLine: requestedSlug && !opened ? `/connect ${requestedSlug}` : undefined,
+        currentPath: argv[1],
         ...(opened ? { checkout: { slug: opened.slug, root: opened.root } } : {}),
       });
     }

--- a/apps/cli/src/repl.test.ts
+++ b/apps/cli/src/repl.test.ts
@@ -1,4 +1,5 @@
-import { mkdtempSync, writeFileSync } from 'node:fs';
+import { mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { createHash } from 'node:crypto';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { describe, expect, it } from 'vitest';
@@ -272,6 +273,46 @@ describe('repl turn loop', () => {
     expect(result.next).toBe('continue');
     expect(lines.join('\n')).toContain('open a browser');
     expect(lines.join('\n')).not.toMatch(/gamedevpl <[a-z]+\|/);
+  });
+
+  it('dispatches /update to the active running binary destination', async () => {
+    const lines: string[] = [];
+    const customBin = join(mkdtempSync(join(tmpdir(), 'gdpl-repl-')), 'bin', 'gamedevpl');
+    const api = createApi({
+      origin: 'https://www.gamedev.pl',
+      store: memoryStore({ accessToken: 'gdpl_oat_t', tokenType: 'Bearer', scope: 'creator' }),
+      fetch: async () => new Response('{}', { status: 404 }),
+    });
+    const bytes = Buffer.from('#!/usr/bin/env node\n');
+    const hash = createHash('sha256').update(bytes).digest('hex');
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = async (url: RequestInfo | URL) => {
+      const s = String(url);
+      if (s.endsWith('releases?per_page=100')) {
+        return new Response(JSON.stringify([{ tag_name: 'cli-v0.14.0' }]), { status: 200 });
+      }
+      if (s.endsWith('SHA256SUMS')) {
+        return new Response(`${hash}  gamedevpl\n`, { status: 200 });
+      }
+      if (s.endsWith('/gamedevpl')) {
+        return new Response(bytes, { status: 200 });
+      }
+      return new Response('nope', { status: 404 });
+    };
+    try {
+      const result = await handleReplLine({
+        line: '/update',
+        api,
+        token: null,
+        currentPath: customBin,
+        write: (s) => lines.push(s),
+      });
+      expect(result.next).toBe('continue');
+      expect(lines.join('\n')).toContain('updated gamedevpl to 0.14.0');
+      expect(readFileSync(customBin)).toEqual(bytes);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
   });
 });
 

--- a/apps/cli/src/repl.ts
+++ b/apps/cli/src/repl.ts
@@ -49,6 +49,7 @@ export async function handleReplLine(input: {
   onWorkshop?: (ws: Workshop) => void;
   write: (s: string) => void;
   onActivity?: (activity: string) => void;
+  currentPath?: string;
 }): Promise<ReplLineResult> {
   const retry = input.line.trim() === '/retry' ? input.pendingExecution?.current : undefined;
   if (input.line.trim() === '/retry' && !retry) {
@@ -223,6 +224,7 @@ export async function handleReplLine(input: {
           api: input.api,
           io: { stdout },
           env: input.env,
+          currentPath: input.currentPath,
         });
         if (code !== null) {
           input.write(chunks.join('').trimEnd() || `/${cmd}`);

--- a/apps/cli/src/tui/host.ts
+++ b/apps/cli/src/tui/host.ts
@@ -1,3 +1,4 @@
+import { startUpdateNotice } from '../update-notice.js';
 import { runInteractive, type InteractiveRun } from '../agy-interactive.js';
 import { offerKitUpdate } from '../kit-update.js';
 import { activityApi } from './activity.js';
@@ -59,6 +60,7 @@ export async function runInkRepl(input: {
     });
   };
   mount();
+  const stopUpdateNotice = startUpdateNotice({ write: session.writeLine });
   const interactiveRun: InteractiveRun = async (request) => {
     const offset = session.get().lines.length;
     host.instance?.unmount();
@@ -211,6 +213,7 @@ export async function runInkRepl(input: {
       if (result.next === 'quit') break;
     }
   } finally {
+    stopUpdateNotice();
     watch.stop();
     session.close();
     host.instance?.unmount();

--- a/apps/cli/src/tui/host.ts
+++ b/apps/cli/src/tui/host.ts
@@ -28,6 +28,7 @@ export async function runInkRepl(input: {
   initialLine?: string;
   // Set when a checkout in the working directory opened this session.
   checkout?: { slug: string; root: string };
+  currentPath?: string;
 }): Promise<number> {
   const isTty = Boolean(input.io.stdout.isTTY);
   const color = wantsColor(input.env, isTty);
@@ -165,6 +166,7 @@ export async function runInkRepl(input: {
           conversationId,
           workshop,
           env: input.env,
+          currentPath: input.currentPath,
           pick: session.prompt,
           abort,
           telemetry,

--- a/apps/cli/src/tui/transcript.tsx
+++ b/apps/cli/src/tui/transcript.tsx
@@ -13,7 +13,11 @@ export function lineStyle(line: string): { label: string; tone?: string; quiet?:
     )
   )
     return { label: '!', tone: 'red' };
-  if (/^Sending validation|^No new output|^Warning|^kept locally|^.*permission.*(?:denied|refused)/i.test(line))
+  if (
+    /^Update available:|^Sending validation|^No new output|^Warning|^kept locally|^.*permission.*(?:denied|refused)/i.test(
+      line,
+    )
+  )
     return { label: '!', tone: 'yellow' };
   if (/^verifying|^preparing|^Preparing|^installing/.test(line)) return { label: 'CHECK', tone: 'yellow', space: true };
   if (/^[\w-]+ · (?:Running|Tool:|\+\d+ more)/.test(line) || /^[\w-]+ ▸ [⚙✓]/.test(line))

--- a/apps/cli/src/update-notice.test.ts
+++ b/apps/cli/src/update-notice.test.ts
@@ -1,0 +1,90 @@
+import { afterEach, expect, it, vi } from 'vitest';
+import { startUpdateNotice } from './update-notice.js';
+
+const releases = (...versions: string[]) => new Response(JSON.stringify(versions.map((tag_name) => ({ tag_name }))));
+afterEach(() => vi.useRealTimers());
+
+it('announces a newer stable CLI without waiting to return control', async () => {
+  const write = vi.fn();
+  let finish!: (response: Response) => void;
+  const stop = startUpdateNotice({
+    currentVersion: '0.12.0',
+    write,
+    fetchImpl: () =>
+      new Promise((resolve) => {
+        finish = resolve;
+      }),
+  });
+  expect(typeof stop).toBe('function');
+  expect(write).not.toHaveBeenCalled();
+  finish(releases('cli-v0.13.0', 'cli-v0.9.0'));
+  await vi.waitFor(() => expect(write).toHaveBeenCalledTimes(1));
+  expect(write.mock.calls[0]![0]).toContain('0.12.0 → 0.13.0. Run /update');
+  stop();
+});
+
+it.each(['cli-v0.12.0', 'cli-v0.11.0', 'cli-v0.14.0-beta'])('does not suggest %s', async (tag) => {
+  const write = vi.fn();
+  const stop = startUpdateNotice({ currentVersion: '0.12.0', write, fetchImpl: async () => releases(tag) });
+  await new Promise((resolve) => setTimeout(resolve, 10));
+  expect(write).not.toHaveBeenCalled();
+  stop();
+});
+
+it('ignores draft and prerelease builds', async () => {
+  const write = vi.fn();
+  const stop = startUpdateNotice({
+    currentVersion: '0.12.0',
+    write,
+    fetchImpl: async () =>
+      new Response(
+        JSON.stringify([
+          { tag_name: 'cli-v0.14.0', draft: true },
+          { tag_name: 'cli-v0.13.0', prerelease: true },
+          { tag_name: 'cli-v0.12.0' },
+        ]),
+      ),
+  });
+  await new Promise((resolve) => setTimeout(resolve, 10));
+  expect(write).not.toHaveBeenCalled();
+  stop();
+});
+
+it.each(['offline', 'rate-limit', 'invalid-json'])('silently handles %s', async (failure) => {
+  const write = vi.fn();
+  const stop = startUpdateNotice({
+    currentVersion: '0.12.0',
+    write,
+    fetchImpl: async () => {
+      if (failure === 'offline') throw new Error('offline');
+      return new Response('invalid', { status: failure === 'rate-limit' ? 403 : 200 });
+    },
+  });
+  await new Promise((resolve) => setTimeout(resolve, 10));
+  expect(write).not.toHaveBeenCalled();
+  stop();
+});
+
+it.each(['timeout', 'close'])('aborts on %s and suppresses late results', async (reason) => {
+  vi.useFakeTimers();
+  const write = vi.fn();
+  let signal!: AbortSignal;
+  let finish!: (response: Response) => void;
+  const stop = startUpdateNotice({
+    currentVersion: '0.12.0',
+    write,
+    fetchImpl: (_url, init) => {
+      signal = init!.signal!;
+      return new Promise((resolve) => {
+        finish = resolve;
+      });
+    },
+  });
+  if (reason === 'close') stop();
+  else await vi.advanceTimersByTimeAsync(3000);
+  expect(signal.aborted).toBe(true);
+  finish(releases('cli-v0.13.0'));
+  await vi.runAllTimersAsync();
+  expect(write).not.toHaveBeenCalled();
+  stop();
+});

--- a/apps/cli/src/update-notice.ts
+++ b/apps/cli/src/update-notice.ts
@@ -1,0 +1,29 @@
+import { CLI_BIN } from './bin-name.js';
+import { CLI_VERSION, compareSemver, resolveUpdateVersion, type FetchLike } from './update.js';
+
+export function startUpdateNotice(input: {
+  write: (line: string) => void;
+  currentVersion?: string;
+  fetchImpl?: FetchLike;
+}): () => void {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 3000);
+  timeout.unref?.();
+  const current = input.currentVersion ?? CLI_VERSION;
+  const stop = (): void => {
+    clearTimeout(timeout);
+    controller.abort();
+  };
+  void resolveUpdateVersion({
+    fallbackVersion: current,
+    fetchImpl: (url, init) => (input.fetchImpl ?? fetch)(url, { ...init, signal: controller.signal }),
+  })
+    .then((version) => {
+      if (!controller.signal.aborted && compareSemver(version, current) > 0) {
+        input.write(`Update available: ${CLI_BIN} ${current} → ${version}. Run /update, then restart ${CLI_BIN}.`);
+      }
+    })
+    .catch(() => {})
+    .finally(() => clearTimeout(timeout));
+  return stop;
+}

--- a/apps/cli/src/update.test.ts
+++ b/apps/cli/src/update.test.ts
@@ -3,7 +3,16 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { createHash } from 'node:crypto';
 import { describe, expect, it } from 'vitest';
-import { assetName, compareSemver, expectedHash, helperDest, resolveUpdateVersion, updateCli } from './update.js';
+import {
+  assetName,
+  compareSemver,
+  defaultInstallDest,
+  expectedHash,
+  helperDest,
+  resolveUpdateVersion,
+  runningBinaryPath,
+  updateCli,
+} from './update.js';
 import { CliError } from './exit-codes.js';
 
 describe('updateCli', () => {
@@ -98,5 +107,56 @@ describe('updateCli', () => {
       fetchImpl: async () => new Response(JSON.stringify(mockReleases), { status: 200 }),
     });
     expect(version).toBe('0.10.0');
+  });
+
+  describe('runningBinaryPath', () => {
+    it('recognizes installed gamedevpl and companion git-remote helper paths', () => {
+      expect(runningBinaryPath('/usr/local/bin/gamedevpl')).toBe('/usr/local/bin/gamedevpl');
+      expect(runningBinaryPath('/usr/local/bin/git-remote-gamedevpl')).toBe('/usr/local/bin/gamedevpl');
+      expect(runningBinaryPath('/opt/homebrew/bin/gamedevpl')).toBe('/opt/homebrew/bin/gamedevpl');
+    });
+
+    it('preserves Windows executable extensions', () => {
+      expect(runningBinaryPath('C:\\bin\\gamedevpl.exe')).toBe('C:\\bin\\gamedevpl.exe');
+      expect(runningBinaryPath('C:\\bin\\git-remote-gamedevpl.exe')).toBe('C:\\bin\\gamedevpl.exe');
+    });
+
+    it('rejects node_modules development paths and non-cli filenames', () => {
+      expect(runningBinaryPath('/repo/apps/cli/src/main.ts')).toBeNull();
+      expect(runningBinaryPath('/repo/apps/cli/dist/main.js')).toBeNull();
+      expect(runningBinaryPath('/repo/node_modules/vitest/vitest.mjs')).toBeNull();
+      expect(runningBinaryPath('/repo/node_modules/.bin/gamedevpl')).toBeNull();
+      expect(runningBinaryPath(undefined)).toBeNull();
+    });
+  });
+
+  describe('defaultInstallDest', () => {
+    it('defaults to ~/.local/bin/gamedevpl when outside installed binary', () => {
+      expect(defaultInstallDest({ env: {}, currentPath: '/repo/apps/cli/src/main.ts' })).toMatch(
+        /[/\\]\.local[/\\]bin[/\\]gamedevpl$/,
+      );
+    });
+
+    it('honors GAMEDEV_BIN_DIR when set', () => {
+      expect(defaultInstallDest({ env: { GAMEDEV_BIN_DIR: '/custom/bin' }, currentPath: '/repo/main.ts' })).toBe(
+        '/custom/bin/gamedevpl',
+      );
+      expect(
+        defaultInstallDest({
+          env: { GAMEDEV_BIN_DIR: 'C:\\custom\\bin' },
+          currentPath: 'C:\\other\\gamedevpl.exe',
+        }),
+      ).toBe('C:\\custom\\bin\\gamedevpl.exe');
+    });
+
+    it('preserves the active running binary installation path', () => {
+      expect(defaultInstallDest({ env: {}, currentPath: '/opt/bin/gamedevpl' })).toBe('/opt/bin/gamedevpl');
+      expect(defaultInstallDest({ env: {}, currentPath: '/opt/bin/git-remote-gamedevpl' })).toBe(
+        '/opt/bin/gamedevpl',
+      );
+      expect(defaultInstallDest({ env: {}, currentPath: 'C:\\tools\\gamedevpl.exe' })).toBe(
+        'C:\\tools\\gamedevpl.exe',
+      );
+    });
   });
 });

--- a/apps/cli/src/update.ts
+++ b/apps/cli/src/update.ts
@@ -2,7 +2,7 @@ import { createHash } from 'node:crypto';
 import { copyFileSync, mkdirSync, writeFileSync } from 'node:fs';
 import { createRequire } from 'node:module';
 import { homedir } from 'node:os';
-import { basename, dirname, join } from 'node:path';
+import { basename, dirname, join, resolve } from 'node:path';
 import { CLI_BIN, GIT_REMOTE_HELPER } from './bin-name.js';
 import { CliError, EXIT_REFUSED } from './exit-codes.js';
 
@@ -41,7 +41,53 @@ export function expectedHash(sums: string, asset: string): string | null {
   return null;
 }
 
-export function defaultInstallDest(): string {
+export type DefaultInstallDestOptions = {
+  env?: NodeJS.ProcessEnv;
+  currentPath?: string;
+};
+
+export function runningBinaryPath(currentPath?: string): string | null {
+  if (!currentPath) return null;
+  const normalized = currentPath.replaceAll('\\', '/');
+  const parts = normalized.split('/');
+  if (parts.includes('node_modules')) return null;
+  const lastSlash = normalized.lastIndexOf('/');
+  const base = lastSlash >= 0 ? normalized.slice(lastSlash + 1) : normalized;
+  const lower = base.toLowerCase();
+  const ext = /\.exe$/i.test(lower) ? '.exe' : '';
+  const raw = ext ? lower.slice(0, -4) : lower;
+  if (raw !== CLI_ASSET && raw !== GIT_REMOTE_HELPER) return null;
+  const sep = currentPath.includes('\\') && !currentPath.includes('/') ? '\\' : '/';
+  const resolved =
+    currentPath.startsWith('/') || /^[a-zA-Z]:[/\\]/.test(currentPath) ? currentPath : resolve(currentPath);
+  if (raw === CLI_ASSET) return resolved;
+  const resolvedNorm = resolved.replaceAll('\\', '/');
+  const dirEnd = resolvedNorm.lastIndexOf('/');
+  const dir = dirEnd >= 0 ? resolved.slice(0, dirEnd) : '';
+  return dir ? `${dir}${sep}${CLI_ASSET}${ext}` : `${CLI_ASSET}${ext}`;
+}
+
+export function defaultInstallDest(options?: NodeJS.ProcessEnv | DefaultInstallDestOptions): string {
+  const isOptionsObject =
+    options &&
+    typeof options === 'object' &&
+    ('currentPath' in options || ('env' in options && typeof options.env === 'object'));
+  const env =
+    (isOptionsObject ? (options as DefaultInstallDestOptions).env : (options as NodeJS.ProcessEnv | undefined)) ??
+    (typeof process !== 'undefined' ? process.env : {});
+  const current =
+    (isOptionsObject ? (options as DefaultInstallDestOptions).currentPath : undefined) ??
+    (typeof process !== 'undefined' && Array.isArray(process.argv) ? process.argv[1] : undefined);
+  const binDir = env.GAMEDEV_BIN_DIR?.trim();
+  if (binDir) {
+    const ext = /\.exe$/i.test(current ?? '') ? '.exe' : '';
+    const sep = binDir.includes('\\') && !binDir.includes('/') ? '\\' : '/';
+    return binDir.endsWith(sep) ? `${binDir}${CLI_ASSET}${ext}` : `${binDir}${sep}${CLI_ASSET}${ext}`;
+  }
+  const running = runningBinaryPath(current);
+  if (running) {
+    return running;
+  }
   return join(homedir(), '.local', 'bin', CLI_ASSET);
 }
 

--- a/apps/cli/src/update.ts
+++ b/apps/cli/src/update.ts
@@ -61,20 +61,25 @@ export function compareSemver(a: string, b: string): number {
   return 0;
 }
 
-export async function resolveUpdateVersion(input: { version?: string; fetchImpl: FetchLike }): Promise<string> {
+export async function resolveUpdateVersion(input: {
+  version?: string;
+  fetchImpl: FetchLike;
+  fallbackVersion?: string;
+}): Promise<string> {
   if (input.version) return input.version.replace(/^cli-v/, '');
   const res = await input.fetchImpl(CLI_RELEASES_API, {
     headers: { accept: 'application/vnd.github+json' },
   });
-  if (!res.ok) return CLI_VERSION;
-  const rows = (await res.json()) as Array<{ tag_name?: string }>;
+  if (!res.ok) return input.fallbackVersion ?? CLI_VERSION;
+  const rows = (await res.json()) as Array<{ tag_name?: string; draft?: boolean; prerelease?: boolean }>;
   const versions = rows
+    .filter((row) => !row.draft && !row.prerelease)
     .map((row) => row.tag_name ?? '')
-    .filter((tag) => tag.startsWith(CLI_RELEASE_PREFIX))
+    .filter((tag) => /^cli-v\d+\.\d+\.\d+$/.test(tag))
     .map((tag) => tag.slice(CLI_RELEASE_PREFIX.length))
     .sort(compareSemver);
   const newest = versions[versions.length - 1];
-  return newest || CLI_VERSION;
+  return newest || input.fallbackVersion || CLI_VERSION;
 }
 
 export async function updateCli(input: {

--- a/apps/cli/src/verbs.ts
+++ b/apps/cli/src/verbs.ts
@@ -27,6 +27,7 @@ export async function dispatchReadVerb(input: {
   api: ApiClient;
   io: Io;
   env?: NodeJS.ProcessEnv;
+  currentPath?: string;
 }): Promise<number | null> {
   const asJson = jsonMode(input.flags);
   const { verb, args, api, io, flags } = input;
@@ -93,7 +94,10 @@ export async function dispatchReadVerb(input: {
     return EXIT_GREEN;
   }
   if (verb === 'update') {
-    const dest = typeof flags.dest === 'string' ? flags.dest : defaultInstallDest();
+    const dest =
+      typeof flags.dest === 'string'
+        ? flags.dest
+        : defaultInstallDest({ env: input.env, currentPath: input.currentPath });
     const version = typeof flags.version === 'string' ? flags.version : undefined;
     const result = await updateCli({ dest, version });
     if (input.env) noteInstallChannel(input.env, 'update');


### PR DESCRIPTION
Starting an interactive session checks Creator Kit updates but never checks the CLI release, so creators can keep using an old CLI without knowing an update exists.

Check for a newer stable CLI release in the background when the TUI starts and show the installed/new version with `/update` and restart instructions. The check has a three-second timeout, never blocks input, silently tolerates network/rate-limit failures, and suppresses late results after exit. Draft, prerelease and malformed version tags are excluded.

Validation: type-check and lint pass. All 18 updater/notification tests pass. Full-suite CLI timeouts pass when rerun separately (20 tests); rule tests pass (76). Three unrelated API cases still hit their existing 5-second timeout locally after a serial retry; CI is running. Production build passes. Tests cover pending requests, unchanged/older versions, unstable releases, failed requests, timeout and session closure.
