### PR TITLE
fix(api): accept Creator Kit editor imports on delivery

### DIFF
--- a/apps/api/src/creation/typecheck-editor.test.ts
+++ b/apps/api/src/creation/typecheck-editor.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+import { KIT_ROOT_DIR } from '../platform/kit-registry.js';
+import type { KitTree } from '../agent-surface/kit-files.js';
+import { sharedSourcesFromKitTree, typecheckDeliverySources } from './typecheck-preflight.js';
+
+const KIT_DTS = `
+interface GameKitGameContext {
+  draw: { circle(x: number, y: number, r: number): void };
+  width: number;
+  height: number;
+}
+declare const GameKit: { defineGame(): unknown };
+`;
+
+function kitTree(files: Record<string, string>): KitTree {
+  const map = new Map<string, Buffer>();
+  for (const [rel, body] of Object.entries(files)) {
+    map.set(`${KIT_ROOT_DIR}/${rel}`, Buffer.from(body, 'utf8'));
+  }
+  return { engineRef: 'abc', sha256: 'a'.repeat(64), files: map };
+}
+
+describe('editor Kit preflight', () => {
+  it('checks editor imports against the pinned Kit, including missing exports and files', () => {
+    const kitShared = sharedSourcesFromKitTree(
+      kitTree({
+        'shared/game-kit.d.ts': KIT_DTS,
+        'shared/editor-def.ts': 'export function defineEditor(value: number) { return value; }',
+      }),
+    );
+    const check = (name: string, file: string) =>
+      typecheckDeliverySources({
+        slug: 'comet',
+        kitShared,
+        sources: { 'EDITOR.ts': `import { ${name} } from '../../shared/${file}.ts'; export default ${name}(1);` },
+      });
+    expect(check('defineEditor', 'editor-def').ok).toBe(true);
+    expect(check('missingExport', 'editor-def').ok).toBe(false);
+    expect(check('defineEditor', 'missing-file').ok).toBe(false);
+  });
+});

--- a/apps/api/src/creation/typecheck-preflight.test.ts
+++ b/apps/api/src/creation/typecheck-preflight.test.ts
@@ -28,6 +28,7 @@ describe('typecheck preflight', () => {
     const shared = sharedSourcesFromKitTree(
       kitTree({
         'shared/game-kit.d.ts': KIT_DTS,
+        'shared/editor-def.ts': 'export const defineEditor = 1;\n',
         'shared/modules/core.ts': 'export const core = 1;\n',
         'shared/sim/box-world.ts': 'export const boxWorld = 1;\n',
         'SKILL.md': '# ignore\n',
@@ -35,10 +36,29 @@ describe('typecheck preflight', () => {
       }),
     );
     expect(Object.keys(shared).sort()).toEqual([
+      'shared/editor-def.ts',
       'shared/game-kit.d.ts',
       'shared/modules/core.ts',
       'shared/sim/box-world.ts',
     ]);
+  });
+
+  it('checks editor imports against the pinned Kit, including missing exports and files', () => {
+    const kitShared = sharedSourcesFromKitTree(
+      kitTree({
+        'shared/game-kit.d.ts': KIT_DTS,
+        'shared/editor-def.ts': 'export function defineEditor(value: number) { return value; }',
+      }),
+    );
+    const check = (name: string, file: string) =>
+      typecheckDeliverySources({
+        slug: 'comet',
+        kitShared,
+        sources: { 'EDITOR.ts': `import { ${name} } from '../../shared/${file}.ts'; export default ${name}(1);` },
+      });
+    expect(check('defineEditor', 'editor-def').ok).toBe(true);
+    expect(check('missingExport', 'editor-def').ok).toBe(false);
+    expect(check('defineEditor', 'missing-file').ok).toBe(false);
   });
 
   it('refuses the Round-field transcript failure with one grouped line', () => {

--- a/apps/api/src/creation/typecheck-preflight.test.ts
+++ b/apps/api/src/creation/typecheck-preflight.test.ts
@@ -28,7 +28,6 @@ describe('typecheck preflight', () => {
     const shared = sharedSourcesFromKitTree(
       kitTree({
         'shared/game-kit.d.ts': KIT_DTS,
-        'shared/editor-def.ts': 'export const defineEditor = 1;\n',
         'shared/modules/core.ts': 'export const core = 1;\n',
         'shared/sim/box-world.ts': 'export const boxWorld = 1;\n',
         'SKILL.md': '# ignore\n',
@@ -36,29 +35,10 @@ describe('typecheck preflight', () => {
       }),
     );
     expect(Object.keys(shared).sort()).toEqual([
-      'shared/editor-def.ts',
       'shared/game-kit.d.ts',
       'shared/modules/core.ts',
       'shared/sim/box-world.ts',
     ]);
-  });
-
-  it('checks editor imports against the pinned Kit, including missing exports and files', () => {
-    const kitShared = sharedSourcesFromKitTree(
-      kitTree({
-        'shared/game-kit.d.ts': KIT_DTS,
-        'shared/editor-def.ts': 'export function defineEditor(value: number) { return value; }',
-      }),
-    );
-    const check = (name: string, file: string) =>
-      typecheckDeliverySources({
-        slug: 'comet',
-        kitShared,
-        sources: { 'EDITOR.ts': `import { ${name} } from '../../shared/${file}.ts'; export default ${name}(1);` },
-      });
-    expect(check('defineEditor', 'editor-def').ok).toBe(true);
-    expect(check('missingExport', 'editor-def').ok).toBe(false);
-    expect(check('defineEditor', 'missing-file').ok).toBe(false);
   });
 
   it('refuses the Round-field transcript failure with one grouped line', () => {

--- a/apps/api/src/creation/typecheck-preflight.ts
+++ b/apps/api/src/creation/typecheck-preflight.ts
@@ -49,11 +49,7 @@ export function sharedSourcesFromKitTree(tree: KitTree): Record<string, string> 
   for (const [filePath, buf] of tree.files) {
     if (!filePath.startsWith(prefix)) continue;
     const rel = filePath.slice(prefix.length);
-    const isKitDts = rel === 'shared/game-kit.d.ts';
-    const isModule = rel.startsWith('shared/modules/') && rel.endsWith('.ts');
-    const isVertical = rel.startsWith('shared/verticals/') && rel.endsWith('.ts');
-    const isSharedSim = rel.startsWith('shared/sim/') && rel.endsWith('.ts');
-    if (isKitDts || isModule || isVertical || isSharedSim) {
+    if (rel.startsWith('shared/') && /\.tsx?$/.test(rel)) {
       out[rel] = buf.toString('utf8');
     }
   }

--- a/apps/api/src/delivery/games-store.test.ts
+++ b/apps/api/src/delivery/games-store.test.ts
@@ -41,6 +41,17 @@ describe('validateSourceUpload — the delivery contract', () => {
     expect(validateSourceUpload(MINIMAL)).toHaveLength(MINIMAL.length);
   });
 
+  it('accepts editor authoring imports from the Kit without uploading shared sources', () => {
+    const files = [
+      ...MINIMAL,
+      {
+        path: 'EDITOR.ts',
+        content: "import { defineEditor } from '../../shared/editor-def.ts'; export default defineEditor({});",
+      },
+    ];
+    expect(validateSourceUpload(files)).toHaveLength(files.length);
+  });
+
   it('refuses a publish with no behavioural golden', () => {
     const withoutTrace = MINIMAL.filter((file) => file.path !== 'TRACE.json');
     expect(() => validateSourceUpload(withoutTrace)).toThrow(/TRACE.json is required/);

--- a/apps/api/src/delivery/source-link-check.test.ts
+++ b/apps/api/src/delivery/source-link-check.test.ts
@@ -9,6 +9,16 @@ import {
 } from './source-link-check.js';
 
 describe('source-link-check', () => {
+  it('defers external Kit imports but still rejects missing local and other external modules', () => {
+    const check = (from: string, target: string) =>
+      findUnresolvedSourceLinks(new Map([[from, `import { defineEditor } from '${target}';`]]));
+    expect(check('EDITOR.ts', '../../shared/editor-def.ts')).toEqual([]);
+    expect(check('game/editor.ts', '../../../shared/editor-def.ts')).toEqual([]);
+    expect(check('EDITOR.ts', './shared/editor-def.ts')).toHaveLength(1);
+    expect(check('EDITOR.ts', '../../shared/../private/editor-def.ts')).toHaveLength(1);
+    expect(check('EDITOR.ts', '../../other-game/editor-def.ts')).toHaveLength(1);
+  });
+
   it('collects named exports, default, renames, and export *', () => {
     const info = collectExports(`
       export const WIN_SCORE = 10;

--- a/apps/api/src/delivery/source-link-check.ts
+++ b/apps/api/src/delivery/source-link-check.ts
@@ -1,3 +1,5 @@
+import { posix } from 'node:path';
+
 // Cross-file symbol link check; prefer false negatives.
 
 export type SourceLinkFinding = {
@@ -268,6 +270,9 @@ export function findUnresolvedSourceLinks(files: ReadonlyMap<string, string>): S
     let bindingBudget = MAX_IMPORT_BINDINGS_PER_FILE;
     for (const imp of imports) {
       if (imp.isTypeOnly || imp.isNamespace) continue;
+      // Kit imports are checked against the pinned Kit by typecheck.
+      const workspacePath = posix.resolve('/games/delivery', posix.dirname(from), imp.path);
+      if (workspacePath.startsWith('/shared/')) continue;
       const resolved = resolveRelativeImport(from, imp.path, files);
       if (resolved == null) {
         if (/\.(?:[cm]?[jt]s|tsx|jsx)$/.test(imp.path) || !/\.[a-zA-Z0-9]+$/.test(imp.path)) {


### PR DESCRIPTION
Delivering a game with `EDITOR.ts` importing `../../shared/editor-def.ts` was rejected first by typecheck and then by the source link check. Creators were incorrectly told to upload a file owned by the Creator Kit.

Load shared TypeScript sources from the pinned Kit into typecheck, including editor helpers and their dependencies. The delivery-only link checker defers imports resolving to the workspace `/shared/` directory to that Kit-aware check. Local missing imports and paths escaping to other directories remain checked; no Kit files are added to the uploaded game.

Validation: full repository tests, lint and build passed locally. Repository type-check passed before rebasing; the build also checks TypeScript. Regression coverage includes upload acceptance, missing Kit exports/files, nested import paths, missing local files and traversal outside shared. GitHub CI is running.
