### PR TITLE
Record the 302-vs-CSP miss when verifying media redirects

### DIFF
--- a/.claude/skills/verify-agent-work/SKILL.md
+++ b/.claude/skills/verify-agent-work/SKILL.md
@@ -77,6 +77,18 @@ Two concrete instances of that (observed 2026-07-23):
   blocked promotion. When a PR changes _when_ a frame mounts (or the copy of an error
   state the gate asserts), update `apps/e2e` in the same PR — the unit suite never
   drives that path.
+- **A 302 to another host can be unit-green while CSP forbids the destination.**
+  Observed (#1261 review, 2026-09-11): game media started answering 302 to a
+  15-minute GCS V4 URL. Route tests asserted `Location` and an empty body; CI was
+  green. Catalog/detail/theater load `gameplay.mp4` via `<video src="/api/…/media/…">`,
+  and CSP checks the *final* URL after redirects. `img-src` already allowed `https:`;
+  `media-src` was still `'self' data: blob:` — report-only today (a `/api/csp-report`
+  warn per catalog preview), enforcing later would block the file the PR exists to
+  move. `app.inject()` never executes CSP. When a PR changes the *origin* of a
+  media/img/script/connect URL (redirect, signed URL, new CDN), grep `img-src` /
+  `media-src` / `connect-src` / `script-src` and the actual tags (`<video>`, `<img>`,
+  `fetch`), not only the handler. Report-only still matters: the report sink logs
+  every violation.
 - **A responsive control can move into an overflow menu while its e2e selector stays
   direct.** Observed (#878, 2026-08-18): the mobile Studio Code action moved behind
   More, but the deploy gate still searched for a visible inline Code button. When a


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Reviewing #1261 (signed GCS redirects for catalog media) showed a hole this playbook did not name: `app.inject()` can assert a `302 Location` while CSP `media-src` still forbids the host the browser will actually load.

Adds that failure mode to `.claude/skills/verify-agent-work/SKILL.md` so the next review greps `img-src` / `media-src` / `connect-src` when a PR changes the origin of a media URL, including report-only (the report sink still logs every preview).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f9b56827-fdbe-46d8-9d51-6140efa22c88?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f9b56827-fdbe-46d8-9d51-6140efa22c88&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

