### PR TITLE
feat(web): make matched game title and thumbnail link to game subpage

### DIFF
--- a/apps/web/src/HeroPromptSection.navigation.test.tsx
+++ b/apps/web/src/HeroPromptSection.navigation.test.tsx
@@ -1,0 +1,156 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from 'react';
+import { createRoot } from 'react-dom/client';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { HeroPromptSection } from './HeroPromptSection.js';
+import { NAVIGATE_EVENT } from './core/router.js';
+import i18n from './i18n/index.js';
+
+async function flushEffects() {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+const mockCatalog = [
+  {
+    slug: 'mexico-86',
+    title: "Mexico '86 Arcade Football",
+    genre: 'sports',
+    controls: 'Arrows / Enter / Tap to navigate; 1–4 to pick action',
+    status: 'published',
+    media: {
+      screenshots: [
+        { name: 'opening', file: 'opening.png' },
+        { name: 'action', file: 'action.png' },
+      ],
+      video: null,
+    },
+    multiplayer: { mode: 'controllers' as const, minPlayers: 1, maxPlayers: 2 },
+    saves: null,
+    world: null,
+    sensing: null,
+    editor: null,
+    orientation: 'landscape' as const,
+    submittedBy: null,
+  },
+];
+
+describe('HeroPromptSection navigation', () => {
+  afterEach(() => {
+    document.body.innerHTML = '';
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it('renders matched title and thumbnail with game subpage links', async () => {
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    await i18n.changeLanguage('en');
+
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(
+        createElement(HeroPromptSection, {
+          initialPrompt: 'mexico',
+          catalogEntries: mockCatalog,
+          submissionStatus: 'idle',
+          submissionError: null,
+          onSubmitSpec: vi.fn(),
+        }),
+      );
+      await flushEffects();
+    });
+
+    const thumbLink = container.querySelector<HTMLAnchorElement>('.matched-thumb-wrap');
+    expect(thumbLink?.tagName.toLowerCase()).toBe('a');
+    expect(thumbLink?.getAttribute('href')).toBe('/gamedevpl/mexico-86?via=composer_match');
+
+    const titleLink = container.querySelector<HTMLAnchorElement>('.matched-title-link');
+    expect(titleLink).not.toBeNull();
+    expect(titleLink?.getAttribute('href')).toBe('/gamedevpl/mexico-86?via=composer_match');
+
+    await act(async () => root.unmount());
+  });
+
+  it('calls onNavigate on title click when provided', async () => {
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    await i18n.changeLanguage('en');
+
+    const onNavigate = vi.fn();
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(
+        createElement(HeroPromptSection, {
+          initialPrompt: 'mexico',
+          catalogEntries: mockCatalog,
+          onNavigate,
+          submissionStatus: 'idle',
+          submissionError: null,
+          onSubmitSpec: vi.fn(),
+        }),
+      );
+      await flushEffects();
+    });
+
+    const titleLink = container.querySelector<HTMLAnchorElement>('.matched-title-link');
+    expect(titleLink).not.toBeNull();
+
+    await act(async () => {
+      titleLink?.click();
+      await flushEffects();
+    });
+
+    expect(onNavigate).toHaveBeenCalledTimes(1);
+    expect(onNavigate).toHaveBeenCalledWith('/gamedevpl/mexico-86?via=composer_match');
+
+    await act(async () => root.unmount());
+  });
+
+  it('dispatches popstate and NAVIGATE_EVENT when onNavigate is omitted', async () => {
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    await i18n.changeLanguage('en');
+
+    const popstateSpy = vi.fn();
+    const navigateEventSpy = vi.fn();
+    window.addEventListener('popstate', popstateSpy);
+    window.addEventListener(NAVIGATE_EVENT, navigateEventSpy);
+
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(
+        createElement(HeroPromptSection, {
+          initialPrompt: 'mexico',
+          catalogEntries: mockCatalog,
+          submissionStatus: 'idle',
+          submissionError: null,
+          onSubmitSpec: vi.fn(),
+        }),
+      );
+      await flushEffects();
+    });
+
+    const titleLink = container.querySelector<HTMLAnchorElement>('.matched-title-link');
+    expect(titleLink).not.toBeNull();
+
+    await act(async () => {
+      titleLink?.click();
+      await flushEffects();
+    });
+
+    expect(popstateSpy).toHaveBeenCalled();
+    expect(navigateEventSpy).toHaveBeenCalled();
+
+    window.removeEventListener('popstate', popstateSpy);
+    window.removeEventListener(NAVIGATE_EVENT, navigateEventSpy);
+    await act(async () => root.unmount());
+  });
+});

--- a/apps/web/src/HeroPromptSection.tsx
+++ b/apps/web/src/HeroPromptSection.tsx
@@ -1,7 +1,8 @@
 import { useState, useMemo, useRef, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { recordCreateStep, type PlayVia } from './visitTelemetry.js';
-import { catalogMediaUrl, defaultScreenshotIndex, type CatalogEntry } from './catalog.js';
+import { catalogMediaUrl, defaultScreenshotIndex, gamePageHandle, type CatalogEntry } from './catalog.js';
+import { gamePath, NAVIGATE_EVENT } from './core/router.js';
 import { SketchModal } from './SketchModal.js';
 import { PixelIcon } from './PixelIcon.js';
 import { getQuota, type PlatformBuilderAvailability } from './submissionApi.js';
@@ -17,6 +18,7 @@ type HeroPromptSectionProps = {
   initialPrompt?: string;
   catalogEntries?: CatalogEntry[];
   onPlayGame?: (entry: CatalogEntry, via?: PlayVia) => void;
+  onNavigate?: (path: string) => void;
   // refining = pre-submit spec refiner; nothing sent yet
   submissionStatus: 'idle' | 'refining' | 'loading';
   submissionError: string | null;
@@ -67,6 +69,7 @@ export function HeroPromptSection({
   initialPrompt = '',
   catalogEntries = [],
   onPlayGame,
+  onNavigate,
   submissionStatus,
   submissionError,
   onSubmitSpec,
@@ -228,6 +231,22 @@ export function HeroPromptSection({
   }, [rawVectorGame, catalogEntries]);
 
   const matchedGame = localMatchedGame || vectorMatchedGame;
+  const matchedGameHref = matchedGame
+    ? `${gamePath(gamePageHandle(matchedGame), matchedGame.slug)}?via=composer_match`
+    : '';
+
+  const handleGameLinkClick = (path: string) => (event: React.MouseEvent<HTMLAnchorElement>) => {
+    if (event.defaultPrevented || event.button !== 0) return;
+    if (event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) return;
+    event.preventDefault();
+    if (onNavigate) {
+      onNavigate(path);
+      return;
+    }
+    window.history.pushState(null, '', path);
+    window.dispatchEvent(new PopStateEvent('popstate'));
+    window.dispatchEvent(new CustomEvent(NAVIGATE_EVENT, { detail: { path } }));
+  };
 
   useEffect(() => {
     if (!needsVectorSearch) return;
@@ -541,15 +560,21 @@ export function HeroPromptSection({
           {matchedGame ? (
             <div className="smart-intent-card matched-card">
               {matchedPoster ? (
-                <div className="matched-thumb-wrap">
+                <a
+                  href={matchedGameHref}
+                  className="matched-thumb-wrap"
+                  onClick={handleGameLinkClick(matchedGameHref)}
+                  tabIndex={-1}
+                  aria-hidden="true"
+                >
                   <img
                     src={matchedPoster}
-                    alt={matchedGame.title}
+                    alt=""
                     className="matched-thumb"
                     loading="lazy"
                     decoding="async"
                   />
-                </div>
+                </a>
               ) : null}
               <div className="matched-info">
                 <div className="matched-badges">
@@ -564,7 +589,15 @@ export function HeroPromptSection({
                     </span>
                   )}
                 </div>
-                <h3 className="matched-title">{matchedGame.title}</h3>
+                <h3 className="matched-title">
+                  <a
+                    href={matchedGameHref}
+                    className="matched-title-link"
+                    onClick={handleGameLinkClick(matchedGameHref)}
+                  >
+                    {matchedGame.title}
+                  </a>
+                </h3>
                 {(() => {
                   const isPl = (i18n?.language || '').startsWith('pl');
                   const tagline = isPl ? matchedGame.tagline?.pl : matchedGame.tagline?.en;

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -1010,6 +1010,18 @@
   flex-shrink: 0;
   background: rgba(0, 0, 0, 0.3);
   border: 1px solid rgba(255, 255, 255, 0.1);
+  display: block;
+  transition: border-color 0.15s ease, transform 0.15s ease;
+}
+
+.matched-thumb-wrap:hover {
+  border-color: rgba(0, 240, 255, 0.5);
+  transform: scale(1.02);
+}
+
+.matched-thumb-wrap:focus-visible {
+  outline: 2px solid var(--turquoise);
+  outline-offset: 2px;
 }
 
 .matched-thumb {
@@ -1052,6 +1064,24 @@
   font-size: 1.25rem;
   color: #fff;
   font-weight: 700;
+}
+
+.matched-title-link {
+  color: inherit;
+  text-decoration: none;
+  transition: color 0.15s ease;
+}
+
+.matched-title-link:hover {
+  color: var(--turquoise);
+  text-decoration: underline;
+  text-underline-offset: 3px;
+}
+
+.matched-title-link:focus-visible {
+  outline: 2px solid var(--turquoise);
+  outline-offset: 2px;
+  border-radius: 2px;
 }
 
 .matched-desc {


### PR DESCRIPTION
In the hero composer / search intent card (`HeroPromptSection`), only the "Play now" (`smartPlayBtn`) button had a click handler. The matched game's title and thumbnail were inert elements without links or cursor indicators.

### Changes
- Wrapped the matched game title in `<a className="matched-title-link">` and the thumbnail in `<a className="matched-thumb-wrap">`, pointing to the game's canonical subpage (`gamePath(gamePageHandle(matchedGame), matchedGame.slug)` with `?via=composer_match`).
- Wired in-app navigation via `onNavigate` or standalone `pushState` + `PopStateEvent` / `NAVIGATE_EVENT` to preserve SPA routing while respecting standard browser link behaviors (`Ctrl`/`Cmd` click, middle click).
- Added hover & focus-visible styles in `styles.css` matching design conventions.
- Added thumbnail accessibility attributes (`tabIndex={-1}`, `aria-hidden="true"`, empty `alt`).
- Updated `HeroPromptSection.test.tsx` to verify the link targets and navigation dispatch.

### Verification
- `npm run test -w @gamedevpl/web -- src/HeroPromptSection.test.tsx` passed (19 tests).
- `npm run lint` passed (0 errors).
- `npm run type-check` passed across all workspaces.