### PR TITLE
fix(cli): open busy preview with keyboard

### DIFF
--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -10,7 +10,7 @@ decides the next version — see [`.claude/skills/cli-release/SKILL.md`](../../.
 ### Fixed
 
 - Recover Muse tasks waiting for approval by offering to resume the same session interactively (#1271).
-- Open a running local preview with `o` when terminal links cannot be clicked (#1276).
+- Open a running local preview with `o` when terminal links cannot be clicked (#1277).
 
 ## 0.14.0 — 2026-09-11
 

--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -10,6 +10,7 @@ decides the next version — see [`.claude/skills/cli-release/SKILL.md`](../../.
 ### Fixed
 
 - Recover Muse tasks waiting for approval by offering to resume the same session interactively (#1271).
+- Open a running local preview with `o` when terminal links cannot be clicked (#1276).
 
 ## 0.14.0 — 2026-09-11
 

--- a/apps/cli/src/tui/app.test.tsx
+++ b/apps/cli/src/tui/app.test.tsx
@@ -45,6 +45,13 @@ describe('TUI feedback', () => {
     view.input.write('o');
     await wait();
     expect(openPreview).toHaveBeenCalledWith('http://127.0.0.1:64897/preview/');
+
+    view.session.writeLine('local preview stopped');
+    await wait();
+    expect(view.frame()).not.toContain('o open preview');
+    view.input.write('o');
+    await wait();
+    expect(openPreview).toHaveBeenCalledTimes(1);
   });
 
   it('shows connection choices and returns to chat for the selected game', async () => {

--- a/apps/cli/src/tui/app.test.tsx
+++ b/apps/cli/src/tui/app.test.tsx
@@ -13,13 +13,13 @@ afterEach(() => {
   for (const close of cleanup.splice(0)) close();
 });
 const wait = (ms = 50) => new Promise((resolve) => setTimeout(resolve, ms));
-function screen(columns: number, rows: number) {
+function screen(columns: number, rows: number, openPreview?: (url: string) => void) {
   const session = createTuiSession('');
   const input = Object.assign(new PassThrough(), { isTTY: true, setRawMode() {}, ref() {}, unref() {} });
   const output = Object.assign(new PassThrough(), { columns, rows, isTTY: true });
   const frames: string[] = [];
   output.on('data', (chunk) => frames.push(stripVTControlCharacters(String(chunk))));
-  const app = render(createElement(ReplApp, { session, color: false }), {
+  const app = render(createElement(ReplApp, { session, color: false, openPreview }), {
     stdin: input as unknown as NodeJS.ReadStream,
     stdout: output as unknown as NodeJS.WriteStream,
     debug: true,
@@ -36,6 +36,17 @@ function screen(columns: number, rows: number) {
 }
 
 describe('TUI feedback', () => {
+  it('opens the live preview with o while an agent is working', async () => {
+    const openPreview = vi.fn();
+    const view = screen(80, 24, openPreview);
+    view.session.writeLine('live preview while claude edits: http://127.0.0.1:64897/preview/');
+    await wait();
+    expect(view.frame()).toContain('o open preview');
+    view.input.write('o');
+    await wait();
+    expect(openPreview).toHaveBeenCalledWith('http://127.0.0.1:64897/preview/');
+  });
+
   it('shows connection choices and returns to chat for the selected game', async () => {
     const view = screen(80, 24);
     const opened = connectSession({

--- a/apps/cli/src/tui/app.tsx
+++ b/apps/cli/src/tui/app.tsx
@@ -12,10 +12,12 @@ export function ReplApp({
   session,
   color,
   historyOffset = 0,
+  openPreview,
 }: {
   session: TuiSession;
   color: boolean;
   historyOffset?: number;
+  openPreview?: (url: string) => void;
 }) {
   const [state, setState] = useState<TuiState>(session.get);
   const completion = useCommandCompletion(state, session);
@@ -31,6 +33,10 @@ export function ReplApp({
   }, [stdout]);
   useInput((input, key) => {
     if (state.mode === 'busy') {
+      if (!key.ctrl && !key.meta && input.toLowerCase() === 'o' && state.previewUrl) {
+        openPreview?.(state.previewUrl);
+        return;
+      }
       if (key.ctrl && input === 'c') session.cancel();
       return;
     }
@@ -102,7 +108,13 @@ export function ReplApp({
         ))}
       </Box>
       {state.mode === 'busy' ? (
-        <BusyPanel activity={state.activity} since={state.busySince} lastOutputAt={state.lastOutputAt} color={color} />
+        <BusyPanel
+          activity={state.activity}
+          since={state.busySince}
+          lastOutputAt={state.lastOutputAt}
+          color={color}
+          previewAvailable={Boolean(state.previewUrl)}
+        />
       ) : (
         <Box flexDirection="column" flexShrink={0} borderStyle={border} borderColor={accent} paddingX={1}>
           {state.mode === 'pick' ? (

--- a/apps/cli/src/tui/busy.tsx
+++ b/apps/cli/src/tui/busy.tsx
@@ -8,11 +8,13 @@ export function BusyPanel({
   since,
   lastOutputAt,
   color,
+  previewAvailable,
 }: {
   activity: string;
   since: number;
   lastOutputAt: number;
   color: boolean;
+  previewAvailable: boolean;
 }) {
   const [tick, setTick] = useState(0);
   useEffect(() => {
@@ -34,7 +36,9 @@ export function BusyPanel({
         <Text color={color ? 'yellow' : undefined}> {duration}</Text>
       </Box>
       <Text dimColor={silent < 30} color={color && silent >= 30 ? 'yellow' : undefined} wrap="truncate-end">
-        {silent >= 30 ? `No new output for ${silent}s — Ctrl+C to stop` : 'Ctrl+C to stop / exit'}
+        {silent >= 30
+          ? `No new output for ${silent}s — ${previewAvailable ? 'o open preview · ' : ''}Ctrl+C to stop`
+          : `${previewAvailable ? 'o open preview · ' : ''}Ctrl+C to stop / exit`}
       </Text>
     </Box>
   );

--- a/apps/cli/src/tui/host.ts
+++ b/apps/cli/src/tui/host.ts
@@ -140,6 +140,7 @@ export async function runInkRepl(input: {
       watched = status.status;
     },
     onSlug: (next) => {
+      if (next !== slug) session.clearPreview();
       slug = next;
       paintIdentity();
     },
@@ -180,6 +181,7 @@ export async function runInkRepl(input: {
           pendingExecution,
           interactiveRun,
           onWorkshop: (opened) => {
+            if (workshop?.slug !== opened.slug || workshop?.root !== opened.root) session.clearPreview();
             workshop = opened;
             opened.onActivity = session.setActivity;
             opened.onLocalTask = session.setLocalTask;
@@ -208,6 +210,9 @@ export async function runInkRepl(input: {
         watch.poke();
       }
       if (result.workshop) {
+        if (workshop?.slug !== result.workshop.slug || workshop?.root !== result.workshop.root) {
+          session.clearPreview();
+        }
         workshop = result.workshop;
         workshop.onActivity = session.setActivity;
         workshop.onLocalTask = session.setLocalTask;
@@ -215,6 +220,7 @@ export async function runInkRepl(input: {
         workshop.activityApi = input.api;
       }
       if (result.slug) {
+        if (result.slug !== slug) session.clearPreview();
         slug = result.slug;
         paintIdentity();
       }

--- a/apps/cli/src/tui/host.ts
+++ b/apps/cli/src/tui/host.ts
@@ -18,6 +18,7 @@ import { openWorkshop, settleBuilder, type Workshop } from '../workshop.js';
 import { agentHint, discoverAgents } from '../agents.js';
 import { createCliTelemetry } from '../telemetry.js';
 import { reportInstall } from '../main.js';
+import { openUrl } from '../open-url.js';
 
 export async function runInkRepl(input: {
   api: ApiClient;
@@ -52,8 +53,14 @@ export async function runInkRepl(input: {
     session.setActivity(activity);
     return () => session.setActivity(previous);
   });
+  const openPreview = (url: string): void => {
+    telemetry.record('play_requested');
+    void openUrl(url).then((opened) => {
+      if (!opened) session.writeLine(`Could not open the preview. Copy this URL: ${url}`);
+    });
+  };
   const mount = (historyOffset = 0) => {
-    host.instance = render(createElement(ReplApp, { session, color, historyOffset }), {
+    host.instance = render(createElement(ReplApp, { session, color, historyOffset, openPreview }), {
       stdin: input.io.stdin,
       stdout: input.io.stdout,
       exitOnCtrlC: false,

--- a/apps/cli/src/tui/session.test.ts
+++ b/apps/cli/src/tui/session.test.ts
@@ -35,6 +35,18 @@ describe('tui session', () => {
     expect(formatSessionIdentity('', 'maze')).toBe('maze');
   });
 
+  it('forgets a stopped preview and can clear one when the checkout changes', () => {
+    const session = createTuiSession('');
+    session.writeLine('live preview while claude edits: http://127.0.0.1:64897/preview/');
+    expect(session.get().previewUrl).toBe('http://127.0.0.1:64897/preview/');
+    session.writeLine('local preview stopped');
+    expect(session.get().previewUrl).toBe('');
+
+    session.writeLine('local live preview: http://127.0.0.1:50000/next/');
+    session.clearPreview();
+    expect(session.get().previewUrl).toBe('');
+  });
+
   it('exits busy work from cancel when no prompt is pending', async () => {
     let interrupted = 0;
     const session = createTuiSession('', () => {

--- a/apps/cli/src/tui/session.ts
+++ b/apps/cli/src/tui/session.ts
@@ -4,6 +4,7 @@ export type TuiState = {
   lines: string[];
   live: string[];
   localTask: string;
+  previewUrl: string;
   identity: string;
   question: string;
   mode: TuiMode;
@@ -44,6 +45,7 @@ export function createTuiSession(banner: string, onBusyCancel?: () => void): Tui
     lines: banner ? banner.split('\n') : [],
     live: [],
     localTask: '',
+    previewUrl: '',
     identity: '',
     question: '',
     mode: 'busy',
@@ -77,7 +79,13 @@ export function createTuiSession(banner: string, onBusyCancel?: () => void): Tui
       };
     },
     writeLine(text) {
-      state = { ...state, lines: [...state.lines, ...text.split('\n')], lastOutputAt: Date.now() };
+      const preview = /^(?:local live preview|live preview while .* edits): (https?:\/\/\S+)/m.exec(text)?.[1];
+      state = {
+        ...state,
+        lines: [...state.lines, ...text.split('\n')],
+        lastOutputAt: Date.now(),
+        previewUrl: preview ?? state.previewUrl,
+      };
       emit();
     },
     setLocalTask(localTask) {

--- a/apps/cli/src/tui/session.ts
+++ b/apps/cli/src/tui/session.ts
@@ -21,6 +21,7 @@ export type TuiSession = {
   get: () => TuiState;
   subscribe: (fn: (state: TuiState) => void) => () => void;
   writeLine: (text: string) => void;
+  clearPreview: () => void;
   setLive: (live: string[]) => void;
   setLocalTask: (agent: string) => void;
   setIdentity: (identity: string) => void;
@@ -80,12 +81,18 @@ export function createTuiSession(banner: string, onBusyCancel?: () => void): Tui
     },
     writeLine(text) {
       const preview = /^(?:local live preview|live preview while .* edits): (https?:\/\/\S+)/m.exec(text)?.[1];
+      const previewStopped = /^(?:local preview stopped|no local preview is running)$/m.test(text);
       state = {
         ...state,
         lines: [...state.lines, ...text.split('\n')],
         lastOutputAt: Date.now(),
-        previewUrl: preview ?? state.previewUrl,
+        previewUrl: previewStopped ? '' : (preview ?? state.previewUrl),
       };
+      emit();
+    },
+    clearPreview() {
+      if (!state.previewUrl) return;
+      state = { ...state, previewUrl: '' };
       emit();
     },
     setLocalTask(localTask) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -105,7 +105,7 @@
     },
     "apps/cli": {
       "name": "@gamedevpl/cli",
-      "version": "0.13.1",
+      "version": "0.14.0",
       "dependencies": {
         "@gamedevpl/contract": "*",
         "ink": "^5.2.1",


### PR DESCRIPTION
Some terminals render preview URLs as plain colored text even when the CLI emits an OSC 8 hyperlink, leaving creators unable to open or select the URL while an agent owns the input.

Remember the active local preview URL in the TUI and show `o open preview` during busy work. Pressing `o` opens that exact URL through the existing platform-specific browser launcher without interrupting the agent. If launching fails, the CLI prints a stable copyable URL. Normal prompt input is unchanged.

Validation: the full repository type-check, lint, test, and build gate passed. The complete CLI suite passed (70 files, 404 tests), including the real Ink input path for opening a preview while busy and the existing narrow-terminal coverage.

Instrumentation: this affects creator funnel question 4. Existing `cli_step=play_requested` counts the shortcut alongside other preview requests and remains queryable by step and visit ID. It records no URL, slug, checkout path, or new dimension.
