### PR TITLE
fix(cli): pass preview context and report no-op tasks

### DIFF
--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -9,7 +9,7 @@ decides the next version — see [`.claude/skills/cli-release/SKILL.md`](../../.
 
 ### Fixed
 
-- Pass the running preview to local agents, retain startup diagnostics, and skip success and delivery prompts when no game files changed.
+- Pass the running preview to local agents, retain startup diagnostics, and skip success and delivery prompts when no game files changed (#1295).
 
 - Move the prompt cursor with the left and right arrow keys and edit long messages in place (#1290).
 - Show each local agent's model and reasoning effort in the task picker, with an inline path to change them (#1292).

--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -9,6 +9,8 @@ decides the next version — see [`.claude/skills/cli-release/SKILL.md`](../../.
 
 ### Fixed
 
+- Pass the running preview to local agents, retain startup diagnostics, and skip success and delivery prompts when no game files changed.
+
 - Move the prompt cursor with the left and right arrow keys and edit long messages in place (#1290).
 - Show each local agent's model and reasoning effort in the task picker, with an inline path to change them (#1292).
 

--- a/apps/cli/src/agy-interactive.test.ts
+++ b/apps/cli/src/agy-interactive.test.ts
@@ -1,7 +1,14 @@
-import { expect, it, vi } from 'vitest';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { afterEach, expect, it, vi } from 'vitest';
 import { agyConversation, interactiveArgs } from './agy-interactive.js';
 import { loadAdapters } from './adapters.js';
 import { runLocalBuild, type Workshop } from './workshop.js';
+const roots: string[] = [];
+afterEach(() => {
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
 const spec = loadAdapters().adapters.find((a) => a.name === 'agy')!;
 const id = '12345678-1234-1234-1234-123456789abc';
 it('resumes the specific conversation with sandbox and without permission bypass or print mode', () => {
@@ -24,16 +31,20 @@ it('resumes the specific conversation with sandbox and without permission bypass
 });
 for (const outcome of ['success', 'decline', 'failure', 'unattended'] as const) {
   it(`handles interactive permission fallback: ${outcome}`, async () => {
+    const root = mkdtempSync(join(tmpdir(), 'gdpl-agy-edit-'));
+    roots.push(root);
+    mkdirSync(join(root, 'games/game'), { recursive: true });
     const verify = vi.fn(() => ({ status: 0 }));
     const interactiveRun = vi.fn(async (input) => {
       expect(input.conversation).toBe(id);
-      expect(input.cwd).toBe('/checkout/games/game');
+      expect(input.cwd).toBe(join(root, 'games/game'));
       expect(input.prompt).toContain('make game');
+      writeFileSync(join(input.cwd, 'game.ts'), 'edited');
       return { code: outcome === 'failure' ? 1 : 0 };
     });
     const ws: Workshop = {
       slug: 'game',
-      root: '/checkout',
+      root,
       token: '',
       env: {},
       adapters: [spec],

--- a/apps/cli/src/muse-approval.test.ts
+++ b/apps/cli/src/muse-approval.test.ts
@@ -96,15 +96,19 @@ it('keeps ordinary completion and refuses disabled session logging', async () =>
 });
 for (const mode of ['resume', 'decline', 'unattended', 'failure'] as const)
   it(`handles Muse approval recovery: ${mode}`, async () => {
+    const root = await mkdtemp(join(tmpdir(), 'gdpl-muse-edit-'));
+    roots.push(root);
+    await mkdir(join(root, 'games/game'), { recursive: true });
     const verify = vi.fn(() => ({ status: 0 }));
     const interactiveRun = vi.fn(async (input) => {
       expect(interactiveArgs(input)).toEqual(['--trust-workspace', '--approval-mode', 'on-request', 'resume', id]);
+      await writeFile(join(input.cwd, 'game.ts'), 'edited');
       return { code: mode === 'failure' ? 1 : 0 };
     });
     const pick = vi.fn(async () => (mode === 'decline' ? 'Keep edits and return' : 'Open Muse interactively'));
     const ws: Workshop = {
       slug: 'game',
-      root: '/checkout',
+      root,
       token: '',
       env: {},
       adapters: [spec],

--- a/apps/cli/src/play-startup.test.ts
+++ b/apps/cli/src/play-startup.test.ts
@@ -1,0 +1,33 @@
+import { EventEmitter } from 'node:events';
+import { mkdtempSync, readFileSync, rmSync, statSync, writeSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { expect, it, vi } from 'vitest';
+import { startLocalPlay } from './play.js';
+
+vi.mock('node:child_process', () => ({
+  spawn: vi.fn((_command, _args, options) => {
+    writeSync(options.stdio[2], 'listen EPERM: loopback permission denied');
+    const child = Object.assign(new EventEmitter(), { unref: vi.fn(), kill: vi.fn() });
+    queueMicrotask(() => child.emit('exit', 1));
+    return child;
+  }),
+}));
+
+it('retains private startup diagnostics when the preview child exits', async () => {
+  const root = mkdtempSync(join(tmpdir(), 'gdpl-startup-'));
+  try {
+    let message = '';
+    try {
+      await startLocalPlay({ root, slug: 'robot', env: {}, prepared: true, write: () => {} });
+    } catch (error) {
+      message = String((error as { next?: string }).next);
+    }
+    const log = /Startup diagnostics: (.+\/startup\.log)\./.exec(message)?.[1];
+    expect(log).toBeTruthy();
+    expect(readFileSync(log!, 'utf8')).toContain('listen EPERM');
+    if (process.platform !== 'win32') expect(statSync(log!).mode & 0o777).toBe(0o600);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/apps/cli/src/play.ts
+++ b/apps/cli/src/play.ts
@@ -1,7 +1,16 @@
 import { privatePlayDirectory, readPlayState, lockAge } from './play-state.js';
 import { createHash } from 'node:crypto';
 import { spawn } from 'node:child_process';
-import { mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from 'node:fs';
+import {
+  closeSync,
+  openSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { findCheckout } from './checkout.js';
@@ -109,15 +118,25 @@ export async function startLocalPlay(input: {
     checkAbort();
     const runtime = join(mkdtempSync(join(dir, 'runtime-')), 'server.mjs');
     writeFileSync(runtime, PLAY_RUNTIME, { mode: 0o600 });
-    const child = spawn(process.execPath, [runtime, root, input.slug, statePath, key], {
-      cwd: root,
-      env: childEnv(input.env, ''),
-      stdio: 'ignore',
-      detached: true,
-      windowsHide: true,
-    });
+    const logPath = join(runtime, '..', 'startup.log');
+    const log = openSync(logPath, 'wx', 0o600);
+    let child: ReturnType<typeof spawn>;
+    try {
+      child = spawn(process.execPath, [runtime, root, input.slug, statePath, key], {
+        cwd: root,
+        env: childEnv(input.env, ''),
+        stdio: ['ignore', log, log],
+        detached: true,
+        windowsHide: true,
+      });
+    } finally {
+      closeSync(log);
+    }
     let failed = false;
     child.once('error', () => {
+      failed = true;
+    });
+    child.once('exit', () => {
       failed = true;
     });
     child.unref();
@@ -137,7 +156,11 @@ export async function startLocalPlay(input: {
       await delay(100);
     }
     child.kill();
-    throw new CliError('local preview could not start', EXIT_REFUSED, 'check the Creator Kit and Node installation');
+    throw new CliError(
+      'local preview could not start',
+      EXIT_REFUSED,
+      `Startup diagnostics: ${logPath}. Check browser/loopback permissions and the Creator Kit; do not bypass sandbox restrictions.`,
+    );
   } finally {
     rmSync(lock, { recursive: true, force: true });
   }

--- a/apps/cli/src/workshop-brief.test.ts
+++ b/apps/cli/src/workshop-brief.test.ts
@@ -1,0 +1,9 @@
+import { expect, it } from 'vitest';
+import { workshopBrief } from './workshop-brief.js';
+it('writes a brief that names the game and forbids publishing', () => {
+  const brief = workshopBrief('airtime', 'add a boss');
+  expect(brief).toContain('"airtime"');
+  expect(brief).toContain('add a boss');
+  expect(brief).not.toContain('Studio understood');
+  expect(brief).toMatch(/Do not run git/);
+});

--- a/apps/cli/src/workshop-brief.ts
+++ b/apps/cli/src/workshop-brief.ts
@@ -1,0 +1,14 @@
+export function workshopBrief(slug: string, request: string, ack?: string): string {
+  return [
+    `You are editing the gamedev.pl game "${slug}". This directory is its source tree (games/${slug} in the checkout).`,
+    `Creator request: ${request}`,
+    ack ? `Studio understood it as: ${ack}` : '',
+    'Change only files in this directory. Do not run git, install packages, or publish — the creator delivers with `gamedevpl submit`.',
+    'Use the live preview supplied below for browser work. A preview URL alone does not provide browser tooling. Check whether your browser tool is available before promising screenshots.',
+    'If browser access is unavailable or denied, report that limitation and finish; never claim visual verification or change sandbox permissions to obtain it.',
+    'The CLI runs typecheck and check:static after you exit. Do not run these checks yourself.',
+    'This is a non-interactive task: do not wait for replies or approvals. If blocked, report the blocker and finish.',
+  ]
+    .filter(Boolean)
+    .join('\n');
+}

--- a/apps/cli/src/workshop-preview.test.ts
+++ b/apps/cli/src/workshop-preview.test.ts
@@ -196,13 +196,13 @@ it.each([true, false])('configures agy before preparation and launch: confirm=%s
   expect(ws.abort.current).toBeNull();
 });
 
-it('skips static success for a no-op, preserving previous local edits', async () => {
+it.each([false, true])('skips static success for a no-op: permission handoff=%s', async (handoff) => {
   const root = mkdtempSync(join(tmpdir(), 'gdpl-noop-'));
   roots.push(root);
   mkdirSync(join(root, 'games/robot'), { recursive: true });
   writeFileSync(join(root, 'games/robot/game.ts'), 'previous local work');
   const { loadAdapters } = await import('./adapters.js');
-  const spec = loadAdapters().adapters.find((item) => item.name === 'codex')!;
+  const spec = loadAdapters().adapters.find((item) => item.name === (handoff ? 'muse' : 'codex'))!;
   const run = vi.fn();
   const write = vi.fn();
   const ws: Workshop = {
@@ -212,14 +212,15 @@ it('skips static success for a no-op, preserving previous local edits', async ()
     env: {},
     adapters: [spec],
     builder: 'self',
-    pick: vi.fn(),
+    pick: vi.fn(async (choices) => choices[0]!),
+    interactiveRun: async () => ({ code: 0 }),
     abort: { current: null },
     run,
-    runAdapter: async () => ({ code: 0 }),
+    runAdapter: async () => ({ code: 0, ...(handoff ? { permissionSession: 'session-1' } : {}) }),
   };
   expect(await runLocalBuild({ ws, spec, brief: 'take screenshots', write })).toBe(false);
   expect(run).not.toHaveBeenCalled();
-  expect(ws.pick).not.toHaveBeenCalled();
+  expect(ws.pick).toHaveBeenCalledTimes(handoff ? 1 : 0);
   expect(write).toHaveBeenCalledWith(expect.stringContaining('No game files changed'));
   expect(write).not.toHaveBeenCalledWith('✓ static ladder green');
 });

--- a/apps/cli/src/workshop-preview.test.ts
+++ b/apps/cli/src/workshop-preview.test.ts
@@ -1,5 +1,5 @@
 import { requireClaudeSubscription } from './claude-auth.js';
-import { mkdirSync, mkdtempSync, rmSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, expect, it, vi } from 'vitest';
@@ -15,7 +15,9 @@ vi.mock('./adapters.js', async (original) => ({
 }));
 vi.mock('./delegate.js', async (original) => ({
   ...(await original<typeof import('./delegate.js')>()),
-  spawnAdapter: vi.fn(() => {
+  spawnAdapter: vi.fn((input: { cwd: string }) => {
+    mkdirSync(input.cwd, { recursive: true });
+    writeFileSync(join(input.cwd, 'game.ts'), 'edited');
     const child = new EventEmitter();
     setTimeout(() => child.emit('close', 0), 0);
     return child;
@@ -61,6 +63,11 @@ it.each([true, false])('starts a preview only in interactive delegation: unatten
   const { spawnAdapter } = await import('./delegate.js');
   expect(spawnAdapter).toHaveBeenCalledWith(expect.objectContaining({ authCheck: expect.any(Promise) }));
   expect(startLocalPlay).toHaveBeenCalledTimes(unattended ? 0 : 1);
+  expect(spawnAdapter).toHaveBeenCalledWith(
+    expect.objectContaining({
+      prompt: expect.stringContaining(unattended ? 'No live preview was supplied' : 'http://127.0.0.1:1/'),
+    }),
+  );
   if (!unattended)
     expect(startLocalPlay).toHaveBeenCalledWith(expect.objectContaining({ abort: expect.any(AbortSignal) }));
 });
@@ -78,7 +85,12 @@ it.each([true, false])('distinguishes empty Antigravity runs from partial Claude
     exit: { success: [0], failure: [1] },
   };
   const ws: Workshop = {
-    root: '/checkout',
+    root: (() => {
+      const root = mkdtempSync(join(tmpdir(), 'gdpl-partial-'));
+      roots.push(root);
+      mkdirSync(join(root, 'games/robot'), { recursive: true });
+      return root;
+    })(),
     slug: 'robot',
     token: 'tok',
     env: {},
@@ -88,6 +100,7 @@ it.each([true, false])('distinguishes empty Antigravity runs from partial Claude
     abort: { current: null },
     run,
     runAdapter: async (input) => {
+      if (!empty) writeFileSync(join(input.cwd, 'game.ts'), 'edited');
       input.onLine?.(
         empty
           ? 'jetski: no output produced — headless mode cannot prompt, so it was auto-denied.'
@@ -122,7 +135,12 @@ it('checks subscription before preparation, preview, telemetry or agent launch',
     exit: { success: [0], failure: [1] },
   };
   const ws: Workshop = {
-    root: '/checkout',
+    root: (() => {
+      const root = mkdtempSync(join(tmpdir(), 'gdpl-partial-'));
+      roots.push(root);
+      mkdirSync(join(root, 'games/robot'), { recursive: true });
+      return root;
+    })(),
     slug: 'robot',
     token: 'tok',
     env: {},
@@ -176,4 +194,32 @@ it.each([true, false])('configures agy before preparation and launch: confirm=%s
     );
   }
   expect(ws.abort.current).toBeNull();
+});
+
+it('skips static success for a no-op, preserving previous local edits', async () => {
+  const root = mkdtempSync(join(tmpdir(), 'gdpl-noop-'));
+  roots.push(root);
+  mkdirSync(join(root, 'games/robot'), { recursive: true });
+  writeFileSync(join(root, 'games/robot/game.ts'), 'previous local work');
+  const { loadAdapters } = await import('./adapters.js');
+  const spec = loadAdapters().adapters.find((item) => item.name === 'codex')!;
+  const run = vi.fn();
+  const write = vi.fn();
+  const ws: Workshop = {
+    root,
+    slug: 'robot',
+    token: '',
+    env: {},
+    adapters: [spec],
+    builder: 'self',
+    pick: vi.fn(),
+    abort: { current: null },
+    run,
+    runAdapter: async () => ({ code: 0 }),
+  };
+  expect(await runLocalBuild({ ws, spec, brief: 'take screenshots', write })).toBe(false);
+  expect(run).not.toHaveBeenCalled();
+  expect(ws.pick).not.toHaveBeenCalled();
+  expect(write).toHaveBeenCalledWith(expect.stringContaining('No game files changed'));
+  expect(write).not.toHaveBeenCalledWith('✓ static ladder green');
 });

--- a/apps/cli/src/workshop-repair.test.ts
+++ b/apps/cli/src/workshop-repair.test.ts
@@ -1,10 +1,20 @@
-import { expect, it } from 'vitest';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { afterEach, expect, it } from 'vitest';
 import { loadAdapters } from './adapters.js';
 import { runLocalBuild, type Workshop } from './workshop.js';
+const roots: string[] = [];
+afterEach(() => {
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
 const spec = loadAdapters().adapters.find((row) => row.name === 'codex')!;
 function workshop(over: Partial<Workshop>): Workshop {
+  const root = mkdtempSync(join(tmpdir(), 'gdpl-repair-'));
+  roots.push(root);
+  mkdirSync(join(root, 'games/game'), { recursive: true });
   return {
-    root: '/checkout',
+    root,
     slug: 'game',
     token: '',
     env: {},
@@ -24,8 +34,9 @@ it('repairs editor validation in the same workspace and keeps ownership through 
     onLocalTask: (agent) => local.push(agent),
     runAdapter: async (input) => {
       expect(input.spec).toMatchObject(spec);
-      expect(input.cwd).toBe('/checkout/games/game');
+      expect(input.cwd).toBe(join(ws.root, 'games/game'));
       prompts.push(input.prompt);
+      writeFileSync(join(input.cwd, 'game.ts'), String(prompts.length));
       return { code: 0 };
     },
     run: (_cmd, args) => {
@@ -49,6 +60,7 @@ it('stops the repair loop on cancellation and releases local ownership', async (
     onLocalTask: (agent) => local.push(agent),
     runAdapter: async (input) => {
       calls += 1;
+      writeFileSync(join(input.cwd, 'game.ts'), String(calls));
       if (calls === 2) ws.abort.current?.abort();
       expect(input.abort).toBe(ws.abort.current?.signal);
       return { code: 0 };

--- a/apps/cli/src/workshop.test.ts
+++ b/apps/cli/src/workshop.test.ts
@@ -147,10 +147,14 @@ describe('workshopTurn', () => {
     const seen: string[] = [];
     const lines: string[] = [];
     let picks = 0;
+    let edits = 0;
     const ok = await workshopTurn({
       api: platform(seen),
       ws: workshop(root, {
-        runAdapter: async () => ({ code: 0 }),
+        runAdapter: async () => {
+          writeFileSync(join(root, 'games', SLUG, 'game.ts'), String(edits++));
+          return { code: 0 };
+        },
         run: (_cmd, args) =>
           args[1] === 'check:static' ? { status: 1, stderr: 'game.ts:3 unused import' } : { status: 0, stderr: '' },
         pick: async (choices) => {
@@ -323,7 +327,11 @@ describe('the REPL inside a checkout', () => {
     const lines: string[] = [];
     const prompts: string[] = [];
     const ws = workshop(root, {
-      runAdapter: async (input) => (prompts.push(input.prompt), { code: 0 }),
+      runAdapter: async (input) => {
+        prompts.push(input.prompt);
+        writeFileSync(join(input.cwd, 'game.ts'), 'updated');
+        return { code: 0 };
+      },
       pick: async (choices) => choices[1]!,
     });
     await handleReplLine({

--- a/apps/cli/src/workshop.test.ts
+++ b/apps/cli/src/workshop.test.ts
@@ -14,7 +14,6 @@ import {
   openWorkshop,
   settleBuilder,
   syncWarning,
-  workshopBrief,
   workshopTurn,
   chooseAdapter,
   refreshBuilder,
@@ -469,14 +468,6 @@ describe('opening a checkout', () => {
       write: () => undefined,
     });
     expect(published).toBe('platform');
-  });
-
-  it('writes a brief that names the game and forbids publishing', () => {
-    const brief = workshopBrief(SLUG, 'add a boss');
-    expect(brief).toContain('"airtime"');
-    expect(brief).toContain('add a boss');
-    expect(brief).not.toContain('Studio understood');
-    expect(brief).toMatch(/Do not run git/);
   });
 });
 

--- a/apps/cli/src/workshop.ts
+++ b/apps/cli/src/workshop.ts
@@ -1,3 +1,5 @@
+import { workshopBrief } from './workshop-brief.js';
+export { workshopBrief } from './workshop-brief.js';
 import { runMuseWithApprovals } from './muse-approval.js';
 import { permissionHandoff } from './permission-handoff.js';
 import { prepareAgyPermissions } from './agy-permissions.js';
@@ -14,7 +16,7 @@ import { createInterface } from 'node:readline';
 import type { ApiClient } from './api.js';
 import { detectAdapter, loadAdapters, preflightAdapter, whichOnPath, type AdapterSpec } from './adapters.js';
 import { cliUsage } from './bin-name.js';
-import { formatSyncLines, inspectGame, type SyncResult } from './checkout.js';
+import { changedPaths, localGameFiles, formatSyncLines, inspectGame, type SyncResult } from './checkout.js';
 import { childEnv, createDelegateStream, spawnAdapter } from './delegate.js';
 import { formatError } from './errors.js';
 import { CliError, EXIT_INPUT, EXIT_REFUSED } from './exit-codes.js';
@@ -93,20 +95,6 @@ async function spawnLocalAdapter(input: Parameters<AdapterRun>[0]): ReturnType<A
       child.once('close', resolve);
     }),
   };
-}
-
-export function workshopBrief(slug: string, request: string, ack?: string): string {
-  return [
-    `You are editing the gamedev.pl game "${slug}". This directory is its source tree (games/${slug} in the checkout).`,
-    `Creator request: ${request}`,
-    ack ? `Studio understood it as: ${ack}` : '',
-    'Change only files in this directory. Do not run git, install packages, or publish — the creator delivers with `gamedevpl submit`.',
-    'If the creator wants to play, run `gamedevpl play` in this checkout; it opens a live preview without delivering or publishing. Use --no-open for a link only and --stop to close the server.',
-    'The CLI runs typecheck and check:static after you exit. Do not run these checks yourself.',
-    'This is a non-interactive task: do not wait for replies or approvals. If blocked, report the blocker and finish.',
-  ]
-    .filter(Boolean)
-    .join('\n');
 }
 
 export function describeAdapters(adapters: AdapterSpec[], all = loadAdapters().adapters): string {
@@ -298,6 +286,7 @@ export async function runLocalBuild(input: {
         output.preparing(false);
       }
     }
+    let previewUrl: string | undefined;
     if (!ws.runAdapter && !ws.unattended) {
       try {
         const preview = await startLocalPlay({
@@ -308,6 +297,7 @@ export async function runLocalBuild(input: {
           prepared: true,
           abort: controller.signal,
         });
+        previewUrl = preview?.url;
         if (preview) input.write(`live preview while ${spec.name} edits: ${preview.url}`);
       } catch (error) {
         input.write(formatError(error));
@@ -322,7 +312,7 @@ export async function runLocalBuild(input: {
       );
     ws.telemetry?.record('delegate_used', { adapter: spec.name });
     success = await repairLoop({
-      brief: input.brief,
+      brief: `${input.brief}\n${previewUrl ? `The CLI already started this live preview: ${previewUrl}. Open this exact URL with your available browser tool. Do not start or stop another preview server.` : 'No live preview was supplied. If visual work requires a browser or preview unavailable here, report the blocker; the creator can start /play in their terminal.'}`,
       abort: controller.signal,
       activity: (text) => ws.onActivity?.(text),
       write: input.write,
@@ -333,6 +323,7 @@ export async function runLocalBuild(input: {
       },
       run: async (prompt) => {
         presence?.phase('editing');
+        const before = localGameFiles(ws.root, ws.slug);
         const stream = createDelegateStream(spec.name);
         const failure = trackAgentFailure(spec.name);
         let blocked = false;
@@ -381,6 +372,15 @@ export async function runLocalBuild(input: {
             formatError(
               failure.error(result.code, '/diff to review partial edits, then repeat your request when ready'),
             ),
+          );
+          return false;
+        }
+        if (changedPaths(before, localGameFiles(ws.root, ws.slug)).length === 0) {
+          input.write(
+            'No game files changed. Task completion is not confirmed; static checks and delivery were skipped.',
+          );
+          input.write(
+            'If the agent reported missing browser access, enable its browser tool or provide screenshots, then retry. /diff shows existing local edits; /submit delivers them explicitly.',
           );
           return false;
         }

--- a/apps/cli/src/workshop.ts
+++ b/apps/cli/src/workshop.ts
@@ -349,8 +349,9 @@ export async function runLocalBuild(input: {
           },
         });
         if (controller.signal.aborted) return false;
+        let handedOff = false;
         if (result.permissionSession || (blocked && spec.name === 'agy' && ws.interactiveRun && !ws.unattended)) {
-          return permissionHandoff({
+          handedOff = await permissionHandoff({
             ws,
             spec,
             cwd,
@@ -360,14 +361,15 @@ export async function runLocalBuild(input: {
             abort: controller.signal,
             phase: (phase) => presence?.phase(phase),
           });
+          if (!handedOff) return false;
         }
-        if (blocked) {
+        if (blocked && !handedOff) {
           input.write(
             `${spec.name} could not obtain tool permissions in headless mode. No successful edit is confirmed; review its permissions for this game directory and retry.`,
           );
           return false;
         }
-        if ((result.code ?? 1) !== 0) {
+        if (!handedOff && (result.code ?? 1) !== 0) {
           input.write(
             formatError(
               failure.error(result.code, '/diff to review partial edits, then repeat your request when ready'),


### PR DESCRIPTION
A delegated agent could try to launch another preview even though the CLI already had one running, then exit without edits and still trigger a green validation message and delivery prompt.

Pass the existing preview URL in the agent brief, explain browser capability limits, retain private preview startup diagnostics, and compare game files before and after the agent (including permission handoffs). Unchanged tasks now skip validation and automatic delivery, preserving earlier local edits for explicit submission.

Validation: all GitHub CI checks pass on `a888b4ba4a`, including the full type-check/lint/test/build gate. Codex review of that head reports no major issues; the PR is conflict-free. Local focused preview/workshop regressions pass (32 tests), and the full CLI suite passes (423 tests). The local full suite encountered an unchanged API self-build test timeout, which also timed out in an isolated retry; therefore no claim of a clean local full-suite run. This does not provision a browser for third-party agents; unavailable browser access remains an explicit limitation.

Instrumentation: existing CLI delegate/verify events remain unchanged. No new telemetry fields or URLs are recorded; this change improves local task reporting, not measured publication success.
