### PR TITLE
docs(zones): say that re-admission is offered, never initiated

### DIFF
--- a/docs/p3-zone-protocol.md
+++ b/docs/p3-zone-protocol.md
@@ -188,11 +188,21 @@ That last sentence is a claim about the shell, so the shell has to honour it. A 
 that reaches a final reason disposes itself, and a disposed one left installed in the
 bridge is worse than none at all: admission refuses to start because a client already
 exists, and every input goes to a socket that is never going to open again. So the bridge
-drops the link when it closes for good, and rebuilds it on the next input — but only when
-the reason was `idle`. That is the one final reason a player is expected to come back
-from, and playing is how they say so. `kicked` and `bad_ticket` are decisions about the
-player rather than about their attention; redialling those on a keypress would be a loop
-that spends a request per key for as long as the tab is open.
+drops the link when it closes for good, and accepts a fresh `zone:hello` — or rebuilds on
+an input — but only when the reason was `idle`. That is the one final reason a player is
+expected to come back from, and playing is how they say so. `kicked` and `bad_ticket` are
+decisions about the player rather than about their attention; redialling those on a
+keypress would be a loop that spends a request per key for as long as the tab is open.
+
+**The game has to do the asking, and that is easy to miss.** Being *able* to re-admit is
+not the same as being asked to, and the bridge is only ever asked by the thing inside the
+frame. GameKit's zone module settles offline on a close and then posts to the host only
+while it is live — so for one release the platform stood ready to hand back a seat that
+nothing would ever request, and a reaped player kept playing a world nobody else could
+see until they reloaded. The games-repo half now remembers an `idle` close as a seat to
+reclaim and posts a fresh `zone:hello` on the next input, once per retirement. Anything
+else written against this bridge has to do the same; re-admission is offered here, never
+initiated.
 
 The input that triggers the rebuild is itself lost, and that is not a gap to close later.
 An input is an intent about a moment (§5), and by the time a seat comes back the moment it


### PR DESCRIPTION
Doc-only. One paragraph in `docs/p3-zone-protocol.md` §7, correcting something I wrote in #1270 that turned out to describe only half the round trip.

## What was wrong

§7 said the bridge "drops the link when it closes for good, and rebuilds it on the next input". True of the bridge, and misleading about the system: it reads as though the platform handles re-admission end to end. It does not. **The bridge is only ever asked by the thing inside the frame.**

GameKit's zone module settles offline on a close and posts to the host only while it is `live` ([`shared/modules/zone.ts`](https://github.com/gamedevpl/www.gamedev.pl-games/blob/main/shared/modules/zone.ts), the `send` guard). So after an `idle` close it went permanently silent, and the re-admission path merged in #1270 — which waits for exactly an input or a hello — never heard from it. For one release the platform stood ready to hand back a seat that nothing would ever request, and a reaped player kept playing a world nobody else could see until they reloaded the page.

I found this while checking whether #1270 actually worked end to end. It did not. Both review bots flagged the bridge-side half of it and neither could see this half, since it lives in the other repo.

## What the paragraph now says

That the game has to do the asking, that this is easy to miss, what GameKit now does about it (remembers an `idle` close as a seat to reclaim, posts a fresh `zone:hello` on the next input, once per retirement), and that **anything else written against this bridge has to do the same — re-admission is offered here, never initiated.**

The bridge's own behaviour is unchanged; it already accepted both a fresh `zone:hello` and an input, and both are covered by tests from #1270.

## Companion

The games-repo half is in [`gamedevpl/www.gamedev.pl-games`](https://github.com/gamedevpl/www.gamedev.pl-games) on the same branch name — that is the change that makes this paragraph true. This PR is safe to merge independently; it describes behaviour that is correct once the games-repo side lands, and the honest account of the gap either way.

## Verification

Documentation only — no code, no tests touched. `npm run comment-prose` and `npm run module-size` both clean (markdown is outside both ratchets; run anyway to confirm nothing moved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HYYdEkwKcoH6Nv1f69Qoty

---
_Generated by [Claude Code](https://claude.ai/code/session_01HYYdEkwKcoH6Nv1f69Qoty)_