### PR TITLE
fix(web): stop welcome tap-to-play landing on Page not found

### DIFF
--- a/apps/api/src/creation/creator-studio.ts
+++ b/apps/api/src/creation/creator-studio.ts
@@ -5,6 +5,7 @@ import { DEFAULT_SIGNED_URL_TTL_SECONDS, type GcsObjectStore } from '../delivery
 import { KitRegistryError, parseKitRegistry, parseKitSidecar } from '../platform/kit-registry.js';
 import { codeSurfaceEnabled } from './code-surface.js';
 import { collapseJobsToOwnerGames, MAX_OWNER_GAMES, pageOwnerGames } from './owner-games.js';
+import { loadShelfRecords } from './studio-shelf-records.js';
 import { readTarEntries, type TarEntry } from '../platform/tar.js';
 import { hydrateRecentBuildSummaries } from '../platform/build-changelog.js';
 import type {
@@ -158,7 +159,8 @@ export async function registerCreatorStudioRoutes(
       return reply.status(400).send({ error: parsed.error.issues[0]?.message ?? 'invalid query' });
     }
 
-    const records = await store.listSubmissionsByOwner(request.user!.uid);
+    const mint = options.mintStatusToken;
+    const records = await loadShelfRecords(store, request.user!.uid, parsed.data.game, mint);
     const collapsed = collapseJobsToOwnerGames(records, 'shelf');
     const total = collapsed.length;
     const truncated = total > MAX_OWNER_GAMES;

--- a/apps/api/src/creation/studio-shelf-records.test.ts
+++ b/apps/api/src/creation/studio-shelf-records.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+import { InMemoryStore } from '../platform/store.js';
+import { mintToken } from '../platform/submission-token.js';
+import { loadShelfRecords } from './studio-shelf-records.js';
+
+const SECRET = 'shelf-test-secret';
+const mint = (jobId: number) => mintToken(jobId, SECRET);
+
+describe('loadShelfRecords', () => {
+  it('fills in a game the owner query has not yet returned', async () => {
+    const store = new InMemoryStore();
+    await store.createSubmission(10, 'g:creator', 'Sky Dodge');
+    await store.setSubmissionSlug(10, 'sky-dodge');
+    const realList = store.listSubmissionsByOwner.bind(store);
+    store.listSubmissionsByOwner = async (uid, opts) =>
+      (await realList(uid, opts)).filter((row) => row.slug !== 'sky-dodge');
+
+    const records = await loadShelfRecords(store, 'g:creator', 'sky-dodge', mint);
+    expect(records.map((row) => row.slug)).toContain('sky-dodge');
+  });
+
+  it('fills in a game when slug and owner queries both lag', async () => {
+    const store = new InMemoryStore();
+    await store.createSubmission(10, 'g:creator', 'Sky Dodge');
+    await store.setSubmissionSlug(10, 'sky-dodge');
+    store.listSubmissionsByOwner = async () => [];
+    store.getSubmissionBySlug = async () => null;
+
+    const records = await loadShelfRecords(store, 'g:creator', mint(10), mint);
+    expect(records.map((row) => row.jobId)).toEqual([10]);
+  });
+
+  it('does not surface someone else’s slug', async () => {
+    const store = new InMemoryStore();
+    await store.createSubmission(10, 'g:other', 'Sky Dodge');
+    await store.setSubmissionSlug(10, 'sky-dodge');
+    const records = await loadShelfRecords(store, 'g:creator', 'sky-dodge', () => 'tok');
+    expect(records).toEqual([]);
+  });
+
+  it('does not surface a forged token', async () => {
+    const store = new InMemoryStore();
+    await store.createSubmission(10, 'g:creator', 'Sky Dodge');
+    store.listSubmissionsByOwner = async () => [];
+    store.getSubmissionBySlug = async () => null;
+    const records = await loadShelfRecords(store, 'g:creator', 'not-a-token', mint);
+    expect(records).toEqual([]);
+  });
+});

--- a/apps/api/src/creation/studio-shelf-records.ts
+++ b/apps/api/src/creation/studio-shelf-records.ts
@@ -1,0 +1,43 @@
+import type { Store, SubmissionRecord } from '../platform/store.js';
+
+type ShelfStore = Pick<Store, 'listSubmissionsByOwner' | 'getSubmissionBySlug' | 'getSubmission'>;
+
+function jobIdFromToken(token: string): number | null {
+  try {
+    const [raw] = Buffer.from(token, 'base64url').toString('utf8').split('.');
+    if (!raw || !/^\d+$/.test(raw)) return null;
+    const jobId = Number.parseInt(raw, 10);
+    return Number.isSafeInteger(jobId) && jobId > 0 ? jobId : null;
+  } catch {
+    return null;
+  }
+}
+
+async function lookupRequested(
+  store: ShelfStore,
+  requested: string,
+  mintStatusToken: (jobId: number) => string,
+): Promise<SubmissionRecord | null> {
+  const bySlug = await store.getSubmissionBySlug(requested);
+  if (bySlug) return bySlug;
+  const jobId = jobIdFromToken(requested);
+  if (!jobId || mintStatusToken(jobId) !== requested) return null;
+  return store.getSubmission(jobId);
+}
+
+// Owner-query lag: document GET still finds a just-written draft.
+export async function loadShelfRecords(
+  store: ShelfStore,
+  ownerUid: string,
+  requested: string | undefined,
+  mintStatusToken: (jobId: number) => string,
+): Promise<SubmissionRecord[]> {
+  const records = await store.listSubmissionsByOwner(ownerUid);
+  if (!requested) return records;
+  const known = records.some((record) => record.slug === requested || mintStatusToken(record.jobId) === requested);
+  if (known) return records;
+
+  const extra = await lookupRequested(store, requested, mintStatusToken);
+  if (!extra || extra.ownerUid !== ownerUid || extra.abandonedAt) return records;
+  return [extra, ...records.filter((record) => record.jobId !== extra.jobId)];
+}

--- a/apps/api/src/delivery/draft-preview-routes.ts
+++ b/apps/api/src/delivery/draft-preview-routes.ts
@@ -57,10 +57,13 @@ export async function registerDraftPreviewRoutes(
   // Playable only by its owner, or anyone the creator shared it with.
   async function canPlayDraft(request: FastifyRequest, slug: string): Promise<DraftGrant | null> {
     if (!store) return null;
-    const record = await store.getSubmissionBySlug(slug);
-    // Abandoned builds are unplayable, even by their own creator.
-    if (!record || record.abandonedAt) return null;
+    let record = await store.getSubmissionBySlug(slug);
     const uid = request.user?.uid;
+    // Slug index can lag the owner query on a just-written draft.
+    if (!record && uid) {
+      record = (await store.listSubmissionsByOwner(uid)).find((row) => row.slug === slug) ?? null;
+    }
+    if (!record || record.abandonedAt) return null;
     // The owner sees their own red build; a stranger never does.
     if (uid && uid === record.ownerUid) return { jobId: record.jobId };
     // A pulled game is not re-opened by flipping the switch.

--- a/apps/api/src/delivery/draft-share.test.ts
+++ b/apps/api/src/delivery/draft-share.test.ts
@@ -177,4 +177,17 @@ describe('sharing a draft', () => {
     expect(off.statusCode).toBe(200);
     expect((await app.inject({ method: 'GET', url: `/api/games/${SLUG}` })).statusCode).toBe(404);
   });
+
+  it('lets the owner play when the slug index has not caught up', async () => {
+    const { app, store } = await draftApp();
+    store.getSubmissionBySlug = async () => null;
+    const mine = await app.inject({ method: 'GET', url: `/api/games/${SLUG}`, headers: headers() });
+    expect(mine.statusCode).toBe(200);
+    const stranger = await app.inject({
+      method: 'GET',
+      url: `/api/games/${SLUG}`,
+      headers: headers('g:someone-else'),
+    });
+    expect(stranger.statusCode).toBe(404);
+  });
 });

--- a/apps/web/src/surfaces/studio/CreatorStudioView.tsx
+++ b/apps/web/src/surfaces/studio/CreatorStudioView.tsx
@@ -14,6 +14,7 @@ import { CodeSurface } from './CodeSurface.js';
 import { EditorPanel } from './EditorPanel.js';
 import { StudioStage, type StagePosture, type StageStatus } from './StudioStage.js';
 import { StudioStrip } from './StudioStrip.js';
+import { useHandoffClickGuard } from './useHandoffClickGuard.js';
 import { usePlayChromeIdle } from '../../usePlayChromeIdle.js';
 import { StudioChatRail } from './StudioChatRail.js';
 import { StudioStageCard } from './StudioStageCard.js';
@@ -117,10 +118,10 @@ export function CreatorStudioView({
   onPlay,
   onRetryConcept,
 }: CreatorStudioViewProps) {
+  useHandoffClickGuard();
   const { t, i18n } = useTranslation();
   const { user } = useAuth();
   const [authOpen, setAuthOpen] = useState(false);
-  /** Claim-handle modal — only opened when the creator asks to clear the publish gate. */
   const [claimOpen, setClaimOpen] = useState(false);
   const [games, setGames] = useState<StudioGame[]>([]);
   const [healthRows, setHealthRows] = useState<GameHealth[]>([]);
@@ -914,6 +915,7 @@ export function CreatorStudioView({
                         onClaim={() => setClaimOpen(true)}
                         shareSlot={shareSlot}
                         onOpenTheater={() => setTheaterOpen(true)}
+                        onPlayPermalink={onPlay}
                         isCompact={shelfIsDrawer}
                         isChromeIdle={playChromeIdle}
                         onExit={() => onNavigate('/')}

--- a/apps/web/src/surfaces/studio/StudioStrip.test.tsx
+++ b/apps/web/src/surfaces/studio/StudioStrip.test.tsx
@@ -54,9 +54,7 @@ async function renderStrip(props: Partial<StudioStripProps> = {}) {
 afterEach(async () => {
   while (hosts.length) {
     const cleanup = hosts.pop()!;
-    await act(async () => {
-      cleanup();
-    });
+    await act(async () => cleanup());
   }
 });
 
@@ -72,12 +70,13 @@ describe('StudioStrip layout structure', () => {
   } as unknown as SubmissionStatus;
 
   it('renders title as a link to /play/:slug when slug is present', async () => {
-    const host = await renderStrip({ slug: 'my-game', title: 'My Game' });
+    const onPlayPermalink = vi.fn();
+    const host = await renderStrip({ slug: 'my-game', title: 'My Game', onPlayPermalink });
     const link = host.querySelector<HTMLAnchorElement>('.studio-strip-title a');
-
-    expect(link).toBeTruthy();
     expect(link?.getAttribute('href')).toBe('/play/my-game');
     expect(link?.textContent).toBe('My Game');
+    await act(async () => link?.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true, button: 0 })));
+    expect(onPlayPermalink).toHaveBeenCalledWith('my-game');
   });
 
   it('renders title as text without link when slug is not present', async () => {
@@ -129,8 +128,6 @@ describe('StudioStrip layout structure', () => {
       lastAgentSignalAt: new Date().toISOString(),
     } as unknown as SubmissionStatus;
     const host = await renderStrip({ status: firstRoundStatus, onOpenBuild });
-
-    // No build has ever landed yet — the bar has nothing to show.
     expect(host.querySelector('.studio-build-bar')).toBeNull();
 
     const button = host.querySelector<HTMLButtonElement>('.studio-strip-phase-button');

--- a/apps/web/src/surfaces/studio/StudioStrip.tsx
+++ b/apps/web/src/surfaces/studio/StudioStrip.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { latestAgentActivityAt } from '../../agentActivity.js';
 import { PixelIcon } from '../../PixelIcon.js';
 import { playPath } from '../../core/router.js';
+import { interceptPlayPermalink } from './playPermalink.js';
 import { StudioBuildBar } from './StudioBuildBar.js';
 import { StudioStripOverflowMenu } from './StudioStripOverflowMenu.js';
 import { formatRelativeTime } from '../../relativeTime.js';
@@ -11,8 +12,6 @@ import type { StagePosture } from './StudioStage.js';
 import { recordCodeStep } from '../../visitTelemetry.js';
 import './studio-strip.css';
 import './studio-chat-rail.css';
-
-// Always over the stage: a workroom, so no auto-hide (B1).
 
 const HEARTBEAT_STATES = new Set<SubmissionStatus['status']>(['queued', 'building', 'in_review', 'publishing']);
 
@@ -43,13 +42,9 @@ export type StudioStripProps = {
   canClaim: boolean;
   onClaim: () => void;
   shareSlot?: ReactNode;
-  /** Opens the build in the full site `GameTheater` (fullscreen, share, report) — see
-   * studio-game-first-implementation-plan.md's follow-up: the stage's own play posture
-   * is Studio's lighter theater, and this is the way to the site's fuller one. */
   onOpenTheater?: () => void;
-  // ≤800px (shelfIsDrawer): fold secondary actions behind a ⋯ menu.
+  onPlayPermalink?: (slug: string) => void;
   isCompact?: boolean;
-  // Replaces the global header's back arrow, hidden below 800px.
   onExit?: () => void;
   isChromeIdle?: boolean;
 };
@@ -80,6 +75,7 @@ export function StudioStrip({
   onClaim,
   shareSlot,
   onOpenTheater,
+  onPlayPermalink,
   isCompact = false,
   onExit,
   isChromeIdle = false,
@@ -131,7 +127,11 @@ export function StudioStrip({
       <div className="studio-strip-title-block">
         <h2 className="studio-strip-title">
           {slug ? (
-            <a href={playPath(slug)} className="studio-strip-title-link">
+            <a
+              href={playPath(slug)}
+              className="studio-strip-title-link"
+              onClick={(event) => interceptPlayPermalink(event, slug, onPlayPermalink)}
+            >
               {title}
             </a>
           ) : (

--- a/apps/web/src/surfaces/studio/StudioWelcomeView.test.tsx
+++ b/apps/web/src/surfaces/studio/StudioWelcomeView.test.tsx
@@ -74,7 +74,7 @@ describe('StudioWelcomeView', () => {
     await act(async () => {
       cta.click();
     });
-    expect(onOpenStudio).toHaveBeenCalledWith('/studio/bastion-wave?from=handoff');
+    expect(onOpenStudio).toHaveBeenCalledWith('/studio/tok-welcome?from=handoff');
     expect(localStorage.getItem('gamedev_studio_onboarded')).toBe('1');
   });
 
@@ -116,7 +116,7 @@ describe('StudioWelcomeView', () => {
     await act(async () => {
       callout.click();
     });
-    expect(onOpenStudio).toHaveBeenCalledWith('/studio/bastion-wave?from=handoff');
+    expect(onOpenStudio).toHaveBeenCalledWith('/studio/tok-welcome/playtest?from=handoff');
   });
 
   it('keeps building while the only playable builds are the seed and the staged tree', async () => {

--- a/apps/web/src/surfaces/studio/StudioWelcomeView.tsx
+++ b/apps/web/src/surfaces/studio/StudioWelcomeView.tsx
@@ -3,7 +3,7 @@ import { createPortal } from 'react-dom';
 import { useTranslation } from 'react-i18next';
 import { InteractiveMascot, type MascotEmotion } from '../../Mascot.js';
 import { PixelIcon } from '../../PixelIcon.js';
-import { studioPath } from '../../core/router.js';
+import { welcomeHandoffHref } from './welcomeHandoff.js';
 import { BuildProgressChecklist } from '../../BuildProgressChecklist.js';
 import { isStudioOnboarded, markStudioOnboarded, resolveWelcomeToken } from './studioWelcome.js';
 import { pollDelayMs } from './studioStatusPoll.js';
@@ -232,8 +232,7 @@ export function StudioWelcomeView({ game, onOpenStudio }: StudioWelcomeViewProps
   const openStudio = () => {
     markStudioOnboarded();
     recordCreateStep('handoff_enter_studio', 'platform');
-    const address = status?.slug ?? game;
-    onOpenStudio(`${studioPath(address)}?from=handoff`);
+    onOpenStudio(welcomeHandoffHref(token ?? status?.slug ?? game, isReady));
   };
 
   const progress = welcomeProgressMessage(status, t);

--- a/apps/web/src/surfaces/studio/playPermalink.test.ts
+++ b/apps/web/src/surfaces/studio/playPermalink.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it, vi } from 'vitest';
+import { interceptPlayPermalink } from './playPermalink.js';
+
+function click(extra: Partial<Parameters<typeof interceptPlayPermalink>[0]> = {}) {
+  return {
+    button: 0,
+    metaKey: false,
+    ctrlKey: false,
+    shiftKey: false,
+    altKey: false,
+    preventDefault: vi.fn(),
+    ...extra,
+  };
+}
+
+describe('interceptPlayPermalink', () => {
+  it('keeps an unmodified left-click in the app', () => {
+    const onPlayPermalink = vi.fn();
+    const event = click();
+    interceptPlayPermalink(event, 'sky-dodge', onPlayPermalink);
+    expect(event.preventDefault).toHaveBeenCalledTimes(1);
+    expect(onPlayPermalink).toHaveBeenCalledWith('sky-dodge');
+  });
+
+  it('leaves modified clicks to the real permalink', () => {
+    const onPlayPermalink = vi.fn();
+    interceptPlayPermalink(click({ metaKey: true }), 'sky-dodge', onPlayPermalink);
+    expect(onPlayPermalink).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/surfaces/studio/playPermalink.ts
+++ b/apps/web/src/surfaces/studio/playPermalink.ts
@@ -1,0 +1,19 @@
+// Same-tab /play stays in-app so a fresh draft can retry.
+export function interceptPlayPermalink(
+  event: {
+    button: number;
+    metaKey: boolean;
+    ctrlKey: boolean;
+    shiftKey: boolean;
+    altKey: boolean;
+    preventDefault: () => void;
+  },
+  slug: string,
+  onPlayPermalink?: (slug: string) => void,
+): void {
+  if (!onPlayPermalink || event.button !== 0 || event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) {
+    return;
+  }
+  event.preventDefault();
+  onPlayPermalink(slug);
+}

--- a/apps/web/src/surfaces/studio/useHandoffClickGuard.test.tsx
+++ b/apps/web/src/surfaces/studio/useHandoffClickGuard.test.tsx
@@ -1,0 +1,67 @@
+// @vitest-environment jsdom
+
+import { act } from 'react';
+import { createRoot } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { HANDOFF_CLICK_GUARD_MS, useHandoffClickGuard } from './useHandoffClickGuard.js';
+
+function Probe() {
+  useHandoffClickGuard();
+  return null;
+}
+
+describe('useHandoffClickGuard', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    window.history.replaceState(null, '', '/studio/bastion-wave?from=handoff');
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    window.history.replaceState(null, '', '/');
+  });
+
+  it('swallows clicks for a beat after the welcome handoff', async () => {
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    const root = createRoot(host);
+    await act(async () => {
+      root.render(<Probe />);
+    });
+
+    const click = new MouseEvent('click', { bubbles: true, cancelable: true });
+    document.body.dispatchEvent(click);
+    expect(click.defaultPrevented).toBe(true);
+
+    await act(async () => {
+      vi.advanceTimersByTime(HANDOFF_CLICK_GUARD_MS + 1);
+    });
+    const later = new MouseEvent('click', { bubbles: true, cancelable: true });
+    document.body.dispatchEvent(later);
+    expect(later.defaultPrevented).toBe(false);
+
+    await act(async () => {
+      root.unmount();
+    });
+    host.remove();
+  });
+
+  it('does not swallow clicks on an ordinary studio visit', async () => {
+    window.history.replaceState(null, '', '/studio/bastion-wave');
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    const root = createRoot(host);
+    await act(async () => {
+      root.render(<Probe />);
+    });
+
+    const click = new MouseEvent('click', { bubbles: true, cancelable: true });
+    document.body.dispatchEvent(click);
+    expect(click.defaultPrevented).toBe(false);
+
+    await act(async () => {
+      root.unmount();
+    });
+    host.remove();
+  });
+});

--- a/apps/web/src/surfaces/studio/useHandoffClickGuard.ts
+++ b/apps/web/src/surfaces/studio/useHandoffClickGuard.ts
@@ -1,0 +1,18 @@
+import { useEffect } from 'react';
+
+export const HANDOFF_CLICK_GUARD_MS = 500;
+
+// Swallow the welcome tap so it cannot hit Studio chrome.
+export function useHandoffClickGuard(windowMs = HANDOFF_CLICK_GUARD_MS): void {
+  useEffect(() => {
+    if (new URLSearchParams(window.location.search).get('from') !== 'handoff') return;
+    const until = Date.now() + windowMs;
+    const block = (event: Event) => {
+      if (Date.now() >= until) return;
+      event.preventDefault();
+      event.stopPropagation();
+    };
+    document.addEventListener('click', block, true);
+    return () => document.removeEventListener('click', block, true);
+  }, [windowMs]);
+}

--- a/apps/web/src/surfaces/studio/welcomeHandoff.test.ts
+++ b/apps/web/src/surfaces/studio/welcomeHandoff.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest';
+import { studioPlaytestPath, welcomeHandoffHref } from './welcomeHandoff.js';
+
+describe('welcomeHandoffHref', () => {
+  it('opens playtest when the draft is ready', () => {
+    expect(welcomeHandoffHref('bastion-wave', true)).toBe('/studio/bastion-wave/playtest?from=handoff');
+    expect(studioPlaytestPath('a b')).toBe('/studio/a%20b/playtest');
+  });
+
+  it('opens the thread while the agent is still building', () => {
+    expect(welcomeHandoffHref('bastion-wave', false)).toBe('/studio/bastion-wave?from=handoff');
+  });
+});

--- a/apps/web/src/surfaces/studio/welcomeHandoff.ts
+++ b/apps/web/src/surfaces/studio/welcomeHandoff.ts
@@ -1,0 +1,12 @@
+import { studioPath } from '../../core/router.js';
+
+// Play posture URL. studioPath would 404 playtest.
+export function studioPlaytestPath(game: string): string {
+  return `/studio/${encodeURIComponent(game)}/playtest`;
+}
+
+// Ready opens playtest; otherwise the thread.
+export function welcomeHandoffHref(address: string, ready: boolean): string {
+  const path = ready ? studioPlaytestPath(address) : studioPath(address);
+  return `${path}?from=handoff`;
+}

--- a/apps/web/src/usePublishedGameFetch.test.tsx
+++ b/apps/web/src/usePublishedGameFetch.test.tsx
@@ -1,0 +1,67 @@
+// @vitest-environment jsdom
+
+import { act } from 'react';
+import { createRoot } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { PUBLISHED_FETCH_RETRY_MS, usePublishedGameFetch } from './usePublishedGameFetch.js';
+import { fetchPublishedGame } from './catalog.js';
+
+vi.mock('./catalog.js', async () => {
+  const actual = await vi.importActual<typeof import('./catalog.js')>('./catalog.js');
+  return { ...actual, fetchPublishedGame: vi.fn() };
+});
+
+const fetchGame = vi.mocked(fetchPublishedGame);
+
+function Probe({ slug }: { slug: string }) {
+  const { game, error } = usePublishedGameFetch(slug);
+  return (
+    <div>
+      {game ? <p id="title">{game.title}</p> : null}
+      {error ? <p id="error">{String(error.status)}</p> : null}
+    </div>
+  );
+}
+
+describe('usePublishedGameFetch', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    fetchGame.mockReset();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('retries a 404/409 miss then shows the draft', async () => {
+    const miss = Object.assign(new Error('game not found'), { status: 404 });
+    fetchGame
+      .mockRejectedValueOnce(miss)
+      .mockResolvedValueOnce({ slug: 'bastion-wave', title: 'Bastion Wave', html: '<p>ok</p>' });
+
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    const root = createRoot(host);
+    await act(async () => {
+      root.render(<Probe slug="bastion-wave" />);
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(host.querySelector('#error')).toBeNull();
+    expect(host.querySelector('#title')).toBeNull();
+
+    await act(async () => {
+      vi.advanceTimersByTime(PUBLISHED_FETCH_RETRY_MS);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(host.querySelector('#title')?.textContent).toBe('Bastion Wave');
+    expect(fetchGame).toHaveBeenCalledTimes(2);
+
+    await act(async () => {
+      root.unmount();
+    });
+    host.remove();
+  });
+});

--- a/apps/web/src/usePublishedGameFetch.ts
+++ b/apps/web/src/usePublishedGameFetch.ts
@@ -6,6 +6,10 @@ function asFetchError(err: unknown): GameFetchError {
   return new Error(typeof err === 'string' ? err : 'Game request failed') as GameFetchError;
 }
 
+const RETRY_STATUSES = new Set([404, 409, 502, 503]);
+const MAX_FETCH_RETRIES = 3;
+export const PUBLISHED_FETCH_RETRY_MS = 4_000;
+
 export function usePublishedGameFetch(slug: string, attempt = 0) {
   const [game, setGame] = useState<PublishedGame | null>(null);
   const [progress, setProgress] = useState<FetchProgress>({ loaded: 0, total: null });
@@ -14,27 +18,39 @@ export function usePublishedGameFetch(slug: string, attempt = 0) {
   useEffect(() => {
     let cancelled = false;
     const abort = new AbortController();
+    let retryTimer: ReturnType<typeof setTimeout> | undefined;
+    let tries = 0;
     setGame(null);
     setError(null);
     setProgress({ loaded: 0, total: null });
 
-    fetchPublishedGame(slug, {
-      signal: abort.signal,
-      onProgress: (next) => {
-        if (!cancelled) setProgress(next);
-      },
-    })
-      .then((next) => {
-        if (!cancelled) setGame(next);
+    const run = () => {
+      fetchPublishedGame(slug, {
+        signal: abort.signal,
+        onProgress: (next) => {
+          if (!cancelled) setProgress(next);
+        },
       })
-      .catch((err: unknown) => {
-        if (cancelled || (err instanceof Error && err.name === 'AbortError')) return;
-        setError(asFetchError(err));
-      });
+        .then((next) => {
+          if (!cancelled) setGame(next);
+        })
+        .catch((err: unknown) => {
+          if (cancelled || (err instanceof Error && err.name === 'AbortError')) return;
+          const failure = asFetchError(err);
+          if (failure.status && RETRY_STATUSES.has(failure.status) && tries < MAX_FETCH_RETRIES) {
+            tries += 1;
+            retryTimer = setTimeout(run, PUBLISHED_FETCH_RETRY_MS);
+            return;
+          }
+          setError(failure);
+        });
+    };
+    run();
 
     return () => {
       cancelled = true;
       abort.abort();
+      if (retryTimer) clearTimeout(retryTimer);
     };
   }, [slug, attempt]);
 

--- a/eslint-rules/module-boundary-map.mjs
+++ b/eslint-rules/module-boundary-map.mjs
@@ -271,6 +271,7 @@ const FILE_BUCKET = {
   // Collapses jobs to distinct games for the Studio shelf -- pure Store-record
   // grouping, no catalog dependency, only ever read by creator-studio.ts.
   'owner-games': 'creation',
+  'studio-shelf-records': 'creation',
 
   // agent-surface: channel + MCP + kit
   'agent-channel': 'agent-surface',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

From Create, when the welcome screen says **Draft ready — tap here to play your game preview!**, the first tap could show **Page not found**. A few reloads later the same draft played. That is a race, not a missing game.

Three things stacked:

1. **Ghost click.** Welcome unmounts and Studio mounts under the same tap. The strip title is a real `/play/<slug>` link. On a phone that leftover click did a full document load of `/play/<slug>` (or a token that is not a slug, which the router maps to `notFound`).
2. **Firestore query lag.** `GET /api/me/studio` and `GET /api/games/:slug` both used list/slug **queries**. A just-written submission is visible by document id immediately, but those queries can miss for a few seconds — empty shelf / 404, then fine after reload.
3. **No retry.** Unpublished `/play` treated 404/409 as terminal, so a draft whose artifact was not readable yet stayed on the error page until the creator reloaded.

`?from=handoff` was written on the URL and never read.

## Fix

- Ready CTA goes to `/studio/<token>/playtest?from=handoff` (play posture, job token — not the slug permalink). Still-building still opens the thread.
- Shelf load: if the owner query does not have the deep-linked game, look it up by slug, then by **document GET** from the capability token (HMAC-checked via remint).
- `canPlayDraft` falls back to the owner list when the slug index misses, so the owner can still play.
- Capture-phase click guard for 500ms after a `from=handoff` Studio mount, so the welcome tap cannot hit the title link.
- Title `/play` clicks stay in the SPA (modifier-clicks still use the real `href`).
- `usePublishedGameFetch` retries 404/409/502/503 up to 3×4s and stays on the load screen while it waits.

## Tests

- Welcome ready CTA → `/studio/tok-welcome/playtest?from=handoff`
- Shelf fill when owner and slug queries both lag
- Owner can play when `getSubmissionBySlug` returns null
- Handoff click guard swallows then releases
- Published fetch retries a 404 then shows the draft
- Title permalink intercept

Green gate running after this draft PR.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dfe492fb-7090-4056-ae2b-717470058fa8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dfe492fb-7090-4056-ae2b-717470058fa8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

