### PR TITLE
fix(web): declutter catalog game tiles and streamline overlay

### DIFF
--- a/apps/web/src/surfaces/catalog/CatalogCard.tsx
+++ b/apps/web/src/surfaces/catalog/CatalogCard.tsx
@@ -265,50 +265,43 @@ export function CatalogCard({
           // Both badges anchor one corner, so they stack instead of overlapping.
         }
         <div className="catalog-badges-top-left">
-          {
-            // Label sits in its own span; a finger gets the icon alone.
-            hasVideo && (
-              <button
-                type="button"
-                className="preview-toggle preview-toggle--video"
-                aria-pressed={isPreviewPlaying}
-                aria-label={isPreviewPlaying ? t('catalog.pausePreview') : t('catalog.watchPreview')}
-                disabled={!inView}
-                onClick={togglePreview}
-              >
-                <PixelIcon name={isPreviewPlaying ? 'pause' : 'play'} size={11} />
-                <span className="btn-label">
-                  {isPreviewPlaying ? t('catalog.pausePreview') : t('catalog.watchPreview')}
-                </span>
-              </button>
-            )
-          }
-
-          {
-            // Trailer-less cards still need a deliberate way to open moments.
-            !hasVideo && hasMoments && (
-              <button
-                type="button"
-                className="preview-toggle"
-                aria-pressed={extrasOpen}
-                aria-label={extrasOpen ? t('catalog.hideMoments') : t('catalog.showMoments')}
-                disabled={!inView}
-                onClick={toggleMoments}
-              >
-                <PixelIcon name="image" size={11} />
-                <span className="btn-label">{extrasOpen ? t('catalog.hideMoments') : t('catalog.showMoments')}</span>
-              </button>
-            )
-          }
-
-          {
-            // Only 'none' earns a badge: a finger cannot drive the game.
-            entry.touch === 'none' && (
-              <span className="touch-warning-pill" title={t('catalog.keyboardOnlyTooltip')}>
-                <PixelIcon name="gamepad" size={10} /> {t('catalog.keyboardOnly')}
+          {hasVideo && (
+            <button
+              type="button"
+              className="preview-toggle preview-toggle--video"
+              aria-pressed={isPreviewPlaying}
+              aria-label={isPreviewPlaying ? t('catalog.pausePreview') : t('catalog.watchPreview')}
+              title={isPreviewPlaying ? t('catalog.pausePreview') : t('catalog.watchPreview')}
+              disabled={!inView}
+              onClick={togglePreview}
+            >
+              <PixelIcon name={isPreviewPlaying ? 'pause' : 'play'} size={12} />
+              <span className="btn-label">
+                {isPreviewPlaying ? t('catalog.pausePreview') : t('catalog.watchPreview')}
               </span>
-            )
-          }
+            </button>
+          )}
+
+          {!hasVideo && hasMoments && (
+            <button
+              type="button"
+              className="preview-toggle"
+              aria-pressed={extrasOpen}
+              aria-label={extrasOpen ? t('catalog.hideMoments') : t('catalog.showMoments')}
+              title={extrasOpen ? t('catalog.hideMoments') : t('catalog.showMoments')}
+              disabled={!inView}
+              onClick={toggleMoments}
+            >
+              <PixelIcon name="image" size={12} />
+              <span className="btn-label">{extrasOpen ? t('catalog.hideMoments') : t('catalog.showMoments')}</span>
+            </button>
+          )}
+
+          {entry.touch === 'none' && (
+            <span className="touch-warning-pill" title={t('catalog.keyboardOnlyTooltip')}>
+              <PixelIcon name="gamepad" size={10} /> {t('catalog.keyboardOnly')}
+            </span>
+          )}
 
           {isYours ? (
             <span className="yours-pill" title={t('catalog.yoursBadge')}>
@@ -337,46 +330,12 @@ export function CatalogCard({
         )}
 
         {
-          // Title, hint and CTA sit over the preview, saving a content row.
+          // Title, author, capabilities and CTAs sit over the preview.
         }
         <div className="catalog-overlay">
           <div className="card-copy">
-            <h3 className="card-title">
+            <h3 className="card-title" title={entry.title}>
               {entry.title}
-              {entry.multiplayer && (
-                <span className="card-party-badge">
-                  <PixelIcon name="phone" size={12} /> {t('party.playersBadge', { max: entry.multiplayer.maxPlayers })}
-                </span>
-              )}
-              {
-                // Says what the game does, not what this signed-out visitor gets.
-                entry.saves === 'player' && (
-                  <span className="card-saves-badge">
-                    <PixelIcon name="clock" size={12} /> {t('catalog.savesBadge')}
-                  </span>
-                )
-              }
-              {
-                // The one badge about other people rather than about the game.
-                entry.world === 'shared' && (
-                  <span className="card-world-badge">
-                    <PixelIcon name="star" size={12} /> {t('catalog.worldBadge')}
-                  </span>
-                )
-              }
-              {
-                // Advisory: the game answers tilt where the device offers it.
-                entry.sensing === 'tilt' && (
-                  <span className="card-party-badge" title={t('catalog.tiltTooltip')}>
-                    <PixelIcon name="phone" size={12} /> {t('catalog.tiltBadge')}
-                  </span>
-                )
-              }
-              {entry.sensing === 'backdrop' && (
-                <span className="card-party-badge" title={t('catalog.cameraTooltip')}>
-                  <PixelIcon name="phone" size={12} /> {t('catalog.cameraBadge')}
-                </span>
-              )}
             </h3>
             <p className="card-author">
               {entry.creatorHandle && !isPlatformAuthor(entry.submittedBy) ? (
@@ -391,11 +350,9 @@ export function CatalogCard({
                   author: isPlatformAuthor(entry.submittedBy) ? t('catalog.platformAuthor') : entry.submittedBy,
                 })
               )}
-            </p>
-            {
-              // Contributor credit on its own line, so authorship stays unblurred.
-              entry.contributorHandles && entry.contributorHandles.length > 0 ? (
-                <p className="card-contributors">
+              {entry.contributorHandles && entry.contributorHandles.length > 0 ? (
+                <span className="card-contributors">
+                  {' · '}
                   {t('catalog.withContributions')}{' '}
                   {entry.contributorHandles.map((handle, index) => (
                     <span key={handle}>
@@ -405,17 +362,50 @@ export function CatalogCard({
                       </a>
                     </span>
                   ))}
-                </p>
-              ) : null
-            }
+                </span>
+              ) : null}
+            </p>
+            <div className="card-capabilities">
+              {entry.multiplayer && (
+                <span className="card-party-badge">
+                  <PixelIcon name="phone" size={10} /> {t('party.playersBadge', { max: entry.multiplayer.maxPlayers })}
+                </span>
+              )}
+              {entry.saves === 'player' && (
+                <span className="card-saves-badge" title={t('catalog.savesBadge')}>
+                  <PixelIcon name="clock" size={10} /> {t('catalog.savesBadge')}
+                </span>
+              )}
+              {entry.world === 'shared' && (
+                <span className="card-world-badge" title={t('catalog.worldBadge')}>
+                  <PixelIcon name="star" size={10} /> {t('catalog.worldBadge')}
+                </span>
+              )}
+              {entry.sensing === 'tilt' && (
+                <span className="card-party-badge" title={t('catalog.tiltTooltip')}>
+                  <PixelIcon name="phone" size={10} /> {t('catalog.tiltBadge')}
+                </span>
+              )}
+              {entry.sensing === 'backdrop' && (
+                <span className="card-party-badge" title={t('catalog.cameraTooltip')}>
+                  <PixelIcon name="phone" size={10} /> {t('catalog.cameraBadge')}
+                </span>
+              )}
+            </div>
           </div>
           <div className="card-actions">
             <button type="button" className="primary-btn" onClick={() => onPlayGame(entry)}>
               <PixelIcon name="play" size={13} /> {t('catalog.play')}
             </button>
             {entry.multiplayer && (
-              <button type="button" className="secondary-btn party-btn" onClick={() => onPlayTogether(entry)}>
-                <PixelIcon name="phone" size={13} /> {t('party.playTogether')}
+              <button
+                type="button"
+                className="secondary-btn party-btn card-party-action"
+                title={t('party.playTogether')}
+                aria-label={t('party.playTogether')}
+                onClick={() => onPlayTogether(entry)}
+              >
+                <PixelIcon name="phone" size={13} />
               </button>
             )}
           </div>

--- a/apps/web/src/surfaces/catalog/catalog.css
+++ b/apps/web/src/surfaces/catalog/catalog.css
@@ -97,23 +97,35 @@
 .preview-toggle {
   display: inline-flex;
   align-items: center;
-  gap: 5px;
-  padding: 7px 10px;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  padding: 0;
   border: 1px solid rgba(255, 255, 255, 0.3);
   border-radius: 999px;
   color: #fff;
   /* Solid scrim — backdrop-filter on every visible card is scroll paint cost. */
   background: rgba(6, 10, 14, 0.92);
-  font-size: 0.72rem;
-  font-weight: 700;
-  letter-spacing: 0.02em;
   box-shadow: 0 4px 16px rgba(0, 0, 0, 0.35);
+  cursor: pointer;
 }
 
 .preview-toggle:hover,
 .preview-toggle:focus-visible {
   border-color: var(--turquoise);
   color: var(--turquoise);
+}
+
+.preview-toggle .btn-label {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border-width: 0;
 }
 
 /* Moments sit under the genre chip, clear of the title/Play overlay below. */
@@ -204,8 +216,8 @@
   z-index: 1;
   top: 10px;
   right: 10px;
-  /* Genre text is agent-authored and can run long; 40% leaves toggle room. */
-  max-width: 40%;
+  /* Leaves room for the 28px preview button on the left */
+  max-width: calc(100% - 48px);
   overflow: hidden;
   white-space: nowrap;
   text-overflow: ellipsis;
@@ -220,34 +232,23 @@
   text-transform: uppercase;
 }
 
-/* Title/hint/Play overlay the bottom scrim; card is just the 16:9 media box. */
+/* Title/author/capabilities and Play overlay the bottom scrim; card is just the 16:9 media box. */
 .catalog-overlay {
   position: absolute;
   inset: auto 0 0 0;
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) auto;
-  align-items: end;
-  gap: 12px;
-  padding: 32px 12px 12px;
-  background: linear-gradient(to top, rgba(4, 7, 10, 0.92) 15%, rgba(4, 7, 10, 0.6) 55%, rgba(4, 7, 10, 0));
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 10px;
+  padding: 36px 12px 10px;
+  background: linear-gradient(to top, rgba(4, 7, 10, 0.94) 15%, rgba(4, 7, 10, 0.65) 60%, rgba(4, 7, 10, 0));
   /* Pass hovers through the scrim to the video underneath; only the buttons catch clicks. */
   pointer-events: none;
   z-index: 2;
 }
 
-.card-title {
-  margin: 0;
-  display: flex;
-  align-items: center;
-  flex-wrap: wrap;
-  gap: 8px;
-  font-size: 1.05rem;
-  line-height: 1.2;
-  color: #fff;
-  text-shadow: 0 1px 6px rgba(0, 0, 0, 0.6);
-}
-
 .card-copy {
+  flex: 1 1 auto;
   min-width: 0;
 }
 
@@ -255,32 +256,91 @@
   pointer-events: auto;
 }
 
+.card-title {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 700;
+  line-height: 1.25;
+  color: #fff;
+  text-shadow: 0 1px 6px rgba(0, 0, 0, 0.8);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+}
+
 .card-author {
-  margin: -4px 0 0;
-  font-size: 0.8rem;
+  margin: 2px 0 0;
+  font-size: 0.76rem;
   line-height: 1.2;
-  color: rgba(255, 255, 255, 0.7);
-  text-shadow: 0 1px 4px rgba(0, 0, 0, 0.5);
+  color: rgba(255, 255, 255, 0.75);
+  text-shadow: 0 1px 4px rgba(0, 0, 0, 0.7);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.card-contributors {
+  color: rgba(255, 255, 255, 0.6);
+}
+
+.card-capabilities {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 4px;
+  margin-top: 5px;
+}
+
+.card-capabilities .card-party-badge,
+.card-capabilities .card-saves-badge,
+.card-capabilities .card-world-badge {
+  margin-left: 0;
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  padding: 1px 6px;
+  font-size: 0.66rem;
+  font-weight: 600;
+  line-height: 1.3;
+  background: rgba(6, 10, 14, 0.85);
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.4);
 }
 
 /* Actions stay bottom-right; title/author take the remaining width, card link owns navigation. */
 .card-actions {
   display: flex;
+  align-items: center;
   justify-content: flex-end;
-  flex-wrap: wrap;
-  gap: 8px;
+  gap: 6px;
+  flex-shrink: 0;
 }
 
-/* Wrap uses natural button size; shrink/ellipsis guard only an over-long single button. */
 .card-actions button {
   pointer-events: auto;
-  flex: 0 1 auto;
-  min-width: 0;
-  padding: 7px 14px;
+  border-radius: 8px;
+  cursor: pointer;
+}
+
+.card-actions .primary-btn {
+  padding: 6px 12px;
   font-size: 13px;
-  overflow: hidden;
-  text-overflow: ellipsis;
+  font-weight: 700;
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
   white-space: nowrap;
+}
+
+.card-actions .card-party-action {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  padding: 0;
+  flex-shrink: 0;
 }
 
 @media (prefers-reduced-motion: reduce) {


### PR DESCRIPTION
## Summary

Cleans up the visual clutter and layout collisions on catalog game cards (`CatalogCard`):
- **Top bar**: Replaced wide preview toggle button (`Obejrzyj podgląd` / `Watch preview`) with a compact 28x28px icon button (retaining screen reader accessible text via `.btn-label`). Removed narrow width constraint on `.genre-pill` so full genre names are displayed without truncation.
- **Title & Metadata hierarchy**: Extracted capabilities badges (`card-party-badge`, `card-saves-badge`, `card-world-badge`, etc.) out of `h3.card-title`. Moved them to a neat `.card-capabilities` row.
- **Removed negative margin**: Eliminated `-4px` margin on `.card-author` which caused overlapping with badges.
- **Compact multiplayer CTA**: Replaced wide secondary button with a compact icon button (`.card-party-action`, matching `CatalogRail`), keeping actions from crushing the title/author column.

## Verification
- `vitest run src/surfaces/catalog`: 64/64 passed
- `vitest run src/App.catalog.test.ts`: 5/5 passed
- `npm run type-check`: 0 errors
- `npm run lint`: 0 errors
- `npm run build`: built successfully