### PR TITLE
Keep the budget amount out of a public repo

### DIFF
--- a/infra/setup-spend-brake.sh
+++ b/infra/setup-spend-brake.sh
@@ -199,6 +199,9 @@ Bandwidth is the one an open site spends without anybody asking for it, and it h
 no per-service budget yet. Create one, and point the two that already exist at the
 topic — a budget that only emails is not a brake:
 
+  # Amounts and the billing account id live in the ops repo's setup-budgets.sh,
+  # never here: this repo is public and the money is not.
+  #
   # services/95FF-2EF5-5EA1 is Cloud Storage, read from the Catalog API on
   # 2026-09-12. Pasted rather than looked up on purpose: gcloud has no
   # 'billing services list', and a lookup that fails leaves the filter empty,
@@ -210,7 +213,7 @@ topic — a budget that only emails is not a brake:
   #     python3 -c 'import sys,json; [print(s["name"], s["displayName"]) for s in json.load(sys.stdin)["services"]]'
   gcloud billing budgets create --billing-account ACCOUNT_ID \\
     --display-name='GCS egress lanes=video_media' \\
-    --budget-amount=100PLN --filter-services=services/95FF-2EF5-5EA1 \\
+    --budget-amount=AMOUNT --filter-services=services/95FF-2EF5-5EA1 \\
     --threshold-rule=percent=0.5 --threshold-rule=percent=1.0 \\
     --notifications-rule-pubsub-topic=projects/${PROJECT_ID}/topics/${TOPIC}
 


### PR DESCRIPTION
`infra/setup-spend-brake.sh` prints a worked `gcloud billing budgets create` example, and I put a real figure in it. The billing account id in the same command was already a placeholder — the amount should have been one too, for the same reason: this repo is public, and budget amounts live in the ops repo's `setup-budgets.sh` with the account id.

One line, `--budget-amount=100PLN` → `--budget-amount=AMOUNT`, plus a line saying where the numbers actually live so the next person does not repeat it.

The Cloud Storage service id stays — that is a public constant of Google's, not ours.

🤖 Generated with [Claude Code](https://claude.com/claude-code)