### PR TITLE
fix(cli): expose agent model settings

### DIFF
--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -10,6 +10,7 @@ decides the next version — see [`.claude/skills/cli-release/SKILL.md`](../../.
 ### Fixed
 
 - Move the prompt cursor with the left and right arrow keys and edit long messages in place (#1290).
+- Show each local agent's model and reasoning effort in the task picker, with an inline path to change them.
 
 ## 0.14.1 — 2026-09-12
 

--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -10,7 +10,7 @@ decides the next version — see [`.claude/skills/cli-release/SKILL.md`](../../.
 ### Fixed
 
 - Move the prompt cursor with the left and right arrow keys and edit long messages in place (#1290).
-- Show each local agent's model and reasoning effort in the task picker, with an inline path to change them.
+- Show each local agent's model and reasoning effort in the task picker, with an inline path to change them (#1292).
 
 ## 0.14.1 — 2026-09-12
 

--- a/apps/cli/src/execution.test.ts
+++ b/apps/cli/src/execution.test.ts
@@ -30,6 +30,19 @@ console.log('-p --print --verbose --permission-mode --output-format --mode --san
 }
 
 describe('conversational builder selection', () => {
+  it('keeps the platform selectable when local settings are corrupt', async () => {
+    const env = environment();
+    saveAgentSelection('claude', {}, env);
+    writeFileSync(join(env.HOME!, '.config/gamedevpl/agent-settings.json'), '{broken');
+    const choice = await chooseExecution({
+      env,
+      pick: async (choices) => {
+        expect(choices[0]).toContain('unavailable');
+        return choices.find((row) => row.startsWith('gamedev.pl builder'))!;
+      },
+    });
+    expect(choice).toEqual({ builder: 'platform' });
+  });
   it('chooses self before creating a new game and starts MCP afterwards', async () => {
     const order: string[] = [];
     const bodies: unknown[] = [];

--- a/apps/cli/src/execution.test.ts
+++ b/apps/cli/src/execution.test.ts
@@ -6,6 +6,7 @@ import { handleReplLine } from './repl.js';
 import { chooseExecution, type PendingExecution } from './execution.js';
 import { connectGame } from './connect.js';
 import type { ApiClient } from './api.js';
+import { saveAgentSelection } from './agent-settings.js';
 
 vi.mock('./connect.js', () => ({ connectGame: vi.fn(async () => ({ spawned: true, mcp: true })) }));
 const roots: string[] = [];
@@ -106,6 +107,36 @@ describe('conversational builder selection', () => {
       },
     });
     expect(picked).toMatchObject({ builder: 'self', spec: { name: 'agy' }, mode: 'local' });
+  });
+
+  it('shows model settings and lets the user change them before choosing an agent', async () => {
+    const env = environment('claude');
+    const questions: string[] = [];
+    const replies = ['Configure agent model and effort…', 'claude', 'Change model and effort', 'opus', 'high'];
+    const picked = await chooseExecution({
+      env,
+      write: () => undefined,
+      pick: async (choices, question) => {
+        questions.push(question ?? '');
+        if (replies.length) return replies.shift()!;
+        expect(choices[0]).toContain('model: opus; effort: high');
+        return choices[0]!;
+      },
+    });
+    expect(questions[0]).toContain('agent defaults may not be reported');
+    expect(picked).toMatchObject({ builder: 'self', spec: { name: 'claude' } });
+  });
+
+  it('shows saved model and effort in the initial agent choice', async () => {
+    const env = environment('claude');
+    saveAgentSelection('claude', { model: 'sonnet', effort: 'medium' }, env);
+    await chooseExecution({
+      env,
+      pick: async (choices) => {
+        expect(choices[0]).toContain('model: sonnet; effort: medium');
+        return '/quit';
+      },
+    });
   });
 });
 

--- a/apps/cli/src/execution.ts
+++ b/apps/cli/src/execution.ts
@@ -9,16 +9,24 @@ import { connectGame } from './connect.js';
 import { CliError, EXIT_REFUSED } from './exit-codes.js';
 import { detectLocalAdapters, workshopTurn, type Workshop, type PickChoice } from './workshop.js';
 import type { CliTelemetry } from './telemetry.js';
+import { readAgentSelection } from './agent-settings.js';
+import { modelCommand } from './model-command.js';
 
 export type ExecutionChoice = { builder: 'platform' } | { builder: 'self'; spec: AdapterSpec; mode: 'local' | 'mcp' };
 
 export type PendingExecution = { current?: { choice: ExecutionChoice; request: string } };
+
+export function executionSettingsLabel(spec: AdapterSpec, env: NodeJS.ProcessEnv): string {
+  const selection = readAgentSelection(spec.name, env);
+  return `model: ${selection.model ?? 'agent default*'}; effort: ${selection.effort ?? 'agent default*'}`;
+}
 
 export async function chooseExecution(input: {
   env: NodeJS.ProcessEnv;
   pick: PickChoice;
   workshop?: Workshop;
   telemetry?: CliTelemetry;
+  write?: (line: string) => void;
 }): Promise<ExecutionChoice | null> {
   const adapters = input.workshop?.adapters ?? detectLocalAdapters(input.env);
   if (!adapters.length) return { builder: 'platform' };
@@ -26,23 +34,39 @@ export async function chooseExecution(input: {
     const spec = adapters.find((row) => row.name === input.workshop!.selectedAgent);
     if (spec) return { builder: 'self', spec, mode: 'local' };
   }
-  const local = adapters.map((spec) => {
-    const mode = input.workshop ? 'local' : adapterMcpSupported(spec.name) ? 'mcp' : 'local';
-    const where = mode === 'mcp' ? 'MCP' : input.workshop ? 'this checkout' : 'download a checkout';
-    return {
-      choice: { builder: 'self' as const, spec, mode: mode as 'local' | 'mcp' },
-      label: `${spec.name} — ${where}; its own credentials and billing`,
-    };
-  });
   for (const spec of adapters) input.telemetry?.record('delegate_offered', { adapter: spec.name });
   const platform = 'gamedev.pl builder — uses platform quota';
-  const chosen = await input.pick([...local.map((row) => row.label), platform], 'Who should build this task?');
-  if (chosen === platform) return { builder: 'platform' };
-  const choice = local.find((row) => row.label === chosen)?.choice;
-  if (!choice) return null;
-  if (!input.workshop?.runAdapter) preflightAdapter(choice.spec, input.env);
-  if (input.workshop) input.workshop.selectedAgent = choice.spec.name;
-  return choice;
+  const configure = 'Configure agent model and effort…';
+  while (true) {
+    const local = adapters.map((spec) => {
+      const mode = input.workshop ? 'local' : adapterMcpSupported(spec.name) ? 'mcp' : 'local';
+      const where = mode === 'mcp' ? 'MCP' : input.workshop ? 'this checkout' : 'download a checkout';
+      return {
+        choice: { builder: 'self' as const, spec, mode: mode as 'local' | 'mcp' },
+        label: `${spec.name} — ${executionSettingsLabel(spec, input.env)} — ${where}; own billing`,
+      };
+    });
+    const chosen = await input.pick(
+      [...local.map((row) => row.label), configure, platform],
+      'Who should build this task? (* agent defaults may not be reported)',
+    );
+    if (chosen === configure) {
+      await modelCommand({
+        args: [],
+        flags: {},
+        env: input.env,
+        pick: input.pick,
+        write: input.write ?? (() => undefined),
+      });
+      continue;
+    }
+    if (chosen === platform) return { builder: 'platform' };
+    const choice = local.find((row) => row.label === chosen)?.choice;
+    if (!choice) return null;
+    if (!input.workshop?.runAdapter) preflightAdapter(choice.spec, input.env);
+    if (input.workshop) input.workshop.selectedAgent = choice.spec.name;
+    return choice;
+  }
 }
 
 export async function executeChoice(input: {

--- a/apps/cli/src/execution.ts
+++ b/apps/cli/src/execution.ts
@@ -17,8 +17,12 @@ export type ExecutionChoice = { builder: 'platform' } | { builder: 'self'; spec:
 export type PendingExecution = { current?: { choice: ExecutionChoice; request: string } };
 
 export function executionSettingsLabel(spec: AdapterSpec, env: NodeJS.ProcessEnv): string {
-  const selection = readAgentSelection(spec.name, env);
-  return `model: ${selection.model ?? 'agent default*'}; effort: ${selection.effort ?? 'agent default*'}`;
+  try {
+    const selection = readAgentSelection(spec.name, env);
+    return `model: ${selection.model ?? 'agent default*'}; effort: ${selection.effort ?? 'agent default*'}`;
+  } catch {
+    return 'model/effort unavailable: cannot read local settings';
+  }
 }
 
 export async function chooseExecution(input: {

--- a/apps/cli/src/repl.ts
+++ b/apps/cli/src/repl.ts
@@ -276,7 +276,12 @@ export async function handleReplLine(input: {
       if (result.kind === 'proposal') {
         if (!input.pick) return { next: 'continue', conversationId: result.conversationId };
         const env = input.env ?? process.env;
-        const choice = await chooseExecution({ env, pick: input.pick, telemetry: input.telemetry });
+        const choice = await chooseExecution({
+          env,
+          pick: input.pick,
+          write: input.write,
+          telemetry: input.telemetry,
+        });
         if (!choice) return { next: 'continue', conversationId: result.conversationId };
         input.telemetry?.record('build_requested');
         const created = await input.api.request<{ token: string; slug: string }>('POST', '/api/submissions', {
@@ -362,6 +367,7 @@ export async function handleReplLine(input: {
           (await chooseExecution({
             env,
             pick: input.pick,
+            write: input.write,
             workshop: input.workshop,
             telemetry: input.telemetry,
           }));

--- a/apps/cli/src/tui/app.test.tsx
+++ b/apps/cli/src/tui/app.test.tsx
@@ -36,6 +36,16 @@ function screen(columns: number, rows: number, openPreview?: (url: string) => vo
 }
 
 describe('TUI feedback', () => {
+  it('shows the selected model and effort in a narrow picker', async () => {
+    const view = screen(40, 12);
+    void view.session.prompt(
+      ['codex — model: gpt-5.3-codex; effort: xhigh — this checkout; own billing', 'Configure agent model and effort…'],
+      'Who should build this task?',
+    );
+    await wait();
+    expect(view.frame()).toContain('effort: xhigh');
+    expect(view.frame()).toContain('gpt-5.3-codex');
+  });
   it('moves the cursor and inserts text inside a long draft', async () => {
     const view = screen(40, 12);
     void view.session.prompt();

--- a/apps/cli/src/tui/app.tsx
+++ b/apps/cli/src/tui/app.tsx
@@ -105,13 +105,16 @@ export function ReplApp({
   const border = color ? 'round' : 'single';
   const accent = color ? 'cyan' : undefined;
   const prompt = glyphs(color).prompt;
-  const choiceCount = Math.min(state.choices.length, Math.max(1, rows - 10));
+  const choiceWidth = Math.max(1, Math.min(stdout.columns || 80, 110) - 4);
+  const selectedRows = Math.max(1, Math.ceil(((state.choices[state.pickIndex]?.length ?? 0) + 5) / choiceWidth));
+  const choiceCount = Math.min(state.choices.length, Math.max(1, rows - 10 - (selectedRows - 1)));
   const choiceStart = Math.max(
     0,
     Math.min(state.pickIndex - Math.floor(choiceCount / 2), state.choices.length - choiceCount),
   );
   const suggestionRows = Math.min(completion.suggestions.length, 5, Math.max(0, rows - 9));
-  const panelRows = suggestionRows + (state.mode === 'pick' ? choiceCount + 3 : state.mode === 'busy' ? 2 : 3);
+  const panelRows =
+    suggestionRows + (state.mode === 'pick' ? choiceCount + selectedRows + 2 : state.mode === 'busy' ? 2 : 3);
   const live = state.localTask
     ? [`Local task: ${state.localTask}`, 'Studio receives your changes after /submit']
     : state.live;
@@ -151,7 +154,7 @@ export function ReplApp({
                 const index = choiceStart + offset;
                 return (
                   <Text
-                    wrap="truncate-end"
+                    wrap={index === state.pickIndex ? 'wrap' : 'truncate-end'}
                     bold={index === state.pickIndex}
                     key={`pick:${index}:${choice}`}
                     color={index === state.pickIndex ? accent : undefined}


### PR DESCRIPTION
The task builder picker currently hides the local agent model and reasoning effort, so users choose an executor without knowing its saved configuration or having a way to change it in that flow.

Each local-agent row now leads with its configured model and effort. Unreported native defaults are labelled explicitly, and a Configure option opens the existing model picker before returning to the refreshed executor list.

Validation: `npm run type-check && npm run lint && npm run test && npm run build`.

Instrumentation: this changes local agent selection only. It adds no event or field; existing per-run CLI funnel telemetry remains unchanged.