### PR TITLE
fix(cli): allow prompt cursor movement

### DIFF
--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -9,7 +9,7 @@ decides the next version — see [`.claude/skills/cli-release/SKILL.md`](../../.
 
 ### Fixed
 
-- Move the prompt cursor with the left and right arrow keys and edit long messages in place (#TBD).
+- Move the prompt cursor with the left and right arrow keys and edit long messages in place (#1290).
 
 ## 0.14.1 — 2026-09-12
 

--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -7,6 +7,10 @@ decides the next version — see [`.claude/skills/cli-release/SKILL.md`](../../.
 
 ## Unreleased
 
+### Fixed
+
+- Move the prompt cursor with the left and right arrow keys and edit long messages in place (#TBD).
+
 ## 0.14.1 — 2026-09-12
 
 ### Fixed

--- a/apps/cli/src/tui/app.test.tsx
+++ b/apps/cli/src/tui/app.test.tsx
@@ -36,6 +36,21 @@ function screen(columns: number, rows: number, openPreview?: (url: string) => vo
 }
 
 describe('TUI feedback', () => {
+  it('moves the cursor and inserts text inside a long draft', async () => {
+    const view = screen(40, 12);
+    void view.session.prompt();
+    view.session.setDraft('0123456789'.repeat(5));
+    await wait();
+    expect(view.frame()).toContain('█');
+    view.input.write('\u001b[D');
+    await wait();
+    view.input.write('X');
+    await wait();
+    expect(view.session.get()).toMatchObject({ draft: `${'0123456789'.repeat(4)}012345678X9`, draftCursor: 50 });
+    expect(view.frame()).toContain('█9');
+    expect(view.frame()).toContain('←→');
+  });
+
   it('opens the live preview with o while an agent is working', async () => {
     const openPreview = vi.fn();
     const view = screen(80, 24, openPreview);

--- a/apps/cli/src/tui/app.tsx
+++ b/apps/cli/src/tui/app.tsx
@@ -8,6 +8,22 @@ import { glyphs } from '../renderer.js';
 import { CLI_VERSION } from '../update.js';
 import type { TuiSession, TuiState } from './session.js';
 
+export function draftViewport(draft: string, cursor: number, width: number) {
+  const chars = [...draft];
+  const room = Math.max(1, width - 3);
+  const leftRoom = Math.floor(room / 2);
+  let start = Math.max(0, cursor - leftRoom);
+  let end = Math.min(chars.length, start + room);
+  if (end === chars.length) start = Math.max(0, end - room);
+  if (start === 0) end = Math.min(chars.length, room);
+  return {
+    before: chars.slice(start, cursor).join(''),
+    after: chars.slice(cursor, end).join(''),
+    hiddenBefore: start > 0,
+    hiddenAfter: end < chars.length,
+  };
+}
+
 export function ReplApp({
   session,
   color,
@@ -59,6 +75,14 @@ export function ReplApp({
       }
       return;
     }
+    if (key.leftArrow) {
+      session.moveDraftCursor(-1);
+      return;
+    }
+    if (key.rightArrow) {
+      session.moveDraftCursor(1);
+      return;
+    }
     if (key.upArrow) {
       session.historyPrev();
       return;
@@ -75,7 +99,7 @@ export function ReplApp({
       session.deleteLast();
       return;
     }
-    if (!key.ctrl && !key.meta && input) session.setDraft(state.draft + input);
+    if (!key.ctrl && !key.meta && input) session.insertDraft(input);
   });
 
   const border = color ? 'round' : 'single';
@@ -93,6 +117,7 @@ export function ReplApp({
     : state.live;
   const liveRows = Math.min(live.length, Math.max(0, rows - panelRows - 4));
   const footer = `${state.identity || CLI_BIN} · ${CLI_VERSION}`;
+  const draft = draftViewport(state.draft, state.draftCursor, Math.min(stdout.columns || 80, 110) - 5);
   return (
     <Box flexDirection="column" width={Math.min(stdout.columns || 80, 110)}>
       <Static items={state.lines.slice(historyOffset)} style={{ width: Math.min(stdout.columns || 80, 110) }}>
@@ -142,7 +167,15 @@ export function ReplApp({
               <Text color={accent} bold>
                 {prompt}
               </Text>{' '}
-              {state.draft ? `${state.draft}█` : <Text dimColor>What would you like to do? /help</Text>}
+              {state.draft ? (
+                <>
+                  {draft.hiddenBefore ? '…' : ''}
+                  {draft.before}█{draft.after}
+                  {draft.hiddenAfter ? '…' : ''}
+                </>
+              ) : (
+                <Text dimColor>What would you like to do? /help</Text>
+              )}
             </Text>
           )}
         </Box>
@@ -161,7 +194,7 @@ export function ReplApp({
           : state.mode === 'prompt'
             ? completion.suggestions.length
               ? `↑↓ select · Tab fill · Enter ${completion.suggestions[completion.selected]?.command === state.draft ? 'send' : 'fill'} · Esc hide · ${completion.selected + 1}/${completion.suggestions.length}`
-              : 'Enter send · / commands · Tab fill · ↑↓ history'
+              : 'Enter send · / commands · Tab fill · ←→ cursor · ↑↓ history'
             : 'Working — input paused'}
       </Text>
       <Text dimColor wrap="truncate-end">

--- a/apps/cli/src/tui/session.test.ts
+++ b/apps/cli/src/tui/session.test.ts
@@ -117,4 +117,20 @@ describe('tui session', () => {
     session.deleteLast();
     expect(session.get().draft).toBe('hi');
   });
+
+  it('moves through code points and edits at the cursor', () => {
+    const session = createTuiSession('');
+    void session.prompt();
+    session.setDraft('a😀c');
+    session.moveDraftCursor(-1);
+    session.insertDraft('b');
+    expect(session.get()).toMatchObject({ draft: 'a😀bc', draftCursor: 3 });
+    session.deleteLast();
+    expect(session.get()).toMatchObject({ draft: 'a😀c', draftCursor: 2 });
+    session.moveDraftCursor(-20);
+    session.deleteLast();
+    expect(session.get()).toMatchObject({ draft: 'a😀c', draftCursor: 0 });
+    session.moveDraftCursor(20);
+    expect(session.get().draftCursor).toBe(3);
+  });
 });

--- a/apps/cli/src/tui/session.ts
+++ b/apps/cli/src/tui/session.ts
@@ -12,6 +12,7 @@ export type TuiState = {
   busySince: number;
   lastOutputAt: number;
   draft: string;
+  draftCursor: number;
   draftFromHistory: boolean;
   choices: string[];
   pickIndex: number;
@@ -27,6 +28,8 @@ export type TuiSession = {
   setIdentity: (identity: string) => void;
   setActivity: (activity: string) => void;
   setDraft: (draft: string) => void;
+  insertDraft: (text: string) => void;
+  moveDraftCursor: (delta: number) => void;
   deleteLast: () => void;
   movePick: (delta: number) => void;
   historyPrev: () => void;
@@ -54,6 +57,7 @@ export function createTuiSession(banner: string, onBusyCancel?: () => void): Tui
     busySince: Date.now(),
     lastOutputAt: Date.now(),
     draft: '',
+    draftCursor: 0,
     draftFromHistory: false,
     choices: [],
     pickIndex: 0,
@@ -119,14 +123,45 @@ export function createTuiSession(banner: string, onBusyCancel?: () => void): Tui
         if (code >= 32 && code !== 127 && (code < 0x80 || code > 0x9f)) next += ch;
       }
       histIndex = history.length;
-      state = { ...state, draft: next, draftFromHistory: false };
+      state = { ...state, draft: next, draftCursor: [...next].length, draftFromHistory: false };
+      emit();
+    },
+    insertDraft(text) {
+      let insert = '';
+      for (const ch of text) {
+        const code = ch.charCodeAt(0);
+        if (code >= 32 && code !== 127 && (code < 0x80 || code > 0x9f)) insert += ch;
+      }
+      if (!insert) return;
+      const chars = [...state.draft];
+      const added = [...insert];
+      chars.splice(state.draftCursor, 0, ...added);
+      histIndex = history.length;
+      state = {
+        ...state,
+        draft: chars.join(''),
+        draftCursor: state.draftCursor + added.length,
+        draftFromHistory: false,
+      };
+      emit();
+    },
+    moveDraftCursor(delta) {
+      const next = Math.max(0, Math.min([...state.draft].length, state.draftCursor + delta));
+      if (next === state.draftCursor) return;
+      state = { ...state, draftCursor: next };
       emit();
     },
     deleteLast() {
+      if (state.draftCursor === 0) return;
       const chars = [...state.draft];
-      chars.pop();
+      chars.splice(state.draftCursor - 1, 1);
       histIndex = history.length;
-      state = { ...state, draft: chars.join(''), draftFromHistory: false };
+      state = {
+        ...state,
+        draft: chars.join(''),
+        draftCursor: state.draftCursor - 1,
+        draftFromHistory: false,
+      };
       emit();
     },
     movePick(delta) {
@@ -139,15 +174,18 @@ export function createTuiSession(banner: string, onBusyCancel?: () => void): Tui
       if (state.mode !== 'prompt' || !history.length || histIndex === 0) return;
       if (histIndex === history.length) stash = state.draft;
       histIndex -= 1;
-      state = { ...state, draft: history[histIndex] ?? '', draftFromHistory: true };
+      const draft = history[histIndex] ?? '';
+      state = { ...state, draft, draftCursor: [...draft].length, draftFromHistory: true };
       emit();
     },
     historyNext() {
       if (state.mode !== 'prompt' || histIndex >= history.length) return;
       histIndex += 1;
+      const draft = histIndex === history.length ? stash : (history[histIndex] ?? '');
       state = {
         ...state,
-        draft: histIndex === history.length ? stash : (history[histIndex] ?? ''),
+        draft,
+        draftCursor: [...draft].length,
         draftFromHistory: true,
       };
       emit();
@@ -169,6 +207,7 @@ export function createTuiSession(banner: string, onBusyCancel?: () => void): Tui
           question: question ?? '',
           pickIndex: 0,
           draft: '',
+          draftCursor: 0,
           draftFromHistory: false,
         };
         emit();
@@ -194,6 +233,7 @@ export function createTuiSession(banner: string, onBusyCancel?: () => void): Tui
         busySince: Date.now(),
         lastOutputAt: Date.now(),
         draft: '',
+        draftCursor: 0,
         choices: [],
         question: '',
         pickIndex: 0,
@@ -203,7 +243,7 @@ export function createTuiSession(banner: string, onBusyCancel?: () => void): Tui
     },
     cancel() {
       if (state.mode === 'prompt' && state.draft) {
-        state = { ...state, draft: '' };
+        state = { ...state, draft: '', draftCursor: 0 };
         emit();
         return;
       }
@@ -213,7 +253,7 @@ export function createTuiSession(banner: string, onBusyCancel?: () => void): Tui
       }
       const resolve = pending;
       pending = null;
-      state = { ...state, mode: 'busy', draft: '', choices: [], question: '', pickIndex: 0 };
+      state = { ...state, mode: 'busy', draft: '', draftCursor: 0, choices: [], question: '', pickIndex: 0 };
       emit();
       resolve('/quit');
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -105,7 +105,7 @@
     },
     "apps/cli": {
       "name": "@gamedevpl/cli",
-      "version": "0.14.0",
+      "version": "0.14.1",
       "dependencies": {
         "@gamedevpl/contract": "*",
         "ink": "^5.2.1",


### PR DESCRIPTION
The TUI prompt only appended text, so correcting an earlier word required clearing and retyping the message. Left and right arrows now move a Unicode-aware cursor, insertion and Backspace edit at that position, and long drafts keep the cursor visible in a horizontally windowed prompt.

Validation: `npm run type-check && npm run lint && npm run test && npm run build`.

Instrumentation: this changes local text editing only and affects none of the seven product measurement questions. It adds no event or field; existing per-run CLI funnel telemetry remains unchanged.