### PR TITLE
Classify game merges so snapshot publish is not a 45-minute catalog gate

### DIFF
--- a/.github/workflows/games-catalog-gate.yml
+++ b/.github/workflows/games-catalog-gate.yml
@@ -258,13 +258,24 @@ jobs:
                 fetch --depth=1 "https://github.com/${GAMES_REPO}.git" "$parent" \
                 || echo "Baseline fetch failed — classify from compare patches only"
             fi
+            set +e
             scope=$(printf '%s\n' "$files" | node tools/gate-scope.mjs --event push --base "$parent" --diffs-json "$diffs_json" --json)
+            status=$?
+            set -e
             rm -f "$diffs_json"
-            MODE=$(printf '%s' "$scope" | jq -r '.mode')
+            if [ "$status" -ne 0 ]; then
+              echo "gate-scope exited ${status} — full catalog gate"
+              return 1
+            fi
+            MODE=$(printf '%s' "$scope" | jq -r '.mode // empty')
+            if [ -z "$MODE" ] || [ "$MODE" = null ]; then
+              echo "gate-scope returned no mode — full catalog gate"
+              return 1
+            fi
             SLUGS=$(printf '%s' "$scope" | jq -r '.slugs | join(" ")')
-            NEED_WEBKIT=$(printf '%s' "$scope" | jq -r '.need_webkit')
-            NARROW_CONFORMANCE=$(printf '%s' "$scope" | jq -r '.narrow_conformance')
-            RUN_GATE=$(printf '%s' "$scope" | jq -r '.run_gate')
+            NEED_WEBKIT=$(printf '%s' "$scope" | jq -r '.need_webkit // empty')
+            NARROW_CONFORMANCE=$(printf '%s' "$scope" | jq -r '.narrow_conformance // empty')
+            RUN_GATE=$(printf '%s' "$scope" | jq -r '.run_gate // empty')
             echo "Push scope: mode=${MODE} run_gate=${RUN_GATE} webkit=${NEED_WEBKIT} slugs=${SLUGS:-"(none)"}"
             return 0
           }
@@ -469,6 +480,8 @@ jobs:
           ' $SLUGS)
           if [ "$need_webgl" = 1 ]; then npm run check:webgl; fi
 
+  # Overlaps catalog-gate (needs: resolve, not catalog-gate). A red gate still
+  # pays this sweep; cancel-in-progress makes that rare.
   webkit:
     needs: resolve
     if: needs.resolve.outputs.need_webkit == '1'

--- a/.github/workflows/games-catalog-gate.yml
+++ b/.github/workflows/games-catalog-gate.yml
@@ -276,6 +276,10 @@ jobs:
             NEED_WEBKIT=$(printf '%s' "$scope" | jq -r '.need_webkit // empty')
             NARROW_CONFORMANCE=$(printf '%s' "$scope" | jq -r '.narrow_conformance // empty')
             RUN_GATE=$(printf '%s' "$scope" | jq -r '.run_gate // empty')
+            if [ -z "$NEED_WEBKIT" ] || [ -z "$NARROW_CONFORMANCE" ] || [ -z "$RUN_GATE" ]; then
+              echo "gate-scope returned incomplete flags — full catalog gate"
+              return 1
+            fi
             echo "Push scope: mode=${MODE} run_gate=${RUN_GATE} webkit=${NEED_WEBKIT} slugs=${SLUGS:-"(none)"}"
             return 0
           }

--- a/.github/workflows/games-catalog-gate.yml
+++ b/.github/workflows/games-catalog-gate.yml
@@ -9,9 +9,9 @@ name: Games catalog gate
 # reverse-index to GAME.json consumers and run static + those slugs.
 # Those two catalog seals are the Sunday 06:17 UTC cron ('17 6 * * 0'); scoped
 # still playtests touched slugs. A games-published dispatch re-classifies the
-# SHA with tools/gate-scope.mjs --event push so a one-game merge does not wait
-# on a full-catalog check:pr (measured ~40 min). The daily snapshot is a cheap
-# rebuild, not a second full-catalog seal.
+# SHA with tools/gate-scope.mjs --event push --base <parent> --diffs-json so a
+# one-game merge does not wait on a full-catalog check:pr (measured ~40 min).
+# The daily snapshot is a cheap rebuild, not a second full-catalog seal.
 
 on:
   workflow_call:
@@ -178,6 +178,8 @@ jobs:
           token: ${{ secrets.GAMES_REPO_TOKEN }}
           path: games-repo
           persist-credentials: false
+          # HEAD~1 for --base fallback when GitHub omitted a file patch.
+          fetch-depth: 2
 
       - name: Resolve checked out games commit
         id: checkout_sha
@@ -206,7 +208,11 @@ jobs:
 
           classify_from_parent() {
             local parent="$1"
-            local compare status files file_count scope
+            local compare status files file_count scope diffs_json
+            if [ "${#parent}" -ne 40 ] || printf '%s' "$parent" | grep -q '[^0-9a-f]'; then
+              echo "Parent SHA is not 40 hex — full catalog gate"
+              return 1
+            fi
             compare=$(mktemp)
             status=$(curl -sS -o "$compare" -w '%{http_code}' \
               -H "Accept: application/vnd.github+json" \
@@ -225,8 +231,19 @@ jobs:
               return 1
             fi
             files=$(jq -r '.files[]? | [.filename, (.previous_filename // empty)] | .[] | select(. != "")' "$compare")
+            diffs_json=$(mktemp)
+            jq -c '[.files[]? | select(.filename != null and .patch != null) | {key: .filename, value: .patch}] | from_entries' "$compare" > "$diffs_json"
             rm -f "$compare"
-            scope=$(printf '%s\n' "$files" | node tools/gate-scope.mjs --event push --base "$parent" --json)
+            # Checkout is shallow. Fetch the API parent so --base can git-diff
+            # when GitHub omitted a patch (binary / too large). Compare patches
+            # are the primary input and work without this object.
+            if ! git cat-file -e "${parent}^{commit}" 2>/dev/null; then
+              git -c "http.extraheader=AUTHORIZATION: bearer ${GAMES_REPO_TOKEN}" \
+                fetch --depth=1 "https://github.com/${GAMES_REPO}.git" "$parent" \
+                || echo "Parent fetch failed — classify from compare patches only"
+            fi
+            scope=$(printf '%s\n' "$files" | node tools/gate-scope.mjs --event push --base "$parent" --diffs-json "$diffs_json" --json)
+            rm -f "$diffs_json"
             MODE=$(printf '%s' "$scope" | jq -r '.mode')
             SLUGS=$(printf '%s' "$scope" | jq -r '.slugs | join(" ")')
             NEED_WEBKIT=$(printf '%s' "$scope" | jq -r '.need_webkit')

--- a/.github/workflows/games-catalog-gate.yml
+++ b/.github/workflows/games-catalog-gate.yml
@@ -2,9 +2,11 @@ name: Games catalog gate
 
 # Runs the games repository's real post-merge gate on public Actions minutes.
 # publish-games.yml calls this workflow before advancing the snapshot pointer.
-# mode=full on schedule / manual dispatch / universal GameKit (core/gfx/audio/…):
-# playtest --suite default, no catalog agent-play. Opt-in modules (gfx3d,
-# sensing, …) reverse-index to GAME.json consumers and run static + those slugs.
+# mode=full on schedule / manual dispatch / unidentifiable universal GameKit
+# patches (and catalog-wide fields like draw.rect): playtest --suite default, no
+# catalog agent-play. Named function/field edits of core/drawing/gfx/… run
+# static on the games that call that surface. Opt-in modules (gfx3d, sensing, …)
+# reverse-index to GAME.json consumers and run static + those slugs.
 # Those two catalog seals are the Sunday 06:17 UTC cron ('17 6 * * 0'); scoped
 # still playtests touched slugs. A games-published dispatch re-classifies the
 # SHA with tools/gate-scope.mjs --event push so a one-game merge does not wait
@@ -224,7 +226,7 @@ jobs:
             fi
             files=$(jq -r '.files[]? | [.filename, (.previous_filename // empty)] | .[] | select(. != "")' "$compare")
             rm -f "$compare"
-            scope=$(printf '%s\n' "$files" | node tools/gate-scope.mjs --event push --json)
+            scope=$(printf '%s\n' "$files" | node tools/gate-scope.mjs --event push --base "$parent" --json)
             MODE=$(printf '%s' "$scope" | jq -r '.mode')
             SLUGS=$(printf '%s' "$scope" | jq -r '.slugs | join(" ")')
             NEED_WEBKIT=$(printf '%s' "$scope" | jq -r '.need_webkit')

--- a/.github/workflows/games-catalog-gate.yml
+++ b/.github/workflows/games-catalog-gate.yml
@@ -9,8 +9,11 @@ name: Games catalog gate
 # reverse-index to GAME.json consumers and run static + those slugs.
 # Those two catalog seals are the Sunday 06:17 UTC cron ('17 6 * * 0'); scoped
 # still playtests touched slugs. A games-published dispatch re-classifies the
-# SHA with tools/gate-scope.mjs --event push --base <parent> --diffs-json so a
-# one-game merge does not wait on a full-catalog check:pr (measured ~40 min).
+# SHA with tools/gate-scope.mjs --event push --base <last-published-sha>
+# --diffs-json so a one-game merge does not wait on a full-catalog check:pr
+# (measured ~40 min). The base is current.json's commitSha, not HEAD's
+# parent: cancel-in-progress would otherwise let a game-only B skip A's
+# unvalidated runtime. Missing pointer → full.
 # The daily snapshot is a cheap rebuild, not a second full-catalog seal.
 
 on:
@@ -75,6 +78,7 @@ concurrency:
 
 permissions:
   contents: read
+  id-token: write
 
 jobs:
   resolve:
@@ -186,6 +190,16 @@ jobs:
         working-directory: games-repo
         run: echo "games_sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
+      - name: Authenticate to GCP for snapshot pointer
+        if: steps.resolve.outputs.classify_push == '1'
+        id: gcp_auth
+        continue-on-error: true
+        uses: google-github-actions/auth@c200f3691d83b41bf9bbd8638997a462592937ed # v2
+        with:
+          workload_identity_provider: 'projects/334141807880/locations/global/workloadIdentityPools/github-pool/providers/github-provider'
+          service_account: 'github-actions-deployer@gamedevpl.iam.gserviceaccount.com'
+          token_format: access_token
+
       - name: Classify merge scope
         id: scope
         working-directory: games-repo
@@ -194,6 +208,8 @@ jobs:
           GAMES_REPO: ${{ env.GAMES_REPO }}
           SHA: ${{ steps.checkout_sha.outputs.games_sha }}
           CLASSIFY_PUSH: ${{ steps.resolve.outputs.classify_push }}
+          GCS_TOKEN: ${{ steps.gcp_auth.outputs.access_token }}
+          SNAPSHOT_BUCKET: 'gamedevpl-games-snapshots'
           INPUT_MODE: ${{ inputs.mode }}
           INPUT_SLUGS: ${{ inputs.slugs }}
           INPUT_NEED_WEBKIT: ${{ inputs.need_webkit }}
@@ -234,13 +250,13 @@ jobs:
             diffs_json=$(mktemp)
             jq -c '[.files[]? | select(.filename != null and .patch != null) | {key: .filename, value: .patch}] | from_entries' "$compare" > "$diffs_json"
             rm -f "$compare"
-            # Checkout is shallow. Fetch the API parent so --base can git-diff
-            # when GitHub omitted a patch (binary / too large). Compare patches
-            # are the primary input and work without this object.
+            # Checkout is shallow. Fetch the last-published SHA so --base can
+            # git-diff when GitHub omitted a patch (binary / too large). Compare
+            # patches are the primary input and work without this object.
             if ! git cat-file -e "${parent}^{commit}" 2>/dev/null; then
               git -c "http.extraheader=AUTHORIZATION: bearer ${GAMES_REPO_TOKEN}" \
                 fetch --depth=1 "https://github.com/${GAMES_REPO}.git" "$parent" \
-                || echo "Parent fetch failed — classify from compare patches only"
+                || echo "Baseline fetch failed — classify from compare patches only"
             fi
             scope=$(printf '%s\n' "$files" | node tools/gate-scope.mjs --event push --base "$parent" --diffs-json "$diffs_json" --json)
             rm -f "$diffs_json"
@@ -254,37 +270,34 @@ jobs:
           }
 
           if [ "$CLASSIFY_PUSH" = 1 ]; then
-            commit=$(mktemp)
-            status=$(curl -sS -o "$commit" -w '%{http_code}' \
-              -H "Accept: application/vnd.github+json" \
-              -H "Authorization: Bearer ${GAMES_REPO_TOKEN}" \
-              -H "User-Agent: gamedev-snapshot-publish" \
-              "https://api.github.com/repos/${GAMES_REPO}/commits/${SHA}")
-            if [ "$status" != 200 ]; then
-              echo "Commit lookup returned ${status} — full catalog gate"
+            # Cumulative range since the live snapshot, not HEAD^: a cancelled
+            # full gate for runtime A plus game-only B would otherwise classify
+            # only B and bake A's unvalidated modules into every game.
+            baseline=
+            if [ -n "${GCS_TOKEN:-}" ]; then
+              if pointer=$(curl -sS -f --max-time 30 \
+                -H "Authorization: Bearer ${GCS_TOKEN}" \
+                "https://storage.googleapis.com/storage/v1/b/${SNAPSHOT_BUCKET}/o/current.json?alt=media"); then
+                baseline=$(printf '%s' "$pointer" | jq -r '.commitSha // empty')
+                baseline="${baseline,,}"
+              else
+                echo "Could not read snapshot pointer — full catalog gate"
+              fi
+            fi
+            if [ "${#baseline}" -ne 40 ] || printf '%s' "$baseline" | grep -q '[^0-9a-f]'; then
+              echo "No published snapshot SHA — full catalog gate"
               MODE=full
               SLUGS=
               NEED_WEBKIT=1
               NARROW_CONFORMANCE=0
               RUN_GATE=1
-            else
-              parent=$(jq -r '.parents[0].sha // empty' "$commit")
-              if [ -z "$parent" ]; then
-                echo "No parent commit — full catalog gate"
-                MODE=full
-                SLUGS=
-                NEED_WEBKIT=1
-                NARROW_CONFORMANCE=0
-                RUN_GATE=1
-              elif ! classify_from_parent "$parent"; then
-                MODE=full
-                SLUGS=
-                NEED_WEBKIT=1
-                NARROW_CONFORMANCE=0
-                RUN_GATE=1
-              fi
+            elif ! classify_from_parent "$baseline"; then
+              MODE=full
+              SLUGS=
+              NEED_WEBKIT=1
+              NARROW_CONFORMANCE=0
+              RUN_GATE=1
             fi
-            rm -f "$commit"
           fi
 
           case "$MODE" in

--- a/.github/workflows/games-catalog-gate.yml
+++ b/.github/workflows/games-catalog-gate.yml
@@ -2,12 +2,14 @@ name: Games catalog gate
 
 # Runs the games repository's real post-merge gate on public Actions minutes.
 # publish-games.yml calls this workflow before advancing the snapshot pointer.
-# mode=full on schedule / manual dispatch / GameKit merges: playtest --suite
-# default, no catalog agent-play. Those two are the Sunday 06:17 UTC seal
-# (cron '17 6 * * 0'); scoped still playtests touched slugs. A games-published
-# dispatch re-classifies the SHA with tools/gate-scope.mjs --event push so a
-# one-game merge does not wait on a full-catalog check:pr (measured ~40 min).
-# The daily snapshot is a cheap rebuild, not a second full-catalog seal.
+# mode=full on schedule / manual dispatch / universal GameKit (core/gfx/audio/…):
+# playtest --suite default, no catalog agent-play. Opt-in modules (gfx3d,
+# sensing, …) reverse-index to GAME.json consumers and run static + those slugs.
+# Those two catalog seals are the Sunday 06:17 UTC cron ('17 6 * * 0'); scoped
+# still playtests touched slugs. A games-published dispatch re-classifies the
+# SHA with tools/gate-scope.mjs --event push so a one-game merge does not wait
+# on a full-catalog check:pr (measured ~40 min). The daily snapshot is a cheap
+# rebuild, not a second full-catalog seal.
 
 on:
   workflow_call:

--- a/.github/workflows/games-catalog-gate.yml
+++ b/.github/workflows/games-catalog-gate.yml
@@ -2,10 +2,12 @@ name: Games catalog gate
 
 # Runs the games repository's real post-merge gate on public Actions minutes.
 # publish-games.yml calls this workflow before advancing the snapshot pointer.
-# mode=full on merge/dispatch/daily 04:23 UTC: playtest --suite default, no
-# catalog agent-play. Those two are the Sunday 06:17 UTC seal (cron
-# '17 6 * * 0'); scoped still playtests touched slugs. The daily snapshot is a
-# cheap rebuild, not a second full-catalog seal.
+# mode=full on schedule / manual dispatch / GameKit merges: playtest --suite
+# default, no catalog agent-play. Those two are the Sunday 06:17 UTC seal
+# (cron '17 6 * * 0'); scoped still playtests touched slugs. A games-published
+# dispatch re-classifies the SHA with tools/gate-scope.mjs --event push so a
+# one-game merge does not wait on a full-catalog check:pr (measured ~40 min).
+# The daily snapshot is a cheap rebuild, not a second full-catalog seal.
 
 on:
   workflow_call:
@@ -44,10 +46,15 @@ on:
         type: string
         required: false
         default: '0'
+      classify_push:
+        description: '1 = re-classify this SHA as a main push (ignore payload mode)'
+        type: string
+        required: false
+        default: '0'
     outputs:
       games_sha:
         description: 'Commit SHA checked by every gate job'
-        value: ${{ jobs.catalog-gate.outputs.games_sha }}
+        value: ${{ jobs.resolve.outputs.games_sha }}
     secrets:
       GAMES_REPO_TOKEN:
         required: true
@@ -66,15 +73,19 @@ permissions:
   contents: read
 
 jobs:
-  catalog-gate:
+  resolve:
     runs-on: ubuntu-latest
-    timeout-minutes: 180
+    timeout-minutes: 10
     outputs:
       games_ref: ${{ steps.resolve.outputs.games_ref }}
       games_sha: ${{ steps.checkout_sha.outputs.games_sha }}
-      mode: ${{ steps.resolve.outputs.mode }}
-      slugs: ${{ steps.resolve.outputs.slugs }}
-      need_webkit: ${{ steps.resolve.outputs.need_webkit }}
+      mode: ${{ steps.scope.outputs.mode }}
+      slugs: ${{ steps.scope.outputs.slugs }}
+      need_webkit: ${{ steps.scope.outputs.need_webkit }}
+      narrow_conformance: ${{ steps.scope.outputs.narrow_conformance }}
+      run_gate: ${{ steps.scope.outputs.run_gate }}
+      catalog_playtest: ${{ steps.resolve.outputs.catalog_playtest }}
+      catalog_agent_play: ${{ steps.resolve.outputs.catalog_agent_play }}
     env:
       GAMES_REPO: 'gamedevpl/www.gamedev.pl-games'
     steps:
@@ -89,6 +100,7 @@ jobs:
           INPUT_NARROW_CONFORMANCE: ${{ inputs.narrow_conformance }}
           INPUT_CATALOG_PLAYTEST: ${{ inputs.catalog_playtest }}
           INPUT_CATALOG_AGENT_PLAY: ${{ inputs.catalog_agent_play }}
+          INPUT_CLASSIFY_PUSH: ${{ inputs.classify_push }}
         run: |
           set -euo pipefail
           REF="${INPUT_SHA:-${INPUT_REF:-main}}"
@@ -98,6 +110,7 @@ jobs:
           NARROW_CONFORMANCE="${INPUT_NARROW_CONFORMANCE:-0}"
           CATALOG_PLAYTEST="${INPUT_CATALOG_PLAYTEST:-default}"
           CATALOG_AGENT_PLAY="${INPUT_CATALOG_AGENT_PLAY:-0}"
+          CLASSIFY_PUSH="${INPUT_CLASSIFY_PUSH:-0}"
 
           case "$REF" in
             *[!A-Za-z0-9._/-]*)
@@ -112,8 +125,8 @@ jobs:
               exit 1
               ;;
           esac
-          case "$NEED_WEBKIT:$NARROW_CONFORMANCE" in
-            0:0|0:1|1:0|1:1) ;;
+          case "$NEED_WEBKIT:$NARROW_CONFORMANCE:$CLASSIFY_PUSH" in
+            0:0:0|0:0:1|0:1:0|0:1:1|1:0:0|1:0:1|1:1:0|1:1:1) ;;
             *)
               echo "Error: gate flags must be 0 or 1"
               exit 1
@@ -141,17 +154,14 @@ jobs:
                 ;;
             esac
           done
-          if [ "$MODE" = scoped ] && [ -z "${SLUGS// /}" ]; then
+          if [ "$CLASSIFY_PUSH" != 1 ] && [ "$MODE" = scoped ] && [ -z "${SLUGS// /}" ]; then
             echo "Error: scoped validation requires at least one game"
             exit 1
           fi
 
           {
             echo "games_ref=$REF"
-            echo "mode=$MODE"
-            echo "slugs=$SLUGS"
-            echo "need_webkit=$NEED_WEBKIT"
-            echo "narrow_conformance=$NARROW_CONFORMANCE"
+            echo "classify_push=$CLASSIFY_PUSH"
             echo "catalog_playtest=$CATALOG_PLAYTEST"
             echo "catalog_agent_play=$CATALOG_AGENT_PLAY"
           } >> "$GITHUB_OUTPUT"
@@ -169,6 +179,147 @@ jobs:
         id: checkout_sha
         working-directory: games-repo
         run: echo "games_sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: Classify merge scope
+        id: scope
+        working-directory: games-repo
+        env:
+          GAMES_REPO_TOKEN: ${{ secrets.GAMES_REPO_TOKEN }}
+          GAMES_REPO: ${{ env.GAMES_REPO }}
+          SHA: ${{ steps.checkout_sha.outputs.games_sha }}
+          CLASSIFY_PUSH: ${{ steps.resolve.outputs.classify_push }}
+          INPUT_MODE: ${{ inputs.mode }}
+          INPUT_SLUGS: ${{ inputs.slugs }}
+          INPUT_NEED_WEBKIT: ${{ inputs.need_webkit }}
+          INPUT_NARROW_CONFORMANCE: ${{ inputs.narrow_conformance }}
+        run: |
+          set -euo pipefail
+          MODE="${INPUT_MODE:-full}"
+          SLUGS="${INPUT_SLUGS:-}"
+          NEED_WEBKIT="${INPUT_NEED_WEBKIT:-1}"
+          NARROW_CONFORMANCE="${INPUT_NARROW_CONFORMANCE:-0}"
+          RUN_GATE=1
+
+          classify_from_parent() {
+            local parent="$1"
+            local compare status files file_count scope
+            compare=$(mktemp)
+            status=$(curl -sS -o "$compare" -w '%{http_code}' \
+              -H "Accept: application/vnd.github+json" \
+              -H "Authorization: Bearer ${GAMES_REPO_TOKEN}" \
+              -H "User-Agent: gamedev-snapshot-publish" \
+              "https://api.github.com/repos/${GAMES_REPO}/compare/${parent}...${SHA}")
+            if [ "$status" != 200 ]; then
+              echo "Compare ${parent:0:7}...${SHA:0:7} returned ${status} — full catalog gate"
+              rm -f "$compare"
+              return 1
+            fi
+            file_count=$(jq '.files | length' "$compare")
+            if [ "$file_count" -ge 300 ]; then
+              echo "Compare listed ${file_count} files (GitHub cap) — full catalog gate"
+              rm -f "$compare"
+              return 1
+            fi
+            files=$(jq -r '.files[]? | [.filename, (.previous_filename // empty)] | .[] | select(. != "")' "$compare")
+            rm -f "$compare"
+            scope=$(printf '%s\n' "$files" | node tools/gate-scope.mjs --event push --json)
+            MODE=$(printf '%s' "$scope" | jq -r '.mode')
+            SLUGS=$(printf '%s' "$scope" | jq -r '.slugs | join(" ")')
+            NEED_WEBKIT=$(printf '%s' "$scope" | jq -r '.need_webkit')
+            NARROW_CONFORMANCE=$(printf '%s' "$scope" | jq -r '.narrow_conformance')
+            RUN_GATE=$(printf '%s' "$scope" | jq -r '.run_gate')
+            echo "Push scope: mode=${MODE} run_gate=${RUN_GATE} webkit=${NEED_WEBKIT} slugs=${SLUGS:-"(none)"}"
+            return 0
+          }
+
+          if [ "$CLASSIFY_PUSH" = 1 ]; then
+            commit=$(mktemp)
+            status=$(curl -sS -o "$commit" -w '%{http_code}' \
+              -H "Accept: application/vnd.github+json" \
+              -H "Authorization: Bearer ${GAMES_REPO_TOKEN}" \
+              -H "User-Agent: gamedev-snapshot-publish" \
+              "https://api.github.com/repos/${GAMES_REPO}/commits/${SHA}")
+            if [ "$status" != 200 ]; then
+              echo "Commit lookup returned ${status} — full catalog gate"
+              MODE=full
+              SLUGS=
+              NEED_WEBKIT=1
+              NARROW_CONFORMANCE=0
+              RUN_GATE=1
+            else
+              parent=$(jq -r '.parents[0].sha // empty' "$commit")
+              if [ -z "$parent" ]; then
+                echo "No parent commit — full catalog gate"
+                MODE=full
+                SLUGS=
+                NEED_WEBKIT=1
+                NARROW_CONFORMANCE=0
+                RUN_GATE=1
+              elif ! classify_from_parent "$parent"; then
+                MODE=full
+                SLUGS=
+                NEED_WEBKIT=1
+                NARROW_CONFORMANCE=0
+                RUN_GATE=1
+              fi
+            fi
+            rm -f "$commit"
+          fi
+
+          case "$MODE" in
+            full|static|scoped) ;;
+            *)
+              echo "Error: invalid classified mode: $MODE"
+              exit 1
+              ;;
+          esac
+          case "$NEED_WEBKIT:$NARROW_CONFORMANCE:$RUN_GATE" in
+            0:0:0|0:0:1|0:1:0|0:1:1|1:0:0|1:0:1|1:1:0|1:1:1) ;;
+            *)
+              echo "Error: classified flags must be 0 or 1"
+              exit 1
+              ;;
+          esac
+          for slug in $SLUGS; do
+            case "$slug" in
+              *[!a-z0-9-]*)
+                echo "Error: invalid classified slug: $slug"
+                exit 1
+                ;;
+            esac
+          done
+          if [ "$RUN_GATE" = 1 ] && [ "$MODE" = scoped ] && [ -z "${SLUGS// /}" ]; then
+            echo "Error: scoped validation requires at least one game"
+            exit 1
+          fi
+
+          {
+            echo "mode=$MODE"
+            echo "slugs=$SLUGS"
+            echo "need_webkit=$NEED_WEBKIT"
+            echo "narrow_conformance=$NARROW_CONFORMANCE"
+            echo "run_gate=$RUN_GATE"
+          } >> "$GITHUB_OUTPUT"
+
+  catalog-gate:
+    needs: resolve
+    if: needs.resolve.outputs.run_gate == '1'
+    runs-on: ubuntu-latest
+    timeout-minutes: 180
+    env:
+      GAMES_REPO: 'gamedevpl/www.gamedev.pl-games'
+    steps:
+      - name: Gate scope
+        run: echo "mode=${{ needs.resolve.outputs.mode }} slugs=${{ needs.resolve.outputs.slugs || '(none)' }} webkit=${{ needs.resolve.outputs.need_webkit }}"
+
+      - name: Check out games repo
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          repository: ${{ env.GAMES_REPO }}
+          ref: ${{ needs.resolve.outputs.games_sha }}
+          token: ${{ secrets.GAMES_REPO_TOKEN }}
+          path: games-repo
+          persist-credentials: false
 
       - name: Check Playwright image matches games package
         working-directory: games-repo
@@ -201,29 +352,29 @@ jobs:
           chrome-version: stable
 
       - name: Run the full games gate
-        if: steps.resolve.outputs.mode == 'full'
+        if: needs.resolve.outputs.mode == 'full'
         working-directory: games-repo
         env:
           GAME_CAPTURE_CHROME: ${{ steps.chrome.outputs.chrome-path }}
         run: |
           set -euo pipefail
           npm run check:pr
-          if [ "${{ steps.resolve.outputs.catalog_agent_play }}" = 1 ]; then
+          if [ "${{ needs.resolve.outputs.catalog_agent_play }}" = 1 ]; then
             npm run agent-play
           fi
-          if [ "${{ steps.resolve.outputs.catalog_playtest }}" = all ]; then
+          if [ "${{ needs.resolve.outputs.catalog_playtest }}" = all ]; then
             npm run playtest -- --all
           else
             npm run playtest -- --suite default
           fi
 
       - name: Run the static games gate
-        if: steps.resolve.outputs.mode == 'static'
+        if: needs.resolve.outputs.mode == 'static'
         working-directory: games-repo
         env:
           GAME_CAPTURE_CHROME: ${{ steps.chrome.outputs.chrome-path }}
-          SLUGS: ${{ steps.resolve.outputs.slugs }}
-          NARROW_CONFORMANCE: ${{ steps.resolve.outputs.narrow_conformance }}
+          SLUGS: ${{ needs.resolve.outputs.slugs }}
+          NARROW_CONFORMANCE: ${{ needs.resolve.outputs.narrow_conformance }}
         run: |
           set -euo pipefail
           npm run check:no-js
@@ -255,11 +406,11 @@ jobs:
           fi
 
       - name: Run the scoped games gate
-        if: steps.resolve.outputs.mode == 'scoped'
+        if: needs.resolve.outputs.mode == 'scoped'
         working-directory: games-repo
         env:
           GAME_CAPTURE_CHROME: ${{ steps.chrome.outputs.chrome-path }}
-          SLUGS: ${{ steps.resolve.outputs.slugs }}
+          SLUGS: ${{ needs.resolve.outputs.slugs }}
         run: |
           set -euo pipefail
           npm run check:no-js
@@ -285,8 +436,8 @@ jobs:
           if [ "$need_webgl" = 1 ]; then npm run check:webgl; fi
 
   webkit:
-    needs: catalog-gate
-    if: needs.catalog-gate.outputs.need_webkit == '1'
+    needs: resolve
+    if: needs.resolve.outputs.need_webkit == '1'
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -301,7 +452,7 @@ jobs:
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           repository: ${{ env.GAMES_REPO }}
-          ref: ${{ needs.catalog-gate.outputs.games_sha }}
+          ref: ${{ needs.resolve.outputs.games_sha }}
           token: ${{ secrets.GAMES_REPO_TOKEN }}
           path: games-repo
           persist-credentials: false
@@ -320,8 +471,8 @@ jobs:
       - name: Check games on WebKit
         working-directory: games-repo
         env:
-          MODE: ${{ needs.catalog-gate.outputs.mode }}
-          SLUGS: ${{ needs.catalog-gate.outputs.slugs }}
+          MODE: ${{ needs.resolve.outputs.mode }}
+          SLUGS: ${{ needs.resolve.outputs.slugs }}
         run: |
           set -euo pipefail
           if [ "$MODE" = full ]; then

--- a/.github/workflows/publish-games.yml
+++ b/.github/workflows/publish-games.yml
@@ -5,9 +5,11 @@ name: Publish games snapshot
 # the request path (apps/api/src/game-snapshot.ts).
 #
 # The games repo dispatches its exact SHA after a main push. This workflow
-# re-classifies that SHA (tools/gate-scope.mjs --event push --base <parent>) so
-# a one-game merge runs the scoped gate (~8–10 min) instead of check:pr over the
-# catalog (~40 min). Opt-in GameKit modules reverse-index to GAME.json consumers
+# re-classifies that SHA (tools/gate-scope.mjs --event push --base <last-published>)
+# so a one-game merge runs the scoped gate (~8–10 min) instead of check:pr over the
+# catalog (~40 min). The base is the live snapshot's commitSha, not HEAD's parent:
+# cancel-in-progress would otherwise let a game-only follow-up skip an earlier
+# unvalidated runtime change. Opt-in GameKit modules reverse-index to GAME.json consumers
 # (static + those slugs). A named universal helper (drawGrid / draw.grid) is
 # static on callers; an unidentifiable or catalog-wide surface (draw.rect)
 # stays full.
@@ -74,10 +76,12 @@ jobs:
       slugs: ${{ github.event.client_payload.slugs || '' }}
       need_webkit: ${{ github.event.client_payload.need_webkit || '1' }}
       narrow_conformance: ${{ github.event.client_payload.narrow_conformance || '0' }}
-      # Merge dispatches always re-classify against the SHA. Payload mode is a
-      # hint (and the fallback if compare fails). games-validate keeps its payload
-      # (including WebKit) and does not publish. Schedule / workflow_dispatch
-      # keep the full catalog seal.
+      # Merge dispatches re-classify against current.json's commitSha (the
+      # last SHA that actually published). Payload mode is unused when
+      # classify_push=1; compare/pointer failure is full, not a payload
+      # fallback. games-validate keeps its payload (including WebKit) and
+      # does not publish. Schedule / workflow_dispatch keep the full catalog
+      # seal.
       classify_push: ${{ github.event_name == 'repository_dispatch' && github.event.action == 'games-published' && '1' || '0' }}
       # github.event.schedule is the cron string that fired this run (empty on
       # dispatch / workflow_dispatch). Match the Sunday cron above, not

--- a/.github/workflows/publish-games.yml
+++ b/.github/workflows/publish-games.yml
@@ -75,9 +75,10 @@ jobs:
       need_webkit: ${{ github.event.client_payload.need_webkit || '1' }}
       narrow_conformance: ${{ github.event.client_payload.narrow_conformance || '0' }}
       # Merge dispatches always re-classify against the SHA. Payload mode is a
-      # hint (and the fallback if compare fails); schedule / workflow_dispatch
+      # hint (and the fallback if compare fails). games-validate keeps its payload
+      # (including WebKit) and does not publish. Schedule / workflow_dispatch
       # keep the full catalog seal.
-      classify_push: ${{ github.event_name == 'repository_dispatch' && '1' || '0' }}
+      classify_push: ${{ github.event_name == 'repository_dispatch' && github.event.action == 'games-published' && '1' || '0' }}
       # github.event.schedule is the cron string that fired this run (empty on
       # dispatch / workflow_dispatch). Match the Sunday cron above, not
       # event_name == 'schedule' — the daily 04:23 cron is also a schedule.

--- a/.github/workflows/publish-games.yml
+++ b/.github/workflows/publish-games.yml
@@ -7,8 +7,9 @@ name: Publish games snapshot
 # The games repo dispatches its exact SHA after a main push. This workflow
 # re-classifies that SHA (tools/gate-scope.mjs --event push) so a one-game
 # merge runs the scoped gate (~8–10 min) instead of check:pr over the catalog
-# (~40 min). GameKit / universal-module pushes stay full. A failed gate leaves
-# the previous snapshot pointer untouched.
+# (~40 min). Opt-in GameKit modules reverse-index to GAME.json consumers
+# (static + those slugs). Universal modules (core/gfx/audio/…) stay full.
+# A failed gate leaves the previous snapshot pointer untouched.
 #
 # Nothing needs to be redeployed afterwards. Running instances re-read the pointer
 # on its short TTL, so a publish becomes visible on its own within about a minute.

--- a/.github/workflows/publish-games.yml
+++ b/.github/workflows/publish-games.yml
@@ -5,10 +5,12 @@ name: Publish games snapshot
 # the request path (apps/api/src/game-snapshot.ts).
 #
 # The games repo dispatches its exact SHA after a main push. This workflow
-# re-classifies that SHA (tools/gate-scope.mjs --event push) so a one-game
-# merge runs the scoped gate (~8–10 min) instead of check:pr over the catalog
-# (~40 min). Opt-in GameKit modules reverse-index to GAME.json consumers
-# (static + those slugs). Universal modules (core/gfx/audio/…) stay full.
+# re-classifies that SHA (tools/gate-scope.mjs --event push --base <parent>) so
+# a one-game merge runs the scoped gate (~8–10 min) instead of check:pr over the
+# catalog (~40 min). Opt-in GameKit modules reverse-index to GAME.json consumers
+# (static + those slugs). A named universal helper (drawGrid / draw.grid) is
+# static on callers; an unidentifiable or catalog-wide surface (draw.rect)
+# stays full.
 # A failed gate leaves the previous snapshot pointer untouched.
 #
 # Nothing needs to be redeployed afterwards. Running instances re-read the pointer

--- a/.github/workflows/publish-games.yml
+++ b/.github/workflows/publish-games.yml
@@ -4,9 +4,11 @@ name: Publish games snapshot
 # pre-assembled documents instead of rebuilding each game from GitHub + esbuild on
 # the request path (apps/api/src/game-snapshot.ts).
 #
-# The games repo dispatches its exact SHA and gate scope after a main push. This
-# workflow validates that checkout before baking its snapshot; a failed gate
-# leaves the previous snapshot pointer untouched.
+# The games repo dispatches its exact SHA after a main push. This workflow
+# re-classifies that SHA (tools/gate-scope.mjs --event push) so a one-game
+# merge runs the scoped gate (~8–10 min) instead of check:pr over the catalog
+# (~40 min). GameKit / universal-module pushes stay full. A failed gate leaves
+# the previous snapshot pointer untouched.
 #
 # Nothing needs to be redeployed afterwards. Running instances re-read the pointer
 # on its short TTL, so a publish becomes visible on its own within about a minute.
@@ -69,6 +71,10 @@ jobs:
       slugs: ${{ github.event.client_payload.slugs || '' }}
       need_webkit: ${{ github.event.client_payload.need_webkit || '1' }}
       narrow_conformance: ${{ github.event.client_payload.narrow_conformance || '0' }}
+      # Merge dispatches always re-classify against the SHA. Payload mode is a
+      # hint (and the fallback if compare fails); schedule / workflow_dispatch
+      # keep the full catalog seal.
+      classify_push: ${{ github.event_name == 'repository_dispatch' && '1' || '0' }}
       # github.event.schedule is the cron string that fired this run (empty on
       # dispatch / workflow_dispatch). Match the Sunday cron above, not
       # event_name == 'schedule' — the daily 04:23 cron is also a schedule.

--- a/docs/games-snapshot.md
+++ b/docs/games-snapshot.md
@@ -111,7 +111,10 @@ merge to games-repo main
   → repository_dispatch (pinned SHA, scoped/static/full)
       (docs/tools-only pushes skip this — they cannot change served HTML)
   → publish-games.yml: re-classify that SHA after checkout (the live tree is
-    the authority; a deleted game drops out of the slug list and still bakes)
+    the authority; a deleted game drops out of the slug list and still bakes).
+    `games-published` only: `--event push --base <parent> --diffs-json` from
+    the compare API (patches work on a shallow clone; parent is fetched if
+    GitHub omitted a patch). `games-validate` keeps the payload as sent.
   → scoped/static/full games gate (one-game merges: scoped, no WebKit)
   → npm run snapshot:publish (only after a green gate, or immediately when
     the classified push needs no gate — a deletion, a docs-only dispatch)

--- a/docs/games-snapshot.md
+++ b/docs/games-snapshot.md
@@ -107,14 +107,30 @@ still in flight.
 
 ```
 merge to games-repo main
-  → validate.yml: calculate scope + repository_dispatch (pinned SHA)
-  → publish-games.yml: run the scoped/static/full games gate
-  → publish-games.yml: npm run snapshot:publish (only after a green gate)
+  → gate-service: classify the push (tools/gate-scope.mjs --event push)
+  → repository_dispatch (pinned SHA, scoped/static/full)
+      (docs/tools-only pushes skip this — they cannot change served HTML)
+  → publish-games.yml: re-classify that SHA after checkout (the live tree is
+    the authority; a deleted game drops out of the slug list and still bakes)
+  → scoped/static/full games gate (one-game merges: scoped, no WebKit)
+  → npm run snapshot:publish (only after a green gate, or immediately when
+    the classified push needs no gate — a deletion, a docs-only dispatch)
       (derives catalog.json from the games archive — including code-derived touch —
        and writes it into the snapshot; the games repo does not commit catalog.json)
   → objects written, then current.json moves (only if every game baked cleanly)
   → running instances pick it up within the pointer TTL (~1 min)
 ```
+
+A typical one-game merge used to wait on `check:pr` over the whole catalog
+(~40 min) plus WebKit and the bake (~47 min wall clock in
+[run 34680596062](https://github.com/gamedevpl/www.gamedev.pl/actions/runs/34680596062)).
+That is also why a merge train cancelled in-progress publishes: the next push
+arrived before the 45-minute job finished, so `current.json` never moved. The
+scoped path is the same `check:game` the PR already attested, re-run on a
+clean runner, and WebKit is skipped on push because the PR already sealed it
+(`gate-scope.mjs` `eventName === 'push'`). GameKit / universal-module merges
+still pay the full catalog gate. The nightly 04:23 UTC run remains the
+cheap full rebuild; Sunday 06:17 UTC remains the catalog seal.
 
 No redeploy is needed — instances re-read the pointer on its own TTL.
 

--- a/docs/games-snapshot.md
+++ b/docs/games-snapshot.md
@@ -128,9 +128,13 @@ That is also why a merge train cancelled in-progress publishes: the next push
 arrived before the 45-minute job finished, so `current.json` never moved. The
 scoped path is the same `check:game` the PR already attested, re-run on a
 clean runner, and WebKit is skipped on push because the PR already sealed it
-(`gate-scope.mjs` `eventName === 'push'`). GameKit / universal-module merges
-still pay the full catalog gate. The nightly 04:23 UTC run remains the
-cheap full rebuild; Sunday 06:17 UTC remains the catalog seal.
+(`gate-scope.mjs` `eventName === 'push'`). Opt-in GameKit modules
+(`gfx3d`, `sensing`, verticals, …) reverse-index to the games that select
+them in `GAME.json` and run `mode=static` on those slugs, with WebKit.
+Universal modules (`core`, `gfx`, `audio`, …) and `game-shell.css` still
+pay the full catalog gate — every published game loads them. The nightly
+04:23 UTC run remains the cheap full rebuild; Sunday 06:17 UTC remains the
+catalog seal.
 
 No redeploy is needed — instances re-read the pointer on its own TTL.
 

--- a/docs/games-snapshot.md
+++ b/docs/games-snapshot.md
@@ -112,9 +112,12 @@ merge to games-repo main
       (docs/tools-only pushes skip this — they cannot change served HTML)
   → publish-games.yml: re-classify that SHA after checkout (the live tree is
     the authority; a deleted game drops out of the slug list and still bakes).
-    `games-published` only: `--event push --base <parent> --diffs-json` from
-    the compare API (patches work on a shallow clone; parent is fetched if
-    GitHub omitted a patch). `games-validate` keeps the payload as sent.
+    `games-published` only: `--event push --base <last-published-sha>
+    --diffs-json` from the compare API (patches work on a shallow clone; the
+    last-published commit is fetched if GitHub omitted a patch). The base is
+    `current.json`'s `commitSha`, not `HEAD^`: with `cancel-in-progress`, a
+    game-only B would otherwise skip a cancelled/failed runtime A and bake it.
+    Missing pointer or compare → full. `games-validate` keeps the payload as sent.
   → scoped/static/full games gate (one-game merges: scoped, no WebKit)
   → npm run snapshot:publish (only after a green gate, or immediately when
     the classified push needs no gate — a deletion, a docs-only dispatch)
@@ -135,7 +138,7 @@ clean runner, and WebKit is skipped on push because the PR already sealed it
 (`gfx3d`, `sensing`, verticals, …) reverse-index to the games that select
 them in `GAME.json` and run `mode=static` on those slugs, with WebKit.
 Universal modules (`core`, `drawing`, `gfx`, `audio`, …) use the same
-`--base <parent>` classify: a named function or `draw.*` field that only
+`--base <last-published-sha>` classify: a named function or `draw.*` field that only
 a subset of games call is `mode=static` on those slugs (WebKit included).
 An unidentifiable patch, a lifecycle symbol (`mount`, `createRenderer`, …),
 or a surface most of the catalog calls (`draw.rect`) stays full — post-merge

--- a/docs/games-snapshot.md
+++ b/docs/games-snapshot.md
@@ -131,10 +131,14 @@ clean runner, and WebKit is skipped on push because the PR already sealed it
 (`gate-scope.mjs` `eventName === 'push'`). Opt-in GameKit modules
 (`gfx3d`, `sensing`, verticals, …) reverse-index to the games that select
 them in `GAME.json` and run `mode=static` on those slugs, with WebKit.
-Universal modules (`core`, `gfx`, `audio`, …) and `game-shell.css` still
-pay the full catalog gate — every published game loads them. The nightly
-04:23 UTC run remains the cheap full rebuild; Sunday 06:17 UTC remains the
-catalog seal.
+Universal modules (`core`, `drawing`, `gfx`, `audio`, …) use the same
+`--base <parent>` classify: a named function or `draw.*` field that only
+a subset of games call is `mode=static` on those slugs (WebKit included).
+An unidentifiable patch, a lifecycle symbol (`mount`, `createRenderer`, …),
+or a surface most of the catalog calls (`draw.rect`) stays full — post-merge
+`mode=static` would playtest more games than full's default suite.
+`game-shell.css` is still always full. The nightly 04:23 UTC run remains the
+cheap full rebuild; Sunday 06:17 UTC remains the catalog seal.
 
 No redeploy is needed — instances re-read the pointer on its own TTL.
 

--- a/docs/games-snapshot.md
+++ b/docs/games-snapshot.md
@@ -114,9 +114,12 @@ merge to games-repo main
     the authority; a deleted game drops out of the slug list and still bakes).
     `games-published` only: `--event push --base <last-published-sha>
     --diffs-json` from the compare API (patches work on a shallow clone; the
-    last-published commit is fetched if GitHub omitted a patch). The base is
-    `current.json`'s `commitSha`, not `HEAD^`: with `cancel-in-progress`, a
-    game-only B would otherwise skip a cancelled/failed runtime A and bake it.
+    last-published commit is fetched if GitHub omitted a patch). If that
+    object is missing too, classify fails closed to full — it does not fall
+    back to `HEAD~1`, which would classify only the last commit and miss an
+    unpublished runtime change still in range of the live snapshot. The
+    base is `current.json`'s `commitSha`, not `HEAD^`: with `cancel-in-progress`,
+    a game-only B would otherwise skip a cancelled/failed runtime A and bake it.
     Missing pointer or compare → full. `games-validate` keeps the payload as sent.
   → scoped/static/full games gate (one-game merges: scoped, no WebKit)
   → npm run snapshot:publish (only after a green gate, or immediately when


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

[Publish games snapshot #34686093184](https://github.com/gamedevpl/www.gamedev.pl/actions/runs/34686093184) is the current merge path: every `games-published` dispatch runs `check:pr` over the whole catalog (~40 min), then WebKit, then the bake.

A successful run the same morning ([#34680596062](https://github.com/gamedevpl/www.gamedev.pl/actions/runs/34680596062)) was **47 minutes** wall clock. Because this workflow cancels in-progress publishes, a merge train that lands another game before that job finishes never moves `current.json`.

Classifying only `HEAD^...HEAD` is also unsafe with `cancel-in-progress`: if runtime change A starts a full gate and is cancelled when game-only B lands, B would check only that game and bake A's unvalidated modules into every title.

## Change

On `games-published` (not `games-validate`), after checking out the pinned SHA, re-classify with `tools/gate-scope.mjs --event push --base <last-published-sha> --diffs-json` from the compare API. The base is `current.json`'s `commitSha` (read via WIF), not HEAD's parent:

- **one game** (and no unvalidated commits since the live snapshot) → scoped gate, no WebKit → bake.
- **opt-in GameKit** → `static` on `GAME.json` consumers, with WebKit.
- **named universal function / field** → `static` on callers, with WebKit.
- **unidentifiable or catalog-wide kit**, `game-shell.css` → full.
- **cancelled/failed A then game-only B** → compare is last-good...B, so A's files stay in range.
- **missing pointer, compare, or a classify crash** → full (the bake still runs). Payload mode is not a fallback on `games-published`.
- **empty `need_webkit` / `narrow_conformance` / `run_gate`** → same full path as a missing mode (cannot hard-exit `resolve` and freeze the pointer).
- **docs-only / deleted-only** (`run_gate=0`) → skip the gate, still bake.

`games-validate` keeps the payload it was sent (including WebKit) and does not publish.

If GitHub omits a patch and the published SHA is not in the checkout, classify fails closed to full. It does not fall back to `HEAD~1` (that hole is closed in games#1425).

WebKit on a full run starts from the resolve job, so it overlaps the catalog gate. A red gate still pays that sweep; `cancel-in-progress` makes that rare.

Pair: [games#1425](https://github.com/gamedevpl/www.gamedev.pl-games/pull/1425).

Do not merge or deploy until re-review.

## Test plan

- [x] Website files are workflow + docs only
- [x] `classify_push` is `games-published` only
- [x] Classify `last-published...HEAD`, not `parents[0]`; missing pointer → full
- [x] Classify crash / empty mode / empty flags → full, not a frozen pointer
- [x] Regression in games#1425: cancelled runtime + game-only file list stays `full`
- [x] Regression in games#1425: named base + missing S + no API patch stays `full`
- [x] CI on `10ad195` (previous head) was 8/8 green; this commit is the jq-flag guard
- [ ] After both PRs merge, a `gfx3d` landing should log `Push scope: mode=static`
- [ ] A `drawGrid` landing should log `mode=static` with the `draw.grid` games
- [ ] Nightly 04:23 UTC and Sunday 06:17 UTC still run full

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2a8c444b-7a95-431e-952d-669840349ad4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2a8c444b-7a95-431e-952d-669840349ad4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

