### PR TITLE
feat(cli): configure Antigravity headless permissions

### DIFF
--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -7,6 +7,10 @@ decides the next version — see [`.claude/skills/cli-release/SKILL.md`](../../.
 
 ## Unreleased
 
+### Added
+
+- Configure remembered sandboxed headless permissions before starting local Antigravity tasks.
+
 ## 0.13.1 — 2026-09-11
 
 ### Fixed

--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -9,7 +9,7 @@ decides the next version — see [`.claude/skills/cli-release/SKILL.md`](../../.
 
 ### Added
 
-- Configure remembered sandboxed headless permissions before starting local Antigravity tasks.
+- Configure remembered sandboxed headless permissions before starting local Antigravity tasks (#1267).
 
 ## 0.13.1 — 2026-09-11
 

--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -289,3 +289,26 @@ If a previous MCP agent stopped without ending its session, preview delivery can
 ### Push local changes
 
 Use `/push` in the checkout session, or `gamedevpl push [dir]`, to run checks and deliver a preview. `/pull` brings platform changes into the checkout. `/submit` remains an alias for `/push`; neither publishes publicly unless you explicitly pass `--publish`.
+
+### Antigravity permissions
+
+Before a local Antigravity task starts, the interactive CLI offers to enable
+sandboxed headless execution. Confirming sets `enableTerminalSandbox: true` and
+`toolPermission: "proceed-in-sandbox"` in
+`~/.gemini/antigravity-cli/settings.json`. This is an **agy-wide setting**, shared
+by all projects. Existing permission rules and other preferences are preserved;
+the previous file is backed up beside it, with the backup path printed after setup.
+
+Agy runs approved sandboxed commands without opening another terminal UI. Existing
+ask/deny rules still apply, as do any outside-sandbox exceptions you previously
+configured. The CLI does not add wildcard grants or `--dangerously-skip-permissions`.
+If agy still needs permission, you can resume the task interactively or return with
+local edits preserved. Network access and tools outside the sandbox may still need
+approval; enabling this preset does not grant unrestricted access.
+
+The enabled preset is detected on subsequent runs. To change it later, use agy's
+`/config` or restore the printed backup. You can also choose existing permissions
+for one run or cancel before preparation starts. Unattended CLI runs never modify
+agy settings or open a permission picker.
+
+See the [Antigravity sandbox documentation](https://antigravity.google/docs/cli/sandbox/).

--- a/apps/cli/src/agy-permissions.test.ts
+++ b/apps/cli/src/agy-permissions.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, expect, it, vi } from 'vitest';
-import { mkdtemp, mkdir, readFile, readdir, rm, symlink, writeFile } from 'node:fs/promises';
+import { mkdtemp, mkdir, lstat, readFile, readdir, rm, symlink, writeFile } from 'node:fs/promises';
 import { join, dirname } from 'node:path';
 import { tmpdir } from 'node:os';
 import { setupAgyPermissions } from './agy-permissions.js';
@@ -87,13 +87,15 @@ it('cancelling during the picker does not write settings', async () => {
   expect(await setupAgyPermissions(input)).toBe(false);
   expect(await readFile(path, 'utf8')).toBe('{}');
 });
-it('refuses symlink profiles without following or replacing them', async () => {
+it('refuses to modify symlink profiles after explicit setup selection', async () => {
   const { root, path, input } = await fixture();
   const target = join(root, 'original.json');
   await writeFile(target, '{}');
   await symlink(target, path);
   await expect(setupAgyPermissions(input)).rejects.toThrow('safely read');
   expect(await readFile(target, 'utf8')).toBe('{}');
+  expect((await lstat(path)).isSymbolicLink()).toBe(true);
+  expect(input.pick).toHaveBeenCalledTimes(1);
 });
 
 it('does not configure unsupported sandbox platforms', async () => {
@@ -102,3 +104,22 @@ it('does not configure unsupported sandbox platforms', async () => {
   expect(input.pick).not.toHaveBeenCalled();
   expect(await readFile(path, 'utf8')).toBe('{}');
 });
+
+for (const mode of ['current', 'unattended', 'configured', 'cancel'] as const) {
+  it(`preserves symlink profiles when using ${mode} permissions`, async () => {
+    const { root, path, input } = await fixture();
+    const target = join(root, 'dotfiles.json');
+    const raw =
+      mode === 'configured'
+        ? JSON.stringify({ enableTerminalSandbox: true, toolPermission: 'proceed-in-sandbox' })
+        : '{}';
+    await writeFile(target, raw);
+    await symlink(target, path);
+    input.pick.mockImplementation(async (choices) => choices[mode === 'cancel' ? 2 : 1]!);
+    expect(await setupAgyPermissions({ ...input, unattended: mode === 'unattended' })).toBe(mode !== 'cancel');
+    expect(await readFile(target, 'utf8')).toBe(raw);
+    expect((await lstat(path)).isSymbolicLink()).toBe(true);
+    expect(await readdir(dirname(path))).toEqual(['settings.json']);
+    expect(input.pick).toHaveBeenCalledTimes(mode === 'current' || mode === 'cancel' ? 1 : 0);
+  });
+}

--- a/apps/cli/src/agy-permissions.test.ts
+++ b/apps/cli/src/agy-permissions.test.ts
@@ -1,0 +1,97 @@
+import { afterEach, expect, it, vi } from 'vitest';
+import { mkdtemp, mkdir, readFile, readdir, rm, symlink, writeFile } from 'node:fs/promises';
+import { join, dirname } from 'node:path';
+import { tmpdir } from 'node:os';
+import { setupAgyPermissions } from './agy-permissions.js';
+
+const roots: string[] = [];
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+});
+async function fixture(raw?: string) {
+  const root = await mkdtemp(join(tmpdir(), 'agy-settings-test-'));
+  roots.push(root);
+  const path = join(root, '.gemini', 'antigravity-cli', 'settings.json');
+  await mkdir(dirname(path), { recursive: true });
+  if (raw !== undefined) await writeFile(path, raw);
+  const controller = new AbortController();
+  const input = {
+    env: { HOME: root },
+    pick: vi.fn(async (choices: string[]) => choices[0]!),
+    write: vi.fn(),
+    abort: controller.signal,
+  };
+  return { root, path, input, controller };
+}
+it('preserves unrelated settings and permissions, backs up original bytes, remembers setup', async () => {
+  const original = JSON.stringify({
+    model: 'chosen',
+    permissions: { ask: ['command(git push)'], deny: ['read_file(secret)'] },
+    custom: 42,
+  });
+  const { path, input } = await fixture(original);
+  expect(await setupAgyPermissions(input)).toBe(true);
+  expect(JSON.parse(await readFile(path, 'utf8'))).toEqual({
+    ...JSON.parse(original),
+    enableTerminalSandbox: true,
+    toolPermission: 'proceed-in-sandbox',
+  });
+  const backup = (await readdir(dirname(path))).find((name) => name.endsWith('.bak'))!;
+  expect(await readFile(join(dirname(path), backup), 'utf8')).toBe(original);
+  expect(await setupAgyPermissions(input)).toBe(true);
+  expect(input.pick).toHaveBeenCalledTimes(1);
+});
+it('creates a minimal profile without wildcard grants or bypass', async () => {
+  const { path, input } = await fixture();
+  expect(await setupAgyPermissions(input)).toBe(true);
+  expect(JSON.parse(await readFile(path, 'utf8'))).toEqual({
+    enableTerminalSandbox: true,
+    toolPermission: 'proceed-in-sandbox',
+  });
+});
+for (const option of [1, 2])
+  it(`does not modify settings for alternative ${option}`, async () => {
+    const { path, input } = await fixture('{}');
+    input.pick.mockImplementation(async (choices) => choices[option]!);
+    expect(await setupAgyPermissions(input)).toBe(option === 1);
+    expect(await readFile(path, 'utf8')).toBe('{}');
+  });
+it('does not prompt or mutate in unattended mode', async () => {
+  const { path, input } = await fixture('{}');
+  expect(await setupAgyPermissions({ ...input, unattended: true })).toBe(true);
+  expect(input.pick).not.toHaveBeenCalled();
+  expect(await readFile(path, 'utf8')).toBe('{}');
+});
+it('refuses malformed profiles without replacing them', async () => {
+  const { path, input } = await fixture('{broken');
+  await expect(setupAgyPermissions(input)).rejects.toThrow('invalid');
+  expect(input.pick).not.toHaveBeenCalled();
+  expect(await readFile(path, 'utf8')).toBe('{broken');
+});
+it('does not overwrite changes made while the permission picker is open', async () => {
+  const { path, input } = await fixture('{}');
+  input.pick.mockImplementation(async (choices) => {
+    await writeFile(path, '{"custom":1}');
+    return choices[0]!;
+  });
+  await expect(setupAgyPermissions(input)).rejects.toThrow('changed during setup');
+  expect(await readFile(path, 'utf8')).toBe('{"custom":1}');
+  expect(await readdir(dirname(path))).toEqual(['settings.json']);
+});
+it('cancelling during the picker does not write settings', async () => {
+  const { path, input, controller } = await fixture('{}');
+  input.pick.mockImplementation(async (choices) => {
+    controller.abort();
+    return choices[0]!;
+  });
+  expect(await setupAgyPermissions(input)).toBe(false);
+  expect(await readFile(path, 'utf8')).toBe('{}');
+});
+it('refuses symlink profiles without following or replacing them', async () => {
+  const { root, path, input } = await fixture();
+  const target = join(root, 'original.json');
+  await writeFile(target, '{}');
+  await symlink(target, path);
+  await expect(setupAgyPermissions(input)).rejects.toThrow('safely read');
+  expect(await readFile(target, 'utf8')).toBe('{}');
+});

--- a/apps/cli/src/agy-permissions.test.ts
+++ b/apps/cli/src/agy-permissions.test.ts
@@ -95,3 +95,10 @@ it('refuses symlink profiles without following or replacing them', async () => {
   await expect(setupAgyPermissions(input)).rejects.toThrow('safely read');
   expect(await readFile(target, 'utf8')).toBe('{}');
 });
+
+it('does not configure unsupported sandbox platforms', async () => {
+  const { path, input } = await fixture('{}');
+  expect(await setupAgyPermissions({ ...input, platform: 'win32' })).toBe(true);
+  expect(input.pick).not.toHaveBeenCalled();
+  expect(await readFile(path, 'utf8')).toBe('{}');
+});

--- a/apps/cli/src/agy-permissions.ts
+++ b/apps/cli/src/agy-permissions.ts
@@ -39,8 +39,13 @@ export async function setupAgyPermissions(input: {
   write: (line: string) => void;
   abort: AbortSignal;
   unattended?: boolean;
+  platform?: NodeJS.Platform;
 }): Promise<boolean> {
   if (input.abort.aborted) return false;
+  if (!['darwin', 'linux'].includes(input.platform ?? process.platform)) {
+    input.write('Antigravity sandbox setup is available on macOS and Linux; using existing permissions.');
+    return true;
+  }
   const path = join(input.env.HOME ?? homedir(), '.gemini', 'antigravity-cli', 'settings.json');
   const raw = await snapshot(path);
   const settings = decode(raw);

--- a/apps/cli/src/agy-permissions.ts
+++ b/apps/cli/src/agy-permissions.ts
@@ -1,0 +1,97 @@
+import { lstat, mkdir, readFile, rename, unlink, writeFile } from 'node:fs/promises';
+import { homedir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { randomUUID } from 'node:crypto';
+import { CliError, EXIT_REFUSED } from './exit-codes.js';
+import type { PickChoice, Workshop } from './workshop.js';
+
+const ENABLE = 'Enable sandboxed headless mode (remember for agy)';
+const CURRENT = 'Use current agy permissions for this run';
+const CANCEL = 'Return without starting';
+
+type Settings = Record<string, unknown>;
+
+async function snapshot(path: string): Promise<string | undefined> {
+  try {
+    const info = await lstat(path);
+    if (!info.isFile() || info.isSymbolicLink()) throw new Error('not a regular settings file');
+    return await readFile(path, 'utf8');
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return undefined;
+    throw new CliError('Cannot safely read Antigravity settings.', EXIT_REFUSED, 'check agy settings.json');
+  }
+}
+
+function decode(raw: string | undefined): Settings {
+  if (raw === undefined) return {};
+  try {
+    const value: unknown = JSON.parse(raw);
+    if (!value || typeof value !== 'object' || Array.isArray(value)) throw new Error('invalid settings');
+    return value as Settings;
+  } catch {
+    throw new CliError('Antigravity settings.json is invalid; left unchanged.', EXIT_REFUSED);
+  }
+}
+
+export async function setupAgyPermissions(input: {
+  env: NodeJS.ProcessEnv;
+  pick: PickChoice;
+  write: (line: string) => void;
+  abort: AbortSignal;
+  unattended?: boolean;
+}): Promise<boolean> {
+  if (input.abort.aborted) return false;
+  const path = join(input.env.HOME ?? homedir(), '.gemini', 'antigravity-cli', 'settings.json');
+  const raw = await snapshot(path);
+  const settings = decode(raw);
+  if (settings.toolPermission === 'proceed-in-sandbox' && settings.enableTerminalSandbox === true) {
+    input.write('Antigravity: sandboxed headless mode. Existing permission rules still apply.');
+    return true;
+  }
+  if (input.unattended) {
+    input.write('Antigravity: using existing permissions; unattended runs do not change agy settings.');
+    return true;
+  }
+  input.write(
+    'Antigravity can run commands without prompts inside its sandbox. Setup changes global agy settings for all projects, not just this game.',
+  );
+  input.write(
+    'Sets enableTerminalSandbox=true and toolPermission=proceed-in-sandbox. Existing allow/ask/deny rules, including any outside-sandbox exceptions, remain unchanged. A backup is saved.',
+  );
+  const choice = await input.pick([ENABLE, CURRENT, CANCEL], 'How should Antigravity handle permissions?');
+  if (input.abort.aborted || choice === CANCEL) return false;
+  if (choice === CURRENT) return true;
+  if (choice !== ENABLE) return false;
+  await mkdir(dirname(path), { recursive: true });
+  const suffix = randomUUID();
+  const temporary = `${path}.${suffix}.tmp`;
+  const backup = `${path}.gamedevpl-${suffix}.bak`;
+  try {
+    await writeFile(
+      temporary,
+      JSON.stringify({ ...settings, enableTerminalSandbox: true, toolPermission: 'proceed-in-sandbox' }, null, 2) +
+        '\n',
+      { flag: 'wx', mode: 0o600 },
+    );
+    if ((await snapshot(path)) !== raw)
+      throw new CliError('Antigravity settings changed during setup; retry before starting.', EXIT_REFUSED);
+    if (input.abort.aborted) return false;
+    if (raw !== undefined) await writeFile(backup, raw, { flag: 'wx', mode: 0o600 });
+    await rename(temporary, path);
+  } finally {
+    await unlink(temporary).catch(() => {});
+  }
+  input.write('Antigravity: sandboxed headless mode enabled and remembered. Existing permission rules still apply.');
+  input.write(raw === undefined ? `Settings: ${path}` : `Previous settings backup: ${backup}`);
+  return true;
+}
+
+export async function prepareAgyPermissions(
+  ws: Workshop,
+  adapter: string,
+  write: (line: string) => void,
+  abort: AbortSignal,
+): Promise<boolean> {
+  if (adapter !== 'agy' || ws.runAdapter) return true;
+  return setupAgyPermissions({ env: ws.env, pick: ws.pick, write, abort, unattended: !!ws.unattended });
+}

--- a/apps/cli/src/agy-permissions.ts
+++ b/apps/cli/src/agy-permissions.ts
@@ -1,4 +1,4 @@
-import { lstat, mkdir, readFile, rename, unlink, writeFile } from 'node:fs/promises';
+import { lstat, stat, mkdir, readFile, rename, unlink, writeFile } from 'node:fs/promises';
 import { homedir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { randomUUID } from 'node:crypto';
@@ -11,10 +11,11 @@ const CANCEL = 'Return without starting';
 
 type Settings = Record<string, unknown>;
 
-async function snapshot(path: string): Promise<string | undefined> {
+async function snapshot(path: string, followSymlink = false): Promise<string | undefined> {
   try {
-    const info = await lstat(path);
-    if (!info.isFile() || info.isSymbolicLink()) throw new Error('not a regular settings file');
+    const entry = await lstat(path);
+    const info = followSymlink && entry.isSymbolicLink() ? await stat(path) : entry;
+    if (!info.isFile()) throw new Error('not a regular settings file');
     return await readFile(path, 'utf8');
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code === 'ENOENT') return undefined;
@@ -47,7 +48,7 @@ export async function setupAgyPermissions(input: {
     return true;
   }
   const path = join(input.env.HOME ?? homedir(), '.gemini', 'antigravity-cli', 'settings.json');
-  const raw = await snapshot(path);
+  const raw = await snapshot(path, true);
   const settings = decode(raw);
   if (settings.toolPermission === 'proceed-in-sandbox' && settings.enableTerminalSandbox === true) {
     input.write('Antigravity: sandboxed headless mode. Existing permission rules still apply.');

--- a/apps/cli/src/workshop-preview.test.ts
+++ b/apps/cli/src/workshop-preview.test.ts
@@ -139,3 +139,41 @@ it('checks subscription before preparation, preview, telemetry or agent launch',
   expect(record).not.toHaveBeenCalled();
   expect(ws.abort.current).toBeNull();
 });
+
+it.each([true, false])('configures agy before preparation and launch: confirm=%s', async (confirm) => {
+  const { readFileSync } = await import('node:fs');
+  const { loadAdapters } = await import('./adapters.js');
+  const { spawnAdapter } = await import('./delegate.js');
+  const { prepareWorkspace } = await import('./prepare-workspace.js');
+  const root = mkdtempSync(join(tmpdir(), 'gdpl-agy-setup-'));
+  roots.push(root);
+  const spec = loadAdapters().adapters.find((item) => item.name === 'agy')!;
+  const ws: Workshop = {
+    root,
+    slug: 'robot',
+    token: '',
+    env: { HOME: root },
+    adapters: [spec],
+    builder: 'self',
+    pick: async (choices) => {
+      expect(prepareWorkspace).not.toHaveBeenCalled();
+      expect(spawnAdapter).not.toHaveBeenCalled();
+      return choices[confirm ? 0 : 2]!;
+    },
+    abort: { current: null },
+    run: () => ({ status: 0, stderr: '' }),
+  };
+  expect(await runLocalBuild({ ws, spec, brief: 'edit game', write: () => {} })).toBe(confirm);
+  expect(spawnAdapter).toHaveBeenCalledTimes(confirm ? 1 : 0);
+  if (confirm) {
+    expect(JSON.parse(readFileSync(join(root, '.gemini/antigravity-cli/settings.json'), 'utf8')).toolPermission).toBe(
+      'proceed-in-sandbox',
+    );
+    expect(spawnAdapter).toHaveBeenCalledWith(
+      expect.objectContaining({
+        spec: expect.objectContaining({ headless: expect.arrayContaining(['--sandbox', '--print']) }),
+      }),
+    );
+  }
+  expect(ws.abort.current).toBeNull();
+});

--- a/apps/cli/src/workshop.ts
+++ b/apps/cli/src/workshop.ts
@@ -1,3 +1,4 @@
+import { prepareAgyPermissions } from './agy-permissions.js';
 import { localActivity } from './local-activity.js';
 import { agyConversation, type InteractiveRun } from './agy-interactive.js';
 import { taskOutput } from './task-output.js';
@@ -264,11 +265,11 @@ export async function runLocalBuild(input: {
   const cwd = spec.cwd === 'game-dir' ? join(ws.root, 'games', ws.slug) : ws.root;
   const controller = new AbortController();
   ws.abort.current = controller;
-  const presence = localActivity(ws.activityApi, ws.token, spec.name);
+  let presence: ReturnType<typeof localActivity> | undefined;
   let success = false;
-  ws.onLocalTask?.(spec.name);
   let authCheck: Promise<void> | undefined;
   try {
+    if (!(await prepareAgyPermissions(ws, spec.name, input.write, controller.signal))) return false;
     if (!ws.runAdapter && spec.name === 'claude') {
       authCheck = requireClaudeSubscription({
         command: spec.command,
@@ -279,6 +280,8 @@ export async function runLocalBuild(input: {
       });
       await authCheck;
     }
+    presence = localActivity(ws.activityApi, ws.token, spec.name);
+    ws.onLocalTask?.(spec.name);
     input.write(`▸ Preparing ${spec.name} in games/${ws.slug} — Ctrl+C stops it`);
     if (!ws.runAdapter) {
       input.write('Preparing Creator Kit and dependencies…');
@@ -319,11 +322,11 @@ export async function runLocalBuild(input: {
       write: input.write,
       failed: (stage) => ws.telemetry?.record('verify_failed', { adapter: spec.name, stage }),
       verify: () => {
-        presence.phase('verifying');
+        presence?.phase('verifying');
         return runLadderAsync({ cwd: ws.root, run: ws.run, abort: controller.signal });
       },
       run: async (prompt) => {
-        presence.phase('editing');
+        presence?.phase('editing');
         const stream = createDelegateStream(spec.name);
         const failure = trackAgentFailure(spec.name);
         let blocked = false;
@@ -347,7 +350,7 @@ export async function runLocalBuild(input: {
         });
         if (controller.signal.aborted) return false;
         if (blocked && spec.name === 'agy' && ws.interactiveRun && !ws.unattended) {
-          presence.phase('permission');
+          presence?.phase('permission');
           const choice = await ws.pick(
             ['Open Antigravity interactively', 'Keep edits and return'],
             'Antigravity needs permission. Open its permission prompts in this terminal?',
@@ -356,7 +359,7 @@ export async function runLocalBuild(input: {
           input.write(
             'Antigravity now owns the terminal. Answer its permission prompts, then exit Antigravity to return here for verification.',
           );
-          presence.phase('interactive');
+          presence?.phase('interactive');
           const resumed = await ws.interactiveRun({
             spec,
             cwd,
@@ -393,7 +396,7 @@ export async function runLocalBuild(input: {
     return success;
   } finally {
     output.flush();
-    await presence.finish(controller.signal.aborted ? 'stopped' : success ? 'ready' : 'failed');
+    await presence?.finish(controller.signal.aborted ? 'stopped' : success ? 'ready' : 'failed');
     if (controller.signal.aborted) input.write(`${spec.name} stopped — the tree keeps whatever it wrote; /diff to see`);
     ws.abort.current = null;
     ws.onLocalTask?.('');


### PR DESCRIPTION
Antigravity local delegation currently discovers missing command permissions only after starting, then asks the creator to switch terminal interfaces. Offer sandboxed headless setup before preparing the checkout or launching the agent.

The picker explicitly explains that this updates global agy settings for every project. Confirmation sets `enableTerminalSandbox=true` and `toolPermission=proceed-in-sandbox`, preserves existing rules and unrelated settings, and saves an exact backup. Subsequent runs detect the preset. Creators can instead keep current settings or cancel; unattended runs never configure permissions. Existing interactive recovery remains available for denied tools. Setup is offered only on macOS/Linux, where agy documents terminal sandbox support.

No wildcard permissions or permission-bypass flags are added. Existing outside-sandbox exceptions remain in effect. The settings writer rejects malformed profiles and refuses to replace symlinks, while existing-permissions and unattended runs can use symlinked settings. It also detects edits made while the picker is open.

Validation: all 380 CLI tests passed with local-port access, including 26 focused setup/fallback tests. Repository type-check and lint passed. All GitHub CI checks passed at 401fb49b0, including full monorepo lint/type-check/tests/build, CLI bundle smoke test, security checks and production image. The parallel local monorepo run encountered localhost EPERM and timing failures and was stopped after CI completed. The installed agy help supports `--sandbox`, and its binary contains both preset settings; no paid model task or user-global configuration was changed during verification. Reference: https://antigravity.google/docs/cli/sandbox/.

Instrumentation: affects creator funnel question 4. Existing `cli_step` / `delegate_used` records launches only after setup; cancelled setup does not count as a delegation. Permission-choice conversion is not separately measured.


Review follow-up: allow valid symlinked settings for current permissions, unattended runs and an already-enabled preset. Symlink replacement remains refused only after choosing setup. All 26 focused tests, CLI type-check and changed-file ESLint pass; CI is rerunning for this follow-up.
