### PR TITLE
feat(catalog): make featured game title link to game page

### DIFF
--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -1404,6 +1404,24 @@ button:disabled {
   letter-spacing: -0.3px;
 }
 
+.featured-game-title-link {
+  color: inherit;
+  text-decoration: none;
+  transition: color 0.15s ease;
+}
+
+.featured-game-title-link:hover {
+  color: var(--turquoise);
+  text-decoration: underline;
+  text-underline-offset: 3px;
+}
+
+.featured-game-title-link:focus-visible {
+  outline: 2px solid var(--turquoise);
+  outline-offset: 2px;
+  border-radius: 2px;
+}
+
 .featured-game-meta {
   margin: 0;
   font-size: 0.9rem;

--- a/apps/web/src/surfaces/catalog/ArcadeCatalog.test.tsx
+++ b/apps/web/src/surfaces/catalog/ArcadeCatalog.test.tsx
@@ -664,6 +664,9 @@ describe('ArcadeCatalog curated surfaces', () => {
     // The featured poster is clickable too, not just the Play button.
     const featuredHitArea = container.querySelector<HTMLAnchorElement>('.featured-game-hit-area');
     expect(featuredHitArea?.getAttribute('href')).toContain('?via=featured');
+    expect(container.querySelector<HTMLAnchorElement>('.featured-game-title-link')?.getAttribute('href')).toContain(
+      '?via=featured',
+    );
     // Nothing left over for Start here.
     expect(
       [...container.querySelectorAll('.catalog-rail-section')].some((s) => s.textContent?.includes('Start here')),

--- a/apps/web/src/surfaces/catalog/CatalogRail.tsx
+++ b/apps/web/src/surfaces/catalog/CatalogRail.tsx
@@ -358,7 +358,11 @@ export function FeaturedGame({ entry, onPlayGame, onPlayTogether, moreLikeThis =
         <span className="featured-game-kicker">
           <PixelIcon name="sparkle" size={12} /> {t('catalog.featuredKicker')}
         </span>
-        <h3 className="featured-game-title">{entry.title}</h3>
+        <h3 className="featured-game-title">
+          <a className="featured-game-title-link" href={`${gamePath(gamePageHandle(entry), entry.slug)}?via=featured`}>
+            {entry.title}
+          </a>
+        </h3>
         <p className="featured-game-meta">{t('catalog.controlsSummary', { controls: entry.controls })}</p>
         <p className="featured-game-author">
           {entry.creatorHandle && !isPlatformAuthor(entry.submittedBy) ? (


### PR DESCRIPTION
## Summary
Makes the featured/spotlight game title on the home catalog page clickable, linking to the game's canonical subpage (`${gamePath(gamePageHandle(entry), entry.slug)}?via=featured`), matching the behavior of the poster card hit area.

## Changes
- `CatalogRail.tsx`: Wrap `entry.title` in `<a className="featured-game-title-link" href={...}>`
- `styles.css`: Style `.featured-game-title-link` with hover color/underline and focus-visible ring
- `ArcadeCatalog.test.tsx`: Verify `.featured-game-title-link` href