### PR TITLE
Record #1299 review traps in the verify-agent-work playbook

### DIFF
--- a/.claude/skills/verify-agent-work/SKILL.md
+++ b/.claude/skills/verify-agent-work/SKILL.md
@@ -345,6 +345,36 @@ Two concrete instances of that (observed 2026-07-23):
   there (`kitShared: 'defer'`) or a green preview later `seal_failed`. A Set still
   fail-closes agent delivery.
 
+- **A field added to `setCreationLimits` merge but not the Firestore `get` mapper is a
+  silent production no-op.** Observed (#1299 review, 2026-09-12): `videoPaused` /
+  `mediaLean` / `anonymousPaused` were merged on write in both stores. `FirestoreQuotaStore.getCreationLimits`
+  still mapped field-by-field and dropped them, so the spend brake could write
+  `anonymousPaused: true` and every instance shed nothing. `InMemoryStore` returns the
+  merged object as-is, so an InMemory round-trip does not cover this. Walk get and set
+  together; a test that only uses `InMemoryStore` cannot see a mapper hole.
+
+- **An `onSend` hook that becomes `async` reopens Fastify 5 "already sent" on routes that
+  `reply.send()` without returning it.** Observed (#1299): `api-cache-policy` started
+  awaiting `isOpenToVisitors()`, and compression registered an `async` `onSend` too.
+  `/api/submissions/:token/preview` does `reply.send(value)` inside a helper and returns;
+  headers were no longer written on the same tick, Fastify sent again,
+  `ERR_HTTP_HEADERS_SENT`. The test that exists because that log showed up in Studio went
+  red. Keep default `onSend` sync (stash the boolean on the request in `preHandler`), or
+  `return reply.send(...)`. Drive preview/play through `buildApp`, not a bare Fastify.
+
+- **Reusing a wall for a new purpose inherits its exemptions.** Observed (#1299):
+  `anonymousPaused` raised the private-beta wall to stop a bandwidth bill;
+  `/api/games/:slug/media` and public-play documents stayed exempt. Catalog 401'd; the
+  posters and mp4 still flowed. Diff the exemption list against the new goal, not against
+  "same wall as beta."
+
+- **A request rewrite that does not change the URL poisons a public cache keyed on that
+  URL.** Observed (#1299): `mediaLean` set `query.w=96` while the client still requested
+  `?w=320`. Image 302s are `public, max-age=10800` (half of the 6h PNG TTL). Clearing the
+  rung left the 96px object on the 320 URL for three hours. Video 503 correctly set
+  `no-store`; the rewrite path did not. Redirect to the real width, or don't cache while
+  the rung is up. Assert bytes (or `Location`), not only that `request.query` changed.
+
 ## Read the diff against the spec
 
 A passing test suite doesn't catch scope creep, subtle regressions, or malice.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Playbook notes from reviewing #1299. Four ways that change looked verified without being so: Firestore `get` dropping new brake lanes, an async `onSend` reopening Studio preview `already sent`, reusing the beta wall with its media exemption, and a `query.w` rewrite that poisoned a public cache key.

No product code. Same session as the review, per the skill's self-improvement clause.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bc7e094b-b51d-49d3-a38a-028eb99e97b4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bc7e094b-b51d-49d3-a38a-028eb99e97b4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

