### PR TITLE
Notice when master stops reaching production

### DIFF
--- a/.github/workflows/deploy-watchdog.yml
+++ b/.github/workflows/deploy-watchdog.yml
@@ -1,9 +1,4 @@
-# Tells somebody when master stopped reaching production, so nobody has to look.
-#
-# The deploy job is gated on master's CI concluding success, so a red master silently
-# skips every deploy: the merged PR was green, the merge commit is on master, and
-# production keeps serving the old revision with nothing saying so. See
-# infra/check-deploy-freshness.mjs.
+# Why this exists: docs/firestore-read-cost.md, "The deploy gate has no voice of its own".
 name: Deploy watchdog
 
 on:
@@ -20,6 +15,9 @@ concurrency:
   group: deploy-watchdog
   cancel-in-progress: false
 
+env:
+  ISSUE_TITLE: 'Deploy watchdog: master is not deployed'
+
 jobs:
   freshness:
     runs-on: ubuntu-latest
@@ -29,38 +27,49 @@ jobs:
         with:
           node-version: 20
 
+      # 0 deployed, 1 not deployed, 2 the check broke, 3 too early to judge.
       - id: check
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          if node infra/check-deploy-freshness.mjs > verdict.txt 2>&1; then
-            echo "stale=false" >> "$GITHUB_OUTPUT"
-          else
-            echo "stale=true" >> "$GITHUB_OUTPUT"
-          fi
+          set +e
+          node infra/check-deploy-freshness.mjs > verdict.txt 2>&1
+          verdict=$?
+          set -e
           cat verdict.txt
+          echo "verdict=$verdict" >> "$GITHUB_OUTPUT"
+          # Its own failure must never read as a production incident.
+          if [ "$verdict" -eq 2 ]; then
+            echo '::error::deploy watchdog could not reach the GitHub API'
+            exit 1
+          fi
+
+      - id: issue
+        if: steps.check.outputs.verdict == '1' || steps.check.outputs.verdict == '0'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      # One open issue, commented rather than duplicated: the mail is the point.
-      - if: steps.check.outputs.stale == 'true'
         run: |
-          existing="$(gh issue list --state open --json number,title \
-            --jq 'map(select(.title | startswith("Deploy watchdog:"))) | .[0].number // empty')"
-          body="$(printf 'Master has not reached production.\n\n```\n%s\n```\n\nThis is the failure mode from 2026-09-12: a green pull request merges, master CI is red for an unrelated reason, and every deploy is skipped while production serves the previous revision.\n' "$(cat verdict.txt)")"
-          if [ -n "$existing" ]; then
-            gh issue comment "$existing" --body "$body"
+          number="$(gh issue list --state open --search "$ISSUE_TITLE in:title" --limit 100 \
+            --json number,title --jq "map(select(.title == \"$ISSUE_TITLE\")) | .[0].number // empty")"
+          echo "number=$number" >> "$GITHUB_OUTPUT"
+
+      - if: steps.check.outputs.verdict == '1'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          EXISTING: ${{ steps.issue.outputs.number }}
+        run: |
+          body="$(printf 'Master has not reached production. The verdict below says which of the causes it is.\n\n```\n%s\n```\n\nRun: %s/%s/actions/runs/%s\n' \
+            "$(cat verdict.txt)" "$GITHUB_SERVER_URL" "$GITHUB_REPOSITORY" "$GITHUB_RUN_ID")"
+          if [ -n "$EXISTING" ]; then
+            gh issue comment "$EXISTING" --body "$body"
           else
-            gh issue create --title "Deploy watchdog: master is not deployed" --body "$body" --assignee gtanczyk
+            gh issue create --title "$ISSUE_TITLE" --body "$body" --assignee gtanczyk
           fi
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      # Closes itself, so the issue's state is the current answer and not a log.
-      - if: steps.check.outputs.stale == 'false'
-        run: |
-          existing="$(gh issue list --state open --json number,title \
-            --jq 'map(select(.title | startswith("Deploy watchdog:"))) | .[0].number // empty')"
-          if [ -n "$existing" ]; then
-            gh issue close "$existing" --comment "Master is deployed again: $(cat verdict.txt)"
-          fi
+      # Closed only on a definite yes, never on "too early to judge".
+      - if: steps.check.outputs.verdict == '0' && steps.issue.outputs.number != ''
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          EXISTING: ${{ steps.issue.outputs.number }}
+        run: |
+          gh issue close "$EXISTING" --comment "$(printf 'Master is deployed again.\n\n```\n%s\n```\n' "$(cat verdict.txt)")"

--- a/.github/workflows/deploy-watchdog.yml
+++ b/.github/workflows/deploy-watchdog.yml
@@ -1,0 +1,66 @@
+# Tells somebody when master stopped reaching production, so nobody has to look.
+#
+# The deploy job is gated on master's CI concluding success, so a red master silently
+# skips every deploy: the merged PR was green, the merge commit is on master, and
+# production keeps serving the old revision with nothing saying so. See
+# infra/check-deploy-freshness.mjs.
+name: Deploy watchdog
+
+on:
+  schedule:
+    - cron: '*/30 * * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  actions: read
+  issues: write
+
+concurrency:
+  group: deploy-watchdog
+  cancel-in-progress: false
+
+jobs:
+  freshness:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: 20
+
+      - id: check
+        run: |
+          if node infra/check-deploy-freshness.mjs > verdict.txt 2>&1; then
+            echo "stale=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "stale=true" >> "$GITHUB_OUTPUT"
+          fi
+          cat verdict.txt
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # One open issue, commented rather than duplicated: the mail is the point.
+      - if: steps.check.outputs.stale == 'true'
+        run: |
+          existing="$(gh issue list --state open --json number,title \
+            --jq 'map(select(.title | startswith("Deploy watchdog:"))) | .[0].number // empty')"
+          body="$(printf 'Master has not reached production.\n\n```\n%s\n```\n\nThis is the failure mode from 2026-09-12: a green pull request merges, master CI is red for an unrelated reason, and every deploy is skipped while production serves the previous revision.\n' "$(cat verdict.txt)")"
+          if [ -n "$existing" ]; then
+            gh issue comment "$existing" --body "$body"
+          else
+            gh issue create --title "Deploy watchdog: master is not deployed" --body "$body" --assignee gtanczyk
+          fi
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # Closes itself, so the issue's state is the current answer and not a log.
+      - if: steps.check.outputs.stale == 'false'
+        run: |
+          existing="$(gh issue list --state open --json number,title \
+            --jq 'map(select(.title | startswith("Deploy watchdog:"))) | .[0].number // empty')"
+          if [ -n "$existing" ]; then
+            gh issue close "$existing" --comment "Master is deployed again: $(cat verdict.txt)"
+          fi
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/docs/firestore-read-cost.md
+++ b/docs/firestore-read-cost.md
@@ -226,6 +226,15 @@ full working week of post-fix numbers rather than from an estimate — `read-cos
 is what that measurement looks like, and the type split belongs in the PR that moves a
 threshold.
 
+**The deploy gate has no voice of its own.** `Deploy to Cloud Run` triggers on `workflow_run`
+of CI and is gated on that run concluding success, so a red master skips every deploy while
+each merged pull request still reads green. On 2026-09-12 master was red from a direct push
+and two merges deployed nothing; production served the previous revision for over an hour with
+nothing reporting it. `infra/check-deploy-freshness.mjs` (run every half hour by
+`.github/workflows/deploy-watchdog.yml`) now asks whether master's newest settled commit has a
+*successful* deploy run, and opens one issue when it does not. Verified against that incident's
+own data: pointed at the red window it names `25703195c` and `5b5518841` exactly.
+
 **Owed after the sweep fixes land.** A30 and A31 are calibrated against the pre-fix floor
 described above. Give the change a full working week in production, then re-derive both from
 `infra/read-cost-report.sh 7d` and the per-route sums from the read meter, and put the type

--- a/docs/firestore-read-cost.md
+++ b/docs/firestore-read-cost.md
@@ -232,8 +232,24 @@ each merged pull request still reads green. On 2026-09-12 master was red from a 
 and two merges deployed nothing; production served the previous revision for over an hour with
 nothing reporting it. `infra/check-deploy-freshness.mjs` (run every half hour by
 `.github/workflows/deploy-watchdog.yml`) now asks whether master's newest settled commit has a
-*successful* deploy run, and opens one issue when it does not. Verified against that incident's
-own data: pointed at the red window it names `25703195c` and `5b5518841` exactly.
+*successful* deploy run, and opens one issue when it does not.
+
+Four answers, because three of them are not "fine": **deployed** (0) closes the issue,
+**not deployed** (1) opens or comments on it, **too early to judge** (3) touches nothing, and
+**the check itself broke** (2) fails the workflow loudly rather than reporting a production
+incident that may not exist. The distinction between 0 and 3 is the one that matters: a
+watchdog that treats "still deploying" as health closes its own incident thirty seconds after
+raising it.
+
+Three rules the first draft got wrong, all three found in review:
+
+- **Judge only the newest settled CI run.** Scanning backwards for the newest run *older than
+  the grace window* picks a superseded red commit while the green one that fixed it is still
+  building — so the alarm stays on through the recovery it is supposed to notice ending.
+- **Look for a deploy before judging CI.** `deploy.yml` also accepts `workflow_dispatch`, with
+  no CI gate, so a manual deploy of a red-CI commit is a real deploy and must read as one.
+- **A pending deploy expires.** Any in-flight run counted as health meant a queued or hung
+  deploy looked fine for as long as it hung; past `DEPLOY_TIMEOUT_MINUTES` it is a stall.
 
 **Owed after the sweep fixes land.** A30 and A31 are calibrated against the pre-fix floor
 described above. Give the change a full working week in production, then re-derive both from

--- a/infra/check-deploy-freshness.mjs
+++ b/infra/check-deploy-freshness.mjs
@@ -1,29 +1,25 @@
 #!/usr/bin/env node
-// Assert master's tip actually reached production, so nobody has to check by hand.
-//
-// The deploy job runs on `workflow_run` of CI and is gated on that run concluding
-// success, so a red master silently stops every deploy: the PR that merged was green,
-// its merge commit is on master, and production keeps serving the previous revision with
-// nothing anywhere saying so. That happened on 2026-09-12 — master had been red since a
-// direct push, and two merges deployed nothing.
-//
-// So this asks the only question that matters after a merge: does master's newest settled
-// commit have a *successful* deploy run? A skipped deploy (CI red) and a failed deploy
-// both answer no, which is the point — the failure modes look identical from the outside.
+// Why this exists: docs/firestore-read-cost.md, "The deploy gate has no voice of its own".
 //
 //   node infra/check-deploy-freshness.mjs
-//   GRACE_MINUTES=40 node infra/check-deploy-freshness.mjs
+//   GRACE_MINUTES=40 DEPLOY_TIMEOUT_MINUTES=60 node infra/check-deploy-freshness.mjs
 //
-// Needs GITHUB_TOKEN (or GH_TOKEN) with read access to actions.
+// Exit: 0 deployed, 1 not deployed, 2 the check itself failed, 3 too early to judge.
 
 const repo = process.env.GITHUB_REPOSITORY ?? 'gamedevpl/www.gamedev.pl';
 const token = process.env.GITHUB_TOKEN ?? process.env.GH_TOKEN;
 const graceMinutes = Number(process.env.GRACE_MINUTES ?? 25);
+const deployTimeoutMinutes = Number(process.env.DEPLOY_TIMEOUT_MINUTES ?? 45);
 const branch = process.env.DEPLOY_BRANCH ?? 'master';
+
+const DEPLOYED = 0;
+const STALE = 1;
+const BROKEN = 2;
+const TOO_EARLY = 3;
 
 if (!token) {
   console.error('Set GITHUB_TOKEN (or GH_TOKEN) with actions:read.');
-  process.exit(2);
+  process.exit(BROKEN);
 }
 
 async function api(path) {
@@ -36,52 +32,58 @@ async function api(path) {
   });
   if (!response.ok) {
     console.error(`GitHub API ${response.status} for ${path}`);
-    process.exit(2);
+    process.exit(BROKEN);
   }
   return response.json();
 }
 
-function minutesAgo(iso) {
-  return (Date.now() - Date.parse(iso)) / 60_000;
-}
+const minutesAgo = (iso) => (Date.now() - Date.parse(iso)) / 60_000;
 
 const runsFor = async (workflow) =>
   (await api(`/repos/${repo}/actions/workflows/${workflow}/runs?branch=${branch}&per_page=30`)).workflow_runs ?? [];
 
-const ciRuns = await runsFor('ci.yml');
-const settled = ciRuns.filter((run) => run.status === 'completed');
-// Newer commits may still be building; judging them would alarm on normal latency.
-const candidate = settled.find((run) => minutesAgo(run.updated_at) >= graceMinutes);
+// Only ever the newest settled run: an older one is a commit master has moved past.
+const newest = (await runsFor('ci.yml')).find((run) => run.status === 'completed');
 
-if (!candidate) {
-  console.log(`No CI run on ${branch} settled more than ${graceMinutes} minutes ago — nothing to judge yet.`);
-  process.exit(0);
+if (!newest) {
+  console.log(`No CI run on ${branch} has settled yet.`);
+  process.exit(TOO_EARLY);
+}
+if (minutesAgo(newest.updated_at) < graceMinutes) {
+  console.log(`${newest.head_sha.slice(0, 9)} settled ${Math.round(minutesAgo(newest.updated_at))}m ago; deploying.`);
+  process.exit(TOO_EARLY);
 }
 
-const sha = candidate.head_sha;
+const sha = newest.head_sha;
 const short = sha.slice(0, 9);
-
-if (candidate.conclusion !== 'success') {
-  console.error(`master CI is ${candidate.conclusion} at ${short} — every deploy since is skipped.`);
-  console.error(`  ${candidate.html_url}`);
-  process.exit(1);
-}
-
+// Before the CI conclusion: workflow_dispatch deploys carry no such gate.
 const deployRuns = (await runsFor('deploy.yml')).filter((run) => run.head_sha === sha);
 const deployed = deployRuns.find((run) => run.conclusion === 'success');
 
 if (deployed) {
   console.log(`${short} is deployed (${deployed.html_url}).`);
-  process.exit(0);
+  process.exit(DEPLOYED);
 }
 
-const pending = deployRuns.find((run) => run.status !== 'completed');
-if (pending) {
-  console.log(`${short} is still deploying (${pending.html_url}).`);
-  process.exit(0);
+const inFlight = deployRuns.find((run) => run.status !== 'completed');
+if (inFlight) {
+  const running = Math.round(minutesAgo(inFlight.created_at));
+  if (running <= deployTimeoutMinutes) {
+    console.log(`${short} has been deploying for ${running}m (${inFlight.html_url}).`);
+    process.exit(TOO_EARLY);
+  }
+  console.error(`${short} has been deploying for ${running}m, past ${deployTimeoutMinutes}m.`);
+  console.error(`  ${inFlight.html_url}`);
+  process.exit(STALE);
+}
+
+if (newest.conclusion !== 'success') {
+  console.error(`${branch} CI is ${newest.conclusion} at ${short}, so every deploy is skipped.`);
+  console.error(`  ${newest.html_url}`);
+  process.exit(STALE);
 }
 
 const latest = deployRuns[0];
-console.error(`${short} passed CI ${Math.round(minutesAgo(candidate.updated_at))} minutes ago and is not deployed.`);
+console.error(`${short} passed CI ${Math.round(minutesAgo(newest.updated_at))}m ago and is not deployed.`);
 console.error(latest ? `  deploy run ${latest.conclusion}: ${latest.html_url}` : '  no deploy run exists for it');
-process.exit(1);
+process.exit(STALE);

--- a/infra/check-deploy-freshness.mjs
+++ b/infra/check-deploy-freshness.mjs
@@ -1,0 +1,87 @@
+#!/usr/bin/env node
+// Assert master's tip actually reached production, so nobody has to check by hand.
+//
+// The deploy job runs on `workflow_run` of CI and is gated on that run concluding
+// success, so a red master silently stops every deploy: the PR that merged was green,
+// its merge commit is on master, and production keeps serving the previous revision with
+// nothing anywhere saying so. That happened on 2026-09-12 — master had been red since a
+// direct push, and two merges deployed nothing.
+//
+// So this asks the only question that matters after a merge: does master's newest settled
+// commit have a *successful* deploy run? A skipped deploy (CI red) and a failed deploy
+// both answer no, which is the point — the failure modes look identical from the outside.
+//
+//   node infra/check-deploy-freshness.mjs
+//   GRACE_MINUTES=40 node infra/check-deploy-freshness.mjs
+//
+// Needs GITHUB_TOKEN (or GH_TOKEN) with read access to actions.
+
+const repo = process.env.GITHUB_REPOSITORY ?? 'gamedevpl/www.gamedev.pl';
+const token = process.env.GITHUB_TOKEN ?? process.env.GH_TOKEN;
+const graceMinutes = Number(process.env.GRACE_MINUTES ?? 25);
+const branch = process.env.DEPLOY_BRANCH ?? 'master';
+
+if (!token) {
+  console.error('Set GITHUB_TOKEN (or GH_TOKEN) with actions:read.');
+  process.exit(2);
+}
+
+async function api(path) {
+  const response = await fetch(`https://api.github.com${path}`, {
+    headers: {
+      authorization: `Bearer ${token}`,
+      accept: 'application/vnd.github+json',
+      'user-agent': 'gamedev-deploy-freshness',
+    },
+  });
+  if (!response.ok) {
+    console.error(`GitHub API ${response.status} for ${path}`);
+    process.exit(2);
+  }
+  return response.json();
+}
+
+function minutesAgo(iso) {
+  return (Date.now() - Date.parse(iso)) / 60_000;
+}
+
+const runsFor = async (workflow) =>
+  (await api(`/repos/${repo}/actions/workflows/${workflow}/runs?branch=${branch}&per_page=30`)).workflow_runs ?? [];
+
+const ciRuns = await runsFor('ci.yml');
+const settled = ciRuns.filter((run) => run.status === 'completed');
+// Newer commits may still be building; judging them would alarm on normal latency.
+const candidate = settled.find((run) => minutesAgo(run.updated_at) >= graceMinutes);
+
+if (!candidate) {
+  console.log(`No CI run on ${branch} settled more than ${graceMinutes} minutes ago — nothing to judge yet.`);
+  process.exit(0);
+}
+
+const sha = candidate.head_sha;
+const short = sha.slice(0, 9);
+
+if (candidate.conclusion !== 'success') {
+  console.error(`master CI is ${candidate.conclusion} at ${short} — every deploy since is skipped.`);
+  console.error(`  ${candidate.html_url}`);
+  process.exit(1);
+}
+
+const deployRuns = (await runsFor('deploy.yml')).filter((run) => run.head_sha === sha);
+const deployed = deployRuns.find((run) => run.conclusion === 'success');
+
+if (deployed) {
+  console.log(`${short} is deployed (${deployed.html_url}).`);
+  process.exit(0);
+}
+
+const pending = deployRuns.find((run) => run.status !== 'completed');
+if (pending) {
+  console.log(`${short} is still deploying (${pending.html_url}).`);
+  process.exit(0);
+}
+
+const latest = deployRuns[0];
+console.error(`${short} passed CI ${Math.round(minutesAgo(candidate.updated_at))} minutes ago and is not deployed.`);
+console.error(latest ? `  deploy run ${latest.conclusion}: ${latest.html_url}` : '  no deploy run exists for it');
+process.exit(1);

--- a/package.json
+++ b/package.json
@@ -23,6 +23,8 @@
     "lint": "eslint . --report-unused-disable-directives --max-warnings 0 && npm run comment-prose && npm run module-size && npm run module-boundary && npm run env-manifest && npm run runtime-sa && npm run firebase-hosting && npm run action-pins && npm run cli:changelog",
     "// env-manifest": "Both deploy paths must thread the same service env map; --set-env-vars replaces it wholesale. See infra/env-manifest.json.",
     "firebase-hosting": "node infra/check-firebase-hosting.mjs",
+    "// deploy-freshness": "Live check, not part of lint: asks GitHub whether master reached prod. See .github/workflows/deploy-watchdog.yml.",
+    "deploy-freshness": "node infra/check-deploy-freshness.mjs",
     "env-manifest": "node infra/check-env-manifest.mjs",
     "runtime-sa": "node infra/check-runtime-sa.mjs",
     "// action-pins": "A tag is a moving pointer; the deploy job holds the Cloud Run credential. See infra/check-action-pins.mjs.",


### PR DESCRIPTION
## Why

You should not have to check anything after a merge. Today you did, and the reason is
structural: `Deploy to Cloud Run` triggers on `workflow_run` of CI and is gated on that run
concluding `success`. So a **red master skips every deploy, silently** — the pull request
that merged was green, its merge commit is on master, and production keeps serving the
previous revision.

That is not hypothetical. On 2026-09-12 master had been red since `5b5518841` (a direct
push, unrelated to anything being merged). #1294 merged green, deployed nothing, and
production served `gamedev-app-02097-loq` for over an hour. It was found by hand, because
`gh pr view` says green and nothing anywhere says "and it went nowhere".

## What this adds

`infra/check-deploy-freshness.mjs` asks the one question that matters after a merge: does
master's newest **settled** commit have a *successful* deploy run?

It answers four ways, because three of them are not "fine":

| exit | meaning | the workflow |
| --- | --- | --- |
| 0 | deployed | closes the issue |
| 1 | not deployed | opens it, or comments while it stands |
| 3 | too early to judge | touches nothing |
| 2 | the check itself broke | fails loudly, raises no incident |

Telling 0 from 3 is the point: a watchdog that reads "still deploying" as health closes its
own incident a minute after raising it.

A **skipped** deploy (CI red) and a **failed** deploy both answer 1. That is deliberate —
from the outside they look identical to a deploy that never needed to happen.

`.github/workflows/deploy-watchdog.yml` runs it every half hour and keeps **one** issue,
assigned so it mails: it comments rather than duplicating while the problem stands, and
closes it once master is deployed again, so the issue's state is the current answer rather
than a growing log.

## Three things the first draft got wrong

All three were caught in review, and they share a shape — a watchdog that cannot say "I do
not know" ends up lying in one direction or the other.

- **The grace window was applied inside the search**, so it picked the newest run *older*
  than the window. During a recovery that is the superseded red commit, while the green one
  that fixed it is still building: the alarm would have stayed on through exactly the event
  it exists to notice ending. Only the newest settled run is judged now.
- **CI's conclusion was checked before the deploy runs**, but `deploy.yml` also accepts
  `workflow_dispatch` with no CI gate. A manual deploy of a red-CI commit is a real deploy
  and now reads as one.
- **Any in-flight deploy counted as health**, so a queued or hung run looked fine for as
  long as it hung. Past `DEPLOY_TIMEOUT_MINUTES` it is a stall.

Two more from the same review: exit 2 was treated as a stale deployment, so a blink of the
GitHub API would have opened a false production incident; and the issue lookup was capped at
`gh issue list`'s default 30 open issues, which would have duplicated the alert every half
hour once it fell past that.

## Verification against live data

It is an alarm, so what matters is that it fires. Every path, against the real API:

```
skipped CI on a branch            → "CI is skipped … every deploy is skipped"   exit 1
green branch, no deploy run       → "passed CI 88m ago and is not deployed"     exit 1
no token                          → "Set GITHUB_TOKEN …"                        exit 2
branch with nothing settled       → "No CI run … has settled yet"               exit 3
master, deploy in flight          → "has been deploying for 8m"                 exit 3
master, tip deployed              → "… is deployed (<run url>)"                 exit 0
```

Before the fix above it could also be walked back into this afternoon's red window, where it
named `25703195c` and `5b5518841` exactly. It deliberately no longer can: reaching backwards
past the grace window was the bug.

## Notes

- Nothing touches the deploy path, service env, or `infra/env-manifest.json` — the check
  reads the GitHub Actions API only, with the workflow's own `GITHUB_TOKEN`.
- `npm run deploy-freshness` runs it locally (needs `GH_TOKEN`). Deliberately **not** part
  of `npm run lint`: it is a live network check and would make lint fail offline.
- It does not cover "deploy succeeded but traffic never shifted". Revisions carry no commit
  SHA and `/api/health` reports no version, so that comparison needs a deploy-path change;
  worth doing separately if the rarer failure is worth the wiring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

