### PR TITLE
Make a quiet build feed cost one read instead of twenty

### DIFF
--- a/apps/api/src/delivery/build-status-events.test.ts
+++ b/apps/api/src/delivery/build-status-events.test.ts
@@ -9,8 +9,13 @@ async function harness() {
   let clock = 1_700_000_000_000;
   const store = new InMemoryStore();
   await store.createSubmission(JOB, 'g:owner', 'Airtime');
+  // Distinct stamps: prod orders on createdAt alone, so ties are arbitrary there.
   for (let i = 0; i < 20; i += 1) {
-    await store.appendBuildEvent(JOB, { kind: 'progress', text: `step ${i}` });
+    await store.appendBuildEvent(JOB, {
+      kind: 'progress',
+      text: `step ${i}`,
+      createdAt: new Date(clock - (20 - i) * 1_000).toISOString(),
+    });
   }
   const assembler = createBuildStatusAssembler({
     store,
@@ -20,7 +25,7 @@ async function harness() {
   const list = vi.spyOn(store, 'listBuildEvents');
   const poll = async () =>
     assembler.attachBuildEvents({ status: 'building' } as SubmissionStatusResponse, JOB, 'en');
-  return { store, assembler, list, poll, tick: (ms: number) => (clock += ms) };
+  return { store, assembler, list, poll, tick: (ms: number) => (clock += ms), at: () => clock };
 }
 
 // A 3s poll against a 5s window: most polls miss.
@@ -62,10 +67,14 @@ describe('build event reads under a three-second poll', () => {
   });
 
   it('refetches the page as soon as the newest event changes', async () => {
-    const { store, list, poll, tick } = await harness();
+    const { store, list, poll, tick, at } = await harness();
     await poll();
     tick(6_000);
-    await store.appendBuildEvent(JOB, { kind: 'progress', text: 'something new' });
+    await store.appendBuildEvent(JOB, {
+      kind: 'progress',
+      text: 'something new',
+      createdAt: new Date(at() + 1_000).toISOString(),
+    });
     const fresh = await poll();
 
     expect(list.mock.calls.at(-1)?.[1]).toMatchObject({ limit: 20 });

--- a/apps/api/src/delivery/build-status-events.test.ts
+++ b/apps/api/src/delivery/build-status-events.test.ts
@@ -5,16 +5,16 @@ import type { SubmissionStatusResponse } from '../platform/submission-status.js'
 
 const JOB = 4242;
 
-async function harness() {
+async function harness(seed = 20) {
   let clock = 1_700_000_000_000;
   const store = new InMemoryStore();
   await store.createSubmission(JOB, 'g:owner', 'Airtime');
   // Distinct stamps: prod orders on createdAt alone, so ties are arbitrary there.
-  for (let i = 0; i < 20; i += 1) {
+  for (let i = 0; i < seed; i += 1) {
     await store.appendBuildEvent(JOB, {
       kind: 'progress',
       text: `step ${i}`,
-      createdAt: new Date(clock - (20 - i) * 1_000).toISOString(),
+      createdAt: new Date(clock - (seed - i) * 1_000).toISOString(),
     });
   }
   const assembler = createBuildStatusAssembler({
@@ -23,38 +23,56 @@ async function harness() {
     isPresenceEventText: () => false,
   });
   const list = vi.spyOn(store, 'listBuildEvents');
+  const counted = vi.spyOn(store, 'countBuildEvents');
   const poll = async () =>
     assembler.attachBuildEvents({ status: 'building' } as SubmissionStatusResponse, JOB, 'en');
-  return { store, assembler, list, poll, tick: (ms: number) => (clock += ms), at: () => clock };
+  return { store, assembler, list, counted, poll, tick: (ms: number) => (clock += ms), at: () => clock };
 }
 
 // A 3s poll against a 5s window: most polls miss.
 describe('build event reads under a three-second poll', () => {
-  it('serves an unchanged feed from a one-document probe, not a full page', async () => {
-    const { list, poll, tick } = await harness();
+  it('serves an unchanged feed from a single count, never a second page', async () => {
+    const { list, counted, poll, tick } = await harness();
 
     await poll();
-    const first = list.mock.calls.at(-1)?.[1];
-    expect(first).toMatchObject({ limit: 20 });
-
-    tick(6_000);
-    await poll();
-    expect(list.mock.calls.at(-1)?.[1]).toMatchObject({ limit: 1 });
+    expect(list).toHaveBeenCalledTimes(1);
 
     tick(6_000);
     await poll();
-    expect(list.mock.calls.at(-1)?.[1]).toMatchObject({ limit: 1 });
-    expect(list.mock.calls.filter((c) => c[1]?.limit === 20)).toHaveLength(1);
+    tick(6_000);
+    await poll();
+
+    expect(list).toHaveBeenCalledTimes(1);
+    // One for the cold page at the cap, then one per probe.
+    expect(counted).toHaveBeenCalledTimes(3);
   });
 
-  it('probes the count too, so a tie on createdAt cannot hide an append', async () => {
-    const { store, list, poll, tick } = await harness();
-    const counted = vi.spyOn(store, 'countBuildEvents');
+  it('costs one read on a full page, because the count is reused', async () => {
+    const { store, list, counted, poll, tick, at } = await harness();
     await poll();
+    const countsAfterSeed = counted.mock.calls.length;
+    tick(6_000);
+    await store.appendBuildEvent(JOB, {
+      kind: 'progress',
+      text: 'twenty-first',
+      createdAt: new Date(at() + 1_000).toISOString(),
+    });
+
+    await poll();
+    // The probe's count is carried over, not asked twice.
+    expect(counted.mock.calls.length).toBe(countsAfterSeed + 1);
+    expect(list).toHaveBeenCalledTimes(2);
+  });
+
+  it('asks no count at all while the page is short of the cap', async () => {
+    const { counted, poll, tick } = await harness(2);
+    await poll();
+    expect(counted).not.toHaveBeenCalled();
+
     tick(6_000);
     await poll();
-    expect(counted).toHaveBeenCalled();
-    expect(list.mock.calls.filter((c) => c[1]?.limit === 20)).toHaveLength(1);
+    // One probe, and the refreshed page is its own count.
+    expect(counted).toHaveBeenCalledTimes(1);
   });
 
   it('still answers with the events themselves', async () => {
@@ -66,7 +84,7 @@ describe('build event reads under a three-second poll', () => {
     expect(after.events?.length).toBeGreaterThan(0);
   });
 
-  it('refetches the page as soon as the newest event changes', async () => {
+  it('refetches the page as soon as an event is appended', async () => {
     const { store, list, poll, tick, at } = await harness();
     await poll();
     tick(6_000);

--- a/apps/api/src/delivery/build-status-events.test.ts
+++ b/apps/api/src/delivery/build-status-events.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it, vi } from 'vitest';
+import { InMemoryStore } from '../platform/store.js';
+import { createBuildStatusAssembler } from './build-status.js';
+import type { SubmissionStatusResponse } from '../platform/submission-status.js';
+
+const JOB = 4242;
+
+async function harness() {
+  let clock = 1_700_000_000_000;
+  const store = new InMemoryStore();
+  await store.createSubmission(JOB, 'g:owner', 'Airtime');
+  for (let i = 0; i < 20; i += 1) {
+    await store.appendBuildEvent(JOB, { kind: 'progress', text: `step ${i}` });
+  }
+  const assembler = createBuildStatusAssembler({
+    store,
+    now: () => clock,
+    isPresenceEventText: () => false,
+  });
+  const list = vi.spyOn(store, 'listBuildEvents');
+  const poll = async () =>
+    assembler.attachBuildEvents({ status: 'building' } as SubmissionStatusResponse, JOB, 'en');
+  return { store, assembler, list, poll, tick: (ms: number) => (clock += ms) };
+}
+
+// The Studio poll is 3s and the window is 5s, so most polls land past it.
+describe('build event reads under a three-second poll', () => {
+  it('serves an unchanged feed from a one-document probe, not a full page', async () => {
+    const { list, poll, tick } = await harness();
+
+    await poll();
+    const first = list.mock.calls.at(-1)?.[1];
+    expect(first).toMatchObject({ limit: 20 });
+
+    tick(6_000);
+    await poll();
+    expect(list.mock.calls.at(-1)?.[1]).toMatchObject({ limit: 1 });
+
+    tick(6_000);
+    await poll();
+    expect(list.mock.calls.at(-1)?.[1]).toMatchObject({ limit: 1 });
+    expect(list.mock.calls.filter((c) => c[1]?.limit === 20)).toHaveLength(1);
+  });
+
+  it('probes the count too, so a tie on createdAt cannot hide an append', async () => {
+    const { store, list, poll, tick } = await harness();
+    const counted = vi.spyOn(store, 'countBuildEvents');
+    await poll();
+    tick(6_000);
+    await poll();
+    expect(counted).toHaveBeenCalled();
+    expect(list.mock.calls.filter((c) => c[1]?.limit === 20)).toHaveLength(1);
+  });
+
+  it('still answers with the events themselves', async () => {
+    const { poll, tick } = await harness();
+    const before = await poll();
+    tick(6_000);
+    const after = await poll();
+    expect(after.events).toEqual(before.events);
+    expect(after.events?.length).toBeGreaterThan(0);
+  });
+
+  it('refetches the page as soon as the newest event changes', async () => {
+    const { store, list, poll, tick } = await harness();
+    await poll();
+    tick(6_000);
+    await store.appendBuildEvent(JOB, { kind: 'progress', text: 'something new' });
+    const fresh = await poll();
+
+    expect(list.mock.calls.at(-1)?.[1]).toMatchObject({ limit: 20 });
+    expect(fresh.events?.some((event) => event.text === 'something new')).toBe(true);
+  });
+
+  it('takes a full page again once the probe window lapses', async () => {
+    const { list, poll, tick } = await harness();
+    await poll();
+    tick(61_000);
+    await poll();
+    expect(list.mock.calls.filter((c) => c[1]?.limit === 20)).toHaveLength(2);
+  });
+
+  it('reads the page in full after an append on this instance', async () => {
+    const { assembler, list, poll, tick } = await harness();
+    await poll();
+    tick(1_000);
+    assembler.invalidateEvents(JOB);
+    await poll();
+    expect(list.mock.calls.filter((c) => c[1]?.limit === 20)).toHaveLength(2);
+  });
+});

--- a/apps/api/src/delivery/build-status-events.test.ts
+++ b/apps/api/src/delivery/build-status-events.test.ts
@@ -23,7 +23,7 @@ async function harness() {
   return { store, assembler, list, poll, tick: (ms: number) => (clock += ms) };
 }
 
-// The Studio poll is 3s and the window is 5s, so most polls land past it.
+// A 3s poll against a 5s window: most polls miss.
 describe('build event reads under a three-second poll', () => {
   it('serves an unchanged feed from a one-document probe, not a full page', async () => {
     const { list, poll, tick } = await harness();

--- a/apps/api/src/delivery/build-status.ts
+++ b/apps/api/src/delivery/build-status.ts
@@ -54,8 +54,26 @@ export function createBuildStatusAssembler(options: BuildStatusOptions): BuildSt
 
   // Its own short cache, not the 60s status cache.
   const eventsCacheTtlMs = 5_000;
+  // Past the window, one read asks whether the page moved.
+  const eventsProbeWindowMs = 60_000;
   const maxEventsShown = 20;
-  const eventsCache = new Map<number, { expiresAt: number; value: BuildEvent[] }>();
+  interface CachedEvents {
+    expiresAt: number;
+    probeUntil: number;
+    newestId: string | null;
+    total: number;
+    value: BuildEvent[];
+  }
+  const eventsCache = new Map<number, CachedEvents>();
+
+  // Both: the channel prunes on write, and ids can tie on createdAt.
+  async function eventsUnchanged(jobId: number, cached: CachedEvents): Promise<boolean> {
+    const [probe, total] = await Promise.all([
+      store!.listBuildEvents(jobId, { limit: 1 }),
+      store!.countBuildEvents(jobId),
+    ]);
+    return (probe[0]?.id ?? null) === cached.newestId && total === cached.total;
+  }
 
   async function loadBuildEvents(jobId: number): Promise<BuildEvent[]> {
     if (!store) return [];
@@ -64,8 +82,23 @@ export function createBuildStatusAssembler(options: BuildStatusOptions): BuildSt
     if (cached && cached.expiresAt > currentTime) {
       return cached.value;
     }
-    const value = await store.listBuildEvents(jobId, { limit: maxEventsShown });
-    eventsCache.set(jobId, { value, expiresAt: currentTime + eventsCacheTtlMs });
+    // A survivor is stale only if another instance appended.
+    if (cached && cached.probeUntil > currentTime && (await eventsUnchanged(jobId, cached))) {
+      cached.expiresAt = currentTime + eventsCacheTtlMs;
+      return cached.value;
+    }
+    const [value, total] = await Promise.all([
+      store.listBuildEvents(jobId, { limit: maxEventsShown }),
+      store.countBuildEvents(jobId),
+    ]);
+    eventsCache.set(jobId, {
+      value,
+      total,
+      expiresAt: currentTime + eventsCacheTtlMs,
+      // Re-armed by a full read only, so a quiet watch refreshes.
+      probeUntil: currentTime + eventsProbeWindowMs,
+      newestId: value[0]?.id ?? null,
+    });
     return value;
   }
 

--- a/apps/api/src/delivery/build-status.ts
+++ b/apps/api/src/delivery/build-status.ts
@@ -54,26 +54,16 @@ export function createBuildStatusAssembler(options: BuildStatusOptions): BuildSt
 
   // Its own short cache, not the 60s status cache.
   const eventsCacheTtlMs = 5_000;
-  // Past the window, one read asks whether the page moved.
+  // Past the window, a count is asked before the page.
   const eventsProbeWindowMs = 60_000;
   const maxEventsShown = 20;
   interface CachedEvents {
     expiresAt: number;
     probeUntil: number;
-    newestId: string | null;
     total: number;
     value: BuildEvent[];
   }
   const eventsCache = new Map<number, CachedEvents>();
-
-  // Both: the channel prunes on write, and ids can tie on createdAt.
-  async function eventsUnchanged(jobId: number, cached: CachedEvents): Promise<boolean> {
-    const [probe, total] = await Promise.all([
-      store!.listBuildEvents(jobId, { limit: 1 }),
-      store!.countBuildEvents(jobId),
-    ]);
-    return (probe[0]?.id ?? null) === cached.newestId && total === cached.total;
-  }
 
   async function loadBuildEvents(jobId: number): Promise<BuildEvent[]> {
     if (!store) return [];
@@ -82,22 +72,24 @@ export function createBuildStatusAssembler(options: BuildStatusOptions): BuildSt
     if (cached && cached.expiresAt > currentTime) {
       return cached.value;
     }
-    // A survivor is stale only if another instance appended.
-    if (cached && cached.probeUntil > currentTime && (await eventsUnchanged(jobId, cached))) {
-      cached.expiresAt = currentTime + eventsCacheTtlMs;
-      return cached.value;
+    // Append-only, so one count answers whether it moved.
+    let counted: number | undefined;
+    if (cached && cached.probeUntil > currentTime) {
+      counted = await store.countBuildEvents(jobId);
+      if (counted === cached.total) {
+        cached.expiresAt = currentTime + eventsCacheTtlMs;
+        return cached.value;
+      }
     }
-    const [value, total] = await Promise.all([
-      store.listBuildEvents(jobId, { limit: maxEventsShown }),
-      store.countBuildEvents(jobId),
-    ]);
+    const value = await store.listBuildEvents(jobId, { limit: maxEventsShown });
+    // A page under the cap is the whole collection.
+    const total = value.length < maxEventsShown ? value.length : (counted ?? (await store.countBuildEvents(jobId)));
     eventsCache.set(jobId, {
       value,
       total,
       expiresAt: currentTime + eventsCacheTtlMs,
       // Re-armed by a full read only, so a quiet watch refreshes.
       probeUntil: currentTime + eventsProbeWindowMs,
-      newestId: value[0]?.id ?? null,
     });
     return value;
   }


### PR DESCRIPTION
## Why

The read meter from #1294 pointed straight at the biggest per-request cost in the service —
`/api/submissions/:token`, the Studio status poll, at a **3 second cadence per open tab**:

```
/api/submissions/:token reads=27 {submissions/*/events: 16, previews: 4, submissions/*: 2, globalUsage/*: 2, usage/*/counters/*: 2}
/api/submissions/:token reads=35 {submissions/*: 10, globalUsage/*: 4, events: 4, messages: 4, previews: 4}
```

`submissions/*/events` is the largest single chunk, and the cause is `docs/firestore-read-cost.md`'s
own rule applied to a window that clears the bar by too little: 5s against a 3s poll. Most
polls land past it, and every miss re-reads the whole 20-document page whether or not
anything was written — which, during a build, is most of the time.

## What changed

An append on this instance already calls `invalidateEvents`, so a *surviving* cache entry
is stale only when another instance wrote. Past the window the poll therefore asks a
cheaper question first — **a count** — and on a match extends the window instead of
refetching.

A count is enough because build events are **append-only**: `eventsCollection` is only ever
`set`, `get` and `count()`, with no delete anywhere. The count is therefore monotonic and
detects every append. (The "channel prunes on write" comment nearby is about *previews*.)

A full read is still taken whenever the count disagrees, and the probe window is re-armed
only by a full read, so a long quiet watch refreshes completely every minute regardless of
how many probes agreed. The probe's count is carried into the refreshed entry rather than
asked twice, and a page that comes back **short of the cap is the whole collection**, so it
is its own count and no aggregate is asked at all.

| poll | before | after |
| --- | --- | --- |
| nothing new | 20 reads | **1** |
| something new | 20 reads | 21 |
| feed under the cap | 20 reads | 1, with no aggregate in any state |

### What the first two attempts got wrong

Worth recording, because both were caught by review rather than by me. The first version
probed on the newest event id alone; that cannot see an append whose `createdAt` ties with
an existing event, and the test caught it. The second added a count *beside* the id, which
fixed the tie but made a sparse feed cost two reads where the page had cost one — and
counted twice on a changed poll. Both were symptoms of the same unchecked premise: that
events get pruned. They do not, and once that is established the count alone is the whole
probe.

## Not in this PR

- The route reads the submission document once for `abandonedAt` and `refreshStatus` reads
  it again immediately after. That is a real −1, but threading the record through the
  in-flight refresh dedupe is a second change to the same hot path; worth doing separately.
- `job-reconciler.ts:195` re-reads the record deliberately ("Re-read after harvest; do not
  skip the gate") and `attachBuildEvents` wants the post-reconcile record for stall
  detection. Neither is duplication to remove.

## Verification

`apps/api` delivery + submissions suites green (26 files, 555 tests), six new tests covering
the probe, the tie, invalidation, and the one-minute full refresh. Lint and size gates green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

